### PR TITLE
fix: Add support for SQL ESCAPE clause in LIKE expressions

### DIFF
--- a/spec/sql/basic/escape_clause.sql
+++ b/spec/sql/basic/escape_clause.sql
@@ -1,0 +1,39 @@
+-- Test ESCAPE clause support for LIKE expressions
+
+-- Basic ESCAPE clause with backslash
+SELECT *
+FROM (VALUES ('field_name'), ('field\_name'), ('field%name')) AS t(name)
+WHERE name LIKE 'field\_name' ESCAPE '\';
+
+-- ESCAPE clause with different escape character
+SELECT *
+FROM (VALUES ('field_name'), ('field#_name'), ('field%name')) AS t(name)
+WHERE name LIKE 'field#_name' ESCAPE '#';
+
+-- NOT LIKE with ESCAPE clause
+SELECT *
+FROM (VALUES ('field_name'), ('field\_name'), ('field%name')) AS t(name)
+WHERE name NOT LIKE 'field\_name' ESCAPE '\';
+
+-- Complex example from the original error
+SELECT
+  f_67199
+, f_eb709
+, f_c7efd
+FROM (VALUES 
+  (1, 'eur_consents_source', 'gbr_krux_consents_stdx'),
+  (2, 'eur\_consents\_source', 'gbr\_krux\_consents\_stdx'),
+  (3, 'other', 'other')
+) AS t(f_67199, f_eb709, f_c7efd)
+WHERE ((f_eb709 LIKE 'eur\_consents\_source' ESCAPE '\') AND (f_c7efd LIKE 'gbr\_krux\_consents\_stdx' ESCAPE '\'))
+ORDER BY f_67199 ASC, f_eb709 ASC, f_c7efd ASC;
+
+-- ESCAPE with special characters
+SELECT *
+FROM (VALUES ('100%'), ('100!%'), ('100%%')) AS t(value)
+WHERE value LIKE '100!%' ESCAPE '!';
+
+-- Multiple LIKE conditions with different ESCAPE characters
+SELECT *
+FROM (VALUES ('a_b'), ('a%b'), ('a#b'), ('a\_b')) AS t(col)
+WHERE col LIKE 'a\_b' ESCAPE '\' OR col LIKE 'a#%b' ESCAPE '#';

--- a/website/docs/syntax/index.md
+++ b/website/docs/syntax/index.md
@@ -359,7 +359,10 @@ This syntax allows you to define inline data tables that can be referenced in yo
 | `expr` __in__ \{ from ... \}         | True if the expression value is in the given list provided by a sub query        |
 | `expr` __not in__ (`v1`, `v2`, ...)  | True if the expression is not in the given list                                  |
 | `expr` __between__ `v1` __and__ `v2` | True if the expression value is between v1 and v2, i.e., v1 &le; (value) &le; v2 |
-| `expr` __like__ `pattern`            | True if the expression matches the given pattern, e.g., , `'abc%'`               |
+| `expr` __like__ `pattern`            | True if the expression matches the given pattern, e.g., `'abc%'`                 |
+| `expr` __like__ `pattern` __escape__ `char` | Like with escape character for escaping wildcards, e.g., `'ab\_c' escape '\'`   |
+| `expr` __not like__ `pattern`        | True if the expression does not match the given pattern                          |
+| `expr` __not like__ `pattern` __escape__ `char` | Not like with escape character for escaping wildcards                    |
 | __exists__ \{ from ... \}            | True if the subquery returns any rows                                            |
 | __not exists__ \{ from ... \}        | True if the subquery returns no rows                                             |
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1231,12 +1231,12 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
             text("+") + expr(a.child)
           case Sign.Negative =>
             text("-") + expr(a.child)
-      case c: LogicalConditionalExpression =>
-        // For adding optional newlines for AND/OR
-        expr(c.left) + wsOrNL + text(c.operatorName) + ws + expr(c.right)
       case l: LikeExpression =>
         val escapeClause = l.escape.map(e => ws + text("ESCAPE") + ws + expr(e)).getOrElse(empty)
         expr(l.left) + ws + text(l.operatorName) + ws + expr(l.right) + escapeClause
+      case c: LogicalConditionalExpression =>
+        // For adding optional newlines for AND/OR
+        expr(c.left) + wsOrNL + text(c.operatorName) + ws + expr(c.right)
       case b: BinaryExpression =>
         wl(expr(b.left), b.operatorName, expr(b.right))
       case s: StringPart =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1234,6 +1234,12 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
       case c: LogicalConditionalExpression =>
         // For adding optional newlines for AND/OR
         expr(c.left) + wsOrNL + text(c.operatorName) + ws + expr(c.right)
+      case l: Like =>
+        val escapeClause = l.escape.map(e => ws + text("ESCAPE") + ws + expr(e)).getOrElse(empty)
+        expr(l.left) + ws + text(l.operatorName) + ws + expr(l.right) + escapeClause
+      case nl: NotLike =>
+        val escapeClause = nl.escape.map(e => ws + text("ESCAPE") + ws + expr(e)).getOrElse(empty)
+        expr(nl.left) + ws + text(nl.operatorName) + ws + expr(nl.right) + escapeClause
       case b: BinaryExpression =>
         wl(expr(b.left), b.operatorName, expr(b.right))
       case s: StringPart =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1234,12 +1234,9 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
       case c: LogicalConditionalExpression =>
         // For adding optional newlines for AND/OR
         expr(c.left) + wsOrNL + text(c.operatorName) + ws + expr(c.right)
-      case l: Like =>
+      case l: LikeExpression =>
         val escapeClause = l.escape.map(e => ws + text("ESCAPE") + ws + expr(e)).getOrElse(empty)
         expr(l.left) + ws + text(l.operatorName) + ws + expr(l.right) + escapeClause
-      case nl: NotLike =>
-        val escapeClause = nl.escape.map(e => ws + text("ESCAPE") + ws + expr(e)).getOrElse(empty)
-        expr(nl.left) + ws + text(nl.operatorName) + ws + expr(nl.right) + escapeClause
       case b: BinaryExpression =>
         wl(expr(b.left), b.operatorName, expr(b.right))
       case s: StringPart =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -525,6 +525,10 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
               text("+") + expr(a.child)
             case Sign.Negative =>
               text("-") + expr(a.child)
+        case l: LikeExpression =>
+          // Handle LIKE and NOT LIKE with optional ESCAPE clause
+          val escapeClause = l.escape.map(e => ws + text("escape") + ws + expr(e)).getOrElse(empty)
+          expr(l.left) + ws + text(l.operatorName) + ws + expr(l.right) + escapeClause
         case c: LogicalConditionalExpression =>
           expr(c.left) + wsOrNL + text(c.operatorName) + ws + expr(c.right)
         case b: BinaryExpression =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -512,6 +512,13 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
       span
     )
 
+  private def parseEscapeClause(): Option[Expression] =
+    if scanner.lookAhead().token == SqlToken.ESCAPE then
+      consume(SqlToken.ESCAPE)
+      Some(valueExpression())
+    else
+      None
+
   private def parseCommaSeparatedList[T](parseElement: () => T): List[T] =
     val elements = List.newBuilder[T]
     elements += parseElement()
@@ -1545,13 +1552,8 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
           In(expr, values, spanFrom(t))
         case SqlToken.LIKE =>
           consume(SqlToken.LIKE)
-          val right = valueExpression()
-          val escape =
-            if scanner.lookAhead().token == SqlToken.ESCAPE then
-              consume(SqlToken.ESCAPE)
-              Some(valueExpression())
-            else
-              None
+          val right  = valueExpression()
+          val escape = parseEscapeClause()
           Like(expr, right, escape, spanFrom(t))
         case SqlToken.NOT =>
           consume(SqlToken.NOT)
@@ -1559,13 +1561,8 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
           t2.token match
             case SqlToken.LIKE =>
               consume(SqlToken.LIKE)
-              val right = valueExpression()
-              val escape =
-                if scanner.lookAhead().token == SqlToken.ESCAPE then
-                  consume(SqlToken.ESCAPE)
-                  Some(valueExpression())
-                else
-                  None
+              val right  = valueExpression()
+              val escape = parseEscapeClause()
               NotLike(expr, right, escape, spanFrom(t))
             case SqlToken.IN =>
               consume(SqlToken.IN)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1546,7 +1546,13 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
         case SqlToken.LIKE =>
           consume(SqlToken.LIKE)
           val right = valueExpression()
-          Like(expr, right, spanFrom(t))
+          val escape =
+            if scanner.lookAhead().token == SqlToken.ESCAPE then
+              consume(SqlToken.ESCAPE)
+              Some(valueExpression())
+            else
+              None
+          Like(expr, right, escape, spanFrom(t))
         case SqlToken.NOT =>
           consume(SqlToken.NOT)
           val t2 = scanner.lookAhead()
@@ -1554,7 +1560,13 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
             case SqlToken.LIKE =>
               consume(SqlToken.LIKE)
               val right = valueExpression()
-              NotLike(expr, right, spanFrom(t))
+              val escape =
+                if scanner.lookAhead().token == SqlToken.ESCAPE then
+                  consume(SqlToken.ESCAPE)
+                  Some(valueExpression())
+                else
+                  None
+              NotLike(expr, right, escape, spanFrom(t))
             case SqlToken.IN =>
               consume(SqlToken.IN)
               val values = inExprList()

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -243,6 +243,7 @@ enum SqlToken(val tokenType: TokenType, val str: String):
   case NOT     extends SqlToken(Keyword, "not")
   case EXISTS  extends SqlToken(Keyword, "exists")
   case LIKE    extends SqlToken(Keyword, "like")
+  case ESCAPE  extends SqlToken(Keyword, "escape")
   case IN      extends SqlToken(Keyword, "in")
   case BETWEEN extends SqlToken(Keyword, "between")
   case AND     extends SqlToken(Keyword, "and")

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1922,7 +1922,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
             In(expr, valueList, spanFrom(t))
       case WvletToken.LIKE =>
         consume(WvletToken.LIKE)
-        val right = valueExpression()
+        val right  = valueExpression()
         val escape = parseEscapeClause()
         Like(expr, right, escape, spanFrom(t))
       case WvletToken.NOT =>
@@ -1931,7 +1931,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         t2.token match
           case WvletToken.LIKE =>
             consume(WvletToken.LIKE)
-            val right = valueExpression()
+            val right  = valueExpression()
             val escape = parseEscapeClause()
             NotLike(expr, right, escape, spanFrom(t))
           case WvletToken.IN =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1923,7 +1923,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
       case WvletToken.LIKE =>
         consume(WvletToken.LIKE)
         val right = valueExpression()
-        Like(expr, right, spanFrom(t))
+        Like(expr, right, None, spanFrom(t))
       case WvletToken.NOT =>
         consume(WvletToken.NOT)
         val t2 = scanner.lookAhead()
@@ -1931,7 +1931,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
           case WvletToken.LIKE =>
             consume(WvletToken.LIKE)
             val right = valueExpression()
-            NotLike(expr, right, spanFrom(t))
+            NotLike(expr, right, None, spanFrom(t))
           case WvletToken.IN =>
             consume(WvletToken.IN)
             val valueList = inExprList()

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1923,7 +1923,8 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
       case WvletToken.LIKE =>
         consume(WvletToken.LIKE)
         val right = valueExpression()
-        Like(expr, right, None, spanFrom(t))
+        val escape = parseEscapeClause()
+        Like(expr, right, escape, spanFrom(t))
       case WvletToken.NOT =>
         consume(WvletToken.NOT)
         val t2 = scanner.lookAhead()
@@ -1931,7 +1932,8 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
           case WvletToken.LIKE =>
             consume(WvletToken.LIKE)
             val right = valueExpression()
-            NotLike(expr, right, None, spanFrom(t))
+            val escape = parseEscapeClause()
+            NotLike(expr, right, escape, spanFrom(t))
           case WvletToken.IN =>
             consume(WvletToken.IN)
             val valueList = inExprList()
@@ -2110,6 +2112,13 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     primaryExpressionRest(expr)
 
   }
