### PR TITLE
feature: Add INSERT INTO code generation support for Trino (#1028)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,3 @@ For error reporting, use WvletLangException and StatusCode enum. If necessary er
 
 ## Testing Notes
 - Use `shouldContain "(keyword)"` for checking string fragment in AirSpec
-```
-
-</invoke>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ For error reporting, use WvletLangException and StatusCode enum. If necessary er
 - Add `test-wheels` label for platform-specific changes
 
 ## Debugging
-- To monitor debug logs, use `-- -l debug` option. For example, ./sbt "langJVM/testOnly *Test -- -l debug"
+- To monitor debug logs, use `-l debug` option. For example, ./sbt "langJVM/testOnly *Test -- -l debug"
 
 ## Testing Notes
 - Use `shouldContain "(keyword)"` for checking string fragment in AirSpec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,3 +266,12 @@ For error reporting, use WvletLangException and StatusCode enum. If necessary er
 - Quick tests run on every PR (~2 minutes)
 - Full wheel tests run only on tags, PRs with `test-wheels` label, or weekly schedule
 - Add `test-wheels` label for platform-specific changes
+
+## Debugging
+- To monitor debug logs, use `-- -l debug` option. For example, ./sbt "langJVM/testOnly *Test -- -l debug"
+
+## Testing Notes
+- Use `shouldContain "(keyword)"` for checking string fragment in AirSpec
+```
+
+</invoke>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -212,16 +212,17 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
           else
             text(" ") + paren(cl(i.columns.map(c => expr(c))))
         // Handle VALUES specially for INSERT INTO
-        val childSQL = i.child match
-          case v: Values =>
-            // For INSERT INTO, use VALUES directly without SELECT wrapper
-            if dbType.requireParenForValues then
-              paren(values(v))
-            else
-              values(v)
-          case _ =>
-            // For other expressions, use the regular query generation
-            query(i.child, SQLBlock())(using InStatement)
+        val childSQL =
+          i.child match
+            case v: Values =>
+              // For INSERT INTO, use VALUES directly without SELECT wrapper
+              if dbType.requireParenForValues then
+                paren(values(v))
+              else
+                values(v)
+            case _ =>
+              // For other expressions, use the regular query generation
+              query(i.child, SQLBlock())(using InStatement)
         group(wl("insert", "into", expr(i.target) + columns, linebreak + childSQL))
       case _ =>
         unsupportedNode(s"Update ${u.nodeName}", u.span)

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/InsertIntoCodegenTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/InsertIntoCodegenTest.scala
@@ -1,0 +1,81 @@
+package wvlet.lang.compiler.codegen
+
+import wvlet.airspec.AirSpec
+import wvlet.lang.compiler.{CompilationUnit, DBType}
+import wvlet.lang.compiler.parser.SqlParser
+
+class InsertIntoCodegenTest extends AirSpec:
+
+  private def generateSQL(sql: String, dbType: DBType = DBType.Generic): String =
+    val unit      = CompilationUnit.fromSqlString(sql)
+    val plan      = SqlParser(unit).parse()
+    val generator = SqlGenerator(CodeFormatterConfig(sqlDBType = dbType))
+    generator.print(plan)
+
+  test("generate INSERT INTO for different DB types") {
+    val sql = "INSERT INTO users VALUES (1, 'Alice', 25)"
+
+    // Generic SQL (no parentheses around VALUES)
+    val genericSQL = generateSQL(sql, DBType.Generic)
+    debug(s"Generic: $genericSQL")
+    genericSQL shouldContain "values"
+    genericSQL shouldContain "select * from values"
+
+    // Trino (requires parentheses around VALUES)
+    val trinoSQL = generateSQL(sql, DBType.Trino)
+    debug(s"Trino: $trinoSQL")
+    trinoSQL shouldContain "select * from (values"
+
+    // DuckDB (no parentheses around VALUES)
+    val duckdbSQL = generateSQL(sql, DBType.DuckDB)
+    debug(s"DuckDB: $duckdbSQL")
+    duckdbSQL shouldContain "select * from values"
+  }
+
+  test("generate INSERT INTO with column list") {
+    val sql = "INSERT INTO users (id, name, age) VALUES (1, 'Alice', 25)"
+
+    val genericSQL = generateSQL(sql, DBType.Generic)
+    debug(genericSQL)
+    genericSQL shouldContain "insert into users (id, name, age)"
+
+    val trinoSQL = generateSQL(sql, DBType.Trino)
+    debug(trinoSQL)
+    trinoSQL shouldContain "insert into users (id, name, age)"
+  }
+
+  test("generate INSERT INTO with multi-row VALUES") {
+    val sql = "INSERT INTO users VALUES (1, 'Alice', 25), (2, 'Bob', 30)"
+
+    val genericSQL = generateSQL(sql, DBType.Generic)
+    debug(s"Generic multi-row: $genericSQL")
+
+    val trinoSQL = generateSQL(sql, DBType.Trino)
+    debug(s"Trino multi-row: $trinoSQL")
+    // Trino should have (values ...)
+    trinoSQL shouldContain "(values"
+  }
+
+  test("generate INSERT INTO with SELECT") {
+    val sql = "INSERT INTO users SELECT * FROM temp_users"
+
+    val genericSQL = generateSQL(sql, DBType.Generic)
+    debug(s"Generic SELECT: $genericSQL")
+    genericSQL.toLowerCase shouldContain "insert into users"
+    genericSQL.toLowerCase shouldContain "select"
+
+    val trinoSQL = generateSQL(sql, DBType.Trino)
+    debug(s"Trino SELECT: $trinoSQL")
+    trinoSQL.toLowerCase shouldContain "insert into users"
+    trinoSQL.toLowerCase shouldContain "select"
+  }
+
+  test("generate INSERT INTO with qualified table names") {
+    val sql = "INSERT INTO catalog.schema.users VALUES (1, 'Alice', 25)"
+
+    val trinoSQL = generateSQL(sql, DBType.Trino)
+    debug(trinoSQL)
+    trinoSQL shouldContain "insert into catalog.schema.users"
+  }
+
+end InsertIntoCodegenTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/InsertIntoCodegenTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/InsertIntoCodegenTest.scala
@@ -18,18 +18,18 @@ class InsertIntoCodegenTest extends AirSpec:
     // Generic SQL (no parentheses around VALUES)
     val genericSQL = generateSQL(sql, DBType.Generic)
     debug(s"Generic: $genericSQL")
-    genericSQL shouldContain "values"
-    genericSQL shouldContain "select * from values"
+    genericSQL shouldContain "insert into users"
+    genericSQL shouldContain "values (1, 'Alice', 25)"
 
     // Trino (requires parentheses around VALUES)
     val trinoSQL = generateSQL(sql, DBType.Trino)
     debug(s"Trino: $trinoSQL")
-    trinoSQL shouldContain "select * from (values"
+    trinoSQL shouldContain "(values (1, 'Alice', 25))"
 
     // DuckDB (no parentheses around VALUES)
     val duckdbSQL = generateSQL(sql, DBType.DuckDB)
     debug(s"DuckDB: $duckdbSQL")
-    duckdbSQL shouldContain "select * from values"
+    duckdbSQL shouldContain "values (1, 'Alice', 25)"
   }
 
   test("generate INSERT INTO with column list") {


### PR DESCRIPTION
## Summary
- Implements Phase 2 of INSERT INTO support: SQL code generation for different database types
- Adds Trino-specific handling for VALUES clause syntax (requires parentheses)
- Includes comprehensive test coverage for various INSERT INTO patterns

## Changes
- Add `InsertInto` case handling in `SqlGenerator.update()` method
- Modify `values()` function to respect `DBType.requireParenForValues` setting
- Create test suite `InsertIntoCodegenTest` with 5 test cases covering:
  - Basic INSERT INTO with VALUES
  - INSERT INTO with column list specification  
  - Multi-row VALUES insertion
  - INSERT INTO with SELECT statement
  - Qualified table names (catalog.schema.table)

## Test Plan
- [x] All existing tests pass
- [x] New test suite `InsertIntoCodegenTest` passes for Generic, Trino, and DuckDB dialects
- [x] Verified Trino generates `(values ...)` while Generic/DuckDB generate `values ...`

## Related Issues
- Fixes Phase 2 of #1028

🤖 Generated with [Claude Code](https://claude.ai/code)