### PR TITLE
fix: Add .jvmopts to suppress JDK 24 warnings

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,2 @@
+--sun-misc-unsafe-memory-access=allow
+--enable-native-access=ALL-UNNAMED


### PR DESCRIPTION
## Summary
- Added `.jvmopts` file with JVM options to suppress warnings when running with JDK 24
- Includes `--sun-misc-unsafe-memory-access=allow` to suppress sun.misc.Unsafe deprecation warnings  
- Includes `--enable-native-access=ALL-UNNAMED` to enable native method access

## Test plan
- [x] Verify `.jvmopts` file is properly formatted
- [ ] Test SBT startup with JDK 24 to confirm warnings are suppressed

Resolves issues mentioned in https://github.com/sbt/sbt/issues/8073

🤖 Generated with [Claude Code](https://claude.ai/code)