### PR TITLE
fix: Add support for INSERT INTO TABLE syntax with backquoted identifiers

### DIFF
--- a/spec/sql/hive/insert-into-table.sql
+++ b/spec/sql/hive/insert-into-table.sql
@@ -1,0 +1,45 @@
+-- Test INSERT INTO TABLE with various table name formats including backquoted identifiers
+
+-- Basic INSERT INTO TABLE
+INSERT INTO TABLE customers
+SELECT * FROM source_table;
+
+-- INSERT INTO TABLE with backquoted identifier
+INSERT INTO TABLE `cdp_tmp_customers`
+SELECT * FROM source_table;
+
+-- INSERT INTO TABLE with schema and backquoted table name
+INSERT INTO TABLE schema1.`table_name`
+SELECT * FROM source_table;
+
+-- INSERT INTO TABLE with all backquoted identifiers
+INSERT INTO TABLE `schema`.`table`
+SELECT * FROM source_table;
+
+-- INSERT INTO TABLE with column list
+INSERT INTO TABLE `customers` (id, name, email)
+SELECT id, name, email FROM source_table;
+
+-- Complex Hive query from the error example
+INSERT INTO TABLE `cdp_tmp_customers`
+select coalesce(cast(conv(substr(cdp_customer_id,1,2),16,10) as bigint)*3600 div 32,0) as time, * from (
+  select
+    sha1(concat_ws('.', cast(time as string), cast(row_number() over (partition by time) as string))) as cdp_customer_id,
+    m.`user`,
+    m.`host`,
+    m.`path`,
+    m.`referer`,
+    m.`code`,
+    m.`agent`,
+    m.`size`,
+    m.`method`
+  from `sample_datasets`.`www_access` m
+) d;
+
+-- INSERT INTO without TABLE keyword (standard SQL)
+INSERT INTO customers
+SELECT * FROM source_table;
+
+-- INSERT INTO with backquoted identifier without TABLE keyword
+INSERT INTO `cdp_tmp_customers`
+SELECT * FROM source_table;

--- a/spec/sql/hive/insert-into-table.sql
+++ b/spec/sql/hive/insert-into-table.sql
@@ -43,3 +43,15 @@ SELECT * FROM source_table;
 -- INSERT INTO with backquoted identifier without TABLE keyword
 INSERT INTO `cdp_tmp_customers`
 SELECT * FROM source_table;
+
+-- INSERT OVERWRITE TABLE (standard Hive syntax)
+INSERT OVERWRITE TABLE customers
+SELECT * FROM source_table;
+
+-- INSERT OVERWRITE TABLE with backquoted identifier
+INSERT OVERWRITE TABLE `cdp_tmp_customers`
+SELECT * FROM source_table;
+
+-- INSERT OVERWRITE TABLE with schema and backquoted table name
+INSERT OVERWRITE TABLE schema1.`table_name`
+SELECT * FROM source_table;

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -623,6 +623,8 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
         scanner.lookAhead().token match
           case SqlToken.INTO =>
             consume(SqlToken.INTO)
+            // Handle optional TABLE keyword after INSERT INTO (Hive syntax)
+            consumeIfExist(SqlToken.TABLE)
             val target = qualifiedName()
             val (columns, q) =
               if scanner.lookAhead().token == SqlToken.L_PAREN then


### PR DESCRIPTION
## Summary
- Added support for the optional `TABLE` keyword after `INSERT INTO` in Hive SQL syntax
- Fixed parsing errors when encountering queries like `INSERT INTO TABLE \`cdp_tmp_customers\` ...`
- Uses `consumeIfExist(SqlToken.TABLE)` to handle the optional keyword elegantly

## Changes
- Modified `SqlParser.scala` to handle optional TABLE keyword in INSERT statements
- Added comprehensive test cases in `spec/sql/hive/insert-into-table.sql`

## Test Plan
- [x] Added test spec covering various INSERT INTO TABLE formats
- [x] Tested with backquoted identifiers
- [x] Verified backwards compatibility with standard INSERT INTO syntax
- [x] All tests pass: `./sbt "langJVM/testOnly *SqlParserHiveSpec -- spec:sql:hive:insert-into-table.sql"`

## Context
This fixes a parsing error that occurred when processing Hive queries containing `INSERT INTO TABLE` with backquoted table names, which is common in CDP (Customer Data Platform) generated SQL.

🤖 Generated with [Claude Code](https://claude.ai/code)