### PR TITLE
fix: Support JSON_OBJECT with KEY...VALUE syntax in SqlParser

### DIFF
--- a/spec/sql/basic/json-object.sql
+++ b/spec/sql/basic/json-object.sql
@@ -1,0 +1,31 @@
+-- Test JSON_OBJECT with simple alternating key-value (DuckDB style)
+SELECT JSON_OBJECT('age', 30);
+SELECT JSON_OBJECT('name', 'Alice', 'age', 25);
+SELECT JSON_OBJECT('item_count', 10, 'ctr', 0.15);
+
+-- Test JSON_OBJECT with KEY...VALUE syntax (Standard SQL style)
+SELECT JSON_OBJECT(KEY 'age' VALUE 30);
+SELECT JSON_OBJECT(KEY 'name' VALUE 'Alice', KEY 'age' VALUE 25);
+SELECT JSON_OBJECT(KEY 'item_count' VALUE 10, KEY 'ctr' VALUE 0.15);
+
+-- Test with column references (DuckDB style)
+SELECT JSON_OBJECT('id', user_id, 'name', user_name)
+FROM (VALUES (1, 'Alice'), (2, 'Bob')) AS users(user_id, user_name);
+
+-- Test with column references (Standard SQL style)
+SELECT JSON_OBJECT(KEY 'id' VALUE user_id, KEY 'name' VALUE user_name)
+FROM (VALUES (3, 'Charlie'), (4, 'Diana')) AS users2(user_id, user_name);
+
+-- Complex example with KEY...VALUE syntax
+SELECT
+  col1,
+  JSON_OBJECT(KEY 'age' VALUE age, KEY 'item_count' VALUE item_count, KEY 'ctr' VALUE ctr)
+FROM
+  (VALUES ('test', 25, 10, 0.15)) AS t(col1, age, item_count, ctr)
+WHERE col1 IS NOT NULL;
+
+-- Test with modifiers (Standard SQL)
+SELECT JSON_OBJECT(KEY 'age' VALUE age NULL ON NULL)
+FROM (VALUES (25), (NULL)) AS t(age);
+
+SELECT JSON_OBJECT(KEY 'a' VALUE 1, KEY 'b' VALUE 2 WITHOUT UNIQUE KEYS);

--- a/spec/sql/basic/json-object.sql
+++ b/spec/sql/basic/json-object.sql
@@ -28,4 +28,30 @@ WHERE col1 IS NOT NULL;
 SELECT JSON_OBJECT(KEY 'age' VALUE age NULL ON NULL)
 FROM (VALUES (25), (NULL)) AS t(age);
 
+-- Test ABSENT ON NULL modifier
+SELECT JSON_OBJECT(KEY 'data' VALUE data, KEY 'info' VALUE info ABSENT ON NULL)
+FROM (VALUES ('test', NULL), ('example', 'value')) AS t(data, info);
+
+-- Test WITHOUT UNIQUE KEYS modifier  
 SELECT JSON_OBJECT(KEY 'a' VALUE 1, KEY 'b' VALUE 2 WITHOUT UNIQUE KEYS);
+
+-- Test WITH UNIQUE KEYS modifier
+SELECT JSON_OBJECT(KEY 'x' VALUE 10, KEY 'y' VALUE 20 WITH UNIQUE KEYS);
+
+-- Test multiple modifiers with multiple key-value pairs
+SELECT JSON_OBJECT(
+  KEY 'name' VALUE name, 
+  KEY 'age' VALUE age, 
+  KEY 'city' VALUE city 
+  NULL ON NULL
+)
+FROM (VALUES ('Alice', 25, 'NYC'), ('Bob', NULL, 'LA')) AS users(name, age, city);
+
+-- Test complex modifier combinations
+SELECT JSON_OBJECT(
+  KEY 'status' VALUE status,
+  KEY 'count' VALUE count,
+  KEY 'metadata' VALUE metadata
+  ABSENT ON NULL WITHOUT UNIQUE KEYS
+)  
+FROM (VALUES ('active', 5, NULL), ('inactive', 0, '{}')) AS data(status, count, metadata);

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1107,8 +1107,85 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
       case g: UnresolvedGroupingKey =>
         expr(g.child)
       case f: FunctionApply =>
-        // Special handling for TRIM function
+        // Special handling for specific functions
         f.base match
