### PR TITLE
fix: Fix SqlScanner to emit two GT tokens for '>>' in nested array types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ dist
 
 # playground will be built at CI
 website/static/playground
+
+.worktree

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/Scanner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/Scanner.scala
@@ -397,7 +397,17 @@ abstract class ScannerBase[Token](sourceFile: SourceFile, config: ScannerConfig)
   final protected def getOperatorRest(): Unit =
     trace(s"getOperatorRest[${offset}]: ch: '${String.valueOf(ch)}'")
     (ch: @switch) match
-      case '~' | '!' | '@' | '#' | '%' | '^' | '+' | '-' | '<' | '>' | '?' | ':' | '=' | '&' | '|' |
+      case '>' =>
+        // Special handling for '>>' to emit two GT tokens instead of one identifier
+        if tokenBuffer.nonEmpty && tokenBuffer.last == '>' then
+          // We already have a '>' in the buffer, don't consume the next '>'
+          // This will finish the current '>' token and let the next scan pick up the second '>'
+          finishNamedToken()
+        else
+          putChar(ch)
+          nextChar()
+          getOperatorRest()
+      case '~' | '!' | '@' | '#' | '%' | '^' | '+' | '-' | '<' | '?' | ':' | '=' | '&' | '|' |
           '\\' =>
         putChar(ch)
         nextChar()

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/Scanner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/Scanner.scala
@@ -399,7 +399,7 @@ abstract class ScannerBase[Token](sourceFile: SourceFile, config: ScannerConfig)
     (ch: @switch) match
       case '>' =>
         // Special handling for '>>' to emit two GT tokens instead of one identifier
-        if tokenBuffer.nonEmpty && tokenBuffer.last == '>' then
+        if tokenBuffer.last == '>' then
           // We already have a '>' in the buffer, don't consume the next '>'
           // This will finish the current '>' token and let the next scan pick up the second '>'
           finishNamedToken()

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/SqlScannerTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/SqlScannerTest.scala
@@ -74,4 +74,124 @@ class SqlScannerTest extends AirSpec:
     token.length shouldBe 0
   }
 
+  test("scan >> as two GT tokens") {
+    val src     = ">>"
+    val scanner = SqlScanner(SourceFile.fromWvletString(src))
+
+    // First token should be GT
+    var token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.GT
+    token.str shouldBe ">"
+    token.offset shouldBe 0
+    token.length shouldBe 1
+
+    // Second token should also be GT
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.GT
+    token.str shouldBe ">"
+    token.offset shouldBe 1
+    token.length shouldBe 1
+
+    // Third token should be EOF
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.EOF
+  }
+
+  test("scan >>> as three GT tokens") {
+    val src     = ">>>"
+    val scanner = SqlScanner(SourceFile.fromWvletString(src))
+
+    // First GT
+    var token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.GT
+    token.str shouldBe ">"
+
+    // Second GT
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.GT
+    token.str shouldBe ">"
+
+    // Third GT
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.GT
+    token.str shouldBe ">"
+
+    // EOF
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.EOF
+  }
+
+  test("scan nested array type array<array<int>>") {
+    val src     = "array<array<int>>"
+    val scanner = SqlScanner(SourceFile.fromWvletString(src))
+
+    // array
+    var token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.ARRAY
+    token.str shouldBe "array"
+
+    // <
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.LT
+    token.str shouldBe "<"
+
+    // array
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.ARRAY
+    token.str shouldBe "array"
+
+    // <
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.LT
+    token.str shouldBe "<"
+
+    // int
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.IDENTIFIER
+    token.str shouldBe "int"
+
+    // First >
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.GT
+    token.str shouldBe ">"
+
+    // Second >
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.GT
+    token.str shouldBe ">"
+
+    // EOF
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.EOF
+  }
+
+  test("ensure >= still works as single token") {
+    val src     = ">="
+    val scanner = SqlScanner(SourceFile.fromWvletString(src))
+
+    var token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.GTEQ
+    token.str shouldBe ">="
+
+    token = scanner.nextToken()
+    debug(token)
+    token.token shouldBe SqlToken.EOF
+  }
+
 end SqlScannerTest


### PR DESCRIPTION
## Summary
Fixed the SqlScanner to properly tokenize `>>` as two separate GT tokens instead of treating it as a single identifier token. This enables correct parsing of nested array types like `array<array<int>>`.

## Changes
- Modified `getOperatorRest()` in `ScannerBase` to detect when we have consecutive `>` characters
- When a `>` is already in the token buffer and another `>` is encountered, finish the current token instead of consuming the next character
- Added comprehensive test cases covering various scenarios:
  - `>>` tokenized as two GT tokens
  - `>>>` tokenized as three GT tokens  
  - Nested array type parsing: `array<array<int>>`
  - Regression test ensuring `>=` still works as single token

## Test plan
- [x] All existing tests pass (1248 tests)
- [x] New test cases verify correct `>>` tokenization behavior
- [x] No regressions in related operators like `>=`
- [x] Code formatting complies with project standards

## Technical Details
The fix works by modifying the `getOperatorRest()` method in `ScannerBase` to detect when we have a `>` character in the buffer and the next character is also `>`. In this case:

1. The first `>` is processed normally and put into the token buffer
2. When the second `>` is encountered, the method detects this pattern and finishes the current token (containing just one `>`)
3. The scanner then picks up the second `>` on the next token scan

This ensures that `array<array<int>>` is correctly tokenized as:
- `ARRAY`, `<`, `ARRAY`, `<`, `IDENTIFIER(int)`, `GT`, `GT`

🤖 Generated with [Claude Code](https://claude.ai/code)