### PR TITLE
fix: Add DataType serialization codec to handle complex function signatures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,7 @@ The project follows semantic versioning and uses SBT plugins for cross-platform 
 ### Development Workflow
 
 - To develop a code, create a new branch and create a pull request
+- **Before addressing a new task, switch to main and pull, and then create a new branch**
 
 ## Error Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,7 @@ The project follows semantic versioning and uses SBT plugins for cross-platform 
 ### Code Reviews
 
 - Gemini will review pull requests for code quality, adherence to guidelines, and test coverage. Reflect on feedback and make necessary changes.
+- After creating a PR, wait for review from Gemini for a while, and reflect on the suggestions, and update the PR.
 - To ask Gemini review the code change again, comment `/gemini review` to the pull request 
 
 ### Development Workflow

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/CatalogSerializer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/CatalogSerializer.scala
@@ -14,6 +14,7 @@
 package wvlet.lang.catalog
 
 import wvlet.airframe.codec.{MessageCodec, MessageCodecFactory}
+import wvlet.airframe.surface.Surface
 import wvlet.lang.model.DataType
 import wvlet.log.LogSupport
 
@@ -22,14 +23,19 @@ import wvlet.log.LogSupport
   */
 object CatalogSerializer extends LogSupport:
 
+  // Create a custom codec factory that includes our DataType codec
+  private val codecFactory = MessageCodecFactory.defaultFactory.withCodecs(
+    Map(Surface.of[DataType] -> DataTypeCodec)
+  )
+
   // Codec for table definitions
-  private val tableDefCodec = MessageCodec.of[List[Catalog.TableDef]]
+  private val tableDefCodec = codecFactory.of[List[Catalog.TableDef]]
 
   // Codec for SQL functions
-  private val sqlFunctionCodec = MessageCodec.of[List[SQLFunction]]
+  private val sqlFunctionCodec = codecFactory.of[List[SQLFunction]]
 
   // Codec for schema metadata
-  private val schemaCodec = MessageCodec.of[List[Catalog.TableSchema]]
+  private val schemaCodec = codecFactory.of[List[Catalog.TableSchema]]
 
   /**
     * Catalog metadata structure that includes all catalog information
@@ -44,7 +50,7 @@ object CatalogSerializer extends LogSupport:
       version: String = "1.0"
   )
 
-  private val catalogMetadataCodec = MessageCodec.of[CatalogMetadata]
+  private val catalogMetadataCodec = codecFactory.of[CatalogMetadata]
 
   def serializeTables(tables: List[Catalog.TableDef]): String = tableDefCodec.toJson(tables)
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/CatalogSerializer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/CatalogSerializer.scala
@@ -24,9 +24,9 @@ import wvlet.log.LogSupport
 object CatalogSerializer extends LogSupport:
 
   // Create a custom codec factory that includes our DataType codec
-  private val codecFactory = MessageCodecFactory.defaultFactory.withCodecs(
-    Map(Surface.of[DataType] -> DataTypeCodec)
-  )
+  private val codecFactory = MessageCodecFactory
+    .defaultFactory
+    .withCodecs(Map(Surface.of[DataType] -> DataTypeCodec))
 
   // Codec for table definitions
   private val tableDefCodec = codecFactory.of[List[Catalog.TableDef]]

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/DataTypeCodec.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/DataTypeCodec.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.catalog
+
+import wvlet.airframe.codec.{MessageCodec, MessageContext}
+import wvlet.airframe.msgpack.spi.{MessagePack, Packer, Unpacker}
+import wvlet.lang.compiler.Name
+import wvlet.lang.model.DataType
+import wvlet.log.LogSupport
+
+/**
+  * Custom codec for DataType that serializes to/from string representation
+  */
+object DataTypeCodec extends MessageCodec[DataType] with LogSupport:
+
+  override def pack(p: Packer, v: DataType): Unit =
+    // Serialize DataType as its string representation
+    p.packString(v.toString)
+
+  override def unpack(u: Unpacker, v: MessageContext): Unit =
+    try
+      val typeStr = u.unpackString
+      val dataType = 
+        try
+          DataType.parse(typeStr)
+        catch
+          case e: Exception =>
+            // Fallback to GenericType for types that can't be parsed
+            warn(s"Failed to parse DataType '$typeStr', using GenericType as fallback: ${e.getMessage}")
+            DataType.GenericType(Name.typeName(typeStr))
+      v.setObject(dataType)
+    catch
+      case e: Exception =>
+        v.setError(new IllegalArgumentException(s"Failed to parse DataType from string: ${e.getMessage}", e))
+
+end DataTypeCodec

--- a/wvlet-lang/src/test/scala/wvlet/lang/catalog/DataTypeCodecTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/catalog/DataTypeCodecTest.scala
@@ -28,7 +28,7 @@ class DataTypeCodecTest extends AirSpec:
       DataType.DoubleType,
       DataType.ArrayType(DataType.IntType),
       DataType.MapType(DataType.StringType, DataType.IntType),
-      DataType.DecimalType.of(18, 3),
+      DataType.DecimalType.of(18, 3)
       // DataType.ArrayType(DataType.DecimalType.of(18, 3)) // This can't be parsed back from string
     )
 
@@ -49,9 +49,9 @@ class DataTypeCodecTest extends AirSpec:
       returnType = DataType.DecimalType.of(38, 3)
     )
 
-    val json = CatalogSerializer.serializeFunctions(List(function))
+    val json    = CatalogSerializer.serializeFunctions(List(function))
     val decoded = CatalogSerializer.deserializeFunctions(json)
-    
+
     decoded.size shouldBe 1
     val decodedFunc = decoded.head
     decodedFunc.name shouldBe "sum"
