### PR TITLE
feature: Add support for Trino TRIM syntax

### DIFF
--- a/spec/sql/basic/trim-function.sql
+++ b/spec/sql/basic/trim-function.sql
@@ -1,0 +1,31 @@
+-- Test TRIM function with Trino syntax
+-- https://github.com/wvlet/wvlet/issues/1231
+
+-- Basic TRIM (default removes spaces from both sides)
+SELECT trim('  hello  ');
+
+-- TRIM with specific characters FROM
+SELECT trim('!' FROM '!foo!');
+
+-- LEADING option - removes from the beginning
+SELECT trim(LEADING FROM '  abcd');
+SELECT trim(LEADING ' ' FROM '  abcd');
+
+-- TRAILING option - removes from the end  
+SELECT trim(TRAILING FROM 'abcd  ');
+SELECT trim(TRAILING ' ' FROM 'abcd  ');
+
+-- BOTH option (default) - removes from both sides
+SELECT trim(BOTH FROM '  abcd  ');
+SELECT trim(BOTH ' ' FROM '  abcd  ');
+SELECT trim(BOTH '$' FROM '$var$');
+
+-- TRIM with multi-character patterns
+SELECT trim(TRAILING 'ER' FROM upper('worker'));
+
+-- Nested function calls with TRIM
+SELECT trim(BOTH '0' FROM concat('00', '123', '00'));
+
+-- TRIM in WHERE clause
+SELECT * FROM (VALUES ('  test  '), ('test'), ('  test')) AS t(col)
+WHERE trim(col) = 'test';

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1145,17 +1145,13 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
             // Build the TRIM expression
             val trimParts = List.newBuilder[Doc]
             trimType.foreach(t => trimParts += text(t))
-            trimChars.foreach { chars =>
-              if trimType.isDefined then
-                trimParts += text(" ")
-              trimParts += expr(chars)
-            }
+            trimChars.foreach(chars => trimParts += expr(chars))
             if trimType.isDefined || trimChars.isDefined then
-              trimParts += text(" from ")
-
+              trimParts += text("from")
+              
             fromExpr.foreach(e => trimParts += expr(e))
 
-            parts ++= trimParts.result()
+            parts += wl(trimParts.result()*)
             parts += text(")")
 
             val result = group(concat(parts.result()))

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1105,17 +1105,75 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
       case g: UnresolvedGroupingKey =>
         expr(g.child)
       case f: FunctionApply =>
-        val base =
-          f.base match
-            case d: DoubleQuoteString =>
-              // Handle double-quoted strings as identifiers when used as function names
-              text(doubleQuoteIfNecessary(d.unquotedValue))
-            case other =>
-              expr(other)
-        val args = paren(cl(f.args.map(x => expr(x))))
-        val w    = f.window.map(x => expr(x))
-        val stem = base + args
-        wl(stem, w)
+        // Special handling for TRIM function
+        f.base match
+          case id: UnquotedIdentifier if id.unquotedValue.toLowerCase == "trim" =>
+            // Generate special TRIM syntax
+            val parts = List.newBuilder[Doc]
+            parts += text("trim")
+            parts += text("(")
+
+            // Parse the arguments to reconstruct TRIM syntax
+            var trimType: Option[String]      = None
+            var trimChars: Option[Expression] = None
+            var fromExpr: Option[Expression]  = None
+
+            f.args
+              .foreach { arg =>
+                arg.name match
+                  case Some(name) if name.name == "from" =>
+                    fromExpr = Some(arg.value)
+                  case _ =>
+                    arg.value match
+                      case id: UnquotedIdentifier if id.unquotedValue.toUpperCase == "LEADING" =>
+                        trimType = Some("LEADING")
+                      case id: UnquotedIdentifier if id.unquotedValue.toUpperCase == "TRAILING" =>
+                        trimType = Some("TRAILING")
+                      case id: UnquotedIdentifier if id.unquotedValue.toUpperCase == "BOTH" =>
+                        trimType = Some("BOTH")
+                      case _ =>
+                        if trimChars.isEmpty && fromExpr.isEmpty then
+                          // First non-keyword argument is either trimChars or the string to trim
+                          if f.args.exists(_.name.exists(_.name == "from")) then
+                            trimChars = Some(arg.value)
+                          else
+                            fromExpr = Some(arg.value)
+                        else if trimChars.isEmpty then
+                          trimChars = Some(arg.value)
+              }
+
+            // Build the TRIM expression
+            val trimParts = List.newBuilder[Doc]
+            trimType.foreach(t => trimParts += text(t))
+            trimChars.foreach { chars =>
+              if trimType.isDefined then
+                trimParts += text(" ")
+              trimParts += expr(chars)
+            }
+            if trimType.isDefined || trimChars.isDefined then
+              trimParts += text(" from ")
+
+            fromExpr.foreach(e => trimParts += expr(e))
+
+            parts ++= trimParts.result()
+            parts += text(")")
+
+            val result = group(concat(parts.result()))
+            f.window.map(w => wl(result, expr(w))).getOrElse(result)
+
+          case _ =>
+            // Regular function handling
+            val base =
+              f.base match
+                case d: DoubleQuoteString =>
+                  // Handle double-quoted strings as identifiers when used as function names
+                  text(doubleQuoteIfNecessary(d.unquotedValue))
+                case other =>
+                  expr(other)
+            val args = paren(cl(f.args.map(x => expr(x))))
+            val w    = f.window.map(x => expr(x))
+            val stem = base + args
+            wl(stem, w)
       case w: WindowApply =>
         val base   = expr(w.base)
         val window = expr(w.window)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1148,7 +1148,7 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
             trimChars.foreach(chars => trimParts += expr(chars))
             if trimType.isDefined || trimChars.isDefined then
               trimParts += text("from")
