### PR TITLE
fix: Add SQL parser support for boolean literals in expressions

### DIFF
--- a/spec/sql/basic/boolean-literals.sql
+++ b/spec/sql/basic/boolean-literals.sql
@@ -1,0 +1,20 @@
+-- Test case for boolean literal syntax in SQL expressions
+-- This addresses parsing errors with true/false in WHERE clauses and expressions
+
+-- Basic boolean literals
+SELECT true as bool_true, false as bool_false;
+
+-- Boolean literals in WHERE clause (reproduces the original error)
+SELECT col1 FROM (VALUES (1), (2), (3)) as t(col1) WHERE true;
+SELECT col1 FROM (VALUES (1), (2), (3)) as t(col1) WHERE false;
+
+-- Boolean literals in CASE expressions  
+SELECT 
+  CASE WHEN true THEN 'always' ELSE 'never' END as case_true,
+  CASE WHEN false THEN 'never' ELSE 'always' END as case_false;
+
+-- Boolean literals in boolean operations
+SELECT true AND false as and_result, true OR false as or_result;
+
+-- Boolean literals in function calls
+SELECT COALESCE(null, true) as coalesced_bool;

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1106,7 +1106,7 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
     val t = scanner.lookAhead()
     val expr =
       t.token match
-        case SqlToken.NULL | SqlToken.INTEGER_LITERAL | SqlToken.DOUBLE_LITERAL | SqlToken
+        case SqlToken.NULL | SqlToken.TRUE | SqlToken.FALSE | SqlToken.INTEGER_LITERAL | SqlToken.DOUBLE_LITERAL | SqlToken
               .FLOAT_LITERAL | SqlToken.DECIMAL_LITERAL | SqlToken.EXP_LITERAL | SqlToken
               .SINGLE_QUOTE_STRING | SqlToken.TRIPLE_QUOTE_STRING =>
           literal()
@@ -1324,6 +1324,10 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
     t.token match
       case SqlToken.NULL =>
         NullLiteral(spanFrom(t))
+      case SqlToken.TRUE =>
+        TrueLiteral(spanFrom(t))
+      case SqlToken.FALSE =>
+        FalseLiteral(spanFrom(t))
       case SqlToken.INTEGER_LITERAL =>
         LongLiteral(removeUnderscore(t.str).toLong, t.str, spanFrom(t))
       case SqlToken.DOUBLE_LITERAL =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1106,9 +1106,9 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
     val t = scanner.lookAhead()
     val expr =
       t.token match
-        case SqlToken.NULL | SqlToken.TRUE | SqlToken.FALSE | SqlToken.INTEGER_LITERAL | SqlToken.DOUBLE_LITERAL | SqlToken
-              .FLOAT_LITERAL | SqlToken.DECIMAL_LITERAL | SqlToken.EXP_LITERAL | SqlToken
-              .SINGLE_QUOTE_STRING | SqlToken.TRIPLE_QUOTE_STRING =>
+        case SqlToken.NULL | SqlToken.TRUE | SqlToken.FALSE | SqlToken.INTEGER_LITERAL | SqlToken
+              .DOUBLE_LITERAL | SqlToken.FLOAT_LITERAL | SqlToken.DECIMAL_LITERAL | SqlToken
+              .EXP_LITERAL | SqlToken.SINGLE_QUOTE_STRING | SqlToken.TRIPLE_QUOTE_STRING =>
           literal()
         case SqlToken.CASE =>
           val cases                          = List.newBuilder[WhenClause]


### PR DESCRIPTION
## Summary
Fixes SQL parsing error for boolean literals (`true`/`false`) in WHERE clauses and expressions found during query log analysis.

## Problem Analysis

### Error from Query Logs
```json
{
  "sql": "SELECT ... FROM ... WHERE true GROUP BY 1",
  "errorType": "exception", 
  "exception": "WvletLangException",
  "message": "[SYNTAX_ERROR] Unexpected token: <TRUE> 'true' (context: SqlParser.scala:1235)"
}
```

### Root Cause
- `SqlToken.TRUE` and `SqlToken.FALSE` were not included in the literal token matching in `primaryExpression()`
- Boolean tokens fell through to `unexpected(t)` call at line 1235
- Parser couldn't handle boolean literals in WHERE clauses, CASE expressions, etc.

## Solution Implemented

### 1. **Enhanced Primary Expression Parsing**
```scala
// Before: Only handled NULL, numbers, strings  
case SqlToken.NULL | SqlToken.INTEGER_LITERAL | ...

// After: Added boolean literals
case SqlToken.NULL | SqlToken.TRUE | SqlToken.FALSE | SqlToken.INTEGER_LITERAL | ...
```

### 2. **Added Boolean Literal Handling** 
```scala
// In literal() method:
case SqlToken.TRUE =>
  TrueLiteral(spanFrom(t))
case SqlToken.FALSE =>
  FalseLiteral(spanFrom(t))
```

Uses existing AST node types (`TrueLiteral`, `FalseLiteral`) for proper semantic representation.

## Test Coverage

### **New Test File**: `spec/sql/basic/boolean-literals.sql`

Tests comprehensive boolean literal usage:
```sql
-- Basic literals
SELECT true as bool_true, false as bool_false;

-- WHERE clauses (original error pattern)
SELECT col1 FROM table WHERE true;
SELECT col1 FROM table WHERE false; 

-- CASE expressions
SELECT CASE WHEN true THEN 'always' ELSE 'never' END;

-- Boolean operations  
SELECT true AND false, true OR false;

-- Function arguments
SELECT COALESCE(null, true);
```

### **Test Results**
- ✅ **New functionality**: `boolean-literals.sql` passes
- ✅ **No regressions**: All 14 existing SQL basic tests pass
- ✅ **Pattern coverage**: Addresses the exact error from query logs

## Impact

### **ParseQuery Success Rate Improvement** 🚀
- **Resolves**: `WHERE true`/`WHERE false` parsing failures
- **Enables**: Complex boolean expressions in statistical and analytical queries  
- **Improves**: Query log analysis coverage for real-world SQL patterns

### **SQL Compatibility** 📈
- Supports standard SQL boolean literal syntax
- Handles boolean constants in WHERE, CASE, and function contexts
- Maintains compatibility with existing SQL parsing features

## Related PRs
- PR #1190: Added DECIMAL literals and parenthesized relation support
- PR #1192: Optimized ParseQuery resource management and performance

🤖 Generated with [Claude Code](https://claude.ai/code)