### PR TITLE
fix: JSON_OBJECT with KEY...VALUE syntax now parses correctly

### DIFF
--- a/spec/sql/basic/json-object.sql
+++ b/spec/sql/basic/json-object.sql
@@ -55,3 +55,11 @@ SELECT JSON_OBJECT(
   ABSENT ON NULL WITHOUT UNIQUE KEYS
 )  
 FROM (VALUES ('active', 5, NULL), ('inactive', 0, '{}')) AS data(status, count, metadata);
+
+-- Test case from the reported error (with VALUES construct)
+SELECT
+  f_d082a,
+  JSON_OBJECT(KEY 'age' VALUE age, KEY 'item_count' VALUE item_count, KEY 'ctr' VALUE ctr NULL ON NULL WITHOUT UNIQUE KEYS)
+FROM
+  (VALUES ('test1', 25, 10, 0.15), ('test2', 30, 20, 0.25)) AS t_3eea0(f_d082a, age, item_count, ctr)
+WHERE (f_d082a IS NOT NULL);

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1787,7 +1787,7 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
               val jsonObjectModifiers = parseJsonObjectModifiers()
               val jsonObj = JsonObjectConstructor(params, jsonObjectModifiers, spanFrom(t))
               consume(SqlToken.R_PAREN)
-              jsonObj
+              primaryExpressionRest(jsonObj)
             else
               val args = functionArgs()
               consume(SqlToken.R_PAREN)


### PR DESCRIPTION
## Summary
- Fixed parser issue where `JSON_OBJECT` with `KEY...VALUE` syntax was not handled correctly
- Added missing call to `primaryExpressionRest()` after creating `JsonObjectConstructor`
- Added comprehensive test case covering the error scenario

## Problem
The SQL parser was throwing a `SYNTAX_ERROR` when parsing `JSON_OBJECT` with the standard SQL `KEY...VALUE` syntax combined with modifiers like `NULL ON NULL WITHOUT UNIQUE KEYS`. The parser expected `R_PAREN` but encountered the next token instead.

## Solution
The fix ensures that after creating a `JsonObjectConstructor` for the `KEY...VALUE` syntax, the parser properly calls `primaryExpressionRest()` to handle any subsequent tokens, maintaining consistency with how other function calls are handled.

## Test Plan
- [x] Added test case in `spec/sql/basic/json-object.sql` with the exact problematic query structure
- [x] Verified all existing JSON_OBJECT tests pass
- [x] Tested with complex modifier combinations (`NULL ON NULL`, `WITHOUT UNIQUE KEYS`)

🤖 Generated with [Claude Code](https://claude.ai/code)