### PR TITLE
fix: Set working-directory for Scala.js build in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,6 +51,7 @@ jobs:
           cache-dependency-path: package-lock.json
       
       - name: Build Scala.js SDK
+        working-directory: .
         run: ./sbt "sdkJs/fullLinkJS"
       
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Fixes the npm-publish workflow CI failure where the Build Scala.js SDK step couldn't find ./sbt

## Problem
The TypeScript SDK job has `defaults.run.working-directory: sdks/typescript` set, but the Build Scala.js SDK step needs to run from the project root to access ./sbt. This caused exit code 127 (command not found).

## Solution
Added explicit `working-directory: .` to the Build Scala.js SDK step to override the job defaults and run from the project root.

## Test plan
- [ ] CI passes for npm-publish workflow
- [ ] Build Scala.js SDK step successfully finds and executes ./sbt

Fixes the CI failure seen in: https://github.com/wvlet/wvlet/actions/runs/17353758473/job/49263769880

🤖 Generated with [Claude Code](https://claude.ai/code)