### PR TITLE
doc: Add comment syntax documentation to Query Syntax reference

### DIFF
--- a/website/docs/syntax/index.md
+++ b/website/docs/syntax/index.md
@@ -248,10 +248,8 @@ This model provides filtered customer data for analytics:
 - Adds calculated fields for analysis
 
 Example usage:
-```wvlet
-from customer_analysis
-where signup_date >= '2024-01-01':date
-```
+    from customer_analysis
+    where signup_date >= '2024-01-01':date
 ---
 model customer_analysis = {
   from customers

--- a/website/docs/syntax/index.md
+++ b/website/docs/syntax/index.md
@@ -19,6 +19,7 @@ New to Wvlet? Check out the [Quick Start](./quick-start.md) tutorial for a hands
 - [Joining & Combining Data](#joining--combining-data)
 - [Sorting & Transformation](#sorting--transformation)
 - [Advanced Operations](#advanced-operations)
+- [Comments](#comments)
 - [Expressions](#expressions)
 - [Common Query Patterns](#common-query-patterns)
 
@@ -215,6 +216,56 @@ These commands help you understand query structure and data.
 | __describe__ `query` | Show query schema | Understanding output columns |
 | __explain__ `query` | Show logical plan | Query optimization |
 | __explain__ sql"..." | Explain raw SQL | SQL debugging |
+
+## Comments
+
+Wvlet supports two types of comments for documenting your queries and models:
+
+### Single-line Comments (`--`)
+
+Use double hyphens (`--`) for single-line comments. Everything after `--` on the same line is treated as a comment and ignored during query execution:
+
+```wvlet
+-- This is a single-line comment
+from customers
+where age > 18  -- Filter for adults only
+-- Another comment
+select name, email
+```
+
+### Documentation Comments (`---`)
+
+Use triple hyphens (`---`) for documentation comments, especially for documenting models. These comments support Markdown formatting and are used for generating documentation:
+
+```wvlet
+---
+## Customer Analysis Model
+
+This model provides filtered customer data for analytics:
+
+- Includes only active customers
+- Excludes test accounts
+- Adds calculated fields for analysis
+
+Example usage:
+```wvlet
+from customer_analysis
+where signup_date >= '2024-01-01':date
+```
+---
+model customer_analysis = {
+  from customers
+  where status = 'active'
+  where email not like '%test%'
+  add current_date - signup_date as days_since_signup
+}
+```
+
+Documentation comments are particularly useful for:
+- Describing the purpose and usage of models
+- Providing examples of how to use the model
+- Documenting data transformations and business logic
+- Adding metadata for team collaboration
 
 ## Expressions
 

--- a/website/docs/syntax/index.md
+++ b/website/docs/syntax/index.md
@@ -219,7 +219,7 @@ These commands help you understand query structure and data.
 
 ## Comments
 
-Wvlet supports two types of comments for documenting your queries and models:
+Wvlet supports two types of comments for documenting your queries:
 
 ### Single-line Comments (`--`)
 
@@ -248,8 +248,8 @@ This model provides filtered customer data for analytics:
 - Adds calculated fields for analysis
 
 Example usage:
-    from customer_analysis
-    where signup_date >= '2024-01-01':date
+  from customer_analysis
+  where signup_date >= '2024-01-01':date
 ---
 model customer_analysis = {
   from customers


### PR DESCRIPTION
## Summary
Added comprehensive documentation for Wvlet's comment syntax to the Query Syntax reference:

- **Single-line comments (`--`)**: For inline comments and query annotations
- **Documentation comments (`---`)**: For model documentation with Markdown support

## Changes Made
- Added new "Comments" section to `/website/docs/syntax/index.md`
- Updated table of contents to include the Comments section
- Provided clear examples and use cases for both comment types
- Fixed markdown formatting issues with nested code blocks

## Documentation Includes
- Syntax explanations with examples
- Best practices for using each comment type
- Integration examples showing comments in context
- Clear guidance on when to use documentation comments vs regular comments

## Test Plan
- [x] Verified markdown syntax renders correctly
- [x] Confirmed examples are syntactically correct
- [x] Tested navigation links work properly
- [x] Fixed nested code block parsing issues

This addresses the gap in documentation around Wvlet's comment syntax, making it easier for users to understand how to document their queries and models effectively.

🤖 Generated with [Claude Code](https://claude.ai/code)