### PR TITLE
fix: Install libgc-dev for native compilation in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,8 @@ jobs:
           distribution: 'temurin'
           java-version: '23'
           cache: sbt
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgc-dev
       - name: Scala Native test
         run: ./sbt projectNative/test
       - name: Publish Test Report


### PR DESCRIPTION
## Summary
- Add libgc-dev installation step to test_native job in GitHub Actions workflow
- Fix native compilation failures by providing required Boehm GC library dependency

## Test plan
- [x] Verify workflow syntax is correct
- [ ] Confirm native tests pass in CI after dependency installation

🤖 Generated with [Claude Code](https://claude.ai/code)