### PR TITLE
fix: Add nocache parameter to contrib.rocks URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ See [Catalog Management](https://wvlet.org/wvlet/docs/usage/catalog-management) 
 
 Many thanks to everyone who has contributed to our progress:
 
-[![Contributors](https://contrib.rocks/image?repo=wvlet/wvlet)](https://github.com/wvlet/wvlet/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=wvlet/wvlet&nocache=1)](https://github.com/wvlet/wvlet/graphs/contributors)


### PR DESCRIPTION
## Summary
- Add `nocache=1` parameter to contrib.rocks URL in README to ensure fresh contributor badge

## Changes
- Modified the contrib.rocks image URL to include `&nocache=1` parameter
- This prevents browser/CDN caching issues and ensures the contributors badge always displays current data

🤖 Generated with [Claude Code](https://claude.ai/code)