### PR TITLE
doc: Fix capitalization of wvlet to Wvlet in documentation

### DIFF
--- a/website/docs/syntax/quick-start.md
+++ b/website/docs/syntax/quick-start.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## A Walk-Through Example
 
-Let's start with a simple example. If you haven't installed `wv` command, [install wvlet command](../usage/install.md) to your machine. `wv` command starts an [interactive shell](../usage/repl.md), which is backed by DuckDB in-memory database by default.
+Let's start with a simple example. If you haven't installed `wv` command, [install Wvlet command](../usage/install.md) to your machine. `wv` command starts an [interactive shell](../usage/repl.md), which is backed by DuckDB in-memory database by default.
 
 For the ease of learning, let's create a sample [TPC-H benchmark](https://www.tpc.org/tpch/) data set:
 
@@ -30,7 +30,7 @@ wv> show tables;
 │ 8 rows     │
 └────────────┘
 ```
-The `execute sql"call dbgen(sf=0.01)"` command calls DuckDB's [TPC-H extension](https://duckdb.org/docs/extensions/tpch.html) and creates an in-memory TPC-H benchmark database, which will be gone when you exit the wvlet shell. So you can try this command without worrying about the disk space.
+The `execute sql"call dbgen(sf=0.01)"` command calls DuckDB's [TPC-H extension](https://duckdb.org/docs/extensions/tpch.html) and creates an in-memory TPC-H benchmark database, which will be gone when you exit the Wvlet shell. So you can try this command without worrying about the disk space.
 
 The simplest form of queries is `from (table name)`:
 ```wvlet
@@ -51,7 +51,7 @@ wv> from customer;
 ```
 
 This query returns all the columns in the `customer` table.
-If the query result doesn't fit to the screen, wvlet shell enters [UNIX `less` command](https://en.wikipedia.org/wiki/Less_(Unix)#:~:text=less%20is%20a%20terminal%20pager,backward%20navigation%20through%20the%20file.) mode, which
+If the query result doesn't fit to the screen, Wvlet shell enters [UNIX `less` command](https://en.wikipedia.org/wiki/Less_(Unix)#:~:text=less%20is%20a%20terminal%20pager,backward%20navigation%20through%20the%20file.) mode, which
 allows to navigate table data using arrow keys, page up/down keys, and `q` key to exit the mode. See [Interactive Shell](../usage/repl.md) for the list of the available shortcut keys.
 
 To limit the number of rows to display, you can use `limit` operator:
@@ -71,7 +71,7 @@ wv> from customer
 ```
 
 :::tip
-Separators `|` between expressions are shown only while editing queries. You don't need to type `|` in the wvlet shell or in query files.
+Separators `|` between expressions are shown only while editing queries. You don't need to type `|` in the Wvlet shell or in query files.
 :::
 
 

--- a/website/docs/usage/install.md
+++ b/website/docs/usage/install.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Installation
 
-Wvlet is available as a command-line tool. You can install wvlet using Homebrew on macOS or download a binary package for other platforms.
+Wvlet is available as a command-line tool. You can install Wvlet using Homebrew on macOS or download a binary package for other platforms.
 
 ## Command Line Tools
 
@@ -19,7 +19,7 @@ Language SDKs are also available for [Python and TypeScript](../bindings) to com
 
 ## Mac OS X
 
-For macOS, you can install wvlet using [Homebrew](https://brew.sh/):
+For macOS, you can install Wvlet using [Homebrew](https://brew.sh/):
 
 ```bash
 brew install wvlet/wvlet/wvlet
@@ -27,7 +27,7 @@ brew install wvlet/wvlet/wvlet
 
 This will install `wv (wvlet)` command to your system.
 
-To upgrade wvlet, run:
+To upgrade Wvlet, run:
 ```bash
 brew upgrade wvlet
 ```
@@ -46,11 +46,11 @@ For other platforms (e.g., Linux, Windows, etc.), download a binary package wvle
 
 You can find wv command in the bin directory of the package. Add the bin directory to your PATH environment variable.
 
-JDK17 or later is required to run wvlet. Set JAVA_HOME environment variable to the JDK path.
+JDK17 or later is required to run Wvlet. Set JAVA_HOME environment variable to the JDK path.
 
 ## Quick Start
 
-After installing wvlet, start learning the query syntax of Wvlet:
+After installing Wvlet, start learning the query syntax of Wvlet:
 - [Query Syntax](../syntax) to learn the query syntax
 
 
@@ -92,4 +92,4 @@ For full details, including troubleshooting and development guides, please see t
 
 ## Building From Source
 
-See [Building Wvlet](../development/build.md) for building wvlet from source.
+See [Building Wvlet](../development/build.md) for building Wvlet from source.

--- a/website/docs/usage/install.md
+++ b/website/docs/usage/install.md
@@ -92,4 +92,4 @@ For full details, including troubleshooting and development guides, please see t
 
 ## Building From Source
 
-See [Building Wvlet](../development/build.md) for building Wvlet from source.
+See [Building Wvlet](../development/build.md) for instructions on building it from source.


### PR DESCRIPTION
## Summary

Fixed instances where "wvlet" should be capitalized to "Wvlet" when referring to the project name in user-facing documentation. This ensures consistent branding and proper capitalization throughout the docs.

## Changes Made

- `website/docs/usage/install.md`: Fixed 6 instances where "wvlet" should be "Wvlet" when referring to the project
- `website/docs/syntax/quick-start.md`: Fixed 3 instances where "wvlet" should be "Wvlet" when referring to the project/shell

## Notes

- Preserved lowercase "wvlet" when it refers to:
  - Command names (e.g., `wvlet ui`, `wvlet compile`) 
  - Domain names (e.g., wvlet.org)
  - Package names (e.g., @wvlet/wvlet)
  - File extensions and technical references

🤖 Generated with [Claude Code](https://claude.ai/code)