### PR TITLE
feature: Support DuckDB and extended Trino SQL sampling syntax variations

### DIFF
--- a/spec/sql/basic/tablesample.sql
+++ b/spec/sql/basic/tablesample.sql
@@ -15,3 +15,21 @@ SELECT * FROM information_schema.tables TABLESAMPLE SYSTEM (15);
 
 -- TABLESAMPLE with DECIMAL percentage
 SELECT * FROM information_schema.tables TABLESAMPLE BERNOULLI (DECIMAL '12');
+
+-- DuckDB TABLESAMPLE with percentage symbol
+SELECT * FROM information_schema.tables TABLESAMPLE BERNOULLI (10%);
+
+-- DuckDB USING SAMPLE with row count
+SELECT * FROM information_schema.tables USING SAMPLE 5;
+
+-- DuckDB USING SAMPLE with explicit rows keyword
+SELECT * FROM information_schema.tables USING SAMPLE 5 rows;
+
+-- DuckDB USING SAMPLE with percentage
+SELECT * FROM information_schema.tables USING SAMPLE 10%;
+
+-- DuckDB USING SAMPLE with explicit percent keyword  
+SELECT * FROM information_schema.tables USING SAMPLE 10 percent;
+
+-- DuckDB USING SAMPLE with reservoir method
+SELECT * FROM information_schema.tables USING SAMPLE reservoir(10%);

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -654,7 +654,26 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
         consume(SqlToken.TABLESAMPLE)
         val methodName = identifier() // e.g., BERNOULLI, SYSTEM
         consume(SqlToken.L_PAREN)
-        val percentage = expression() // percentage value
+        val sizeExpr = expression() // percentage value or expression
+        
+        // Handle DuckDB percentage syntax: 10% or method(10%)
+        val (percentage, hasPercentSymbol) = sizeExpr match
+          case ArithmeticBinaryExpr(BinaryExprType.Modulus, percentageExpr, _, _) =>
+            // Handle "10 % " as percentage
+            val value = percentageExpr match
+              case LongLiteral(value, _, _) => value.toDouble
+              case DoubleLiteral(value, _, _) => value
+              case DecimalLiteral(value, _, _) => value.toDouble
+              case _ => unexpected(percentageExpr)
+            (value, true)
+          case other =>
+            val value = other match
+              case LongLiteral(value, _, _) => value.toDouble
+              case DoubleLiteral(value, _, _) => value
+              case DecimalLiteral(value, _, _) => value.toDouble
+              case _ => unexpected(other)
+            (value, false)
+        
         consume(SqlToken.R_PAREN)
 
         // Convert method name to SamplingMethod
@@ -665,19 +684,76 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
             case _: IllegalArgumentException =>
               unexpected(methodName)
 
