### PR TITLE
fix(runner): return last successful result; test: flaky LocalFileReadHandoff

### DIFF
--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -160,7 +160,14 @@ class QueryExecutor(
           report(QueryResult.empty)
 
     process(executionPlan)(using context)
-    QueryResult.fromList(results.result())
+    // Prefer the last successful result when no results were accumulated.
+    // This guards against execution paths that update `lastResult` but do not
+    // add to the `results` builder (e.g., nested task flows).
+    val aggregated = QueryResult.fromList(results.result())
+    if aggregated.isEmpty && !lastResult.isEmpty then
+      lastResult
+    else
+      aggregated
 
   end execute
 

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
@@ -74,8 +74,8 @@ class LocalFileReadHandoffTest extends AirSpec:
       result.isSuccessfulQueryResult shouldBe true
 
       // Extract TableRows from the result, handling both direct TableRows and QueryResultList cases
-      val tableRows: TableRows =
-        result match
+      val tableRows =
+        result shouldMatch {
           case t: TableRows =>
             t
           case qrl: QueryResultList =>
@@ -85,24 +85,23 @@ class LocalFileReadHandoffTest extends AirSpec:
               .collectFirst { case t: TableRows =>
                 t
               } match
-              case Some(t) =>
-                t
-              case None =>
+              case Some(rows) =>
+                rows
+              case _ =>
                 fail(s"No TableRows found in QueryResultList: ${qrl}")
-                throw new RuntimeException("unreachable")
-          case other =>
-            fail(s"Unexpected result type: ${other}")
-            throw new RuntimeException("unreachable")
+        }
 
-      tableRows.rows.size shouldBe 1
-      val v = tableRows.rows.head("c")
-      val n =
-        v match
-          case x: java.lang.Number =>
-            x.longValue()
-          case x =>
-            x.toString.toLong
-      n shouldBe 2L
+      tableRows shouldMatch { case t: TableRows =>
+        t.rows.size shouldBe 1
+        val v = t.rows.head("c")
+        val n =
+          v match
+            case x: java.lang.Number =>
+              x.longValue()
+            case x =>
+              x.toString.toLong
+        n shouldBe 2L
+      }
     }
 
     // cleanup best-effort (tmpDir may contain build artifacts)

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
@@ -105,8 +105,8 @@ class LocalFileReadHandoffTest extends AirSpec:
       n shouldBe 2L
     }
 
-      // cleanup best-effort (tmpDir may contain build artifacts)
-      out.delete()
+    // cleanup best-effort (tmpDir may contain build artifacts)
+    out.delete()
   }
 
 end LocalFileReadHandoffTest

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/LocalFileReadHandoffTest.scala
@@ -70,7 +70,7 @@ class LocalFileReadHandoffTest extends AirSpec:
     flaky {
       val result = runner.runStatement(QueryRequest(q, isDebugRun = false))
       // Print for debugging in CI/local runs
-      println(result.toPrettyBox())
+      debug(result.toPrettyBox())
       result.isSuccessfulQueryResult shouldBe true
 
       // Extract TableRows from the result, handling both direct TableRows and QueryResultList cases


### PR DESCRIPTION
Summary
- Fix: Prefer `lastResult` when aggregated results are empty in `QueryExecutor.execute`, ensuring a non-empty `TableRows` is returned when execution updated `lastResult` but didn’t add to the results list.
- Test: Minimize flaky scope in `LocalFileReadHandoffTest` by wrapping only the execution+assertion block in `flaky { ... }`. Replace `println` with `debug` for CI-friendly logging.

Context
- Addresses intermittent failure: LocalFileReadHandoffTest was receiving an empty `QueryResult`, leading to `Unexpected result type`. The executor could process results and update `lastResult` without accumulating into the result list.

Implementation Details
- QueryExecutor: After processing, compute `aggregated = QueryResult.fromList(results)`. If it’s empty and `lastResult` is non-empty, return `lastResult`; otherwise return `aggregated`.
- Test: Keep setup deterministic, only wrap the runner execution/validation in `flaky { ... }`.

Validation
- Suggested: `./sbt "runner/testOnly *LocalFileReadHandoffTest -- -l debug"` then `./sbt runner/test`.

Notes
- This preserves existing error shapes and logging.
- If further flakiness shows up, we can extend retries or add a small await on file readiness, but currently the test already awaits file existence.
