### PR TITLE
doc: Add CDN test page for highlight.js Wvlet extension

### DIFF
--- a/highlightjs-wvlet/README.md
+++ b/highlightjs-wvlet/README.md
@@ -27,6 +27,10 @@ npm install @wvlet/highlightjs-wvlet
 ### Using CDN
 
 ```html
+<!-- Using specific version (recommended for production) -->
+<script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@0.1.0/dist/wvlet.min.js"></script>
+
+<!-- Using latest version -->
 <script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@latest/dist/wvlet.min.js"></script>
 ```
 
@@ -55,14 +59,36 @@ hljs.registerLanguage('wvlet', wvlet);
 ### In the Browser
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11/styles/default.min.css">
-<script src="https://cdn.jsdelivr.net/npm/highlight.js@11"></script>
-<script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@latest/dist/wvlet.min.js"></script>
-<script>
-  hljs.registerLanguage('wvlet', window.hljsWvlet);
-  hljs.highlightAll();
-</script>
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- highlight.js theme -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11/styles/default.min.css">
+</head>
+<body>
+  <!-- Your code blocks -->
+  <pre><code class="language-wvlet">
+  model User = 
+    from 'users.json'
+    select name, age, email
+  </code></pre>
+
+  <!-- highlight.js core -->
+  <script src="https://cdn.jsdelivr.net/npm/highlight.js@11/lib/core.min.js"></script>
+  <!-- Wvlet language support -->
+  <script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@0.1.0/dist/wvlet.min.js"></script>
+  
+  <script>
+    // Register Wvlet language
+    hljs.registerLanguage('wvlet', window.hljsWvlet);
+    // Apply highlighting
+    hljs.highlightAll();
+  </script>
+</body>
+</html>
 ```
+
+For a complete example, see [test-cdn.html](test-cdn.html).
 
 ## Example
 

--- a/highlightjs-wvlet/README.md
+++ b/highlightjs-wvlet/README.md
@@ -28,7 +28,7 @@ npm install @wvlet/highlightjs-wvlet
 
 ```html
 <!-- Using specific version (recommended for production) -->
-<script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@0.1.0/dist/wvlet.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@2025.1.13/dist/wvlet.min.js"></script>
 
 <!-- Using latest version -->
 <script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@latest/dist/wvlet.min.js"></script>
@@ -76,7 +76,7 @@ hljs.registerLanguage('wvlet', wvlet);
   <!-- highlight.js core -->
   <script src="https://cdn.jsdelivr.net/npm/highlight.js@11/lib/core.min.js"></script>
   <!-- Wvlet language support -->
-  <script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@0.1.0/dist/wvlet.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@2025.1.13/dist/wvlet.min.js"></script>
   
   <script>
     // Register Wvlet language

