### PR TITLE
feature: Add support for ${VARIABLE_NAME} format in profile.yml

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/Profile.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/Profile.scala
@@ -96,11 +96,11 @@ object Profile extends LogSupport:
         .split("\n")
         .map { line =>
           // Support both $VAR and ${VAR} formats
-          val envPattern = """\$\{?([A-Za-z0-9_]+)\}?""".r
+          val envPattern = """\$([A-Za-z0-9_]+)|\$\{([A-Za-z0-9_]+)\}""".r
           envPattern.replaceAllIn(
             line,
             m =>
-              val envVar = m.group(1)
+              val envVar = Option(m.group(1)).getOrElse(m.group(2))
               sys
                 .env
                 .get(envVar)

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/Profile.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/Profile.scala
@@ -95,7 +95,8 @@ object Profile extends LogSupport:
       val yamlStringEvaluated = yamlString
         .split("\n")
         .map { line =>
-          val envPattern = """\$([A-Za-z0-9_]+)""".r
+          // Support both $VAR and ${VAR} formats
+          val envPattern = """\$\{?([A-Za-z0-9_]+)\}?""".r
           envPattern.replaceAllIn(
             line,
             m =>


### PR DESCRIPTION
## Summary
- Adds support for `${VARIABLE_NAME}` braces format in profile.yml environment variable substitution
- Maintains backward compatibility with existing `$VARIABLE_NAME` format
- Both formats now properly report errors for missing environment variables

## Changes
- Updated regex pattern from `\$([A-Za-z0-9_]+)` to `\$\{?([A-Za-z0-9_]+)\}?` to support both formats
- Added comprehensive tests for braces format (both missing and existing variables)
- All existing functionality preserved

## Test plan
- [x] Added tests for missing environment variables with braces format
- [x] Added tests for successful environment variable resolution with braces format
- [x] All existing tests continue to pass
- [x] Verified both `$VAR` and `${VAR}` formats work correctly
- [x] Code formatting applied: `./sbt scalafmtAll`

🤖 Generated with [Claude Code](https://claude.ai/code)