### PR TITLE
Add TypeScript SDK based on Scala.js

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,69 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.1.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Publish TypeScript SDK to NPM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '24'
+          cache: sbt
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Build Scala.js SDK
+        run: ./sbt "sdkJs/fullLinkJS"
+      
+      - name: Install dependencies
+        working-directory: sdks/typescript
+        run: npm install
+      
+      - name: Build TypeScript
+        working-directory: sdks/typescript
+        run: npm run build
+      
+      - name: Run tests
+        working-directory: sdks/typescript
+        run: npm run test:ci
+      
+      - name: Set version from release
+        if: github.event_name == 'release'
+        working-directory: sdks/typescript
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed 's/refs\/tags\/v//')
+          npm version $VERSION --no-git-tag-version
+      
+      - name: Set version from input
+        if: github.event_name == 'workflow_dispatch'
+        working-directory: sdks/typescript
+        run: |
+          npm version ${{ inputs.version }} --no-git-tag-version
+      
+      - name: Publish to NPM
+        working-directory: sdks/typescript
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/typescript-npm-publish.yml
+++ b/.github/workflows/typescript-npm-publish.yml
@@ -1,8 +1,9 @@
 name: TypeScript NPM Publish
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       version:
@@ -49,8 +50,8 @@ jobs:
         working-directory: sdks/typescript
         run: npm run test:ci
       
-      - name: Set version from release
-        if: github.event_name == 'release'
+      - name: Set version from tag
+        if: github.event_name == 'push'
         working-directory: sdks/typescript
         run: |
           VERSION=$(echo "${{ github.ref }}" | sed 's/refs\/tags\/v//')

--- a/.github/workflows/typescript-npm-publish.yml
+++ b/.github/workflows/typescript-npm-publish.yml
@@ -1,4 +1,4 @@
-name: Publish to NPM
+name: TypeScript NPM Publish
 
 on:
   release:

--- a/.github/workflows/typescript-sdk.yml
+++ b/.github/workflows/typescript-sdk.yml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: [18, 20, 22]
     
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
       
       - name: Install libgc (Linux)
         if: runner.os == 'Linux'
@@ -75,7 +74,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       
       - name: Install dependencies
         working-directory: sdks/typescript

--- a/.github/workflows/typescript-sdk.yml
+++ b/.github/workflows/typescript-sdk.yml
@@ -60,10 +60,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '24'
+          cache: sbt
+      
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
+      
+      - name: Build Scala.js SDK
+        run: ./sbt "sdkJs/fastLinkJS"
       
       - name: Install dependencies
         working-directory: sdks/typescript

--- a/.github/workflows/typescript-sdk.yml
+++ b/.github/workflows/typescript-sdk.yml
@@ -41,13 +41,13 @@ jobs:
         working-directory: sdks/typescript
         run: npm install
       
-      - name: Build TypeScript
-        working-directory: sdks/typescript
-        run: npm run build
-      
       - name: Run tests
         working-directory: sdks/typescript
         run: npm run test:ci
+      
+      - name: Build TypeScript
+        working-directory: sdks/typescript
+        run: npm run build
       
       - name: Run example
         working-directory: sdks/typescript

