### PR TITLE
fix: Remove deprecated native CLI fallback test

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -168,18 +168,9 @@ jobs:
             pip install dist/wvlet-*-py3-none-manylinux2014_x86_64.whl
           fi
       
-      - name: Test import and basic functionality
+      - name: Test import
         run: |
           python -c "from wvlet import compile; print('Import successful')"
-          # Test compile only if native library or CLI is available
-          python -c "
-from wvlet import compile
-try:
-    sql = compile('select 1')
-    print(f'Compiled SQL: {sql}')
-except NotImplementedError:
-    print('Native library and CLI not available - this is expected in CI without real native libs')
-"
       
       - name: Run tests
         run: |


### PR DESCRIPTION
## Summary

This PR removes the deprecated native CLI fallback test from the Python publish workflow, which was also causing a YAML syntax error.

## Changes

- Removed the test that checked for native CLI fallback functionality
- Simplified to just test the import works correctly
- This fixes the CI failure for Python releases

## Context

The native CLI fallback is deprecated and no longer needed. The test was also causing a YAML syntax error on line 176 that prevented the Python release workflow from running.

🤖 Generated with [Claude Code](https://claude.ai/code)