### PR TITLE
fix: Enable deprecation warnings and fix ambiguous ordering issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ val buildSettings = Seq[Setting[?]](
   description       := "wvlet: A flow-style query language",
   crossPaths        := true,
   publishMavenStyle := true,
+  scalacOptions ++= Seq("-deprecation", "-feature"),
   // Tell the runtime that we are running tests in SBT
   Test / testOptions += Tests.Setup(_ => sys.props("wvlet.sbt.testing") = "true"),
   Test / javaOptions += "-Dwvlet.sbt.testing=true",

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -133,7 +133,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     end attachComments
 
     if allNodes.nonEmpty then
-      val sortedComments = scanner.getCommentTokens().sortBy(_.span.end)
+      val sortedComments = scanner.getCommentTokens().sortBy(_.span.end)(using Ordering.Int)
       attachComments(sortedComments, allNodes.tail, allNodes.head)
 
     l


### PR DESCRIPTION
## Summary
- Added `-deprecation` and `-feature` flags to `buildSettings` in build.sbt
- Fixed ambiguous ordering deprecation warning in WvletParser.scala by explicitly specifying `Ordering.Int`

## Test Plan
- [x] Added deprecation warnings to build configuration for better visibility
- [x] Fixed the specific ambiguous ordering issue that was causing deprecation warnings
- [ ] CI will test that compilation works correctly

This change enables better visibility of deprecation warnings during development while fixing a specific deprecation issue related to ambiguous ordering in sortBy operations.

🤖 Generated with [Claude Code](https://claude.ai/code)