### PR TITLE
fix: Fetch all tags in Python publish workflow for versioning

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all tags for setuptools_scm
       
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -140,6 +142,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all tags for setuptools_scm
       
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

This PR fixes the Python package versioning issue that was causing PyPI uploads to fail with "file already exists" error.

## Problem

The Python publish workflow was building packages with version 2025.1.0 instead of the current release version (2025.1.8) because setuptools_scm couldn't access the git tags.

## Solution

Add `fetch-depth: 0` to the checkout actions to ensure all git tags are fetched. This allows setuptools_scm to correctly determine the version from the latest git tag.

## Impact

- Python packages will now be built with the correct version matching the git release tag
- PyPI uploads will succeed without "file already exists" errors
- Each release will have its own unique version on PyPI

🤖 Generated with [Claude Code](https://claude.ai/code)