### PR TITLE
feature: Remove CLI fallback from Python SDK

### DIFF
--- a/sdks/python/API_REFERENCE.md
+++ b/sdks/python/API_REFERENCE.md
@@ -24,7 +24,7 @@ Compile a Wvlet query to SQL.
 
 **Raises:**
 - `CompilationError`: If the query has syntax errors or cannot be compiled
-- `NotImplementedError`: If neither native library nor CLI is available
+- `NotImplementedError`: If the native library is not available for the current platform
 
 **Example:**
 ```python
@@ -86,7 +86,7 @@ Compile a Wvlet query to SQL.
 
 **Raises:**
 - `CompilationError`: If compilation fails
-- `NotImplementedError`: If no compilation backend is available
+- `NotImplementedError`: If the native library is not available for the current platform
 
 **Example:**
 ```python
@@ -135,13 +135,6 @@ Path to the Wvlet home directory. Defaults to `~/.wvlet`.
 export WVLET_HOME=/opt/wvlet
 ```
 
-### `WVLET_PYTHON_USE_CLI`
-
-Force the SDK to use CLI instead of native library.
-
-```bash
-export WVLET_PYTHON_USE_CLI=1
-```
 
 ### `WVLET_LOG_LEVEL`
 
@@ -161,8 +154,6 @@ The SDK attempts to load the native library in the following order:
    - macOS ARM64: `wvlet/libs/darwin_arm64/libwvlet.dylib`
 
 2. From system library paths (if installed separately)
-
-3. Falls back to CLI if available in PATH
 
 ## Query Syntax
 
@@ -308,7 +299,7 @@ Wvlet supports the following SQL data types:
 1. **Native library not found**
    - Ensure you have the latest version: `pip install --upgrade wvlet`
    - Check platform compatibility
-   - Try CLI fallback by installing Wvlet CLI
+   - Verify your platform is supported
 
 2. **Compilation errors**
    - Verify query syntax
@@ -316,7 +307,7 @@ Wvlet supports the following SQL data types:
    - Ensure proper quote escaping in strings
 
 3. **Performance issues**
-   - Use native library instead of CLI
+   - Ensure native library is properly loaded
    - Reuse compiler instances
    - Consider batch compilation for multiple queries
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -5,9 +5,8 @@ Python SDK for [Wvlet](https://wvlet.org) - A flow-style query language for func
 ## Features
 
 - 🚀 **Fast native compilation** - Uses bundled native library for high-performance query compilation
-- 🔄 **Automatic fallback** - Falls back to CLI when native library is unavailable
 - 🎯 **Multiple SQL targets** - Supports DuckDB, Trino, and other SQL engines
-- 📦 **Zero dependencies** - Pure Python with optional native acceleration
+- 📦 **Zero dependencies** - Pure Python with native acceleration
 - 🐍 **Pythonic API** - Simple and intuitive interface
 
 ## Installation
@@ -162,7 +161,7 @@ Compile a Wvlet query to SQL.
 
 **Raises:**
 - `CompilationError`: If the query cannot be compiled
-- `NotImplementedError`: If neither native library nor CLI is available
+- `NotImplementedError`: If the native library is not available for the current platform
 
 ### `wvlet.compiler.WvletCompiler`
 
@@ -198,25 +197,10 @@ Linux    | aarch64     | ✅ Supported
 macOS    | arm64       | ✅ Supported
 Windows  | x86_64      | 🔄 Planned
 
-### CLI Fallback
-
-The SDK automatically falls back to the Wvlet CLI if:
-1. Native library is not available for your platform
-2. Native library fails to load
-3. You explicitly disable native compilation
-
-To install the CLI for fallback support:
-```bash
-# Install via Homebrew (macOS/Linux)
-brew install wvlet/wvlet/wvlet
-
-# Or download from GitHub releases
-# https://github.com/wvlet/wvlet/releases
-```
 
 ## Performance
 
-The native library provides significant performance improvements over CLI:
+The native library provides high-performance query compilation:
 
 ```python
 import time
@@ -226,15 +210,7 @@ from wvlet import compile
 start = time.time()
 for _ in range(100):
     compile("from users select * where age > 21")
