### PR TITLE
fix: Add skip-existing to PyPI publish to handle partial uploads

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -207,3 +207,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          skip-existing: true


### PR DESCRIPTION
## Summary

This PR fixes the PyPI publish error by adding `skip-existing: true` to handle cases where some files have already been uploaded.

## Problem

The Python publish workflow was failing with "File already exists" error for `wvlet-2025.1.9-py3-none-manylinux2014_x86_64.whl`, even though some files were successfully uploaded.

## Solution

Add `skip-existing: true` to the PyPI publish action. This allows the workflow to:
- Skip files that have already been uploaded
- Continue uploading remaining files
- Complete successfully without errors

## Impact

- Future releases will handle partial uploads gracefully
- No need to manually intervene when some files are already on PyPI
- The workflow will be more robust and reliable

🤖 Generated with [Claude Code](https://claude.ai/code)