-              
+
             fromExpr.foreach(e => trimParts += expr(e))
 
             parts += wl(trimParts.result()*)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -146,6 +146,10 @@ enum SqlToken(val tokenType: TokenType, val str: String):
 
   case CAST     extends SqlToken(Keyword, "cast")
   case TRY_CAST extends SqlToken(Keyword, "try_cast")
+  case TRIM     extends SqlToken(Keyword, "trim")
+  case LEADING  extends SqlToken(Keyword, "leading")
+  case TRAILING extends SqlToken(Keyword, "trailing")
+  case BOTH     extends SqlToken(Keyword, "both")
 
   // window spec
   case PARTITION extends SqlToken(Keyword, "partition")
@@ -306,6 +310,10 @@ object SqlToken:
   val nonReservedKeywords = Set(
     SqlToken.IF,      // IF can be used as a function name
     SqlToken.REPLACE, // REPLACE can be used as a function name
+    SqlToken.TRIM,    // TRIM can be used as a function name
+    SqlToken.LEADING,
+    SqlToken.TRAILING,
+    SqlToken.BOTH,
     SqlToken.KEY,
     SqlToken.SYSTEM,
     SqlToken.PRIMARY,


### PR DESCRIPTION
## Summary

Implements support for advanced TRIM function syntax in Trino SQL, resolving #1231.

## Supported Syntax

The following TRIM syntax variations are now supported:
- `TRIM(string)` - removes spaces from both sides
- `TRIM(chars FROM string)` - removes specific chars from both sides  
- `TRIM(LEADING FROM string)` - removes spaces from beginning
- `TRIM(TRAILING FROM string)` - removes spaces from end
- `TRIM(BOTH chars FROM string)` - removes specific chars from both sides
- `TRIM(TRAILING 'ER' FROM upper('worker'))` - works with nested functions

## Implementation Details

### Parser Changes
- Added `TRIM`, `LEADING`, `TRAILING`, `BOTH` tokens to `SqlToken.scala`
- Added these as non-reserved keywords so they can still be used as identifiers
- Implemented special parsing logic in `SqlParser.scala` to handle TRIM's unique syntax

### Code Generation
- Added special handling in `SqlGenerator.scala` to generate proper TRIM SQL syntax
- TRIM is represented internally as a `FunctionApply` but generates special SQL

## Test plan

- [x] Added comprehensive test cases in `spec/sql/basic/trim-function.sql`
- [x] All tests pass with the new implementation
- [x] Code formatted with `scalafmtAll`

## Example

```sql
SELECT trim('  hello  ');           -- 'hello'
SELECT trim('!' FROM '!foo!');      -- 'foo'
SELECT trim(LEADING FROM '  abcd'); -- 'abcd'
SELECT trim(BOTH '$' FROM '$var$'); -- 'var'
```

🤖 Generated with [Claude Code](https://claude.ai/code)