+
+  private def parseEscapeClause(): Option[Expression] =
+    if scanner.lookAhead().token == WvletToken.ESCAPE then
+      consume(WvletToken.ESCAPE)
+      Some(valueExpression())
+    else
+      None
 
   def inExprList(): List[Expression] =
     def rest(): List[Expression] =

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
@@ -255,6 +255,7 @@ enum WvletToken(val tokenType: TokenType, val str: String):
   case NOT     extends WvletToken(Keyword, "not")
   case IS      extends WvletToken(Keyword, "is")
   case LIKE    extends WvletToken(Keyword, "like")
+  case ESCAPE  extends WvletToken(Keyword, "escape")
   case BETWEEN extends WvletToken(Keyword, "between")
 
   // DML operators

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
@@ -429,19 +429,24 @@ case class TupleNotInRelation(tuple: Expression, in: Relation, span: Span)
     extends ConditionalExpression:
   override def children: Seq[Expression] = Seq(tuple) ++ in.childExpressions
 
-case class Like(left: Expression, right: Expression, escape: Option[Expression] = None, span: Span)
-    extends ConditionalExpression:
-  def operatorName: String               = "like"
+sealed trait LikeExpression extends ConditionalExpression:
+  def left: Expression
+  def right: Expression
+  def escape: Option[Expression]
+  def operatorName: String
   override def children: Seq[Expression] = Seq(left, right) ++ escape.toSeq
