### PR TITLE
feature: Add double-quoted string completion support to wv REPL

### DIFF
--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/LocalFileCompleter.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/LocalFileCompleter.scala
@@ -75,10 +75,13 @@ case class LocalFileCompleter(workEnv: WorkEnv) extends Completer:
 
       if baseDir.exists() && baseDir.isDirectory then
         def escapeQuotes(s: String, quoteChar: Char): String =
-          if quoteChar == '\'' then
-            s.replace("'", "''")
-          else
-            s.replace("\"", "\\\"")
+          quoteChar match
+            case '\'' =>
+              s.replace("'", "''")
+            case '"' =>
+              s.replace("\"", "\\\"")
+            case _ =>
+              s
 
         val showHidden = leafPrefix.startsWith(".")
         val entries: Array[File] = Option(baseDir.listFiles())

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/LocalFileCompleter.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/LocalFileCompleter.scala
@@ -8,7 +8,7 @@ import scala.jdk.CollectionConverters.*
 
 /**
   * A simple completer that offers local filesystem paths when the cursor is inside a single-quoted
-  * or double-quoted string literal, e.g., from 'pa<TAB>' or from "pa<TAB>". Paths are resolved 
+  * or double-quoted string literal, e.g., from 'pa<TAB>' or from "pa<TAB>". Paths are resolved
   * relative to WorkEnv.path and only local (non-remote) suggestions are provided.
   */
 case class LocalFileCompleter(workEnv: WorkEnv) extends Completer:


### PR DESCRIPTION
## Summary
- Extended LocalFileCompleter to support file path completion for double-quoted strings
- Preserves existing single-quoted string completion functionality
- Properly escapes quotes based on the quote type being used

## Changes
- Modified `LocalFileCompleter.scala` to detect both single and double quotes
- Added appropriate escaping for both quote types (single quotes use `''`, double quotes use `\"`)
- Updated documentation to reflect support for both quote types

## Test plan
- [x] Verified code compiles successfully with `./sbt "cli/Test/compile"`
- [ ] Test single-quoted string completion continues to work (e.g., `from 'READ<TAB>'`)
- [ ] Test double-quoted string completion now works (e.g., `from "READ<TAB>"`)
- [ ] Test that files with special characters are properly escaped in both quote types

🤖 Generated with [Claude Code](https://claude.ai/code)