-        // Convert percentage expression to SamplingSize
-        // In Trino SQL, both BERNOULLI and SYSTEM use integer percentage values
-        val percentageValue =
-          percentage match
-            case LongLiteral(value, _, _) =>
-              value.toDouble
-            case DoubleLiteral(value, _, _) =>
-              value
-            case DecimalLiteral(value, _, _) =>
-              value.toDouble
-            case _ =>
-              unexpected(percentage)
-        Sample(r, Some(method), SamplingSize.Percentage(percentageValue), spanFrom(r.span))
+        Sample(r, Some(method), SamplingSize.Percentage(percentage), spanFrom(r.span))
+      case SqlToken.USING =>
+        // Handle DuckDB USING SAMPLE syntax
+        consume(SqlToken.USING)
+        consume(SqlToken.SAMPLE)
+        
+        val sizeExpr = expression()
+        
+        // Check for optional keywords after the size expression
+        val (samplingSize, samplingMethod) = scanner.lookAhead().token match
+          case SqlToken.ROWS =>
+            consume(SqlToken.ROWS)
+            val rows = sizeExpr match
+              case LongLiteral(value, _, _) => value
+              case _ => unexpected(sizeExpr)
+            (SamplingSize.Rows(rows), None)
+          case SqlToken.PERCENT =>
+            consume(SqlToken.PERCENT)
+            val percentage = sizeExpr match
+              case LongLiteral(value, _, _) => value.toDouble
+              case DoubleLiteral(value, _, _) => value
+              case DecimalLiteral(value, _, _) => value.toDouble
+              case _ => unexpected(sizeExpr)
+            (SamplingSize.Percentage(percentage), None)
+          case SqlToken.L_PAREN =>
+            // Handle reservoir(10%) syntax
+            val methodName = sizeExpr match
+              case i: Identifier => i.leafName.toLowerCase
+              case _ => unexpected(sizeExpr)
+            
+            consume(SqlToken.L_PAREN)
+            val percentage = expression() match
+              case ArithmeticBinaryExpr(BinaryExprType.Modulus, percentageExpr, _, _) =>
+                percentageExpr match
+                  case LongLiteral(value, _, _) => value.toDouble
+                  case DoubleLiteral(value, _, _) => value
+                  case DecimalLiteral(value, _, _) => value.toDouble
+                  case _ => unexpected(percentageExpr)
+              case LongLiteral(value, _, _) => value.toDouble
+              case DoubleLiteral(value, _, _) => value
+              case DecimalLiteral(value, _, _) => value.toDouble
+              case other => unexpected(other)
+            consume(SqlToken.R_PAREN)
+            
+            val method = try
+              SamplingMethod.valueOf(methodName)
+            catch
+              case _: IllegalArgumentException => unexpected(sizeExpr)
+            
+            (SamplingSize.Percentage(percentage), Some(method))
+          case _ =>
+            // Default case: determine if it's rows or percentage based on the expression
+            sizeExpr match
+              case ArithmeticBinaryExpr(BinaryExprType.Modulus, percentageExpr, _, _) =>
+                val percentage = percentageExpr match
+                  case LongLiteral(value, _, _) => value.toDouble
+                  case DoubleLiteral(value, _, _) => value
+                  case DecimalLiteral(value, _, _) => value.toDouble
+                  case _ => unexpected(percentageExpr)
+                (SamplingSize.Percentage(percentage), None)
+              case LongLiteral(value, _, _) =>
+                // Could be rows or percentage - default to rows for USING SAMPLE
+                (SamplingSize.Rows(value), None)
+              case DoubleLiteral(value, _, _) =>
+                (SamplingSize.Percentage(value), None)
+              case DecimalLiteral(value, _, _) =>
+                (SamplingSize.Percentage(value.toDouble), None)
+              case _ => unexpected(sizeExpr)
+        
+        Sample(r, samplingMethod, samplingSize, spanFrom(r.span))
       case _ =>
         r
 
@@ -686,6 +762,10 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
     t.token match
       case SqlToken.TABLESAMPLE =>
         // Handle TABLESAMPLE and continue with other relation operations
+        val sampledR = handleTableSample(r)
+        relationRest(sampledR)
+      case SqlToken.USING =>
+        // Handle USING SAMPLE and continue with other relation operations
         val sampledR = handleTableSample(r)
         relationRest(sampledR)
       case SqlToken.COMMA =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -135,6 +135,9 @@ enum SqlToken(val tokenType: TokenType, val str: String):
   case ORDINALITY  extends SqlToken(Keyword, "ordinality")
   case TABLESAMPLE extends SqlToken(Keyword, "tablesample")
   case BERNOULLI   extends SqlToken(Keyword, "bernoulli")
+  case SAMPLE      extends SqlToken(Keyword, "sample")
+  case PERCENT     extends SqlToken(Keyword, "percent")
+  case RESERVOIR   extends SqlToken(Keyword, "reservoir")
 
   case ALL      extends SqlToken(Keyword, "all")
   case DISTINCT extends SqlToken(Keyword, "distinct")
@@ -307,6 +310,9 @@ object SqlToken:
     SqlToken.NO,
     SqlToken.WITHOUT,
     SqlToken.ORDINALITY,
+    SqlToken.SAMPLE,
+    SqlToken.PERCENT,
+    SqlToken.RESERVOIR,
     // DDL entity types - non-reserved so they can be used as table/column names
     SqlToken.CATALOG,
     SqlToken.DATABASE,


### PR DESCRIPTION
Support sampling SQL variations as requested in # 1197

This PR adds comprehensive support for various SQL sampling syntaxes in SqlParser:

### Changes:
- Add SAMPLE, PERCENT, and RESERVOIR tokens to SqlToken
- Enhance SqlParser.handleTableSample to support DuckDB USING SAMPLE syntax
- Support percentage literals with % symbol
- Support explicit rows/percent keywords
- Support method-specific sampling like reservoir()
- Add comprehensive test cases

### Supported Syntax:
- Trino: `TABLESAMPLE BERNOULLI (10)`
- DuckDB: `TABLESAMPLE BERNOULLI (10%)`
- DuckDB: `USING SAMPLE 5`, `USING SAMPLE 5 rows`
- DuckDB: `USING SAMPLE 10%`, `USING SAMPLE 10 percent`
- DuckDB: `USING SAMPLE reservoir(10%)`

Generated with [Claude Code](https://claude.ai/code)