### PR TITLE
runner: Trino→DuckDB local SaveTo — JSONL staging in .cache, COPY to Parquet (with cleanup + unit test)

### DIFF
--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -275,7 +275,7 @@ class QueryExecutor(
   private def executeSaveToLocalFileViaDuckDB(save: SaveTo)(using context: Context): QueryResult =
     import java.io.{BufferedWriter, File, FileWriter}
     import java.sql.ResultSet
-    import java.util.UUID
+    import wvlet.airframe.ulid.ULID
     import java.nio.file.{Files, Paths}
     import scala.util.Using
 
@@ -294,7 +294,7 @@ class QueryExecutor(
         .NOT_IMPLEMENTED
         .newException(s"Only Parquet is supported for Trino local save. Given: ${targetPath}")
 
-    val uid       = UUID.randomUUID().toString.replace('-', '_')
+    val uid       = ULID.newULID.toString
     val stageDir  = File(s"${workEnv.cacheFolder}/wvlet/stage/${uid}")
     val jsonlFile = File(stageDir, "export.jsonl")
     if !stageDir.exists() then

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -294,7 +294,7 @@ class QueryExecutor(
         .NOT_IMPLEMENTED
         .newException(s"Only Parquet is supported for Trino local save. Given: ${targetPath}")
 
-    val uid       = ULID.newULID.toString
+    val uid       = ULID.newULIDString
     val stageDir  = File(s"${workEnv.cacheFolder}/wvlet/stage/${uid}")
     val jsonlFile = File(stageDir, "export.jsonl")
     if !stageDir.exists() then

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/TrinoLocalSaveTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/TrinoLocalSaveTest.scala
@@ -54,13 +54,13 @@ class TrinoLocalSaveTest extends AirSpec:
     // Verify the content is readable as Parquet via DuckDB
     val duck = DuckDBConnector(work)
     try
-      duck.runQuery(s"select count(*) as c from read_parquet('${absOut.getPath.replace("'", "''")}')") {
-        rs =>
-          rs.next() shouldBe true
-          rs.getLong(1) shouldBe 2L
+      duck.runQuery(
+        s"select count(*) as c from read_parquet('${absOut.getPath.replace("'", "''")}')"
+      ) { rs =>
+        rs.next() shouldBe true
+        rs.getLong(1) shouldBe 2L
       }
-    finally
-      duck.close()
+    finally duck.close()
 
     // Cleanup
     absOut.delete() shouldBe true

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/TrinoLocalSaveTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/TrinoLocalSaveTest.scala
@@ -62,9 +62,8 @@ class TrinoLocalSaveTest extends AirSpec:
       }
     finally duck.close()
 
-    // Cleanup
-    absOut.delete() shouldBe true
-    tmpDir.toFile.delete() shouldBe true
+    // Cleanup best-effort (tmpDir may contain build artifacts)
+    absOut.delete()
   }
 
 end TrinoLocalSaveTest

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/TrinoLocalSaveTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/TrinoLocalSaveTest.scala
@@ -1,0 +1,70 @@
+package wvlet.lang.runner
+
+import wvlet.airspec.AirSpec
+import wvlet.lang.api.v1.query.QueryRequest
+import wvlet.lang.catalog.Profile
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.compiler.query.QueryProgressMonitor
+import wvlet.lang.runner.connector.DBConnectorProvider
+import wvlet.lang.runner.connector.duckdb.DuckDBConnector
+
+import java.nio.file.{Files, Paths}
+
+class TrinoLocalSaveTest extends AirSpec:
+
+  test("save to local parquet via DuckDB handoff (Generic profile)") {
+    // Set up a temporary working directory for this test
+    val tmpDir = Files.createTempDirectory("wvlet-local-save-")
+    val work   = WorkEnv(path = tmpDir.toString)
+
+    val provider = DBConnectorProvider(work)
+    val profile  = Profile.defaultGenericProfile
+    val executor = QueryExecutor(provider, profile, work)
+
+    val runner = WvletScriptRunner(
+      workEnv = work,
+      config = WvletScriptRunnerConfig(
+        interactive = false,
+        profile = profile,
+        catalog = Some("memory"),
+        schema = Some("main")
+      ),
+      queryExecutor = executor,
+      threadManager = ThreadManager()
+    )
+
+    given QueryProgressMonitor = QueryProgressMonitor.noOp
+
+    val outPath = "out.parquet"
+    val query =
+      s"""
+         |from [
+         |  [1, "a"],
+         |  [2, "b"]
+         |] as t(id, name)
+         |save to '${outPath}'
+         |""".stripMargin
+
+    val result = runner.runStatement(QueryRequest(query, isDebugRun = false))
+    result.isSuccessfulQueryResult shouldBe true
+
+    val absOut = Paths.get(tmpDir.toString, outPath).toFile
+    absOut.exists() shouldBe true
+
+    // Verify the content is readable as Parquet via DuckDB
+    val duck = DuckDBConnector(work)
+    try
+      duck.runQuery(s"select count(*) as c from read_parquet('${absOut.getPath.replace("'", "''")}')") {
+        rs =>
+          rs.next() shouldBe true
+          rs.getLong(1) shouldBe 2L
+      }
+    finally
+      duck.close()
+
+    // Cleanup
+    absOut.delete() shouldBe true
+    tmpDir.toFile.delete() shouldBe true
+  }
+
+end TrinoLocalSaveTest


### PR DESCRIPTION
Implements the core of #1143 with JSONL staging and robust cleanup.

What’s included
- Detect  on engines without native local file saves (e.g., Trino) and hand off to DuckDB.
- Execute SELECT on the current engine, stream ResultSet to JSONL under .
- Load JSONL via DuckDB  into a temp table and  to the target Parquet with .
- Robust cleanup: wrap DuckDB ops in ; drop temp table with ; log cleanup failures.
- Unit test:  validates local parquet save using Generic (DuckDB-backed) profile and verifies row count via .

Scope & constraints
- Local filesystem paths only (no  or ).
- Parquet only for now; keeps native DuckDB file-saves unchanged.

Why JSONL (not CSV)?
- Avoids CSV quoting edge cases; DuckDB supports efficient JSONL ingestion with .
- Simpler, safer staging without bringing in third-party CSV libraries.

Planned follow-ups
- Map  values (e.g., compression) to DuckDB COPY options.
- Performance tuning for large outputs.
- Integration tests with a live Trino profile.