### PR TITLE
fix: Improve JSON_OBJECT formatting and error handling

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1342,7 +1342,7 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
                   text(m.expr)
                 }
             )
-            text("json_object") + paren(cl(params, modifiers))
+            text("json_object") + paren(wl(params, modifiers))
       case a: ArrayAccess =>
         expr(a.arrayExpr) + text("[") + expr(a.index) + text("]")
       case c: CaseExpr =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1697,7 +1697,7 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
             consumeToken()
             JsonObjectModifier.WITH_UNIQUE_KEYS :: parseJsonObjectModifiers()
           case _ =>
-            Nil
+            unexpected(scanner.lookAhead(), "Expected UNIQUE KEYS or UNIQUE KEY")
       case SqlToken.WITHOUT =>
         consume(SqlToken.WITHOUT)
         consume(SqlToken.UNIQUE)
@@ -1706,7 +1706,7 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
             consumeToken()
             JsonObjectModifier.WITHOUT_UNIQUE_KEYS :: parseJsonObjectModifiers()
           case _ =>
-            Nil
+            unexpected(scanner.lookAhead(), "Expected UNIQUE KEYS or UNIQUE KEY")
       case _ =>
         Nil
 


### PR DESCRIPTION
## Summary
- Improve JSON_OBJECT code formatting in SqlGenerator using `wl()` instead of `cl()`
- Add specific error messages for incomplete UNIQUE KEYS/KEY syntax in parser
- Enhance parser robustness for JSON_OBJECT modifier parsing

## Changes
- **SqlGenerator**: Use `wl(params, modifiers)` for better whitespace formatting
- **SqlParser**: Add specific error messages when UNIQUE is followed by invalid tokens

## Test plan
- Existing JSON_OBJECT tests continue to pass
- Parser now provides better error messages for malformed UNIQUE modifier syntax

🤖 Generated with [Claude Code](https://claude.ai/code)