### PR TITLE
internal: Limit the scope of Scala Steward jobs to this repository

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -21,6 +21,8 @@ jobs:
           github-app-id: ${{ vars.APP_ID }}
           github-app-installation-id: ${{ secrets.APP_INSTALLATION_ID }}
           github-app-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Necessary to process only this repository
+          github-app-auth-only: true
           author-name: 'scala-steward'
           author-email: 'leo+bot@xerial.org'
           other-args: '--do-not-fork --add-labels'


### PR DESCRIPTION
This pull request introduces a minor update to the `.github/workflows/scala-steward.yml` file to restrict the GitHub App's authentication to only the current repository.

* [`.github/workflows/scala-steward.yml`](diffhunk://#diff-5f70f29f856428700109959debc5d1f950fa48d279caee7f9f0962a3caa63958R24-R25): Added the `github-app-auth-only` parameter with a value of `true` to ensure the GitHub App processes only this repository.