### PR TITLE
doc: Remove macOS Intel support references

### DIFF
--- a/website/docs/bindings/index.md
+++ b/website/docs/bindings/index.md
@@ -47,10 +47,10 @@ All language SDKs use the same underlying native library (`libwvlet`) for consis
 | Platform | x86_64 | ARM64 |
 |----------|--------|-------|
 | Linux    | ✅     | ✅    |
-| macOS    | 🔄     | ✅    |
+| macOS    | ❌     | ✅    |
 | Windows  | 🔄     | 🔄    |
 
-✅ Supported | 🔄 Planned
+✅ Supported | 🔄 Planned | ❌ Not Supported
 
 ## Contributing
 

--- a/website/docs/bindings/python.md
+++ b/website/docs/bindings/python.md
@@ -272,7 +272,6 @@ print(f"CLI: {time.time() - start:.2f}s")
 | Linux    | x86_64      | ✅ Supported |
 | Linux    | aarch64     | ✅ Supported |
 | macOS    | arm64       | ✅ Supported |
-| macOS    | x86_64      | 🔄 Planned |
 | Windows  | x86_64      | 🔄 Planned |
 
 The SDK automatically falls back to the CLI if the native library is unavailable.


### PR DESCRIPTION
## Summary
- Remove references to macOS x86_64 (Intel) support from documentation as it is not supported
- Update platform support tables to accurately reflect supported platforms

## Changes
- Updated Python SDK documentation to remove macOS x86_64 from platform support table
- Changed bindings index to mark macOS x86_64 as "Not Supported" instead of "Planned"
- Added legend entry for "Not Supported" status

## Test plan
- [x] Documentation changes only - no code changes
- [x] Verified all macOS Intel references have been removed
- [x] Platform support tables are now consistent across documentation

🤖 Generated with [Claude Code](https://claude.ai/code)