--- a/.github/workflows/typescript-sdk.yml
+++ b/.github/workflows/typescript-sdk.yml
@@ -1,0 +1,86 @@
+name: TypeScript SDK
+
+on:
+  pull_request:
+    paths:
+      - 'sdks/typescript/**'
+      - 'wvlet-sdk-js/**'
+      - '.github/workflows/typescript-sdk.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'sdks/typescript/**'
+      - 'wvlet-sdk-js/**'
+      - '.github/workflows/typescript-sdk.yml'
+
+jobs:
+  test:
+    name: Test TypeScript SDK
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node-version: [18, 20, 22]
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '24'
+          cache: sbt
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      
+      - name: Install libgc (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libgc-dev
+      
+      - name: Install libgc (macOS)
+        if: runner.os == 'macOS'
+        run: brew install bdw-gc
+      
+      - name: Build Scala.js SDK
+        run: ./sbt "sdkJs/fastLinkJS"
+      
+      - name: Install dependencies
+        working-directory: sdks/typescript
+        run: npm install
+      
+      - name: Build TypeScript
+        working-directory: sdks/typescript
+        run: npm run build
+      
+      - name: Run tests
+        working-directory: sdks/typescript
+        run: npm run test:ci
+      
+      - name: Run example
+        working-directory: sdks/typescript
+        run: node examples/node-example.js
+
+  lint:
+    name: Lint TypeScript
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      
+      - name: Install dependencies
+        working-directory: sdks/typescript
+        run: npm install
+      
+      - name: Type check
+        working-directory: sdks/typescript
+        run: npm run lint

--- a/.github/workflows/typescript-sdk.yml
+++ b/.github/workflows/typescript-sdk.yml
@@ -47,7 +47,7 @@ jobs:
       
       - name: Build TypeScript
         working-directory: sdks/typescript
-        run: npm run build
+        run: npx tsc
       
       - name: Run example
         working-directory: sdks/typescript

--- a/.github/workflows/typescript-sdk.yml
+++ b/.github/workflows/typescript-sdk.yml
@@ -17,10 +17,7 @@ on:
 jobs:
   test:
     name: Test TypeScript SDK
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
     
     steps:
       - uses: actions/checkout@v4
@@ -36,14 +33,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-      
-      - name: Install libgc (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get install libgc-dev
-      
-      - name: Install libgc (macOS)
-        if: runner.os == 'macOS'
-        run: brew install bdw-gc
       
       - name: Build Scala.js SDK
         run: ./sbt "sdkJs/fastLinkJS"

--- a/build.sbt
+++ b/build.sbt
@@ -383,15 +383,6 @@ lazy val sdkJs = project
     name := "wvlet-sdk-js",
     // Configure Scala.js output as ES module
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) },
-    // Configure Node.js to use ES modules
-    Test / jsEnv := {
-      import org.scalajs.jsenv.nodejs._
-      new NodeJSEnv(
-        NodeJSEnv.Config()
-          .withArgs(List("--experimental-modules"))
-          .withEnv(Map("NODE_OPTIONS" -> "--experimental-modules"))
-      )
-    },
     // Configure output directory
     Compile / fastLinkJS / scalaJSLinkerOutputDirectory := 
       (ThisBuild / baseDirectory).value / "sdks" / "typescript" / "lib",

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val jvmProjects: Seq[ProjectReference] = Seq(
   cli
 )
 
-lazy val jsProjects: Seq[ProjectReference] = Seq(api.js, client.js, lang.js, ui, uiMain, playground)
+lazy val jsProjects: Seq[ProjectReference] = Seq(api.js, client.js, lang.js, ui, uiMain, playground, sdkJs)
 
 lazy val nativeProjects: Seq[ProjectReference] = Seq(api.native, lang.native, wvc, wvcLib)
 
@@ -374,6 +374,22 @@ lazy val spec = project
   .in(file("wvlet-spec"))
   .settings(buildSettings, specRunnerSettings, noPublish, name := "wvlet-spec")
   .dependsOn(runner)
+
+lazy val sdkJs = project
+  .in(file("wvlet-sdk-js"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    buildSettings,
+    name := "wvlet-sdk-js",
+    // Configure Scala.js output as ES module
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) },
+    // Configure output directory
+    Compile / fastLinkJS / scalaJSLinkerOutputDirectory := 
+      (ThisBuild / baseDirectory).value / "sdks" / "typescript" / "lib",
+    Compile / fullLinkJS / scalaJSLinkerOutputDirectory := 
+      (ThisBuild / baseDirectory).value / "sdks" / "typescript" / "lib"
+  )
+  .dependsOn(lang.js)
 
 lazy val server = project
   .in(file("wvlet-server"))

--- a/build.sbt
+++ b/build.sbt
@@ -383,6 +383,15 @@ lazy val sdkJs = project
     name := "wvlet-sdk-js",
     // Configure Scala.js output as ES module
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) },
+    // Configure Node.js to use ES modules
+    Test / jsEnv := {
+      import org.scalajs.jsenv.nodejs._
+      new NodeJSEnv(
+        NodeJSEnv.Config()
+          .withArgs(List("--experimental-modules"))
+          .withEnv(Map("NODE_OPTIONS" -> "--experimental-modules"))
+      )
+    },
     // Configure output directory
     Compile / fastLinkJS / scalaJSLinkerOutputDirectory := 
       (ThisBuild / baseDirectory).value / "sdks" / "typescript" / "lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wvlet-ui",
   "private": true,
+  "type": "module",
   "workspaces": [
     "wvlet-ui-main",
     "wvlet-ui-playground"

--- a/sdks/typescript/.gitignore
+++ b/sdks/typescript/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+coverage/
+.vscode/
+.idea/

--- a/sdks/typescript/.gitignore
+++ b/sdks/typescript/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
+lib/*.js
+lib/*.js.map
 *.log
 .DS_Store
 coverage/

--- a/sdks/typescript/PUBLISHING.md
+++ b/sdks/typescript/PUBLISHING.md
@@ -9,7 +9,7 @@ This document describes how the TypeScript SDK is published to NPM.
 When a new release is created on GitHub (with a tag like `v0.1.0`), the NPM package is automatically published:
 
 1. Create a GitHub release with a version tag (e.g., `v0.1.0`)
-2. The `npm-publish.yml` workflow automatically:
+2. The `typescript-npm-publish.yml` workflow automatically:
    - Builds the Scala.js SDK
    - Runs tests
    - Updates the package version
@@ -19,7 +19,7 @@ When a new release is created on GitHub (with a tag like `v0.1.0`), the NPM pack
 
 The release workflow can also be triggered manually:
 
-1. Go to Actions → "Publish to NPM" workflow
+1. Go to Actions → "TypeScript NPM Publish" workflow
 2. Click "Run workflow"
 3. Enter the version to publish
 4. The workflow will build and publish the specified version

--- a/sdks/typescript/PUBLISHING.md
+++ b/sdks/typescript/PUBLISHING.md
@@ -6,9 +6,13 @@ This document describes how the TypeScript SDK is published to NPM.
 
 ### Release Versions
 
-When a new release is created on GitHub (with a tag like `v0.1.0`), the NPM package is automatically published:
+When a new version tag is pushed (like `v0.1.0`), the NPM package is automatically published:
 
-1. Create a GitHub release with a version tag (e.g., `v0.1.0`)
+1. Push a version tag to GitHub:
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
 2. The `typescript-npm-publish.yml` workflow automatically:
    - Builds the Scala.js SDK
    - Runs tests

--- a/sdks/typescript/PUBLISHING.md
+++ b/sdks/typescript/PUBLISHING.md
@@ -1,0 +1,55 @@
+# Publishing TypeScript SDK to NPM
+
+This document describes how the TypeScript SDK is published to NPM.
+
+## Automated Publishing
+
+### Release Versions
+
+When a new release is created on GitHub (with a tag like `v0.1.0`), the NPM package is automatically published:
+
+1. Create a GitHub release with a version tag (e.g., `v0.1.0`)
+2. The `npm-publish.yml` workflow automatically:
+   - Builds the Scala.js SDK
+   - Runs tests
+   - Updates the package version
+   - Publishes to NPM with provenance
+
+## Manual Publishing
+
+The release workflow can also be triggered manually:
+
+1. Go to Actions → "Publish to NPM" workflow
+2. Click "Run workflow"
+3. Enter the version to publish
+4. The workflow will build and publish the specified version
+
+## NPM Token Setup
+
+The workflows require an NPM token to be set up as a GitHub secret:
+
+1. Generate an NPM access token at https://www.npmjs.com/
+2. Add it as `NPM_TOKEN` in the repository secrets
+
+## Version Management
+
+- The base version is maintained in `package.json`
+- Release versions are set from the Git tag
+- All publishing includes NPM provenance for security
+
+## Testing Before Release
+
+Before creating a release:
+
+1. Ensure all tests pass: `npm test`
+2. Build the package: `npm run build`
+3. Test the package locally: `npm pack`
+4. Verify the package contents
+
+## Package Contents
+
+The published package includes:
+- `dist/` - Compiled TypeScript files
+- `lib/` - Scala.js compiled output
+- `README.md` - Package documentation
+- Type definitions

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -5,17 +5,17 @@ TypeScript/JavaScript SDK for [Wvlet](https://wvlet.org/) - A flow-style query l
 ## Installation
 
 ```bash
-npm install wvlet
+npm install @wvlet/wvlet
 # or
-yarn add wvlet
+yarn add @wvlet/wvlet
 # or
-pnpm add wvlet
+pnpm add @wvlet/wvlet
 ```
 
 ## Quick Start
 
 ```typescript
-import { WvletCompiler } from 'wvlet';
+import { WvletCompiler } from '@wvlet/wvlet';
 
 const compiler = new WvletCompiler();
 
@@ -30,7 +30,7 @@ console.log(sql);
 ### Basic Compilation
 
 ```typescript
-import { WvletCompiler } from 'wvlet';
+import { WvletCompiler } from '@wvlet/wvlet';
 
 const compiler = new WvletCompiler({
   target: 'duckdb' // or 'trino'
@@ -43,7 +43,7 @@ const sql = compiler.compile('from users where age > 18 select *');
 ### Error Handling
 
 ```typescript
-import { WvletCompiler, CompilationError } from 'wvlet';
+import { WvletCompiler, CompilationError } from '@wvlet/wvlet';
 
 const compiler = new WvletCompiler();
 
@@ -61,7 +61,7 @@ try {
 ### Convenience Function
 
 ```typescript
-import { compile } from 'wvlet';
+import { compile } from '@wvlet/wvlet';
 
 // Use the default compiler with a single function call
 const sql = compile('from orders select count(*)');

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -20,7 +20,7 @@ import { WvletCompiler } from 'wvlet';
 const compiler = new WvletCompiler();
 
 // Compile a Wvlet query to SQL
-const sql = await compiler.compile('from users select name, email');
+const sql = compiler.compile('from users select name, email');
 console.log(sql);
 // Output: SELECT name, email FROM users
 ```
@@ -36,11 +36,8 @@ const compiler = new WvletCompiler({
   target: 'duckdb' // or 'trino'
 });
 
-// Async compilation
-const sql = await compiler.compile('from users where age > 18 select *');
-
-// Sync compilation
-const sqlSync = compiler.compileSync('from products select name, price');
+// Compile a query
+const sql = compiler.compile('from users where age > 18 select *');
 ```
 
 ### Error Handling
@@ -51,7 +48,7 @@ import { WvletCompiler, CompilationError } from 'wvlet';
 const compiler = new WvletCompiler();
 
 try {
-  const sql = await compiler.compile('invalid query syntax');
+  const sql = compiler.compile('invalid query syntax');
 } catch (error) {
   if (error instanceof CompilationError) {
     console.error(`Error at line ${error.location?.line}, column ${error.location?.column}`);
@@ -67,7 +64,7 @@ try {
 import { compile } from 'wvlet';
 
 // Use the default compiler with a single function call
-const sql = await compile('from orders select count(*)');
+const sql = compile('from orders select count(*)');
 ```
 
 ## API Reference
@@ -86,13 +83,9 @@ Options:
 
 #### Methods
 
-##### compile(query: string, options?: CompileOptions): Promise<string>
+##### compile(query: string, options?: CompileOptions): string
 
-Compiles a Wvlet query to SQL asynchronously.
-
-##### compileSync(query: string, options?: CompileOptions): string
-
-Compiles a Wvlet query to SQL synchronously.
+Compiles a Wvlet query to SQL.
 
 ##### static getVersion(): string
 
@@ -103,7 +96,7 @@ Returns the version of the Wvlet compiler.
 ### Query with JOIN
 
 ```typescript
-const sql = await compiler.compile(`
+const sql = compiler.compile(`
   from users u
   join orders o on u.id = o.user_id
   select u.name, count(*) as order_count
@@ -114,7 +107,7 @@ const sql = await compiler.compile(`
 ### Query with CTE
 
 ```typescript
-const sql = await compiler.compile(`
+const sql = compiler.compile(`
   with active_users as (
     from users
     where last_login > current_date - interval '30 days'

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -1,0 +1,138 @@
+# Wvlet TypeScript SDK
+
+TypeScript/JavaScript SDK for [Wvlet](https://wvlet.org/) - A flow-style query language that compiles to SQL.
+
+## Installation
+
+```bash
+npm install wvlet
+# or
+yarn add wvlet
+# or
+pnpm add wvlet
+```
+
+## Quick Start
+
+```typescript
+import { WvletCompiler } from 'wvlet';
+
+const compiler = new WvletCompiler();
+
+// Compile a Wvlet query to SQL
+const sql = await compiler.compile('from users select name, email');
+console.log(sql);
+// Output: SELECT name, email FROM users
+```
+
+## Usage
+
+### Basic Compilation
+
+```typescript
+import { WvletCompiler } from 'wvlet';
+
+const compiler = new WvletCompiler({
+  target: 'duckdb' // or 'trino'
+});
+
+// Async compilation
+const sql = await compiler.compile('from users where age > 18 select *');
+
+// Sync compilation
+const sqlSync = compiler.compileSync('from products select name, price');
+```
+
+### Error Handling
+
+```typescript
+import { WvletCompiler, CompilationError } from 'wvlet';
+
+const compiler = new WvletCompiler();
+
+try {
+  const sql = await compiler.compile('invalid query syntax');
+} catch (error) {
+  if (error instanceof CompilationError) {
+    console.error(`Error at line ${error.location?.line}, column ${error.location?.column}`);
+    console.error(`Message: ${error.message}`);
+    console.error(`Status: ${error.statusCode}`);
+  }
+}
+```
+
+### Convenience Function
+
+```typescript
+import { compile } from 'wvlet';
+
+// Use the default compiler with a single function call
+const sql = await compile('from orders select count(*)');
+```
+
+## API Reference
+
+### WvletCompiler
+
+#### Constructor
+
+```typescript
+new WvletCompiler(options?: CompileOptions)
+```
+
+Options:
+- `target`: Target SQL dialect ('duckdb' | 'trino'). Default: 'duckdb'
+- `profile`: Profile name for configuration
+
+#### Methods
+
+##### compile(query: string, options?: CompileOptions): Promise<string>
+
+Compiles a Wvlet query to SQL asynchronously.
+
+##### compileSync(query: string, options?: CompileOptions): string
+
+Compiles a Wvlet query to SQL synchronously.
+
+##### static getVersion(): string
+
+Returns the version of the Wvlet compiler.
+
+## Examples
+
+### Query with JOIN
+
+```typescript
+const sql = await compiler.compile(`
+  from users u
+  join orders o on u.id = o.user_id
+  select u.name, count(*) as order_count
+  group by u.name
+`);
+```
+
+### Query with CTE
+
+```typescript
+const sql = await compiler.compile(`
+  with active_users as (
+    from users
+    where last_login > current_date - interval '30 days'
+    select *
+  )
+  from active_users
+  select name, email
+`);
+```
+
+## Browser Support
+
+This SDK works in both Node.js and modern browsers that support ES modules.
+
+## License
+
+Apache License 2.0
+
+## Contributing
+
+See the [main Wvlet repository](https://github.com/wvlet/wvlet) for contribution guidelines.

--- a/sdks/typescript/examples/node-example.js
+++ b/sdks/typescript/examples/node-example.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { WvletCompiler } from '../dist/index.js';
+import { WvletCompiler } from '../dist/src/index.js';
 
 function main() {
   console.log('Wvlet Compiler Example\n');

--- a/sdks/typescript/examples/node-example.js
+++ b/sdks/typescript/examples/node-example.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import { WvletCompiler } from '../dist/index.js';
+
+async function main() {
+  console.log('Wvlet Compiler Example\n');
+  
+  const compiler = new WvletCompiler();
+  
+  // Get compiler version
+  console.log(`Compiler version: ${WvletCompiler.getVersion()}\n`);
+  
+  // Example queries
+  const queries = [
+    'from users select name, email',
+    'from orders where total > 100 select order_id, total',
+    'from products select * limit 10',
+    `from users u
+     join orders o on u.id = o.user_id
+     select u.name, count(*) as order_count
+     group by u.name`
+  ];
+  
+  for (const query of queries) {
+    console.log('Wvlet Query:');
+    console.log(query);
+    console.log('\nCompiled SQL:');
+    
+    try {
+      const sql = await compiler.compile(query);
+      console.log(sql);
+    } catch (error) {
+      console.error('Compilation error:', error.message);
+      if (error.location) {
+        console.error(`  at line ${error.location.line}, column ${error.location.column}`);
+      }
+    }
+    
+    console.log('\n' + '-'.repeat(60) + '\n');
+  }
+  
+  // Example with error handling
+  console.log('Example with syntax error:');
+  const invalidQuery = 'this is not valid wvlet syntax';
+  console.log(invalidQuery);
+  
+  try {
+    await compiler.compile(invalidQuery);
+  } catch (error) {
+    console.error('\nExpected error:', error.message);
+  }
+}
+
+main().catch(console.error);

--- a/sdks/typescript/examples/node-example.js
+++ b/sdks/typescript/examples/node-example.js
@@ -2,7 +2,7 @@
 
 import { WvletCompiler } from '../dist/index.js';
 
-async function main() {
+function main() {
   console.log('Wvlet Compiler Example\n');
   
   const compiler = new WvletCompiler();
@@ -27,7 +27,7 @@ async function main() {
     console.log('\nCompiled SQL:');
     
     try {
-      const sql = await compiler.compile(query);
+      const sql = compiler.compile(query);
       console.log(sql);
     } catch (error) {
       console.error('Compilation error:', error.message);
@@ -45,10 +45,10 @@ async function main() {
   console.log(invalidQuery);
   
   try {
-    await compiler.compile(invalidQuery);
+    compiler.compile(invalidQuery);
   } catch (error) {
     console.error('\nExpected error:', error.message);
   }
 }
 
-main().catch(console.error);
+main();

--- a/sdks/typescript/lib/README.md
+++ b/sdks/typescript/lib/README.md
@@ -1,0 +1,10 @@
+# Generated Files
+
+This directory contains the Scala.js compiled output from the `wvlet-sdk-js` module.
+
+The files in this directory are generated during the build process by running:
+```
+./sbt sdkJs/fastLinkJS
+```
+
+Do not commit the generated JavaScript files to version control.

--- a/sdks/typescript/lib/main.d.ts
+++ b/sdks/typescript/lib/main.d.ts
@@ -2,7 +2,7 @@
  * Type definitions for Scala.js generated WvletJS module
  */
 
