### PR TITLE
fix: Handle QueryResultList in LocalFileReadHandoffTest

### DIFF
--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
@@ -78,14 +78,11 @@ class LocalFileReadHandoffTest extends AirSpec:
           t
         case qrl: QueryResultList =>
           // Find the TableRows within the QueryResultList
-          qrl
-            .list
-            .find(_.isInstanceOf[TableRows])
-            .map(_.asInstanceOf[TableRows])
-            .getOrElse {
+          qrl.list.collectFirst { case t: TableRows => t } match
+            case Some(t) => t
+            case None =>
               fail(s"No TableRows found in QueryResultList: ${qrl}")
               throw new RuntimeException("unreachable")
-            }
         case other =>
           fail(s"Unexpected result type: ${other}")
           throw new RuntimeException("unreachable")

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
@@ -72,19 +72,19 @@ class LocalFileReadHandoffTest extends AirSpec:
     result.isSuccessfulQueryResult shouldBe true
 
     // Extract TableRows from the result, handling both direct TableRows and QueryResultList cases
-    val tableRows =
+    val tableRows: TableRows =
       result match
         case t: TableRows =>
           t
         case qrl: QueryResultList =>
           // Find the TableRows within the QueryResultList
-          qrl.list.find(_.isInstanceOf[TableRows]).map(_.asInstanceOf[TableRows]) match
-            case Some(t) =>
-              t
-            case None =>
-              fail(s"No TableRows found in QueryResultList: ${qrl}")
+          qrl.list.find(_.isInstanceOf[TableRows]).map(_.asInstanceOf[TableRows]).getOrElse {
+            fail(s"No TableRows found in QueryResultList: ${qrl}")
+            throw new RuntimeException("unreachable")
+          }
         case other =>
           fail(s"Unexpected result type: ${other}")
+          throw new RuntimeException("unreachable")
 
     tableRows.rows.size shouldBe 1
     val v = tableRows.rows.head("c")

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
@@ -78,10 +78,14 @@ class LocalFileReadHandoffTest extends AirSpec:
           t
         case qrl: QueryResultList =>
           // Find the TableRows within the QueryResultList
-          qrl.list.find(_.isInstanceOf[TableRows]).map(_.asInstanceOf[TableRows]).getOrElse {
-            fail(s"No TableRows found in QueryResultList: ${qrl}")
-            throw new RuntimeException("unreachable")
-          }
+          qrl
+            .list
+            .find(_.isInstanceOf[TableRows])
+            .map(_.asInstanceOf[TableRows])
+            .getOrElse {
+              fail(s"No TableRows found in QueryResultList: ${qrl}")
+              throw new RuntimeException("unreachable")
+            }
         case other =>
           fail(s"Unexpected result type: ${other}")
           throw new RuntimeException("unreachable")

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
@@ -72,16 +72,19 @@ class LocalFileReadHandoffTest extends AirSpec:
     result.isSuccessfulQueryResult shouldBe true
 
     // Extract TableRows from the result, handling both direct TableRows and QueryResultList cases
-    val tableRows = result match
-      case t: TableRows =>
-        t
-      case qrl: QueryResultList =>
-        // Find the TableRows within the QueryResultList
-        qrl.list.find(_.isInstanceOf[TableRows]).map(_.asInstanceOf[TableRows]) match
-          case Some(t) => t
-          case None => fail(s"No TableRows found in QueryResultList: ${qrl}")
-      case other =>
-        fail(s"Unexpected result type: ${other}")
+    val tableRows =
+      result match
+        case t: TableRows =>
+          t
+        case qrl: QueryResultList =>
+          // Find the TableRows within the QueryResultList
+          qrl.list.find(_.isInstanceOf[TableRows]).map(_.asInstanceOf[TableRows]) match
+            case Some(t) =>
+              t
+            case None =>
+              fail(s"No TableRows found in QueryResultList: ${qrl}")
+        case other =>
+          fail(s"Unexpected result type: ${other}")
 
     tableRows.rows.size shouldBe 1
     val v = tableRows.rows.head("c")

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
@@ -78,8 +78,13 @@ class LocalFileReadHandoffTest extends AirSpec:
           t
         case qrl: QueryResultList =>
           // Find the TableRows within the QueryResultList
-          qrl.list.collectFirst { case t: TableRows => t } match
-            case Some(t) => t
+          qrl
+            .list
+            .collectFirst { case t: TableRows =>
+              t
+            } match
+            case Some(t) =>
+              t
             case None =>
               fail(s"No TableRows found in QueryResultList: ${qrl}")
               throw new RuntimeException("unreachable")


### PR DESCRIPTION
The test was failing with "Unexpected result" because the QueryExecutor.execute() method can return either a TableRows directly or a QueryResultList containing a TableRows, depending on how many results are added during execution.

Updated the test to handle both cases by extracting the TableRows from either format.

Fixes ##1150

Generated with [Claude Code](https://claude.ai/code)