+
+case class Like(left: Expression, right: Expression, escape: Option[Expression] = None, span: Span)
+    extends LikeExpression:
+  override def operatorName: String = "like"
 
 case class NotLike(
     left: Expression,
     right: Expression,
     escape: Option[Expression] = None,
     span: Span
-) extends ConditionalExpression:
-  def operatorName: String               = "not like"
-  override def children: Seq[Expression] = Seq(left, right) ++ escape.toSeq
+) extends LikeExpression:
+  override def operatorName: String = "not like"
 
 case class Contains(left: Expression, right: Expression, span: Span)
     extends ConditionalExpression

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
@@ -429,15 +429,19 @@ case class TupleNotInRelation(tuple: Expression, in: Relation, span: Span)
     extends ConditionalExpression:
   override def children: Seq[Expression] = Seq(tuple) ++ in.childExpressions
 
-case class Like(left: Expression, right: Expression, span: Span)
-    extends ConditionalExpression
-    with BinaryExpression:
-  override def operatorName: String = "like"
+case class Like(left: Expression, right: Expression, escape: Option[Expression] = None, span: Span)
+    extends ConditionalExpression:
+  def operatorName: String               = "like"
+  override def children: Seq[Expression] = Seq(left, right) ++ escape.toSeq
 
-case class NotLike(left: Expression, right: Expression, span: Span)
-    extends ConditionalExpression
-    with BinaryExpression:
-  override def operatorName: String = "not like"
+case class NotLike(
+    left: Expression,
+    right: Expression,
+    escape: Option[Expression] = None,
+    span: Span
+) extends ConditionalExpression:
+  def operatorName: String               = "not like"
+  override def children: Seq[Expression] = Seq(left, right) ++ escape.toSeq
 
 case class Contains(left: Expression, right: Expression, span: Span)
     extends ConditionalExpression


### PR DESCRIPTION
## Summary
This PR adds support for the SQL ESCAPE clause in LIKE and NOT LIKE expressions, fixing parsing errors when queries contain escape characters.

## Problem
The parser was failing with a syntax error when encountering ESCAPE clauses in LIKE expressions:
```sql
WHERE f_eb709 LIKE 'eur\_consents\_source' ESCAPE '\'
```
Error: `Expected R_PAREN, but found IDENTIFIER`

## Solution
- Added ESCAPE token to SqlToken.scala
- Updated Like and NotLike case classes to include optional escape expression
- Modified SqlParser to parse ESCAPE clause after LIKE/NOT LIKE patterns
- Updated SqlGenerator to output ESCAPE clauses in generated SQL
- Updated WvletParser for consistency

## Testing
- Added comprehensive test cases in `spec/sql/basic/escape_clause.sql`
- Tests cover various escape characters and complex patterns
- All existing tests continue to pass

## Examples
```sql
-- Escape underscore wildcards with backslash
SELECT * FROM table WHERE name LIKE 'field\_name' ESCAPE '\';

-- Use custom escape character
SELECT * FROM table WHERE value LIKE '100!%' ESCAPE '!';
```

🤖 Generated with [Claude Code](https://claude.ai/code)