### PR TITLE
fix: Address Scala 3.7 upgrade deprecation warnings

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -44,7 +44,7 @@ case class GlobalContext(compilerOptions: CompilerOptions):
   private val contextTable = new ConcurrentHashMap[SourceFile, Context]().asScala
 
   // Globally available definitions (Name and Symbols)
-  var defs: GlobalDefinitions = _
+  var defs: GlobalDefinitions = scala.compiletime.uninitialized
 
   var defaultCatalog: Catalog = loadCatalog(compilerOptions)
   var defaultSchema: String   = compilerOptions.schema.getOrElse("main")

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/Scanner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/Scanner.scala
@@ -95,7 +95,7 @@ abstract class ScannerBase[Token](sourceFile: SourceFile, config: ScannerConfig)
   protected var commentBuffer: List[TokenData[Token]] = Nil
 
   // The last read character
-  protected var ch: Char = _
+  protected var ch: Char = scala.compiletime.uninitialized
   // The offset +1 of the last read character
   protected var charOffset: Int = config.startFrom
   // The offset before the last read character

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/TreeNode.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/TreeNode.scala
@@ -27,8 +27,8 @@ trait TreeNode extends TreeNodeCompat
 
 trait SyntaxTreeNode extends TreeNode with Product with LogSupport:
   private var _symbol: Symbol                  = Symbol.NoSymbol
-  private var _comment: List[TokenData[_]]     = Nil
-  private var _postComment: List[TokenData[_]] = Nil
+  private var _comment: List[TokenData[?]]     = Nil
+  private var _postComment: List[TokenData[?]] = Nil
 
   def linePosition(using ctx: Context): LinePosition = ctx.sourceLocationAt(span).position
 
@@ -70,8 +70,8 @@ trait SyntaxTreeNode extends TreeNode with Product with LogSupport:
   def symbol: Symbol            = _symbol
   def symbol_=(s: Symbol): Unit = _symbol = s
 
-  def comments: List[TokenData[_]]     = _comment
-  def postComments: List[TokenData[_]] = _postComment
+  def comments: List[TokenData[?]]     = _comment
+  def postComments: List[TokenData[?]] = _postComment
 
   def withComment(d: TokenData[?]): this.type =
     _comment = d :: _comment

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/Expression.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/Expression.scala
@@ -51,7 +51,7 @@ trait Expression extends SyntaxTreeNode with LogSupport:
         case Some(x) =>
           Some(recursiveTransform(x))
         case s: Seq[?] =>
-          s.map(recursiveTransform _)
+          s.map(recursiveTransform)
         case other: AnyRef =>
           other
         case null =>
@@ -70,7 +70,7 @@ trait Expression extends SyntaxTreeNode with LogSupport:
         case Some(x) =>
           Some(recursiveTraverse(x))
         case s: Seq[?] =>
-          s.map(recursiveTraverse _)
+          s.map(recursiveTraverse)
         case other: AnyRef =>
         case null          =>
     productIterator.foreach(recursiveTraverse)
@@ -85,7 +85,7 @@ trait Expression extends SyntaxTreeNode with LogSupport:
         case Some(x) =>
           Some(recursiveTraverse(x))
         case s: Seq[?] =>
-          s.map(recursiveTraverse _)
+          s.map(recursiveTraverse)
         case other: AnyRef =>
         case null          =>
     productIterator.foreach(recursiveTraverse)
@@ -225,7 +225,7 @@ trait Expression extends SyntaxTreeNode with LogSupport:
         case Some(x) =>
           recursiveCollect(x)
         case s: Seq[?] =>
-          s.flatMap(recursiveCollect _).toList
+          s.flatMap(recursiveCollect).toList
         case other: AnyRef =>
           Nil
         case null =>
@@ -243,7 +243,7 @@ trait Expression extends SyntaxTreeNode with LogSupport:
         case Some(x) =>
           recursiveTraverse(x)
         case s: Seq[?] =>
-          s.foreach(recursiveTraverse _)
+          s.foreach(recursiveTraverse)
         case other: AnyRef =>
         case null          =>
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/LogicalPlan.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/LogicalPlan.scala
@@ -87,7 +87,7 @@ trait LogicalPlan extends SyntaxTreeNode:
         case Some(x) =>
           collectExpression(x)
         case s: Iterable[?] =>
-          s.flatMap(collectExpression _).toSeq
+          s.flatMap(collectExpression).toSeq
         case other =>
           Nil
 
@@ -117,7 +117,7 @@ trait LogicalPlan extends SyntaxTreeNode:
         case Some(x) =>
           Some(transformElement(x))
         case s: Seq[?] =>
-          s.map(transformElement _)
+          s.map(transformElement)
         case other: AnyRef =>
           other
         case null =>
@@ -269,7 +269,7 @@ trait LogicalPlan extends SyntaxTreeNode:
         case Some(x) =>
           Some(transformElement(x))
         case s: Seq[?] =>
-          s.map(transformElement _)
+          s.map(transformElement)
         case other: AnyRef =>
           other
         case null =>
@@ -302,7 +302,7 @@ trait LogicalPlan extends SyntaxTreeNode:
         case Some(x) =>
           Some(recursiveTransform(x))
         case s: Seq[?] =>
-          s.map(recursiveTransform _)
+          s.map(recursiveTransform)
         case other: AnyRef =>
           other
         case null =>
@@ -337,7 +337,7 @@ trait LogicalPlan extends SyntaxTreeNode:
         case Some(x) =>
           Some(loopOnlyPlan(x))
         case s: Seq[?] =>
-          s.map(loopOnlyPlan _)
+          s.map(loopOnlyPlan)
         case other: AnyRef =>
           other
         case null =>
@@ -381,7 +381,7 @@ trait LogicalPlan extends SyntaxTreeNode:
         case Some(x) =>
           Some(iter(x))
         case s: Seq[?] =>
-          s.map(iter _)
+          s.map(iter)
         case other: AnyRef =>
           other
         case null =>
@@ -418,7 +418,7 @@ trait LogicalPlan extends SyntaxTreeNode:
         case Some(x) =>
           Some(iterOnce(x))
         case s: Seq[?] =>
-          s.map(iterOnce _)
+          s.map(iterOnce)
         case other: AnyRef =>
           other
         case null =>
@@ -445,7 +445,7 @@ trait LogicalPlan extends SyntaxTreeNode:
         case Some(x) =>
           recursiveCollect(x)
         case s: Seq[?] =>
-          s.flatMap(recursiveCollect _).toList
+          s.flatMap(recursiveCollect).toList
         case other: AnyRef =>
           Nil
         case null =>
@@ -481,7 +481,7 @@ trait LogicalPlan extends SyntaxTreeNode:
         case Some(x) =>
           recursiveTraverse(x)
         case s: Seq[?] =>
-          s.foreach(recursiveTraverse _)
+          s.foreach(recursiveTraverse)
         case other: AnyRef =>
         case null          =>
 


### PR DESCRIPTION
## Summary
- Fixed deprecated function `_` syntax by removing trailing `_` (e.g., `map(func _)` → `map(func)`)
- Replaced deprecated `_` wildcard in type arguments with `?` (e.g., `List[_]` → `List[?]`) 
- Updated deprecated `= _` uninitialized fields to use `scala.compiletime.uninitialized`

## Test Plan
- [x] Verified compilation succeeds without Scala 3.7 deprecation warnings
- [x] All changes maintain backward compatibility 
- [ ] CI tests will confirm no functional regressions

Fixes all deprecation warnings introduced by the Scala 3.7.2 upgrade, following modern Scala 3 best practices while maintaining full backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)