### PR TITLE
fix: Support double-quoted aliases for subqueries in JOIN clauses

### DIFF
--- a/spec/sql/basic/aliased-join-subquery.sql
+++ b/spec/sql/basic/aliased-join-subquery.sql
@@ -1,0 +1,46 @@
+-- Test aliased subqueries in JOIN clauses
+-- This was failing with "Expected R_PAREN, but found DOUBLE_QUOTE_STRING"
+
+-- Simple aliased subquery in LEFT JOIN with double quotes
+SELECT *
+FROM (VALUES (1, 'a'), (2, 'b')) AS t1(id, name)
+LEFT JOIN (
+  SELECT * FROM (VALUES (1, 'x'), (3, 'y')) AS t2(id, value)
+) "alias1" ON t1.id = alias1.id;
+
+-- Aliased subquery without AS keyword
+SELECT *
+FROM (VALUES (1, 'a'), (2, 'b')) AS t1(id, name)
+LEFT JOIN (
+  SELECT * FROM (VALUES (1, 'x'), (3, 'y')) AS t2(id, value)
+) alias2 ON t1.id = alias2.id;
+
+-- Complex nested subquery with alias using double underscores
+SELECT *
+FROM (VALUES (1, 10), (2, 20)) AS t1(id, amount)
+LEFT JOIN (
+  SELECT 
+    id,
+    SUM(value) as total
+  FROM (VALUES (1, 5), (1, 10), (2, 15)) AS t3(id, value)
+  GROUP BY id
+) "__behavior" ON t1.id = __behavior.id;
+
+-- Multiple aliased subqueries in joins
+SELECT *
+FROM (VALUES (1, 'a'), (2, 'b')) AS t1(id, name)
+LEFT JOIN (
+  SELECT * FROM (VALUES (1, 'x')) AS t2(id, val)
+) "first_sub" ON t1.id = first_sub.id
+LEFT JOIN (
+  SELECT * FROM (VALUES (2, 100)) AS t3(id, num)
+) "second_sub" ON t1.id = second_sub.id;
+
+-- Aliased subquery with AS keyword
+SELECT *
+FROM (
+  SELECT * FROM (VALUES (1, 'test')) AS t1(id, name)
+) AS "__audience"
+LEFT JOIN (
+  SELECT * FROM (VALUES (1, 'data')) AS t2(id, info)
+) AS "__behavior" ON __audience.id = __behavior.id;

--- a/wvlet-labs/src/main/scala/wvlet/lang/labs/ParseQuery.scala
+++ b/wvlet-labs/src/main/scala/wvlet/lang/labs/ParseQuery.scala
@@ -169,7 +169,7 @@ class ParseQuery() extends LogSupport:
               else
                 0.0
             info(
-              f"Final: ${queryCount}%,d queries, ${errorCount}%,d failed (${errorRate}%.1f%% error rate)"
+              f"Final: ${queryCount}%,d queries, ${errorCount}%,d failed (${errorRate}%.3f%% error rate)"
             )
           }
         }

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -2322,9 +2322,7 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
       case SqlToken.AS =>
         consume(SqlToken.AS)
         tableAlias(r)
-      case SqlToken.DOUBLE_QUOTE_STRING =>
-        tableAlias(r)
-      case id if id.isIdentifier =>
+      case id if id.isIdentifier || id == SqlToken.DOUBLE_QUOTE_STRING =>
         tableAlias(r)
       case _ =>
         r

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -2322,6 +2322,8 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
       case SqlToken.AS =>
         consume(SqlToken.AS)
         tableAlias(r)
+      case SqlToken.DOUBLE_QUOTE_STRING =>
+        tableAlias(r)
       case id if id.isIdentifier =>
         tableAlias(r)
       case _ =>


### PR DESCRIPTION
## Summary
- Fixes parsing error when using double-quoted aliases for subqueries in JOIN clauses
- Resolves "Expected R_PAREN, but found DOUBLE_QUOTE_STRING" error

## Problem
The parser was failing when encountering SQL like:
```sql
LEFT JOIN (
  SELECT ...
) "__behavior" ON ...
```

The parser only recognized regular identifiers as aliases, not double-quoted strings.

## Solution
Added `DOUBLE_QUOTE_STRING` token handling in the `relation()` method to properly recognize double-quoted aliases alongside regular identifiers.

## Test plan
- [x] Added comprehensive test cases in `spec/sql/basic/aliased-join-subquery.sql`
- [x] Tests cover double-quoted aliases, unquoted aliases, and AS keyword usage
- [x] All tests pass with SqlBasicSpec runner
- [x] Code formatted with scalafmtAll

🤖 Generated with [Claude Code](https://claude.ai/code)