### PR TITLE
fix: Support IF function as SQL expression instead of keyword

### DIFF
--- a/spec/sql/basic/if-function.sql
+++ b/spec/sql/basic/if-function.sql
@@ -1,0 +1,14 @@
+-- Test if expression with lowercase
+select
+  if(1 > 0, 'true', 'false') as result1,
+  if(0 > 1, 'true', 'false') as result2;
+
+-- upper case IF
+SELECT
+  IF(1 > 0, 'true', 'false') as result1,
+  IF(0 > 1, 'true', 'false') as result2;
+
+-- Two-argument IF function, supported only in Trino
+SELECT
+  IF(1 > 0, 'condition is true') as result1,
+  IF(0 > 1, 'condition is true') as result2;

--- a/spec/sql/basic/if-function.sql
+++ b/spec/sql/basic/if-function.sql
@@ -9,6 +9,11 @@ SELECT
   IF(0 > 1, 'true', 'false') as result2;
 
 -- Two-argument IF function, supported only in Trino
+-- We need to convert this type of if statement into if(a, b, null)
+SELECT
+  if(1 > 0, 'condition is true') as result1,
+  if(0 > 1, 'condition is true') as result2;
+
 SELECT
   IF(1 > 0, 'condition is true') as result1,
   IF(0 > 1, 'condition is true') as result2;

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -200,6 +200,7 @@ enum SqlToken(val tokenType: TokenType, val str: String):
   case DELETE  extends SqlToken(Keyword, "delete")
   case CREATE  extends SqlToken(Keyword, "create")
   case DROP    extends SqlToken(Keyword, "drop")
+  // If needs to be a token for 'create table if not exists ...' syntax
   case IF      extends SqlToken(Keyword, "if")
   case REPLACE extends SqlToken(Keyword, "replace")
 
@@ -264,7 +265,8 @@ object SqlToken:
     SqlToken.ARRAY,
     SqlToken.DATE,
     SqlToken.INTERVAL,
-    SqlToken.CAST
+    SqlToken.CAST,
+    SqlToken.IF
   )
 
   val allKeywordsAndSymbols = keywords ++ literalStartKeywords ++ specialSymbols


### PR DESCRIPTION
## Summary

- Fixed SQL parser to properly handle IF as both a keyword (for DDL) and a function name (for expressions)
- Added IF function rewrite rule to convert function calls to IfExpr AST nodes
- Supports both 2-argument and 3-argument IF function forms

## Problem

The SQL parser was treating IF as a keyword exclusively for DDL statements like `CREATE TABLE IF NOT EXISTS`, which prevented its use as a function name in SELECT statements. This caused parsing errors when trying to use `IF(condition, true_value, false_value)` in queries.

## Solution

- Added IF to `literalStartKeywords` to allow it to be parsed as a function name in expressions
- Implemented `RewriteIfExpr` rule to convert IF function calls to proper IfExpr AST nodes
- Handles both standard 3-argument form `IF(cond, true_val, false_val)` and Trino's 2-argument form `IF(cond, true_val)`
- Updated WvletGeneratorTest to apply expression rewrites during conversion

## Test Plan

- [x] Added test cases for both 2-argument and 3-argument IF functions in `spec/sql/basic/if-function.sql`
- [x] Verified parser properly handles IF in both DDL and expression contexts
- [x] Confirmed IF function calls are correctly rewritten to IfExpr AST nodes

🤖 Generated with [Claude Code](https://claude.ai/code)