### PR TITLE
fix: Add support for Hive-style array() constructor syntax

### DIFF
--- a/spec/sql/basic/array-hive-syntax.sql
+++ b/spec/sql/basic/array-hive-syntax.sql
@@ -1,0 +1,28 @@
+-- Test Hive-style array constructor with parentheses
+-- Simple array with string literals
+SELECT array('bias');
+
+-- Array with multiple string literals
+SELECT array('car_color', 'car_engine');
+
+-- Array with mixed types
+SELECT array('a', 'b', 'c');
+
+-- Array with numbers
+SELECT array(1, 2, 3);
+
+-- Nested array function call
+SELECT array_concat(
+    array('bias'),
+    array('car_color', 'car_engine', 'car_grade')
+);
+
+-- Traditional bracket syntax should still work
+SELECT array['x', 'y', 'z'];
+
+-- Mixed usage in complex query
+SELECT array_concat(
+    array('prefix'),
+    array['middle1', 'middle2'],
+    array('suffix')
+);

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -2264,10 +2264,8 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
       t.token match
         case SqlToken.L_PAREN =>
           (consume(SqlToken.L_PAREN), SqlToken.R_PAREN)
-        case SqlToken.L_BRACKET =>
-          (consume(SqlToken.L_BRACKET), SqlToken.R_BRACKET)
         case _ =>
-          // Default to bracket syntax if neither is found
+          // Default to bracket syntax
           (consume(SqlToken.L_BRACKET), SqlToken.R_BRACKET)
 
     val elements = List.newBuilder[Expression]

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -2258,7 +2258,18 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
 
   def array(): ArrayConstructor =
     consumeIfExist(SqlToken.ARRAY)
-    val t        = consume(SqlToken.L_BRACKET)
+    // Support both ARRAY[...] and ARRAY(...) syntax for Hive compatibility
+    val t = scanner.lookAhead()
+    val (startToken, endToken) =
+      t.token match
+        case SqlToken.L_PAREN =>
+          (consume(SqlToken.L_PAREN), SqlToken.R_PAREN)
+        case SqlToken.L_BRACKET =>
+          (consume(SqlToken.L_BRACKET), SqlToken.R_BRACKET)
+        case _ =>
+          // Default to bracket syntax if neither is found
+          (consume(SqlToken.L_BRACKET), SqlToken.R_BRACKET)
+
     val elements = List.newBuilder[Expression]
 
     def nextElement: Unit =
@@ -2267,15 +2278,17 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
         case SqlToken.COMMA =>
           consume(SqlToken.COMMA)
           nextElement
-        case SqlToken.R_BRACKET =>
+        case token if token == endToken =>
         // ok
         case _ =>
           elements += expression()
           nextElement
 
     nextElement
-    consume(SqlToken.R_BRACKET)
-    ArrayConstructor(elements.result(), spanFrom(t))
+    consume(endToken)
+    ArrayConstructor(elements.result(), spanFrom(startToken))
+
+  end array
 
   def map(): Expression =
     val t = consume(SqlToken.MAP)


### PR DESCRIPTION
## Summary
- Added support for Hive SQL dialect's array constructor syntax using parentheses: `array('value1', 'value2')`
- Maintains backward compatibility with standard SQL bracket syntax: `array['value1', 'value2']`
- Fixes parsing errors for queries commonly used in Hive/CDP environments

## Changes
- Modified `SqlParser.array()` method to accept both `()` and `[]` delimiters
- Added comprehensive test file `spec/sql/basic/array-hive-syntax.sql` covering both syntaxes

## Test Plan
- [x] Added test file with various array constructor patterns
- [x] Verified parsing of both syntaxes works correctly
- [x] All existing tests pass
- [x] Code formatted with scalafmtAll

🤖 Generated with [Claude Code](https://claude.ai/code)