+          case id: UnquotedIdentifier if id.unquotedValue.toLowerCase == "json_object" =>
+            // Special handling for JSON_OBJECT based on database type
+            dbType match
+              case DBType.DuckDB =>
+                // DuckDB always uses: json_object('key1', value1, 'key2', value2)
+                // Check if we have KEY...VALUE syntax by looking for __JSON_KEY markers
+                val hasKeyValueSyntax = f
+                  .args
+                  .exists(_.name.exists(n => n.name == "__JSON_KEY" || n.name == "__JSON_VALUE"))
+
+                val keyValuePairs = List.newBuilder[Doc]
+                if hasKeyValueSyntax then
+                  // Convert KEY...VALUE pairs to simple alternating key-value
+                  var i = 0
+                  while i < f.args.length do
+                    f.args(i) match
+                      case FunctionArg(Some(name), value, _, _, _) if name.name == "__JSON_KEY" =>
+                        // This is a KEY, next should be VALUE
+                        keyValuePairs += expr(value)
+                        if i + 1 < f.args.length then
+                          f.args(i + 1) match
+                            case FunctionArg(Some(vname), vvalue, _, _, _)
+                                if vname.name == "__JSON_VALUE" =>
+                              keyValuePairs += expr(vvalue)
+                              i += 2
+                            case _ =>
+                              // Just key without value - shouldn't happen
+                              i += 1
+                        else
+                          i += 1
+                      case _ =>
+                        // Skip other args (modifiers)
+                        i += 1
+                else
+                  // Already in simple alternating format - just add all args
+                  f.args
+                    .foreach { arg =>
+                      keyValuePairs += expr(arg.value)
+                    }
+
+                // Always output lowercase json_object for DuckDB
+                val args = paren(cl(keyValuePairs.result()))
+                text("json_object") + args
+              case _ =>
+                // Standard SQL: Reconstruct KEY...VALUE syntax if needed
+                val base = expr(f.base)
+                val hasKeyValueSyntax = f
+                  .args
+                  .exists(_.name.exists(n => n.name == "__JSON_KEY" || n.name == "__JSON_VALUE"))
+
+                if hasKeyValueSyntax then
+                  val argDocs = List.newBuilder[Doc]
+                  var i       = 0
+                  while i < f.args.length do
+                    f.args(i) match
+                      case FunctionArg(Some(name), value, _, _, _) if name.name == "__JSON_KEY" =>
+                        // Output KEY keyword and the expression
+                        argDocs += wl(text("KEY"), expr(value))
+                        i += 1
+                      case FunctionArg(Some(name), value, _, _, _) if name.name == "__JSON_VALUE" =>
+                        // Output VALUE keyword and the expression
+                        argDocs += wl(text("VALUE"), expr(value))
+                        i += 1
+                      case arg =>
+                        // Regular argument or modifier
+                        argDocs += expr(arg)
+                        i += 1
+                  val args = paren(cl(argDocs.result()))
+                  val w    = f.window.map(x => expr(x))
+                  val stem = base + args
+                  wl(stem, w)
+                else
+                  // Simple format - just output as-is
+                  val args = paren(cl(f.args.map(x => expr(x))))
+                  val w    = f.window.map(x => expr(x))
+                  val stem = base + args
+                  wl(stem, w)
           case id: UnquotedIdentifier if id.unquotedValue.toLowerCase == "trim" =>
             // Generate special TRIM syntax
             val parts = List.newBuilder[Doc]

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -360,7 +360,7 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
       case v: Values =>
         // VALUES in FROM clause needs parentheses
         v.relationType match
-          case s: SchemaType =>
+          case s: SchemaType if s.isFullyNamed =>
             // VALUES with alias and schema
             val tableAlias: Doc = tableAliasOf(
               NameExpr.fromString(s.typeName.name),
@@ -1336,7 +1336,13 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
                   wl(group(wl(text("KEY"), expr(p.key))), group(wl(text("VALUE"), expr(p.value))))
                 )
               }
-            text("json_object") + paren(cl(params))
+            val modifiers = wl(
+              j.jsonObjectModifiers
+                .map { m =>
+                  text(m.expr)
+                }
+            )
+            text("json_object") + paren(cl(params, modifiers))
       case a: ArrayAccess =>
         expr(a.arrayExpr) + text("[") + expr(a.index) + text("]")
       case c: CaseExpr =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1663,8 +1663,11 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
                 // Another KEY...VALUE pair
                 keyArg :: valueArg :: parseKeyValuePairs()
               case _ =>
