### PR TITLE
feat: Use json.gz compression for stage cache storage

### DIFF
--- a/sbt
+++ b/sbt
@@ -254,7 +254,7 @@ is_apple_silicon() { [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]
 default_jvm_opts() {
   local -r v="$(java_version)"
   if [[ $v -ge 24 ]]; then
-    echo "default_jvm_opts_common --sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED"
+    echo "$default_jvm_opts_common --sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED"
   elif [[ $v -ge 17 ]]; then
     echo "$default_jvm_opts_common"
   elif [[ $v -ge 10 ]]; then

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -280,8 +280,9 @@ class QueryExecutor(
     * Note: This is a scaffolding entry point; full ingestion will follow.
     */
   private def executeSaveToLocalFileViaDuckDB(save: SaveTo)(using context: Context): QueryResult =
-    import java.io.{BufferedWriter, File, FileWriter}
+    import java.io.{BufferedWriter, File, FileOutputStream, FileWriter, OutputStreamWriter}
     import java.sql.ResultSet
+    import java.util.zip.GZIPOutputStream
     import wvlet.airframe.ulid.ULID
     import java.nio.file.{Files, Paths}
     import scala.util.Using
@@ -303,14 +304,20 @@ class QueryExecutor(
 
     val uid       = ULID.newULIDString
     val stageDir  = File(s"${workEnv.cacheFolder}/wvlet/stage/${uid}")
-    val jsonlFile = File(stageDir, "export.jsonl")
+    val jsonlFile = File(stageDir, "export.jsonl.gz")
     if !stageDir.exists() then
       Files.createDirectories(Paths.get(stageDir.getPath))
 
     def writeJSONL(rs: ResultSet, out: File): Long =
       var rowCount = 0L
       val rowCodec = MessageCodec.of[ListMap[String, Any]]
-      Using.resource(BufferedWriter(FileWriter(out))) { w =>
+      Using.resource(
+        BufferedWriter(
+          OutputStreamWriter(
+            GZIPOutputStream(FileOutputStream(out))
+          )
+        )
+      ) { w =>
         val codec = JDBCCodec(rs)
         val it = codec.mapMsgPackMapRows { msgpack =>
           rowCodec.fromMsgPack(msgpack)
@@ -328,7 +335,7 @@ class QueryExecutor(
     given monitor: QueryProgressMonitor = context.queryProgressMonitor
     getDBConnector(defaultProfile).runQuery(baseSQL.sql) { rs =>
       val n = writeJSONL(rs, jsonlFile)
-      workEnv.info(s"Exported ${n} rows to JSONL at ${jsonlFile.getPath}")
+      workEnv.info(s"Exported ${n} rows to compressed JSONL at ${jsonlFile.getPath}")
       n
     }
 
@@ -350,7 +357,7 @@ class QueryExecutor(
         catch
           case NonFatal(e) =>
             workEnv.warn(s"${msg}: ${e.getMessage}")
-      safe(s"Failed to delete temporary JSONL ${jsonlFile.getPath}") {
+      safe(s"Failed to delete temporary compressed JSONL ${jsonlFile.getPath}") {
         jsonlFile.delete()
       }
       safe(s"Failed to delete stage dir ${stageDir.getPath}") {

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -311,22 +311,17 @@ class QueryExecutor(
     def writeJSONL(rs: ResultSet, out: File): Long =
       var rowCount = 0L
       val rowCodec = MessageCodec.of[ListMap[String, Any]]
-      Using.resource(
-        BufferedWriter(
-          OutputStreamWriter(
-            GZIPOutputStream(FileOutputStream(out))
-          )
-        )
-      ) { w =>
-        val codec = JDBCCodec(rs)
-        val it = codec.mapMsgPackMapRows { msgpack =>
-          rowCodec.fromMsgPack(msgpack)
-        }
-        while it.hasNext do
-          val row = it.next()
-          w.write(rowCodec.toJson(row))
-          w.newLine()
-          rowCount += 1
+      Using.resource(BufferedWriter(OutputStreamWriter(GZIPOutputStream(FileOutputStream(out))))) {
+        w =>
+          val codec = JDBCCodec(rs)
+          val it = codec.mapMsgPackMapRows { msgpack =>
+            rowCodec.fromMsgPack(msgpack)
+          }
+          while it.hasNext do
+            val row = it.next()
+            w.write(rowCodec.toJson(row))
+            w.newLine()
+            rowCount += 1
       }
       rowCount
 


### PR DESCRIPTION
Implement gzip compression for query result caching to reduce disk space usage.
DuckDB's read_json_auto() automatically handles compressed JSON files.

Changes:
- Update file extension from export.jsonl to export.jsonl.gz
- Add GZIPOutputStream wrapper for JSON output stream
- Update logging to mention compressed JSONL format

Fixes #1163

Generated with [Claude Code](https://claude.ai/code)