### PR TITLE
fix: Support escaped quotes in SQL string literals

### DIFF
--- a/spec/sql/basic/escaped-quotes.sql
+++ b/spec/sql/basic/escaped-quotes.sql
@@ -1,0 +1,25 @@
+-- Test escaped quotes in string literals
+
+-- Simple escaped quote
+SELECT 'Don''t worry' as message1;
+
+-- Multiple escaped quotes
+SELECT 'It''s a ''test'' string' as message2;
+
+-- Escaped quotes in function arguments
+SELECT regexp_replace('test', '(''quoted'')', '$1') as result1;
+
+-- Complex regex pattern with escaped quotes (similar to the original error)
+SELECT regexp_replace('test string', '(?ims)(.*)(INSERT INTO)([\\s\\n]*(''?\\S+''?))?(.*)', '$2$3 $1$4') as result2;
+
+-- Standard CASE expression with escaped quotes
+SELECT 
+  CASE 
+    WHEN col1 = 'O''Reilly' THEN 'Author''s name contains apostrophe'
+    WHEN col1 LIKE '%''%' THEN 'Contains quote character'  
+    ELSE 'No quotes'
+  END as quote_check
+FROM VALUES ('O''Reilly'), ('Smith'), ('D''Angelo') AS t(col1);
+
+-- Standard CONCAT with escaped quotes
+SELECT CONCAT('Hello, ', 'it''s me') as greeting;


### PR DESCRIPTION
## Summary
- Fixed SqlParser to properly handle escaped single quotes ('') in SQL string literals
- Updated Scanner.getSingleQuoteString() to follow SQL standard for quote escaping  
- Added comprehensive test cases covering various escaped quote scenarios

## Problem
The original error occurred when parsing complex regex patterns containing escaped quotes:
```
"Expected R_PAREN, but found SINGLE_QUOTE_STRING"
```
This happened because the scanner treated consecutive single quotes as separate tokens instead of an escaped quote within a string.

## Solution  
Modified the string parsing logic to:
1. Detect consecutive single quotes within string literals
2. Treat `''` as a single escaped quote character 
3. Continue parsing the string until the actual terminating quote

## Test plan
- [x] Added spec/sql/basic/escaped-quotes.sql with comprehensive test cases
- [x] Verified existing SQL tests still pass (27/27 passing)
- [x] Tested with patterns similar to the original error case
- [x] Used standard SQL functions instead of vendor-specific ones

🤖 Generated with [Claude Code](https://claude.ai/code)