-                // Not another KEY...VALUE, might be a modifier - just return what we have
-                List(keyArg, valueArg)
+                // After a comma, we must have another KEY...VALUE pair
+                unexpected(
+                  scanner.lookAhead(),
+                  "Expected KEY after a comma in JSON_OBJECT arguments"
+                )
           case SqlToken.NULL | SqlToken.IDENTIFIER | SqlToken.WITHOUT | SqlToken.WITH =>
             // Check for modifiers like NULL ON NULL, WITHOUT UNIQUE KEYS, etc
             val modifiers = parseJsonObjectModifiers()
@@ -1811,14 +1814,9 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
             // Check if this is JSON_OBJECT to use specialized parsing
             val isJsonObject =
               functionName match
-                case id: UnquotedIdentifier =>
-                  debug(s"functionName is UnquotedIdentifier: '${id.unquotedValue}'")
-                  id.unquotedValue.equalsIgnoreCase("JSON_OBJECT") ||
-                  id.unquotedValue.equalsIgnoreCase("json_object")
                 case id: Identifier =>
                   debug(s"functionName is Identifier: '${id.unquotedValue}'")
-                  id.unquotedValue.equalsIgnoreCase("JSON_OBJECT") ||
-                  id.unquotedValue.equalsIgnoreCase("json_object")
+                  id.unquotedValue.equalsIgnoreCase("JSON_OBJECT")
                 case other =>
                   debug(s"functionName is not Identifier, type = ${other.getClass.getName}")
                   false

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1684,8 +1684,8 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
         consume(SqlToken.ON)
         consume(SqlToken.NULL)
         JsonObjectModifier.NULL_ON_NULL :: parseJsonObjectModifiers()
-      case SqlToken.IDENTIFIER if t.str.toUpperCase == "ABSENT" =>
-        consume(SqlToken.IDENTIFIER) // ABSENT
+      case SqlToken.ABSENT =>
+        consume(SqlToken.ABSENT)
         consume(SqlToken.ON)
         consume(SqlToken.NULL)
         JsonObjectModifier.ABSENT_ON_NULL :: parseJsonObjectModifiers()

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -262,6 +262,10 @@ enum SqlToken(val tokenType: TokenType, val str: String):
   case JSON      extends SqlToken(Keyword, "json")
   case INTERVAL  extends SqlToken(Keyword, "interval")
 
+  // JSON OBJECT
+  case ABSENT extends SqlToken(Keyword, "absent")
+  case KEYS   extends SqlToken(Keyword, "keys")
+
   // For internal
   case TO extends SqlToken(Keyword, "to")
 
@@ -354,6 +358,9 @@ object SqlToken:
     SqlToken.VIEW,
     SqlToken.STATEMENT,
     SqlToken.FUNCTIONS,
+    // JSON object modifiers
+    SqlToken.ABSENT,
+    SqlToken.KEYS,
     // ALTER TABLE specific tokens - non-reserved
     SqlToken.RENAME,
     SqlToken.TYPE,

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -141,8 +141,8 @@ enum SqlToken(val tokenType: TokenType, val str: String):
 
   case ALL      extends SqlToken(Keyword, "all")
   case DISTINCT extends SqlToken(Keyword, "distinct")
-  // case VALUE    extends SqlToken(Keyword, "value")
-  case VALUES extends SqlToken(Keyword, "values")
+  case VALUE    extends SqlToken(Keyword, "value")
+  case VALUES   extends SqlToken(Keyword, "values")
 
   case CAST     extends SqlToken(Keyword, "cast")
   case TRY_CAST extends SqlToken(Keyword, "try_cast")
@@ -315,6 +315,7 @@ object SqlToken:
     SqlToken.TRAILING,
     SqlToken.BOTH,
     SqlToken.KEY,
+    SqlToken.VALUE, // VALUE can be used as a column name
     SqlToken.SYSTEM,
     SqlToken.PRIMARY,
     SqlToken.UNIQUE,

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/DataType.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/DataType.scala
@@ -200,9 +200,16 @@ object DataType extends LogSupport:
       override val typeName: TypeName,
       columnTypes: List[NamedType]
   ) extends RelationType(typeName, Nil):
+    def isEmpty: Boolean                 = columnTypes.isEmpty
     override def fields: List[NamedType] = columnTypes
 
     override def isResolved: Boolean = columnTypes.forall(_.isResolved)
