### PR TITLE
internal: Refactor SQL parser test structure for better maintainability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,9 @@ Ensure the code is formatted with `scalafmtAll` command for consistent code styl
 ./sbt "projectJS/Test/compile"
 ./sbt "projectNative/Test/compile"
 
+# Parsing test for a specific SQL in spec/sql/basic folder:
+./sbt "langJVM/testOnly *SqlParserBasicSpec -- spec:sql:basic:query.sql"
+
 # Run specific test class
 ./sbt "runner/testOnly *BasicSpec"
 

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/SqlParserTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/SqlParserTest.scala
@@ -8,6 +8,7 @@ trait SqlParserSpec(specPath: String, ignoredSpec: Map[String, String] = Map.emp
   for unit <- CompilationUnit.fromPath(specPath) do
     // Rename spec path / to : for test name
     test(unit.sourceFile.relativeFilePath.replaceAll("/", ":")) {
+      ignoredSpec.get(unit.sourceFile.fileName).foreach(reason => ignore(reason))
       val parser = SqlParser(unit, isContextUnit = true)
       val stmt   = parser.parse()
       debug(stmt.pp)

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/SqlParserTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/SqlParserTest.scala
@@ -4,40 +4,15 @@ import wvlet.airspec.AirSpec
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.model.plan.*
 
-class SqlParserTest extends AirSpec:
-  test("parse") {
-    val stmt = SqlParser(CompilationUnit.fromSqlString("select * from A")).parse()
-    debug(stmt.pp)
-  }
-
-end SqlParserTest
-
-class SqlParserBasicSpec extends AirSpec:
-  CompilationUnit
-    .fromPath("spec/sql/basic")
-    .foreach { unit =>
-      test(s"parse basic ${unit.sourceFile.fileName}") {
-        val stmt = SqlParser(unit, isContextUnit = true).parse()
-        debug(stmt.pp)
-      }
+trait SqlParserSpec(specPath: String, ignoredSpec: Map[String, String] = Map.empty) extends AirSpec:
+  for unit <- CompilationUnit.fromPath(specPath) do
+    // Rename spec path / to : for test name
+    test(unit.sourceFile.relativeFilePath.replaceAll("/", ":")) {
+      val parser = SqlParser(unit, isContextUnit = true)
+      val stmt   = parser.parse()
+      debug(stmt.pp)
     }
 
-class SqlParserTPCHSpec extends AirSpec:
-  CompilationUnit
-    .fromPath("spec/sql/tpc-h")
-    .foreach { unit =>
-      test(s"parse tpc-h ${unit.sourceFile.fileName}") {
-        val stmt = SqlParser(unit, isContextUnit = true).parse()
-        debug(stmt.pp)
-      }
-    }
-
-class SqlParserTPCDSSpec extends AirSpec:
-  CompilationUnit
-    .fromPath("spec/sql/tpc-ds")
-    .foreach { unit =>
-      test(s"parse tpc-ds ${unit.sourceFile.fileName}") {
-        val stmt = SqlParser(unit, isContextUnit = true).parse()
-        debug(stmt.pp)
-      }
-    }
+class SqlParserBasicSpec extends SqlParserSpec("spec/sql/basic")
+class SqlParserTPCHSpec  extends SqlParserSpec("spec/sql/tpc-h")
+class SqlParserTPCDSSpec extends SqlParserSpec("spec/sql/tpc-ds")


### PR DESCRIPTION
## Summary
- Refactored SQL parser test classes to use a reusable trait pattern
- Reduced code duplication across SqlParserBasicSpec, SqlParserTPCHSpec, and SqlParserTPCDSSpec
- Improved test naming to include full spec path for easier test identification

## Changes
- Created `SqlParserSpec` trait that encapsulates common test logic
- Updated test names to use relative file paths (with `/` replaced by `:`) for clearer test identification
- Added documentation in CLAUDE.md for running specific SQL parser tests

## Test plan
- [x] Run existing SQL parser tests to ensure they still pass
- [x] Verify test names are more descriptive in test output
- [x] Confirm specific test execution works with new naming pattern

🤖 Generated with [Claude Code](https://claude.ai/code)