### PR TITLE
fix: Preserve IS NULL/IS NOT NULL syntax in SQL parser

### DIFF
--- a/spec/sql/basic/is-null.sql
+++ b/spec/sql/basic/is-null.sql
@@ -1,0 +1,28 @@
+-- Test IS NULL and IS NOT NULL syntax
+-- These should NOT generate warnings
+
+-- IS NULL tests
+SELECT 
+    1 IS NULL,
+    'hello' IS NULL,
+    NULL IS NULL,
+    (1 + 2) IS NULL;
+
+-- IS NOT NULL tests  
+SELECT
+    1 IS NOT NULL,
+    'world' IS NOT NULL,
+    NULL IS NOT NULL,
+    (3 * 4) IS NOT NULL;
+
+-- Mixed expressions
+SELECT
+    CASE 
+        WHEN 'test' IS NULL THEN 'is null'
+        WHEN 'test' IS NOT NULL THEN 'is not null'
+    END as null_check;
+
+-- These should still generate warnings (using = and != with NULL)
+SELECT
+    1 = NULL,           -- Should warn
+    'hello' != NULL;    -- Should warn

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SQLValidator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SQLValidator.scala
@@ -14,7 +14,7 @@
 package wvlet.lang.compiler.analyzer
 
 import wvlet.lang.compiler.{CompilationUnit, Context, Phase}
-import wvlet.lang.model.expr.{Eq, Expression, NotEq, NullLiteral}
+import wvlet.lang.model.expr.{Eq, Expression, IsNotNull, IsNull, NotEq, NullLiteral}
 import wvlet.lang.model.plan.LogicalPlan
 
 /**
@@ -42,6 +42,8 @@ class SQLValidator extends Phase("sql-validator"):
         checkNullComparison(eq, left, right, "=", context)
       case neq @ NotEq(left, right, span) =>
         checkNullComparison(neq, left, right, "!=", context)
+      case _: IsNull | _: IsNotNull =>
+      // IS NULL and IS NOT NULL are valid null checks, no warning needed
       case _ =>
       // No validation needed
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -885,6 +885,10 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
         wl(expr(left), "is null")
       case NotEq(left, n: NullLiteral, _) =>
         wl(expr(left), "is not null")
+      case IsNull(child, _) =>
+        wl(expr(child), "is null")
+      case IsNotNull(child, _) =>
+        wl(expr(child), "is not null")
       case a: ArithmeticUnaryExpr =>
         a.sign match
           case Sign.NoSign =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -506,6 +506,10 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
           wl(expr(left), "is", expr(n))
         case NotEq(left, n: NullLiteral, _) =>
           wl(expr(left), "is not", expr(n))
+        case IsNull(child, _) =>
+          wl(expr(child), "is null")
+        case IsNotNull(child, _) =>
+          wl(expr(child), "is not null")
         case a: ArithmeticUnaryExpr =>
           a.sign match
             case Sign.NoSign =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -866,8 +866,16 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
           scanner.lookAhead().token match
             case SqlToken.NOT =>
               consume(SqlToken.NOT)
-              val right = valueExpression()
-              NotEq(expr, right, spanFrom(t))
+              scanner.lookAhead().token match
+                case SqlToken.NULL =>
+                  consume(SqlToken.NULL)
+                  IsNotNull(expr, spanFrom(t))
+                case _ =>
+                  val right = valueExpression()
+                  NotEq(expr, right, spanFrom(t))
+            case SqlToken.NULL =>
+              consume(SqlToken.NULL)
+              IsNull(expr, spanFrom(t))
             case _ =>
               val right = valueExpression()
               Eq(expr, right, spanFrom(t))


### PR DESCRIPTION
## Summary
- Fixed SQL parser incorrectly transforming `IS NULL` to `= NULL` and `IS NOT NULL` to `\!= NULL`
- The parser now properly creates `IsNull` and `IsNotNull` expression nodes
- Fixes #1023

## Background
Previously, when parsing SQL files, expressions like `1 IS NULL` would be transformed into `1 = NULL`, which would then trigger null comparison warnings from the SQLValidator. This was incorrect behavior as `IS NULL` is the proper SQL syntax for null checks and should not generate warnings.

## Changes
- **SqlParser.scala**: Updated to recognize `IS NULL` and `IS NOT NULL` patterns specifically
  - When `IS` is followed by `NULL`, create `IsNull` expression
  - When `IS NOT` is followed by `NULL`, create `IsNotNull` expression
  - Other `IS` patterns continue to work as before (e.g., `IS DISTINCT FROM`)
- **SqlGenerator.scala**: Added cases to generate proper SQL for `IsNull` and `IsNotNull` expressions
- **SQLValidator.scala**: Updated to skip warnings for `IsNull` and `IsNotNull` expressions (they are valid null checks)
- Added comprehensive test file `is-null.sql` to verify correct behavior
- Updated documentation in `null-comparison.sql`

## Test plan
- [x] New test file `is-null.sql` verifies IS NULL/IS NOT NULL don't generate warnings
- [x] Existing `null-comparison.sql` still generates warnings for = NULL/\!= NULL
- [x] All SQL tests pass
- [x] Manual verification that IS NULL generates correct SQL output

🤖 Generated with [Claude Code](https://claude.ai/code)