+
+    /**
+      * @return
+      *   true if all column types have names
+      */
+    def isFullyNamed: Boolean = columnTypes.forall(!_.name.isEmpty)
 
   case object EmptyRelationType extends RelationType(Name.typeName("<empty>"), Nil):
     override def typeDescription: String = "empty"

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
@@ -828,11 +828,11 @@ case class JsonObjectConstructor(
 case class JsonParam(key: Expression, value: Expression, span: Span) extends Expression:
   override def children: Seq[Expression] = Seq(key, value)
 
-enum JsonObjectModifier:
-  case NULL_ON_NULL
-  case ABSENT_ON_NULL
-  case WITHOUT_UNIQUE_KEYS
-  case WITH_UNIQUE_KEYS
+enum JsonObjectModifier(val expr: String):
+  case NULL_ON_NULL        extends JsonObjectModifier("NULL ON NULL")
+  case ABSENT_ON_NULL      extends JsonObjectModifier("ABSENT ON NULL")
+  case WITHOUT_UNIQUE_KEYS extends JsonObjectModifier("WITHOUT UNIQUE KEYS")
+  case WITH_UNIQUE_KEYS    extends JsonObjectModifier("WITH UNIQUE KEYS")
 
 abstract sealed class CurrentTimeBase(name: String, precision: Option[Int]) extends LeafExpression
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
@@ -314,9 +314,9 @@ case class WindowApply(base: Expression, window: Window, span: Span) extends Exp
   override def dataType: DataType        = base.dataType
 
 case class FunctionArg(
-    name: Option[TermName],
+    name: Option[TermName] = None,
     value: Expression,
-    isDistinct: Boolean,
+    isDistinct: Boolean = false,
     orderBy: List[SortItem] = Nil,
     span: Span
 ) extends Expression:
@@ -817,6 +817,22 @@ case class MapValue(entries: List[MapEntry], span: Span) extends Expression:
 
 case class MapEntry(key: Expression, value: Expression, span: Span) extends Expression:
   override def children: Seq[Expression] = Seq(key, value)
+
+case class JsonObjectConstructor(
+    jsonParams: List[JsonParam],
+    jsonObjectModifiers: List[JsonObjectModifier] = Nil,
+    span: Span
+) extends Expression:
+  override def children: Seq[Expression] = jsonParams
+
+case class JsonParam(key: Expression, value: Expression, span: Span) extends Expression:
+  override def children: Seq[Expression] = Seq(key, value)
+
+enum JsonObjectModifier:
+  case NULL_ON_NULL
+  case ABSENT_ON_NULL
+  case WITHOUT_UNIQUE_KEYS
+  case WITH_UNIQUE_KEYS
 
 abstract sealed class CurrentTimeBase(name: String, precision: Option[Int]) extends LeafExpression
 

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/SqlParserTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/SqlParserTest.scala
@@ -12,6 +12,16 @@ class SqlParserTest extends AirSpec:
 
 end SqlParserTest
 
+class SqlParserBasicSpec extends AirSpec:
+  CompilationUnit
+    .fromPath("spec/sql/basic")
+    .foreach { unit =>
+      test(s"parse basic ${unit.sourceFile.fileName}") {
+        val stmt = SqlParser(unit, isContextUnit = true).parse()
+        debug(stmt.pp)
+      }
+    }
+
 class SqlParserTPCHSpec extends AirSpec:
   CompilationUnit
     .fromPath("spec/sql/tpc-h")


### PR DESCRIPTION
## Summary
- Added support for Standard SQL JSON_OBJECT syntax with KEY...VALUE pairs
- Parser now handles both JSON_OBJECT syntaxes:
  - Simple alternating: `JSON_OBJECT('key', value, ...)`
  - Standard SQL: `JSON_OBJECT(KEY 'key' VALUE value, ...)`
- Supports modifiers like `NULL ON NULL` and `WITHOUT UNIQUE KEYS`

## Changes Made
1. **SqlToken.scala**: Added VALUE as a token and marked it as non-reserved (like KEY) to allow its use as a column name
2. **SqlParser.scala**: 
   - Added special handling for JSON_OBJECT function in `functionApply`
   - Implemented `jsonObjectArgs()` to detect and parse both syntaxes
   - Added `parseKeyValuePairs()` for KEY...VALUE syntax parsing
   - Added `parseJsonObjectModifiers()` for handling SQL modifiers
3. **SqlGenerator.scala**: Updated to generate DuckDB-compatible `json_object(k1, v1, k2, v2, ...)` syntax from both input formats
4. **Added test spec**: `spec/sql/basic/json-object.sql` with comprehensive test cases for both syntaxes

## Test Plan
- [x] Added comprehensive test cases in `spec/sql/basic/json-object.sql`
- [x] All existing SqlBasicSpec tests pass
- [x] Verified both JSON_OBJECT syntaxes parse correctly
- [x] Confirmed VALUE can still be used as a column name (non-reserved)

🤖 Generated with [Claude Code](https://claude.ai/code)