### PR TITLE
fix: Exclude JSON file changes from native workflow trigger

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -26,7 +26,6 @@ jobs:
               - '**.scala'
               - '**.sbt'
               - '**.conf'
-              - '**.json'
               - '**.wv'
               - SCALA_VERSION
   build_native:


### PR DESCRIPTION
## Summary
- Removes `**.json` pattern from native.yml workflow filters to prevent unnecessary CI runs
- Optimizes resource usage by excluding package-lock.json and other JSON files that don't affect native builds

## Test plan
- [x] Verify workflow file syntax is valid
- [x] Confirm native workflow no longer triggers on JSON-only changes

🤖 Generated with [Claude Code](https://claude.ai/code)