@@ -63,25 +63,19 @@ class DataTypeCodecTest extends AirSpec:
 
   test("handle complex nested DataTypes") {
     val complexType = DataType.ArrayType(
-      DataType.MapType(
-        DataType.StringType,
-        DataType.ArrayType(DataType.IntType)
-      )
+      DataType.MapType(DataType.StringType, DataType.ArrayType(DataType.IntType))
     )
-    val json = DataTypeCodec.toJson(complexType)
+    val json    = DataTypeCodec.toJson(complexType)
     val decoded = DataTypeCodec.fromJson(json)
     decoded.toString shouldBe complexType.toString
   }
 
   test("fallback to GenericType for unparseable types") {
     // These type strings can't be parsed by DataType.parse()
-    val unparseableTypes = List(
-      "array(decimal(18,3))",
-      "struct(a:int,b:string)"
-    )
-    
+    val unparseableTypes = List("array(decimal(18,3))", "struct(a:int,b:string)")
+
     unparseableTypes.foreach { typeStr =>
-      val json = s""""$typeStr""""
+      val json    = s""""$typeStr""""
       val decoded = DataTypeCodec.fromJson(json)
       decoded.isInstanceOf[DataType.GenericType] shouldBe true
       decoded.toString shouldBe typeStr

--- a/wvlet-lang/src/test/scala/wvlet/lang/catalog/DataTypeCodecTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/catalog/DataTypeCodecTest.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.catalog
+
+import wvlet.airframe.codec.MessageCodec
+import wvlet.airspec.AirSpec
+import wvlet.lang.catalog.SQLFunction.FunctionType
+import wvlet.lang.compiler.Name
+import wvlet.lang.model.DataType
+
+class DataTypeCodecTest extends AirSpec:
+
+  test("serialize and deserialize DataType") {
+    val testCases = List(
+      DataType.IntType,
+      DataType.StringType,
+      DataType.DoubleType,
+      DataType.ArrayType(DataType.IntType),
+      DataType.MapType(DataType.StringType, DataType.IntType),
+      DataType.DecimalType.of(18, 3),
+      // DataType.ArrayType(DataType.DecimalType.of(18, 3)) // This can't be parsed back from string
+    )
+
+    testCases.foreach { dataType =>
+      // Test direct codec
+      val json = DataTypeCodec.toJson(dataType)
+      debug(s"DataType: $dataType -> JSON: $json")
+      val decoded = DataTypeCodec.fromJson(json)
+      decoded shouldBe dataType
+    }
+  }
+
+  test("serialize and deserialize SQLFunction with DataType") {
+    val function = SQLFunction(
+      name = "sum",
+      functionType = FunctionType.AGGREGATE,
+      args = Seq(DataType.DecimalType.of(18, 3)),
+      returnType = DataType.DecimalType.of(38, 3)
+    )
+
+    val json = CatalogSerializer.serializeFunctions(List(function))
+    val decoded = CatalogSerializer.deserializeFunctions(json)
+    
+    decoded.size shouldBe 1
+    val decodedFunc = decoded.head
+    decodedFunc.name shouldBe "sum"
+    decodedFunc.functionType shouldBe FunctionType.AGGREGATE
+    decodedFunc.args.size shouldBe 1
+    decodedFunc.args.head.toString shouldBe "decimal(18,3)"
+    decodedFunc.returnType.toString shouldBe "decimal(38,3)"
+  }
+
+  test("handle complex nested DataTypes") {
+    val complexType = DataType.ArrayType(
+      DataType.MapType(
+        DataType.StringType,
+        DataType.ArrayType(DataType.IntType)
+      )
+    )
+    val json = DataTypeCodec.toJson(complexType)
+    val decoded = DataTypeCodec.fromJson(json)
+    decoded.toString shouldBe complexType.toString
+  }
+
+  test("fallback to GenericType for unparseable types") {
+    // These type strings can't be parsed by DataType.parse()
+    val unparseableTypes = List(
+      "array(decimal(18,3))",
+      "struct(a:int,b:string)"
+    )
+    
+    unparseableTypes.foreach { typeStr =>
+      val json = s""""$typeStr""""
+      val decoded = DataTypeCodec.fromJson(json)
+      decoded.isInstanceOf[DataType.GenericType] shouldBe true
+      decoded.toString shouldBe typeStr
+    }
+  }
+
+end DataTypeCodecTest


### PR DESCRIPTION
## Summary

This PR fixes the DataType serialization issue that was preventing catalog imports from working properly when functions had complex type signatures from external databases like DuckDB.

## What's Changed

- Added a custom `DataTypeCodec` that serializes DataType objects to their string representation
- Implemented fallback logic to use `GenericType` for unparseable type strings 
- Updated `CatalogSerializer` to use the custom codec factory with DataTypeCodec
- Added comprehensive tests for DataType serialization

## Problem

When importing catalogs from DuckDB, functions with complex return types like `array(decimal(18,3))` would cause deserialization failures because:
1. DuckDB returns these as strings in its function metadata
2. Our `DataType.parse()` method doesn't support all complex type formats
3. The default MessageCodec couldn't handle this mismatch

## Solution

The custom codec:
- Serializes DataType objects to their string representation
- Attempts to parse them back using `DataType.parse()`
- Falls back to `GenericType` with a warning for unparseable types
- Ensures catalog import/export works reliably across all database types

## Testing

- Added `DataTypeCodecTest` with tests for basic types, complex nested types, and fallback behavior
- Tested end-to-end catalog import/export with DuckDB
- All existing tests pass

## Related Issues

Part of #920 (Static Catalog Infrastructure)
Implements first fix from #981

🤖 Generated with [Claude Code](https://claude.ai/code)