### PR TITLE
Upgrade sbt-pack to 0.22 with Java 24 JVM options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -344,6 +344,14 @@ lazy val cli = project
         // wvlet compiler/run/ui server command launcher
         "wvlet" -> "wvlet.lang.cli.WvletMain"
       ),
+    packJvmVersionSpecificOpts := Map(
+      "wv" -> Map(
+        24 -> Seq("--sun-misc-unsafe-memory-access=allow", "--enable-native-access=ALL-UNNAMED")
+      ),
+      "wvlet" -> Map(
+        24 -> Seq("--sun-misc-unsafe-memory-access=allow", "--enable-native-access=ALL-UNNAMED")
+      )
+    ),
     packResourceDir ++= Map(file("wvlet-ui-main/dist") -> "web")
   )
   .dependsOn(server)

--- a/build.sbt
+++ b/build.sbt
@@ -344,14 +344,13 @@ lazy val cli = project
         // wvlet compiler/run/ui server command launcher
         "wvlet" -> "wvlet.lang.cli.WvletMain"
       ),
-    packJvmVersionSpecificOpts := Map(
-      "wv" -> Map(
-        24 -> Seq("--sun-misc-unsafe-memory-access=allow", "--enable-native-access=ALL-UNNAMED")
-      ),
-      "wvlet" -> Map(
-        24 -> Seq("--sun-misc-unsafe-memory-access=allow", "--enable-native-access=ALL-UNNAMED")
+    packJvmVersionSpecificOpts := {
+      val java24Opts = Seq("--sun-misc-unsafe-memory-access=allow", "--enable-native-access=ALL-UNNAMED")
+      Map(
+        "wv"    -> Map(24 -> java24Opts),
+        "wvlet" -> Map(24 -> java24Opts)
       )
-    ),
+    },
     packResourceDir ++= Map(file("wvlet-ui-main/dist") -> "web")
   )
   .dependsOn(server)

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -37,7 +37,7 @@ addDependencyTreePlugin
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
 // For packaging Scala project into a executable folder
-addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.21")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.22")
 
 // For compiling model classes from SQL templates
 libraryDependencies += "org.duckdb" % "duckdb_jdbc" % "1.3.2.1"


### PR DESCRIPTION
## Summary
- Upgraded sbt-pack plugin from 0.21 to 0.22
- Added Java 24 specific JVM options to prevent warnings and ensure compatibility

Before this PR:
```
$ wv
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by scala.runtime.LazyVals$ (file:/Users/leo/local/wvlet-cli/wvlet-cli-2025.1.18+18-3d373d14/lib/scala3-library_3-3.7.2.jar)
WARNING: Please consider reporting this to the maintainers of class scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.jline.nativ.JLineNativeLoader in an unnamed module (file:/Users/leo/local/wvlet-cli/wvlet-cli-2025.1.18+18-3d373d14/lib/jline-3.30.5.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

After this PR:
```
$ wv
> wv
```

## Changes
- **sbt-pack upgrade**: Version 0.21 → 0.22
  - Enables new `packJvmVersionSpecificOpts` feature for Java version-specific JVM options
- **Java 24 JVM options**: Added for both `wv` and `wvlet` commands
  - `--sun-misc-unsafe-memory-access=allow`: Allows unsafe memory access (terminally deprecated in Java 24)
  - `--enable-native-access=ALL-UNNAMED`: Enables native access for all unnamed modules

## Test plan
- [x] Verified project compiles successfully with sbt-pack 0.22
- [x] CLI compilation test passed: `./sbt "cli/compile"`
- [ ] Test launch scripts with Java 24 detect and apply the correct JVM options

## Notes
These JVM options address the warnings seen when running with Java 24, particularly:
- `WARNING: sun.misc.Unsafe::objectFieldOffset has been called`
- Native access warnings for unnamed modules

The launch scripts generated by sbt-pack 0.22 will automatically detect the Java version and apply these options only when running with Java 24 or later.

🤖 Generated with [Claude Code](https://claude.ai/code)