--- a/highlightjs-wvlet/test-cdn.html
+++ b/highlightjs-wvlet/test-cdn.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wvlet Syntax Highlighting - CDN Test</title>
+  
+  <!-- highlight.js core -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/default.min.css">
+  <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js"></script>
+  
+  <!-- Wvlet language support from npm CDN -->
+  <script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@0.1.0/dist/wvlet.min.js"></script>
+  
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    h1 {
+      color: #333;
+    }
+    .example {
+      margin: 20px 0;
+    }
+    .example h3 {
+      color: #666;
+      margin-bottom: 10px;
+    }
+    pre {
+      border-radius: 5px;
+      overflow-x: auto;
+    }
+    .theme-selector {
+      margin: 20px 0;
+    }
+    .theme-selector label {
+      margin-right: 10px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Wvlet Syntax Highlighting - CDN Test</h1>
+  <p>This page tests the Wvlet language syntax highlighting using the CDN-hosted package from npm.</p>
+  <p>Package: <a href="https://www.npmjs.com/package/@wvlet/highlightjs-wvlet">@wvlet/highlightjs-wvlet</a></p>
+  
+  <div class="theme-selector">
+    <label>Theme:</label>
+    <select id="theme-select" onchange="changeTheme(this.value)">
+      <option value="default">Default</option>
+      <option value="github">GitHub</option>
+      <option value="monokai">Monokai</option>
+      <option value="nord">Nord</option>
+      <option value="vs">Visual Studio</option>
+    </select>
+  </div>
+
+  <div class="example">
+    <h3>Basic Model Definition</h3>
+    <pre><code class="language-wvlet">-- Basic model definition
+model User = 
+  from 'users.json'
+  select name, age, email
+  where age > 18
+
+-- Using the model
+from User
+where name like 'John%'
+order by age desc
+limit 10</code></pre>
+  </div>
+
+  <div class="example">
+    <h3>Advanced Query with Functions</h3>
+    <pre><code class="language-wvlet">model Sales(year: Int) =
+  from 's3://bucket/sales/year=${year}/*.parquet'
+  select 
+    product_id,
+    sum(quantity) as total_quantity,
+    avg(price) as avg_price,
+    count(*) as transaction_count
+  group by product_id
+  having total_quantity > 100
+
+-- Join with another model
+from Sales(2024) s
+join Product p on s.product_id = p.id
+select 
+  p.name,
+  s.total_quantity,
+  s.avg_price * s.total_quantity as revenue
+order by revenue desc</code></pre>
+  </div>
+
+  <div class="example">
+    <h3>String Interpolation and Operators</h3>
+    <pre><code class="language-wvlet">model Report = 
+  from Orders
+  select 
+    customer_id,
+    "${order_date}" as date,
+    price * quantity as total,
+    case 
+      when total >= 1000 then 'Premium'
+      when total >= 500 then 'Standard'
+      else 'Basic'
+    end as tier
+  where status != 'cancelled' and price > 0</code></pre>
+  </div>
+
+  <div class="example">
+    <h3>Test Assertions</h3>
+    <pre><code class="language-wvlet">-- Test data quality
+test "User data validation" should {
+  from User
+  test _.size should be > 0
+  test _.columns should contain 'email'
+  test _.where(age < 0).size should be 0
+}</code></pre>
+  </div>
+
+  <script>
+    // Register Wvlet language
+    hljs.registerLanguage('wvlet', hljsWvlet);
+    
+    // Initialize highlighting
+    hljs.highlightAll();
+    
+    // Theme switcher
+    function changeTheme(theme) {
+      const link = document.querySelector('link[href*="highlight"]');
+      link.href = `https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/${theme}.min.css`;
+    }
+  </script>
+</body>
+</html>

--- a/highlightjs-wvlet/test-cdn.html
+++ b/highlightjs-wvlet/test-cdn.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js"></script>
   
   <!-- Wvlet language support from npm CDN -->
-  <script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@0.1.0/dist/wvlet.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@2025.1.13/dist/wvlet.min.js"></script>
   
   <style>
     body {


### PR DESCRIPTION
## Summary
Added a CDN test page to demonstrate the published npm package usage and updated documentation with correct version numbers.

## Changes
- Created `test-cdn.html` with comprehensive Wvlet syntax examples
- Updated README.md with correct npm version (2025.1.13) for CDN usage
- Added theme switcher functionality to test different highlight.js themes
- Included examples of all Wvlet language features (models, queries, functions, operators, test assertions)

## Benefits
- Easy testing of the CDN-hosted package without local installation
- Visual demonstration of syntax highlighting for different Wvlet constructs
- Documentation now reflects the actual published npm package version
- Users can quickly verify the package works correctly via CDN

## Links
- NPM Package: https://www.npmjs.com/package/@wvlet/highlightjs-wvlet
- CDN URL: https://cdn.jsdelivr.net/npm/@wvlet/highlightjs-wvlet@2025.1.13/dist/wvlet.min.js

## Test plan
- [x] test-cdn.html loads and highlights Wvlet code correctly
- [x] Theme switcher works for different highlight.js themes
- [x] All syntax examples render with proper highlighting
- [x] CDN links in README are accurate and functional

🤖 Generated with [Claude Code](https://claude.ai/code)