-export interface WvletJS {
+export interface WvletJSType {
   /**
    * Compile a Wvlet query and return the result as JSON
    * @param query The Wvlet query string
@@ -18,4 +18,5 @@ export interface WvletJS {
   getVersion(): string;
 }
 
-export const WvletJS: WvletJS;
+export const WvletJS: WvletJSType;
+export const log: any;

--- a/sdks/typescript/lib/main.d.ts
+++ b/sdks/typescript/lib/main.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Type definitions for Scala.js generated WvletJS module
+ */
+
+export interface WvletJS {
+  /**
+   * Compile a Wvlet query and return the result as JSON
+   * @param query The Wvlet query string
+   * @param options JSON string with compilation options
+   * @returns JSON string with compilation result
+   */
+  compile(query: string, options?: string): string;
+  
+  /**
+   * Get the version of the Wvlet compiler
+   * @returns The version string
+   */
+  getVersion(): string;
+}
+
+export const WvletJS: WvletJS;

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,0 +1,1773 @@
+{
+  "name": "@wvlet/wvlet",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@wvlet/wvlet",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "typescript": "^5.5.0",
+        "vitest": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.0.tgz",
+      "integrity": "sha512-xEiEE5oDW6tK4jXCAyliuntGR+amEMO7HLtdSshVuhFnKTYoeYMyXQK7pLouAJJj5KHdwdn87bfHAR2nSdNAUA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.0.tgz",
+      "integrity": "sha512-uNSk/TgvMbskcHxXYHzqwiyBlJ/lGcv8DaUfcnNwict8ba9GTTNxfn3/FAoFZYgkaXXAdrAA+SLyKplyi349Jw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.0.tgz",
+      "integrity": "sha512-VGF3wy0Eq1gcEIkSCr8Ke03CWT+Pm2yveKLaDvq51pPpZza3JX/ClxXOCmTYYq3us5MvEuNRTaeyFThCKRQhOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.0.tgz",
+      "integrity": "sha512-fBkyrDhwquRvrTxSGH/qqt3/T0w5Rg0L7ZIDypvBPc1/gzjJle6acCpZ36blwuwcKD/u6oCE/sRWlUAcxLWQbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.0.tgz",
+      "integrity": "sha512-u5AZzdQJYJXByB8giQ+r4VyfZP+walV+xHWdaFx/1VxsOn6eWJhK2Vl2eElvDJFKQBo/hcYIBg/jaKS8ZmKeNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.0.tgz",
+      "integrity": "sha512-qC0kS48c/s3EtdArkimctY7h3nHicQeEUdjJzYVJYR3ct3kWSafmn6jkNCA8InbUdge6PVx6keqjk5lVGJf99g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.0.tgz",
+      "integrity": "sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.0.tgz",
+      "integrity": "sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.0.tgz",
+      "integrity": "sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.0.tgz",
+      "integrity": "sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.0.tgz",
+      "integrity": "sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.0.tgz",
+      "integrity": "sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.0.tgz",
+      "integrity": "sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.0.tgz",
+      "integrity": "sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.0.tgz",
+      "integrity": "sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.0.tgz",
+      "integrity": "sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.0.tgz",
+      "integrity": "sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.0.tgz",
+      "integrity": "sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.0.tgz",
+      "integrity": "sha512-3XJ0NQtMAXTWFW8FqZKcw3gOQwBtVWP/u8TpHP3CRPXD7Pd6s8lLdH3sHWh8vqKCyyiI8xW5ltJScQmBU9j7WA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.0.tgz",
+      "integrity": "sha512-Q2Mgwt+D8hd5FIPUuPDsvPR7Bguza6yTkJxspDGkZj7tBRn2y4KSWYuIXpftFSjBra76TbKerCV7rgFPQrn+wQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
+      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "pathe": "^2.0.1",
+        "pkg-types": "^1.3.0",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.0.tgz",
+      "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.44.0",
+        "@rollup/rollup-android-arm64": "4.44.0",
+        "@rollup/rollup-darwin-arm64": "4.44.0",
+        "@rollup/rollup-darwin-x64": "4.44.0",
+        "@rollup/rollup-freebsd-arm64": "4.44.0",
+        "@rollup/rollup-freebsd-x64": "4.44.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.44.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.44.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.44.0",
+        "@rollup/rollup-linux-arm64-musl": "4.44.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.44.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.44.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.44.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.44.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.44.0",
+        "@rollup/rollup-linux-x64-gnu": "4.44.0",
+        "@rollup/rollup-linux-x64-musl": "4.44.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.44.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.44.0",
+        "@rollup/rollup-win32-x64-msvc": "4.44.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build:scalajs": "cd ../.. && ./sbt sdkJs/fastLinkJS",
+    "build": "npm run build:scalajs && tsc",
     "test": "vitest",
     "test:ci": "vitest run",
     "lint": "tsc --noEmit",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wvlet",
+  "name": "@wvlet/wvlet",
   "version": "0.0.0",
   "description": "TypeScript SDK for Wvlet - A flow-style query language",
   "main": "dist/index.js",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "wvlet",
+  "version": "0.0.0",
+  "description": "TypeScript SDK for Wvlet - A flow-style query language",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:ci": "vitest run",
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist",
+    "lib",
+    "README.md"
+  ],
+  "keywords": [
+    "wvlet",
+    "sql",
+    "query",
+    "compiler",
+    "database"
+  ],
+  "author": "wvlet.org",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wvlet/wvlet.git",
+    "directory": "sdks/typescript"
+  },
+  "bugs": {
+    "url": "https://github.com/wvlet/wvlet/issues"
+  },
+  "homepage": "https://wvlet.org/",
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0",
+    "vitest": "^1.6.0"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/sdks/typescript/src/compiler.ts
+++ b/sdks/typescript/src/compiler.ts
@@ -29,43 +29,7 @@ export class WvletCompiler {
    * @returns The compiled SQL string
    * @throws {CompilationError} If compilation fails
    */
-  async compile(query: string, options?: CompileOptions): Promise<string> {
-    const compileOptions = { ...this.options, ...options };
-    const optionsJson = JSON.stringify(compileOptions);
-    
-    try {
-      const responseJson = WvletJS.compile(query, optionsJson);
-      const response: CompileResponse = JSON.parse(responseJson);
-      
-      if (response.success && response.sql) {
-        return response.sql;
-      } else if (response.error) {
-        throw new CompilationError(
-          response.error.message,
-          response.error.statusCode,
-          response.error.location
-        );
-      } else {
-        throw new Error('Invalid response from compiler');
-      }
-    } catch (error) {
-      if (error instanceof CompilationError) {
-        throw error;
-      }
-      
-      // Handle any other errors (e.g., JSON parsing errors)
-      throw new Error(`Compilation failed: ${error}`);
-    }
-  }
-
-  /**
-   * Compile a Wvlet query synchronously
-   * @param query The Wvlet query string
-   * @param options Override compilation options for this query
-   * @returns The compiled SQL string
-   * @throws {CompilationError} If compilation fails
-   */
-  compileSync(query: string, options?: CompileOptions): string {
+  compile(query: string, options?: CompileOptions): string {
     const compileOptions = { ...this.options, ...options };
     const optionsJson = JSON.stringify(compileOptions);
     

--- a/sdks/typescript/src/compiler.ts
+++ b/sdks/typescript/src/compiler.ts
@@ -33,19 +33,28 @@ export class WvletCompiler {
     const compileOptions = { ...this.options, ...options };
     const optionsJson = JSON.stringify(compileOptions);
     
-    const responseJson = WvletJS.compile(query, optionsJson);
-    const response: CompileResponse = JSON.parse(responseJson);
-    
-    if (response.success && response.sql) {
-      return response.sql;
-    } else if (response.error) {
-      throw new CompilationError(
-        response.error.message,
-        response.error.statusCode,
-        response.error.location
-      );
-    } else {
-      throw new Error('Invalid response from compiler');
+    try {
+      const responseJson = WvletJS.compile(query, optionsJson);
+      const response: CompileResponse = JSON.parse(responseJson);
+      
+      if (response.success && response.sql) {
+        return response.sql;
+      } else if (response.error) {
+        throw new CompilationError(
+          response.error.message,
+          response.error.statusCode,
+          response.error.location
+        );
+      } else {
+        throw new Error('Invalid response from compiler');
+      }
+    } catch (error) {
+      if (error instanceof CompilationError) {
+        throw error;
+      }
+      
+      // Re-throw original error to preserve stack trace
+      throw error;
     }
   }
 

--- a/sdks/typescript/src/compiler.ts
+++ b/sdks/typescript/src/compiler.ts
@@ -1,0 +1,95 @@
+import { WvletJS } from '../lib/main.js';
+import { 
+  CompileOptions, 
+  CompileResponse, 
+  CompilationError 
+} from './types.js';
+
+/**
+ * Wvlet compiler for TypeScript/JavaScript
+ */
+export class WvletCompiler {
+  private options: CompileOptions;
+
+  /**
+   * Create a new Wvlet compiler instance
+   * @param options Default compilation options
+   */
+  constructor(options: CompileOptions = {}) {
+    this.options = {
+      target: 'duckdb',
+      ...options
+    };
+  }
+
+  /**
+   * Compile a Wvlet query to SQL
+   * @param query The Wvlet query string
+   * @param options Override compilation options for this query
+   * @returns The compiled SQL string
+   * @throws {CompilationError} If compilation fails
+   */
+  async compile(query: string, options?: CompileOptions): Promise<string> {
+    const compileOptions = { ...this.options, ...options };
+    const optionsJson = JSON.stringify(compileOptions);
+    
+    try {
+      const responseJson = WvletJS.compile(query, optionsJson);
+      const response: CompileResponse = JSON.parse(responseJson);
+      
+      if (response.success && response.sql) {
+        return response.sql;
+      } else if (response.error) {
+        throw new CompilationError(
+          response.error.message,
+          response.error.statusCode,
+          response.error.location
+        );
+      } else {
+        throw new Error('Invalid response from compiler');
+      }
+    } catch (error) {
+      if (error instanceof CompilationError) {
+        throw error;
+      }
+      
+      // Handle any other errors (e.g., JSON parsing errors)
+      throw new Error(`Compilation failed: ${error}`);
+    }
+  }
+
+  /**
+   * Compile a Wvlet query synchronously
+   * @param query The Wvlet query string
+   * @param options Override compilation options for this query
+   * @returns The compiled SQL string
+   * @throws {CompilationError} If compilation fails
+   */
+  compileSync(query: string, options?: CompileOptions): string {
+    const compileOptions = { ...this.options, ...options };
+    const optionsJson = JSON.stringify(compileOptions);
+    
+    const responseJson = WvletJS.compile(query, optionsJson);
+    const response: CompileResponse = JSON.parse(responseJson);
+    
+    if (response.success && response.sql) {
+      return response.sql;
+    } else if (response.error) {
+      throw new CompilationError(
+        response.error.message,
+        response.error.statusCode,
+        response.error.location
+      );
+    } else {
+      throw new Error('Invalid response from compiler');
+    }
+  }
+
+  /**
+   * Get the version of the Wvlet compiler
+   * @returns The version string
+   */
+  static getVersion(): string {
+    return WvletJS.getVersion();
+  }
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Wvlet TypeScript SDK
+ * 
+ * A TypeScript/JavaScript SDK for the Wvlet query language compiler.
+ * Compile Wvlet queries to SQL for various database engines.
+ * 
+ * @packageDocumentation
+ */
+
+export { WvletCompiler } from './compiler.js';
+export { 
+  CompileOptions,
+  CompileResponse,
+  CompileError,
+  ErrorLocation,
+  CompilationError
+} from './types.js';
+
+// Re-export the default compiler function for convenience
+import { WvletCompiler } from './compiler.js';
+
+/**
+ * Compile a Wvlet query to SQL using default options
+ * @param query The Wvlet query string
+ * @returns The compiled SQL string
+ * @throws {CompilationError} If compilation fails
+ */
+export async function compile(query: string): Promise<string> {
+  const compiler = new WvletCompiler();
+  return compiler.compile(query);
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -25,7 +25,7 @@ import { WvletCompiler } from './compiler.js';
  * @returns The compiled SQL string
  * @throws {CompilationError} If compilation fails
  */
-export async function compile(query: string): Promise<string> {
+export function compile(query: string): string {
   const compiler = new WvletCompiler();
   return compiler.compile(query);
 }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Compilation options for Wvlet queries
+ */
+export interface CompileOptions {
+  /**
+   * Target SQL dialect
+   * @default 'duckdb'
+   */
+  target?: 'duckdb' | 'trino';
+  
+  /**
+   * Profile name for configuration
+   */
+  profile?: string;
+}
+
+/**
+ * Compilation response from the Wvlet compiler
+ */
+export interface CompileResponse {
+  /**
+   * Whether the compilation was successful
+   */
+  success: boolean;
+  
+  /**
+   * The compiled SQL query (if successful)
+   */
+  sql?: string;
+  
+  /**
+   * Error information (if failed)
+   */
+  error?: CompileError;
+}
+
+/**
+ * Compilation error information
+ */
+export interface CompileError {
+  /**
+   * Error status code
+   */
+  statusCode: string;
+  
+  /**
+   * Human-readable error message
+   */
+  message: string;
+  
+  /**
+   * Source location where the error occurred
+   */
+  location?: ErrorLocation;
+}
+
+/**
+ * Source location information for errors
+ */
+export interface ErrorLocation {
+  /**
+   * Relative file path
+   */
+  path: string;
+  
+  /**
+   * File name only
+   */
+  fileName: string;
+  
+  /**
+   * Line number (1-based)
+   */
+  line: number;
+  
+  /**
+   * Column number (1-based)
+   */
+  column: number;
+  
+  /**
+   * Content of the source line
+   */
+  lineContent?: string;
+}
+
+/**
+ * Error thrown when compilation fails
+ */
+export class CompilationError extends Error {
+  constructor(
+    message: string,
+    public statusCode: string,
+    public location?: ErrorLocation
+  ) {
+    super(message);
+    this.name = 'CompilationError';
+  }
+}

--- a/sdks/typescript/tests/compiler.test.ts
+++ b/sdks/typescript/tests/compiler.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { WvletCompiler, CompilationError } from '../src/index.js';
+
+describe('WvletCompiler', () => {
+  it('should compile a simple query', async () => {
+    const compiler = new WvletCompiler();
+    const sql = await compiler.compile('from users select name, email');
+    
+    expect(sql).toContain('select name, email');
+    expect(sql).toContain('from users');
+  });
+
+  it('should compile with synchronous method', () => {
+    const compiler = new WvletCompiler();
+    const sql = compiler.compileSync('from users select *');
+    
+    expect(sql).toContain('select *');
+    expect(sql).toContain('from users');
+  });
+
+  it('should support different targets', async () => {
+    const compiler = new WvletCompiler({ target: 'trino' });
+    const sql = await compiler.compile('from users select name');
+    
+    expect(sql).toContain('select name');
+    expect(sql).toContain('from users');
+  });
+
+  it('should handle compilation errors', async () => {
+    const compiler = new WvletCompiler();
+    
+    await expect(compiler.compile('invalid query syntax')).rejects.toThrow(CompilationError);
+  });
+
+  it('should get compiler version', () => {
+    const version = WvletCompiler.getVersion();
+    expect(version).toBeTruthy();
+    expect(typeof version).toBe('string');
+  });
+
+  it('should compile with limit clause', async () => {
+    const compiler = new WvletCompiler();
+    const sql = await compiler.compile('from users select * limit 10');
+    
+    expect(sql).toContain('limit 10');
+  });
+
+  it('should compile with where clause', async () => {
+    const compiler = new WvletCompiler();
+    const sql = await compiler.compile('from users where age > 18 select name');
+    
+    expect(sql).toContain('where age > 18');
+  });
+});

--- a/sdks/typescript/tests/compiler.test.ts
+++ b/sdks/typescript/tests/compiler.test.ts
@@ -2,34 +2,34 @@ import { describe, it, expect } from 'vitest';
 import { WvletCompiler, CompilationError } from '../src/index.js';
 
 describe('WvletCompiler', () => {
-  it('should compile a simple query', async () => {
+  it('should compile a simple query', () => {
     const compiler = new WvletCompiler();
-    const sql = await compiler.compile('from users select name, email');
+    const sql = compiler.compile('from users select name, email');
     
     expect(sql).toContain('select name, email');
     expect(sql).toContain('from users');
   });
 
-  it('should compile with synchronous method', () => {
+  it('should compile with select all', () => {
     const compiler = new WvletCompiler();
-    const sql = compiler.compileSync('from users select *');
+    const sql = compiler.compile('from users select *');
     
     expect(sql).toContain('select *');
     expect(sql).toContain('from users');
   });
 
-  it('should support different targets', async () => {
+  it('should support different targets', () => {
     const compiler = new WvletCompiler({ target: 'trino' });
-    const sql = await compiler.compile('from users select name');
+    const sql = compiler.compile('from users select name');
     
     expect(sql).toContain('select name');
     expect(sql).toContain('from users');
   });
 
-  it('should handle compilation errors', async () => {
+  it('should handle compilation errors', () => {
     const compiler = new WvletCompiler();
     
-    await expect(compiler.compile('invalid query syntax')).rejects.toThrow(CompilationError);
+    expect(() => compiler.compile('invalid query syntax')).toThrow(CompilationError);
   });
 
   it('should get compiler version', () => {
@@ -38,16 +38,16 @@ describe('WvletCompiler', () => {
     expect(typeof version).toBe('string');
   });
 
-  it('should compile with limit clause', async () => {
+  it('should compile with limit clause', () => {
     const compiler = new WvletCompiler();
-    const sql = await compiler.compile('from users select * limit 10');
+    const sql = compiler.compile('from users select * limit 10');
     
     expect(sql).toContain('limit 10');
   });
 
-  it('should compile with where clause', async () => {
+  it('should compile with where clause', () => {
     const compiler = new WvletCompiler();
-    const sql = await compiler.compile('from users where age > 18 select name');
+    const sql = compiler.compile('from users where age > 18 select name');
     
     expect(sql).toContain('where age > 18');
   });

--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -8,13 +8,13 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "allowJs": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]

--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "lib": ["ES2020"],
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/sdks/typescript/vitest.config.ts
+++ b/sdks/typescript/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/website/docs/bindings/index.md
+++ b/website/docs/bindings/index.md
@@ -8,7 +8,7 @@ Wvlet provides SDKs for various programming languages, allowing you to compile W
 ### [Python SDK](python.md) 
 [![PyPI version](https://badge.fury.io/py/wvlet.svg)](https://pypi.org/project/wvlet/)
 
-The Python SDK is now available with native performance and easy installation via pip:
+The Python SDK provides native performance with easy installation via pip:
 
 ```bash
 pip install wvlet
@@ -27,13 +27,35 @@ print(sql)  # SELECT name, age FROM users WHERE age > 18
 - Support for all Wvlet features
 - Integration with pandas, DuckDB, SQLAlchemy
 
+### [TypeScript/JavaScript SDK](typescript.md)
+[![npm version](https://badge.fury.io/js/wvlet.svg)](https://www.npmjs.com/package/wvlet)
+
+The TypeScript SDK enables Wvlet compilation in Node.js and browsers:
+
+```bash
+npm install wvlet
+```
+
+```typescript
+import { WvletCompiler } from 'wvlet';
+
+const compiler = new WvletCompiler();
+const sql = compiler.compile('from users select name, age where age > 18');
+console.log(sql);  // SELECT name, age FROM users WHERE age > 18
+```
+
+**Features:**
+- Pure JavaScript via Scala.js compilation
+- Works in browsers and Node.js
+- Full TypeScript support
+- No native dependencies
+
 ## Planned SDKs
 
 The following language bindings are planned for future releases:
 
 - **Java/Scala** - Native JVM integration
 - **Ruby** - Ruby gem with native extensions
-- **JavaScript/TypeScript** - npm package with WebAssembly support
 - **Rust** - Cargo crate with native bindings
 - **Go** - Go module with CGO bindings
 - **C/C++** - Header-only library

--- a/website/docs/bindings/typescript.md
+++ b/website/docs/bindings/typescript.md
@@ -5,17 +5,17 @@ The Wvlet TypeScript SDK provides a native JavaScript implementation of the Wvle
 ## Installation
 
 ```bash
-npm install wvlet
+npm install @wvlet/wvlet
 # or
-yarn add wvlet
+yarn add @wvlet/wvlet
 # or
-pnpm add wvlet
+pnpm add @wvlet/wvlet
 ```
 
 ## Quick Start
 
 ```typescript
-import { WvletCompiler } from 'wvlet';
+import { WvletCompiler } from '@wvlet/wvlet';
 
 const compiler = new WvletCompiler();
 const sql = compiler.compile('from users select name, email');
@@ -37,7 +37,7 @@ console.log(sql);
 ### Basic Usage
 
 ```typescript
-import { WvletCompiler } from 'wvlet';
+import { WvletCompiler } from '@wvlet/wvlet';
 
 // Create a compiler instance
 const compiler = new WvletCompiler({
@@ -51,7 +51,7 @@ const sql = compiler.compile('from orders where total > 100 select *');
 ### Error Handling
 
 ```typescript
-import { WvletCompiler, CompilationError } from 'wvlet';
+import { WvletCompiler, CompilationError } from '@wvlet/wvlet';
 
 const compiler = new WvletCompiler();
 
@@ -71,7 +71,7 @@ try {
 ### Convenience Function
 
 ```typescript
-import { compile } from 'wvlet';
+import { compile } from '@wvlet/wvlet';
 
 // Quick compilation with default settings
 const sql = compile('from users select count(*)');
@@ -190,7 +190,7 @@ The SDK works directly in browsers that support ES modules:
 
 ```html
 <script type="module">
-  import { WvletCompiler } from 'https://unpkg.com/wvlet/dist/index.js';
+  import { WvletCompiler } from 'https://unpkg.com/@wvlet/wvlet/dist/index.js';
   
   const compiler = new WvletCompiler();
   const sql = compiler.compile('from users select *');
@@ -238,4 +238,4 @@ The SDK requires browsers that support:
 
 The TypeScript SDK source code is available at:
 - [GitHub: sdks/typescript](https://github.com/wvlet/wvlet/tree/main/sdks/typescript)
-- [NPM: wvlet](https://www.npmjs.com/package/wvlet)
+- [NPM: @wvlet/wvlet](https://www.npmjs.com/package/@wvlet/wvlet)

--- a/website/docs/bindings/typescript.md
+++ b/website/docs/bindings/typescript.md
@@ -1,0 +1,241 @@
+# TypeScript/JavaScript SDK
+
+The Wvlet TypeScript SDK provides a native JavaScript implementation of the Wvlet compiler, allowing you to compile Wvlet queries to SQL directly in Node.js or browser environments.
+
+## Installation
+
+```bash
+npm install wvlet
+# or
+yarn add wvlet
+# or
+pnpm add wvlet
+```
+
+## Quick Start
+
+```typescript
+import { WvletCompiler } from 'wvlet';
+
+const compiler = new WvletCompiler();
+const sql = compiler.compile('from users select name, email');
+console.log(sql);
+// Output: SELECT name, email FROM users
+```
+
+## Features
+
+- **Pure JavaScript**: Compiled from Scala.js, no native dependencies required
+- **Type Safety**: Full TypeScript support with comprehensive type definitions
+- **Browser Support**: Works in both Node.js and modern browsers
+- **Multiple Targets**: Support for DuckDB and Trino SQL dialects
+- **Detailed Errors**: Rich error messages with source location information
+- **Small API Surface**: Simple and intuitive API design
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { WvletCompiler } from 'wvlet';
+
+// Create a compiler instance
+const compiler = new WvletCompiler({
+  target: 'duckdb' // or 'trino'
+});
+
+// Compile queries
+const sql = compiler.compile('from orders where total > 100 select *');
+```
+
+### Error Handling
+
+```typescript
+import { WvletCompiler, CompilationError } from 'wvlet';
+
+const compiler = new WvletCompiler();
+
+try {
+  const sql = compiler.compile('invalid query syntax');
+} catch (error) {
+  if (error instanceof CompilationError) {
+    console.error(`Error: ${error.message}`);
+    console.error(`Status: ${error.statusCode}`);
+    if (error.location) {
+      console.error(`Location: line ${error.location.line}, column ${error.location.column}`);
+    }
+  }
+}
+```
+
+### Convenience Function
+
+```typescript
+import { compile } from 'wvlet';
+
+// Quick compilation with default settings
+const sql = compile('from users select count(*)');
+```
+
+## API Reference
+
+### `WvletCompiler`
+
+The main compiler class for Wvlet queries.
+
+#### Constructor
+
+```typescript
+new WvletCompiler(options?: CompileOptions)
+```
+
+**Options:**
+- `target`: Target SQL dialect (`'duckdb'` | `'trino'`). Default: `'duckdb'`
+- `profile`: Profile name for configuration
+
+#### Methods
+
+##### `compile(query: string, options?: CompileOptions): string`
+
+Compiles a Wvlet query to SQL.
+
+**Parameters:**
+- `query`: The Wvlet query string
+- `options`: Optional compilation options to override defaults
+
+**Returns:** The compiled SQL string
+
+**Throws:** `CompilationError` if the query is invalid
+
+##### `static getVersion(): string`
+
+Returns the version of the Wvlet compiler.
+
+### Types
+
+#### `CompileOptions`
+
+```typescript
+interface CompileOptions {
+  target?: 'duckdb' | 'trino';
+  profile?: string;
+}
+```
+
+#### `CompilationError`
+
+```typescript
+class CompilationError extends Error {
+  statusCode: string;
+  location?: ErrorLocation;
+}
+```
+
+#### `ErrorLocation`
+
+```typescript
+interface ErrorLocation {
+  path: string;
+  fileName: string;
+  line: number;      // 1-based
+  column: number;    // 1-based
+  lineContent?: string;
+}
+```
+
+## Examples
+
+### Query with JOIN
+
+```typescript
+const sql = compiler.compile(`
+  from users u
+  join orders o on u.id = o.user_id
+  select u.name, count(*) as order_count
+  group by u.name
+`);
+```
+
+### Query with CTE
+
+```typescript
+const sql = compiler.compile(`
+  with recent_orders as (
+    from orders
+    where created_at > current_date - interval '7 days'
+    select *
+  )
+  from recent_orders
+  select customer_id, sum(total) as weekly_total
+  group by customer_id
+`);
+```
+
+### Window Functions
+
+```typescript
+const sql = compiler.compile(`
+  from sales
+  select 
+    product_id,
+    sale_date,
+    amount,
+    sum(amount) over (partition by product_id order by sale_date) as running_total
+`);
+```
+
+## Browser Usage
+
+The SDK works directly in browsers that support ES modules:
+
+```html
+<script type="module">
+  import { WvletCompiler } from 'https://unpkg.com/wvlet/dist/index.js';
+  
+  const compiler = new WvletCompiler();
+  const sql = compiler.compile('from users select *');
+  console.log(sql);
+</script>
+```
+
+## Performance Considerations
+
+- **Bundle Size**: The compiled Scala.js output is approximately 9MB (uncompressed)
+- **Compilation Speed**: Compilation is performed synchronously and is typically fast for most queries
+- **Memory Usage**: The compiler maintains minimal state between compilations
+
+## Differences from Python SDK
+
+Unlike the Python SDK which uses a native library, the TypeScript SDK:
+- Runs purely in JavaScript (via Scala.js compilation)
+- Works in browser environments
+- Has no native dependencies
+- Provides synchronous-only API
+
+## Troubleshooting
+
+### Module Resolution Issues
+
+If you encounter module resolution issues, ensure your `tsconfig.json` includes:
+
+```json
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  }
+}
+```
+
+### Browser Compatibility
+
+The SDK requires browsers that support:
+- ES2020 features
+- ES modules
+- Dynamic imports (for code splitting)
+
+## Source Code
+
+The TypeScript SDK source code is available at:
+- [GitHub: sdks/typescript](https://github.com/wvlet/wvlet/tree/main/sdks/typescript)
+- [NPM: wvlet](https://www.npmjs.com/package/wvlet)

--- a/website/docs/usage/install.md
+++ b/website/docs/usage/install.md
@@ -65,7 +65,7 @@ pip install wvlet
 
 ### TypeScript/JavaScript
 ```bash
-npm install wvlet
+npm install @wvlet/wvlet
 ```
 
 See [Language Bindings](../bindings) for more details and usage examples.

--- a/website/docs/usage/install.md
+++ b/website/docs/usage/install.md
@@ -14,7 +14,7 @@ Wvlet is available as a command-line tool. You can install wvlet using Homebrew 
 - [Web UI](ui.md)
 
 :::info
-We are also working on [language bingings](../bindings) for various programming languages. 
+Language SDKs are also available for [Python and TypeScript](../bindings) to compile Wvlet queries programmatically.
 :::
 
 ## Mac OS X
@@ -53,6 +53,22 @@ JDK17 or later is required to run wvlet. Set JAVA_HOME environment variable to t
 After installing wvlet, start learning the query syntax of Wvlet:
 - [Query Syntax](../syntax) to learn the query syntax
 
+
+## Language SDKs
+
+If you want to integrate Wvlet compilation into your applications, install one of our language SDKs:
+
+### Python
+```bash
+pip install wvlet
+```
+
+### TypeScript/JavaScript
+```bash
+npm install wvlet
+```
+
+See [Language Bindings](../bindings) for more details and usage examples.
 
 ## Building From Source
 

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -111,69 +111,6 @@ object WvletJS {
   def getVersion(): String = {
     wvlet.lang.BuildInfo.version
   }
-
-  /**
-    * Parse command-line style arguments and compile
-    * @param argsJson JSON array of command line arguments
-    * @return JSON string with compilation result
-    */
-  @JSExport
-  def compileWithArgs(argsJson: String): String = {
-    try {
-      val args = MessageCodec.of[Array[String]].fromJson(argsJson)
-      
-      // Parse arguments to extract query and options
-      var query: Option[String] = None
-      var target: Option[String] = None
-      var i = 0
-      
-      while (i < args.length) {
-        args(i) match {
-          case "-q" | "--query" =>
-            if (i + 1 < args.length) {
-              query = Some(args(i + 1))
-              i += 1
-            }
-          case "--target" =>
-            if (i + 1 < args.length) {
-              target = Some(args(i + 1))
-              i += 1
-            }
-          case arg if !arg.startsWith("-") && query.isEmpty =>
-            query = Some(arg)
-          case _ => // Ignore other arguments
-        }
-        i += 1
-      }
-      
-      query match {
-        case Some(q) =>
-          val options = CompileOptions(target = target)
-          compile(q, MessageCodec.of[CompileOptions].toJson(options))
-        case None =>
-          val error = CompileError(
-            statusCode = StatusCode.INVALID_ARGUMENT,
-            message = "No query provided"
-          )
-          val response = CompileResponse(
-            success = false,
-            error = Some(error)
-          )
-          MessageCodec.of[CompileResponse].toJson(response)
-      }
-    } catch {
-      case e: Throwable =>
-        val error = CompileError(
-          statusCode = StatusCode.INTERNAL_ERROR,
-          message = s"Failed to parse arguments: ${e.getMessage}"
-        )
-        val response = CompileResponse(
-          success = false,
-          error = Some(error)
-        )
-        MessageCodec.of[CompileResponse].toJson(response)
-    }
-  }
 }
 
 /**

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -1,0 +1,185 @@
+package wvlet.lang.sdk.js
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+import wvlet.airframe.codec.MessageCodec
+import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, DBType, Symbol, WorkEnv}
+import wvlet.lang.compiler.codegen.GenSQL
+import wvlet.lang.api.{WvletLangException, StatusCode, SourceLocation}
+import wvlet.lang.api.v1.compile.{CompileResponse, CompileError, ErrorLocation}
+import wvlet.lang.BuildInfo
+
+/**
+  * JavaScript API for Wvlet compiler. This provides a JSON-based interface
+  * similar to the native library's wvlet_compile_query_json function.
+  */
+@JSExportTopLevel("WvletJS")
+object WvletJS {
+
+  /**
+    * Compile a Wvlet query and return the result as JSON.
+    * @param query The Wvlet query string
+    * @param options JSON string with compilation options (e.g., {"target": "duckdb"})
+    * @return JSON string with compilation result
+    */
+  @JSExport
+  def compile(query: String, options: String = "{}"): String = {
+    try {
+      val opts = MessageCodec.of[CompileOptions].fromJson(options)
+      
+      // Create compiler with options
+      val targetDB = opts.target.getOrElse("duckdb").toLowerCase match {
+        case "trino" => DBType.Trino
+        case _ => DBType.DuckDB
+      }
+      
+      val compiler = Compiler(
+        CompilerOptions(
+          workEnv = WorkEnv(path = "."),
+          dbType = targetDB
+        )
+      )
+      
+      // Compile the query
+      val inputUnit = CompilationUnit.fromWvletString(query)
+      val compileResult = compiler.compileSingleUnit(inputUnit)
+      compileResult.reportAllErrors
+      
+      // Generate SQL
+      val ctx = compileResult
+        .context
+        .withCompilationUnit(inputUnit)
+        .withDebugRun(false)
+        .newContext(Symbol.NoSymbol)
+      
+      val sql = GenSQL.generateSQL(inputUnit)(using ctx)
+      
+      val response = CompileResponse(
+        success = true,
+        sql = Some(sql)
+      )
+      
+      MessageCodec.of[CompileResponse].toJson(response)
+    } catch {
+      case e: WvletLangException =>
+        val locationOpt = if e.sourceLocation != SourceLocation.NoSourceLocation then
+          Some(ErrorLocation(
+            path = e.sourceLocation.path,
+            fileName = e.sourceLocation.fileName,
+            line = e.sourceLocation.position.line,
+            column = e.sourceLocation.position.column,
+            lineContent = if e.sourceLocation.codeLineAt.nonEmpty then
+              Some(e.sourceLocation.codeLineAt)
+            else
+              None
+          ))
+        else
+          None
+        
+        val error = CompileError(
+          statusCode = e.statusCode,
+          message = e.getMessage,
+          location = locationOpt
+        )
+        
+        val response = CompileResponse(
+          success = false,
+          error = Some(error)
+        )
+        
+        MessageCodec.of[CompileResponse].toJson(response)
+        
+      case e: Throwable =>
+        val error = CompileError(
+          statusCode = StatusCode.INTERNAL_ERROR,
+          message = Option(e.getMessage).getOrElse(e.getClass.getName)
+        )
+        
+        val response = CompileResponse(
+          success = false,
+          error = Some(error)
+        )
+        
+        MessageCodec.of[CompileResponse].toJson(response)
+    }
+  }
+
+  /**
+    * Get the version of the Wvlet compiler
+    */
+  @JSExport
+  def getVersion(): String = {
+    wvlet.lang.BuildInfo.version
+  }
+
+  /**
+    * Parse command-line style arguments and compile
+    * @param argsJson JSON array of command line arguments
+    * @return JSON string with compilation result
+    */
+  @JSExport
+  def compileWithArgs(argsJson: String): String = {
+    try {
+      val args = MessageCodec.of[Array[String]].fromJson(argsJson)
+      
+      // Parse arguments to extract query and options
+      var query: Option[String] = None
+      var target: Option[String] = None
+      var i = 0
+      
+      while (i < args.length) {
+        args(i) match {
+          case "-q" | "--query" =>
+            if (i + 1 < args.length) {
+              query = Some(args(i + 1))
+              i += 1
+            }
+          case "--target" =>
+            if (i + 1 < args.length) {
+              target = Some(args(i + 1))
+              i += 1
+            }
+          case arg if !arg.startsWith("-") && query.isEmpty =>
+            query = Some(arg)
+          case _ => // Ignore other arguments
+        }
+        i += 1
+      }
+      
+      query match {
+        case Some(q) =>
+          val options = CompileOptions(target = target)
+          compile(q, MessageCodec.of[CompileOptions].toJson(options))
+        case None =>
+          val error = CompileError(
+            statusCode = StatusCode.INVALID_ARGUMENT,
+            message = "No query provided"
+          )
+          val response = CompileResponse(
+            success = false,
+            error = Some(error)
+          )
+          MessageCodec.of[CompileResponse].toJson(response)
+      }
+    } catch {
+      case e: Throwable =>
+        val error = CompileError(
+          statusCode = StatusCode.INTERNAL_ERROR,
+          message = s"Failed to parse arguments: ${e.getMessage}"
+        )
+        val response = CompileResponse(
+          success = false,
+          error = Some(error)
+        )
+        MessageCodec.of[CompileResponse].toJson(response)
+    }
+  }
+}
+
+/**
+  * Compilation options
+  */
+case class CompileOptions(
+    target: Option[String] = None,
+    profile: Option[String] = None
+)

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -1,7 +1,7 @@
 package wvlet.lang.sdk.js
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation._
+import scala.scalajs.js.annotation.*
 import wvlet.airframe.codec.MessageCodec
 import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, DBType, Symbol, WorkEnv}
 import wvlet.lang.compiler.codegen.GenSQL
@@ -10,113 +10,102 @@ import wvlet.lang.api.v1.compile.{CompileResponse, CompileError, ErrorLocation}
 import wvlet.lang.BuildInfo
 
 /**
-  * JavaScript API for Wvlet compiler. This provides a JSON-based interface
-  * similar to the native library's wvlet_compile_query_json function.
+  * JavaScript API for Wvlet compiler. This provides a JSON-based interface similar to the native
+  * library's wvlet_compile_query_json function.
   */
 @JSExportTopLevel("WvletJS")
-object WvletJS {
+object WvletJS:
 
   /**
     * Compile a Wvlet query and return the result as JSON.
-    * @param query The Wvlet query string
-    * @param options JSON string with compilation options (e.g., {"target": "duckdb"})
-    * @return JSON string with compilation result
+    * @param query
+    *   The Wvlet query string
+    * @param options
+    *   JSON string with compilation options (e.g., {"target": "duckdb"})
+    * @return
+    *   JSON string with compilation result
     */
   @JSExport
-  def compile(query: String, options: String = "{}"): String = {
-    try {
+  def compile(query: String, options: String = "{}"): String =
+    try
       val opts = MessageCodec.of[CompileOptions].fromJson(options)
-      
+
       // Create compiler with options
-      val targetDB = opts.target.getOrElse("duckdb").toLowerCase match {
-        case "trino" => DBType.Trino
-        case _ => DBType.DuckDB
-      }
-      
-      val compiler = Compiler(
-        CompilerOptions(
-          workEnv = WorkEnv(path = "."),
-          dbType = targetDB
-        )
-      )
-      
+      val targetDB =
+        opts.target.getOrElse("duckdb").toLowerCase match
+          case "trino" =>
+            DBType.Trino
+          case _ =>
+            DBType.DuckDB
+
+      val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(path = "."), dbType = targetDB))
+
       // Compile the query
-      val inputUnit = CompilationUnit.fromWvletString(query)
+      val inputUnit     = CompilationUnit.fromWvletString(query)
       val compileResult = compiler.compileSingleUnit(inputUnit)
       compileResult.reportAllErrors
-      
+
       // Generate SQL
       val ctx = compileResult
         .context
         .withCompilationUnit(inputUnit)
         .withDebugRun(false)
         .newContext(Symbol.NoSymbol)
-      
+
       val sql = GenSQL.generateSQL(inputUnit)(using ctx)
-      
-      val response = CompileResponse(
-        success = true,
-        sql = Some(sql)
-      )
-      
+
+      val response = CompileResponse(success = true, sql = Some(sql))
+
       MessageCodec.of[CompileResponse].toJson(response)
-    } catch {
+    catch
       case e: WvletLangException =>
-        val locationOpt = if e.sourceLocation != SourceLocation.NoSourceLocation then
-          Some(ErrorLocation(
-            path = e.sourceLocation.path,
-            fileName = e.sourceLocation.fileName,
-            line = e.sourceLocation.position.line,
-            column = e.sourceLocation.position.column,
-            lineContent = if e.sourceLocation.codeLineAt.nonEmpty then
-              Some(e.sourceLocation.codeLineAt)
-            else
-              None
-          ))
-        else
-          None
-        
+        val locationOpt =
+          if e.sourceLocation != SourceLocation.NoSourceLocation then
+            Some(
+              ErrorLocation(
+                path = e.sourceLocation.path,
+                fileName = e.sourceLocation.fileName,
+                line = e.sourceLocation.position.line,
+                column = e.sourceLocation.position.column,
+                lineContent =
+                  if e.sourceLocation.codeLineAt.nonEmpty then
+                    Some(e.sourceLocation.codeLineAt)
+                  else
+                    None
+              )
+            )
+          else
+            None
+
         val error = CompileError(
           statusCode = e.statusCode,
           message = e.getMessage,
           location = locationOpt
         )
-        
-        val response = CompileResponse(
-          success = false,
-          error = Some(error)
-        )
-        
+
+        val response = CompileResponse(success = false, error = Some(error))
+
         MessageCodec.of[CompileResponse].toJson(response)
-        
+
       case e: Throwable =>
         val error = CompileError(
           statusCode = StatusCode.INTERNAL_ERROR,
           message = Option(e.getMessage).getOrElse(e.getClass.getName)
         )
-        
-        val response = CompileResponse(
-          success = false,
-          error = Some(error)
-        )
-        
+
+        val response = CompileResponse(success = false, error = Some(error))
+
         MessageCodec.of[CompileResponse].toJson(response)
-    }
-  }
 
   /**
     * Get the version of the Wvlet compiler
     */
   @JSExport
-  def getVersion(): String = {
-    wvlet.lang.BuildInfo.version
-  }
-}
+  def getVersion(): String = wvlet.lang.BuildInfo.version
+
+end WvletJS
 
 /**
   * Compilation options
   */
-case class CompileOptions(
-    target: Option[String] = None,
-    profile: Option[String] = None
-)
+case class CompileOptions(target: Option[String] = None, profile: Option[String] = None)


### PR DESCRIPTION
## Summary
- Implement TypeScript SDK for Wvlet using Scala.js compilation
- Provides JavaScript/TypeScript developers with native Wvlet query compilation
- Enables browser-based compilation without server dependencies

## Implementation Details

### Scala.js Module (`wvlet-sdk-js`)
- Created new Scala.js module that exports JavaScript API
- Uses `@JSExport` annotations for clean JavaScript interface
- Provides JSON-based compile function similar to native library
- Generates ES module output for modern JavaScript environments

### TypeScript SDK Structure (`sdks/typescript/`)
```
sdks/typescript/
├── src/
│   ├── index.ts         # Main exports
│   ├── compiler.ts      # WvletCompiler class
│   └── types.ts         # TypeScript type definitions
├── lib/
│   └── main.js          # Scala.js compiled output (8.9MB)
├── tests/
│   └── compiler.test.ts # Vitest tests
├── examples/
│   └── node-example.js  # Usage example
└── package.json         # NPM package configuration
```

### Features
- **Async and sync compilation methods**
- **Full TypeScript type safety**
- **Comprehensive error handling with source locations**
- **Support for multiple SQL targets (DuckDB, Trino)**
- **ES module output for tree-shaking**
- **Works in both Node.js and browsers**

### API Usage
```typescript
import { WvletCompiler } from 'wvlet';

const compiler = new WvletCompiler({ target: 'duckdb' });
const sql = await compiler.compile('from users select name, email');
```

## Test Plan
- [x] Scala.js module compiles successfully
- [x] TypeScript types compile without errors
- [ ] Tests pass with Vitest
- [ ] Example runs in Node.js
- [ ] Bundle size is acceptable for browser use
- [ ] NPM package can be published

## Related Issues
Closes #1017

## Next Steps
- Add GitHub Actions workflow for TypeScript SDK testing and publishing
- Optimize Scala.js output size for smaller bundle
- Add more examples (React, browser)

🤖 Generated with [Claude Code](https://claude.ai/code)