### PR TITLE
fix: Add TRY_CAST function support to SqlParser

### DIFF
--- a/spec/sql/basic/try-cast.sql
+++ b/spec/sql/basic/try-cast.sql
@@ -1,0 +1,15 @@
+-- Basic TRY_CAST functionality tests
+
+-- Simple TRY_CAST with string to integer
+SELECT TRY_CAST('123' AS bigint) as result1;
+
+-- TRY_CAST with invalid conversion (should return NULL)
+SELECT TRY_CAST('abc' AS bigint) as result2;
+
+-- TRY_CAST in SELECT with column alias
+SELECT 
+  TRY_CAST(regexp_extract('job_id:12345', 'job_id:(.*)', 1) AS bigint) as job_id,
+  TRY_CAST('42' AS int) as number;
+
+-- TRY_CAST with function call
+SELECT TRY_CAST(substring('test123', 5) AS int) as extracted_num;

--- a/spec/sql/basic/try-cast.sql
+++ b/spec/sql/basic/try-cast.sql
@@ -13,3 +13,17 @@ SELECT
 
 -- TRY_CAST with function call
 SELECT TRY_CAST(substring('test123', 5) AS int) as extracted_num;
+
+-- TRY_CAST with various data types
+SELECT TRY_CAST('3.14159' AS double) as pi_double;
+SELECT TRY_CAST('123.456' AS decimal) as decimal_num;
+
+-- TRY_CAST with NULL input
+SELECT TRY_CAST(NULL AS int) as null_result;
+
+-- TRY_CAST in WHERE clause
+SELECT * FROM VALUES (1, 'valid'), (2, 'invalid') AS t(id, str_val) 
+WHERE TRY_CAST(t.str_val AS int) IS NULL;
+
+-- TRY_CAST with edge cases and out-of-range values
+SELECT TRY_CAST('999999999999999999999' AS int) as overflow_result;

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1309,7 +1309,12 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
       case b: NotBetween =>
         wl(expr(b.e), "not between", expr(b.a), "and", expr(b.b))
       case c: Cast =>
-        group(wl(text("cast") + paren(wl(expr(c.child), "as", text(c.tpe.typeName.name)))))
+        val castKeyword =
+          if c.tryCast then
+            "try_cast"
+          else
+            "cast"
+        group(wl(text(castKeyword) + paren(wl(expr(c.child), "as", text(c.tpe.typeName.name)))))
       case n: NativeExpression =>
         expr(ExpressionEvaluator.eval(n))
       case e: Exists =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -294,7 +294,8 @@ object SqlToken:
     SqlToken.DECIMAL,
     SqlToken.JSON,
     SqlToken.INTERVAL,
-    SqlToken.CAST
+    SqlToken.CAST,
+    SqlToken.TRY_CAST
   )
 
   // Keywords that can be used as unquoted identifiers


### PR DESCRIPTION
## Summary
- Fixed SqlParser syntax error when encountering TRY_CAST functions
- Added TRY_CAST to literalStartKeywords to allow parsing in SELECT clauses  
- Updated SqlGenerator to emit 'try_cast' instead of 'cast' when tryCast flag is set
- Added comprehensive test cases for TRY_CAST functionality

## Test plan
- [x] Added spec/sql/basic/try-cast.sql with various TRY_CAST test cases
- [x] Verified existing TRY_CAST usage in json-literals.sql still works
- [x] Confirmed original error query now parses correctly
- [x] Ran scalafmt to ensure proper code formatting

🤖 Generated with [Claude Code](https://claude.ai/code)