### PR TITLE
fix: Add support for DIV integer division operator in SqlParser

### DIFF
--- a/spec/sql/hive/div_operator.sql
+++ b/spec/sql/hive/div_operator.sql
@@ -1,0 +1,39 @@
+-- Test DIV integer division operator (Hive/MySQL syntax)
+-- Also test DuckDB's // operator for integer division
+
+-- Basic DIV operator test
+SELECT 10 DIV 3 AS int_div_result;
+
+-- DIV operator with expressions
+SELECT (20 + 5) DIV 4 AS expr_div_result;
+
+-- DIV operator in complex expressions
+SELECT 
+  100 DIV 7 AS simple_div,
+  100 / 7 AS float_div,
+  100 DIV 7 * 7 AS div_multiply;
+
+-- DuckDB integer division operator
+SELECT 10 // 3 AS duckdb_int_div;
+
+-- Mixed operators
+SELECT 
+  20 DIV 3 AS hive_div,
+  20 // 3 AS duckdb_div,
+  20 / 3 AS float_div;
+
+-- The original failing query from CDP (simplified to test DIV operator)
+SELECT
+  cast(conv(substr(cdp_customer_id,1,2),16,10) as bigint)*3600 div 32 AS time
+FROM test_table;
+
+-- Additional test cases with DIV
+SELECT
+  100 div 10 as lowercase_div,
+  100 DIV 10 as uppercase_div,
+  100 Div 10 as mixed_case_div;
+
+-- Complex expression with DIV
+SELECT
+  (a + b) * c DIV d AS complex_expr
+FROM test_table;

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1508,10 +1508,19 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
           consume(SqlToken.DIV)
           val right = valueExpression()
           ArithmeticBinaryExpr(BinaryExprType.Divide, expr, right, spanFrom(t))
+        case SqlToken.DIV_INT =>
+          consume(SqlToken.DIV_INT)
+          val right = valueExpression()
+          ArithmeticBinaryExpr(BinaryExprType.DivideInt, expr, right, spanFrom(t))
         case SqlToken.MOD =>
           consume(SqlToken.MOD)
           val right = valueExpression()
           ArithmeticBinaryExpr(BinaryExprType.Modulus, expr, right, spanFrom(t))
+        case id if id.isIdentifier && t.str.toUpperCase == "DIV" =>
+          // Support DIV keyword as integer division operator (Hive/MySQL)
+          consumeToken()
+          val right = valueExpression()
+          ArithmeticBinaryExpr(BinaryExprType.DivideInt, expr, right, spanFrom(t))
         case SqlToken.EQ =>
           consume(SqlToken.EQ)
           val right = valueExpression()

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1508,16 +1508,13 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
           consume(SqlToken.DIV)
           val right = valueExpression()
           ArithmeticBinaryExpr(BinaryExprType.Divide, expr, right, spanFrom(t))
-        case SqlToken.DIV_INT =>
-          consume(SqlToken.DIV_INT)
-          val right = valueExpression()
-          ArithmeticBinaryExpr(BinaryExprType.DivideInt, expr, right, spanFrom(t))
         case SqlToken.MOD =>
           consume(SqlToken.MOD)
           val right = valueExpression()
           ArithmeticBinaryExpr(BinaryExprType.Modulus, expr, right, spanFrom(t))
-        case id if id.isIdentifier && t.str.toUpperCase == "DIV" =>
-          // Support DIV keyword as integer division operator (Hive/MySQL)
+        case token
+            if token == SqlToken.DIV_INT || (token.isIdentifier && t.str.toUpperCase == "DIV") =>
+          // Support DIV keyword (Hive/MySQL) and // operator (DuckDB) for integer division
           consumeToken()
           val right = valueExpression()
           ArithmeticBinaryExpr(BinaryExprType.DivideInt, expr, right, spanFrom(t))


### PR DESCRIPTION
## Summary
- Added support for `DIV` keyword as integer division operator (Hive/MySQL syntax)
- Added support for `//` operator as integer division operator (DuckDB syntax)  
- Both operators now map to `BinaryExprType.DivideInt` for consistent handling

## Problem
The SqlParser was failing to parse queries containing the `DIV` operator, which is commonly used in Hive and MySQL for integer division. This was causing parse errors for valid CDP/Hive queries like:
```sql
SELECT cast(conv(substr(cdp_customer_id,1,2),16,10) as bigint)*3600 div 32 AS time
```

## Solution
Extended the parser to recognize:
1. `DIV` keyword as an infix operator for integer division
2. `//` operator (DuckDB's integer division syntax)

## Test Plan
- [x] Added comprehensive test spec at `spec/sql/hive/div_operator.sql`
- [x] Verified all test cases pass with `./sbt "langJVM/testOnly *SqlParserHiveSpec -- spec:sql:hive:div_operator.sql"`
- [x] Code formatted with `scalafmtAll`

🤖 Generated with [Claude Code](https://claude.ai/code)