### PR TITLE
doc: Add table variable syntax documentation

### DIFF
--- a/website/docs/syntax/index.md
+++ b/website/docs/syntax/index.md
@@ -267,6 +267,7 @@ val products(id, name, price) = [
 
 from products
 where _.price > 50
+-- Returns [[1, "Laptop", 999.99], [3, "Keyboard", 79.99]]
 ```
 
 You can specify type annotations for table columns:

--- a/website/docs/syntax/index.md
+++ b/website/docs/syntax/index.md
@@ -253,6 +253,37 @@ select s"Hello ${x}!" as msg
 -- Returns [['Hello wvlet!']]
 ```
 
+#### Table Variable Constants
+
+You can also define table constants using the `val` keyword with column names and data:
+
+```wvlet
+-- Basic table value constant
+val products(id, name, price) = [
+  [1, "Laptop", 999.99],
+  [2, "Mouse", 29.99],
+  [3, "Keyboard", 79.99],
+]
+
+from products
+where _.price > 50
+```
+
+You can specify type annotations for table columns:
+
+```wvlet
+-- With type annotations
+val users(id:int, name:string, active:boolean) = [
+  [1, "Alice", true],
+  [2, "Bob", false],
+]
+
+from users
+where active = true
+```
+
+This syntax allows you to define inline data tables that can be referenced in your queries, which is particularly useful for testing, small lookup tables, or providing sample data.
+
 ### Conditional Expressions
 
 | Operator                             | Description                                                                      |

--- a/website/docs/syntax/index.md
+++ b/website/docs/syntax/index.md
@@ -281,6 +281,7 @@ val users(id:int, name:string, active:boolean) = [
 
 from users
 where active = true
+-- Returns [[1, "Alice", true]]
 ```
 
 This syntax allows you to define inline data tables that can be referenced in your queries, which is particularly useful for testing, small lookup tables, or providing sample data.


### PR DESCRIPTION
Add documentation for table variable constants syntax to the Variable Definition section.

This covers the new table constant syntax implemented in #1138:
- Basic table value constant syntax with column names
- Type annotations for table columns
- Usage examples showing how to reference table constants in queries

Fixes #1165

Generated with [Claude Code](https://claude.ai/code)