### PR TITLE
Remove static catalog support mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,28 +36,9 @@ With this flow style, you can describe data processing pipelines in a natural or
 
 - **Flow-style syntax**: Write queries in the natural order of data processing
 - **Multi-database support**: Works with DuckDB, Trino, Hive, and more
-- **Static catalog support**: Compile queries offline without database connections
 - **Interactive REPL**: Explore data interactively with auto-completion
 - **Type-safe queries**: Catch errors at compile time with schema validation
 - **Modular queries**: Organize and reuse queries as functions
-
-### Static Catalog Support
-
-Wvlet can export database catalog metadata (schemas, tables, columns) to JSON files and use them for offline query compilation. This enables:
-
-- **CI/CD Integration**: Validate queries in pull requests without database access
-- **Faster Development**: Compile queries instantly without network latency
-- **Version Control**: Track schema changes alongside your queries
-
-```bash
-# Export catalog metadata
-wvlet catalog import --name mydb
-
-# Compile queries offline
-wvlet compile query.wv --use-static-catalog --catalog mydb
-```
-
-See [Catalog Management](https://wvlet.org/wvlet/docs/usage/catalog-management) for more details.
 
 ## Contributors
 


### PR DESCRIPTION
## Summary
- Removed static catalog support feature from the Key Features list
- Removed the detailed Static Catalog Support section

## Reason
This feature is being deprecated or no longer actively promoted in the project.

## Changes
- Removed mention of "Static catalog support" from the Key Features list
- Removed the entire "Static Catalog Support" subsection including usage examples

🤖 Generated with [Claude Code](https://claude.ai/code)