-print(f"Native: {time.time() - start:.2f}s")
-
-# Force CLI usage (if available)
-import os
-os.environ['WVLET_PYTHON_USE_CLI'] = '1'
-start = time.time()
-for _ in range(100):
-    compile("from users select * where age > 21")
-print(f"CLI: {time.time() - start:.2f}s")
+print(f"Compiled 100 queries in {time.time() - start:.2f}s")
 ```
 
 ## Integration Examples

--- a/sdks/python/tests/test_compiler.py
+++ b/sdks/python/tests/test_compiler.py
@@ -15,28 +15,24 @@
 #
 
 import pytest
-from wvlet.compiler import WvletCompiler
+from wvlet.compiler import WvletCompiler, CompilationError
 from wvlet import compile as wvlet_compile
 
-def test_wvlet_invalid_path():
-    with pytest.raises(ValueError, match="Invalid executable_path: invalid"):
-        WvletCompiler(executable_path="invalid")
-
 def test_wvlet_initialization():
-    """Test that WvletCompiler can be initialized (either with native lib or executable)"""
+    """Test that WvletCompiler can be initialized with native library"""
     try:
         compiler = WvletCompiler()
-        # If we get here, either native library or executable is available
+        # If we get here, native library is available
         assert compiler is not None
     except NotImplementedError:
-        pytest.skip("Neither native library nor wvlet executable is available")
+        pytest.skip("Native library is not available for this platform")
 
 def test_compile_simple_query():
     """Test compiling a simple Wvlet query"""
     try:
         compiler = WvletCompiler()
     except NotImplementedError:
-        pytest.skip("Neither native library nor wvlet executable is available")
+        pytest.skip("Native library is not available for this platform")
     
     # Test a self-contained query that doesn't depend on external schema
     query = "select 1 as num"
@@ -57,7 +53,7 @@ def test_compile_function():
         assert 'select' in sql.lower()
         assert '1' in sql
     except NotImplementedError:
-        pytest.skip("Neither native library nor wvlet executable is available")
+        pytest.skip("Native library is not available for this platform")
 
 def test_native_library_loading():
     """Test that native library loading doesn't crash"""
@@ -72,9 +68,9 @@ def test_compile_error_handling():
     try:
         compiler = WvletCompiler()
     except NotImplementedError:
-        pytest.skip("Neither native library nor wvlet executable is available")
+        pytest.skip("Native library is not available for this platform")
     
     # Test with an invalid query
-    with pytest.raises(ValueError, match="Failed to compile"):
+    with pytest.raises(CompilationError):
         compiler.compile("invalid query syntax !@#")
 

--- a/sdks/python/wvlet/__init__.py
+++ b/sdks/python/wvlet/__init__.py
@@ -25,7 +25,6 @@ while maintaining a simple, Pythonic API.
 Features
 --------
 - Fast native compilation using bundled library
-- Automatic fallback to CLI when native library is unavailable
 - Support for multiple SQL targets (DuckDB, Trino, etc.)
 - Zero dependencies
 - Cross-platform support (Linux x86_64/ARM64, macOS ARM64)
@@ -72,8 +71,8 @@ def compile(query: str, target: str = None) -> str:
     """
     Compile a Wvlet query to SQL.
     
-    This is the primary interface for compiling Wvlet queries. It automatically
-    handles native library loading and falls back to CLI if necessary.
+    This is the primary interface for compiling Wvlet queries. It uses the
+    native library for high-performance compilation.
     
     Parameters
     ----------
@@ -96,7 +95,7 @@ def compile(query: str, target: str = None) -> str:
     CompilationError
         If the query has syntax errors or cannot be compiled.
     NotImplementedError
-        If neither native library nor CLI is available.
+        If the native library is not available for the current platform.
     
     Examples
     --------

--- a/website/docs/bindings/python.md
+++ b/website/docs/bindings/python.md
@@ -5,9 +5,8 @@ The Wvlet Python SDK provides a native Python interface for compiling Wvlet quer
 ## Features
 
 - 🚀 **Fast native compilation** - Uses bundled native library for high-performance query compilation
-- 🔄 **Automatic fallback** - Falls back to CLI when native library is unavailable
 - 🎯 **Multiple SQL targets** - Supports DuckDB, Trino, and other SQL engines
-- 📦 **Zero dependencies** - Pure Python with optional native acceleration
+- 📦 **Zero dependencies** - Pure Python with native acceleration
 - 🐍 **Pythonic API** - Simple and intuitive interface
 
 ## Installation
@@ -253,14 +252,6 @@ start = time.time()
 for _ in range(100):
     compile("from users select * where age > 21")
 print(f"Native: {time.time() - start:.2f}s")
-
-# Force CLI usage (if available)
-import os
-os.environ['WVLET_PYTHON_USE_CLI'] = '1'
-start = time.time()
-for _ in range(100):
-    compile("from users select * where age > 21")
-print(f"CLI: {time.time() - start:.2f}s")
 ```
 
 ## Platform Support
@@ -274,7 +265,6 @@ print(f"CLI: {time.time() - start:.2f}s")
 | macOS    | arm64       | ✅ Supported |
 | Windows  | x86_64      | 🔄 Planned |
 
-The SDK automatically falls back to the CLI if the native library is unavailable.
 
 ## API Reference
 
@@ -291,7 +281,7 @@ Compile a Wvlet query to SQL.
 
 **Raises:**
 - `CompilationError`: If the query cannot be compiled
-- `NotImplementedError`: If neither native library nor CLI is available
+- `NotImplementedError`: If the native library is not available for the current platform
 
 ### `wvlet.compiler.WvletCompiler`
 
@@ -325,7 +315,6 @@ If you see an error about the native library not being found:
 1. Check your platform is supported (see Platform Support above)
 2. Ensure you have the latest version: `pip install --upgrade wvlet`
 3. Try reinstalling: `pip install --force-reinstall wvlet`
-4. Use CLI fallback by installing the Wvlet CLI
 
 ### Compilation Errors
 


### PR DESCRIPTION
## Summary
- Remove CLI fallback functionality from the Python SDK to simplify implementation
- SDK now requires native library to be available for the current platform
- Cleaner, more maintainable codebase with consistent behavior

## Changes
- Removed CLI fallback code from `WvletCompiler` class
- Updated all documentation to remove CLI fallback references  
- Simplified error messages to only mention native library availability
- Removed `WVLET_PYTHON_USE_CLI` environment variable support
- Updated performance documentation to reflect native-only implementation

## Test plan
- [x] Code changes maintain backward compatibility for normal usage
- [x] Error messages are clear when native library is not available
- [x] All documentation consistently reflects the native-only approach
- [ ] Existing tests should pass without modification

🤖 Generated with [Claude Code](https://claude.ai/code)