### PR TITLE
feature: Add CREATE TABLE AS and INSERT INTO support for DuckDB

### DIFF
--- a/spec/sql/basic/create-table-as.sql
+++ b/spec/sql/basic/create-table-as.sql
@@ -1,0 +1,43 @@
+-- Test CREATE TABLE AS functionality
+
+-- Clean up from previous runs
+drop table if exists test_ctas_basic;
+drop table if exists test_ctas_ifnotexists;
+drop table if exists test_ctas_replace;
+
+-- Basic CREATE TABLE AS
+create table test_ctas_basic as
+select * from (values (1, 'hello'), (2, 'world')) as t(id, name);
+
+-- Verify the table was created
+select * from test_ctas_basic order by id;
+
+-- CREATE TABLE IF NOT EXISTS (should succeed)
+create table if not exists test_ctas_ifnotexists as
+select * from test_ctas_basic;
+
+-- Try again (should be a no-op, not an error)
+create table if not exists test_ctas_ifnotexists as
+select 3 as id, 'new' as name;
+
+-- Verify the table wasn't replaced
+select * from test_ctas_ifnotexists order by id;
+
+-- CREATE OR REPLACE TABLE
+create or replace table test_ctas_replace as
+select 10 as id, 'replaced' as name;
+
+-- Verify the table was replaced
+select * from test_ctas_replace;
+
+-- Replace again with different data
+create or replace table test_ctas_replace as
+select * from (values (20, 'replaced again'), (30, 'another row')) as t(id, name);
+
+-- Verify the table was replaced again
+select * from test_ctas_replace order by id;
+
+-- Clean up
+drop table test_ctas_basic;
+drop table test_ctas_ifnotexists;
+drop table test_ctas_replace;

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/SqlSpec.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/SqlSpec.scala
@@ -1,10 +1,6 @@
 package wvlet.lang.runner
 
-class SqlBasicSpec
-    extends SpecRunner(
-      "spec/sql/basic",
-      ignoredSpec = Map("update.sql" -> "CREATE TABLE AS not implemented for DuckDB")
-    )
+class SqlBasicSpec extends SpecRunner("spec/sql/basic")
 
 class SqlTPCHSpec extends SpecRunner("spec/sql/tpc-h", parseOnly = true, prepareTPCH = true)
 


### PR DESCRIPTION
## Summary
- Added execution support for CREATE TABLE AS and INSERT INTO SQL statements in the DuckDB connector
- Previously these operations would throw NOT_IMPLEMENTED errors, now they execute properly
- Fixes #1024

## Changes
- Added `CreateTableAs` case to `generateSaveSQL` method in `GenSQL.scala`
- Added `InsertInto` case to `generateSaveSQL` method in `GenSQL.scala`
- Properly handles all CREATE TABLE modes:
  - `NoOverwrite`: Basic CREATE TABLE
  - `IfNotExists`: CREATE TABLE IF NOT EXISTS
  - `Replace`: CREATE OR REPLACE TABLE (with fallback to DROP + CREATE for unsupported DBs)
- Removed `update.sql` from ignored tests in `SqlSpec.scala`
- Added comprehensive test file `create-table-as.sql` to test various scenarios

## Test plan
- [x] All existing tests pass
- [x] New test file `create-table-as.sql` tests CREATE TABLE AS functionality
- [x] Previously failing `update.sql` now passes
- [x] Tested CREATE TABLE AS with different modes (basic, IF NOT EXISTS, OR REPLACE)
- [x] Tested INSERT INTO functionality

🤖 Generated with [Claude Code](https://claude.ai/code)