### PR TITLE
fix: Add support for Hive CLUSTER BY, DISTRIBUTE BY, and SORT BY syntax in SELECT queries

### DIFF
--- a/spec/sql/hive/with-insert.sql
+++ b/spec/sql/hive/with-insert.sql
@@ -64,3 +64,27 @@ WITH RECURSIVE hierarchy AS (
 INSERT INTO org_chart
 SELECT * FROM hierarchy;
 
+-- WITH clause containing CLUSTER BY (the failing case from the error report)
+WITH tag_top_k AS (
+  SELECT
+    each_top_k(
+      20, cdp_customer_id, tag_score,
+      cdp_customer_id, tag
+    ) AS (rank, tag_score, cdp_customer_id, tag)
+  FROM (
+    SELECT
+      cdp_customer_id,
+      tag,
+      tag_score
+    FROM cdp_tmp_word_tagging_behavior_behv_orders
+    CLUSTER BY
+      cdp_customer_id
+  ) t
+)
+INSERT OVERWRITE TABLE `cdp_tmp_word_tagging_behavior_behv_orders_customers_tags`
+SELECT
+  cdp_customer_id,
+  tag
+FROM
+  tag_top_k;
+

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -201,6 +201,9 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
         }
       case s: Sort =>
         unary(s, "order by", s.orderBy.toList)
+      case h: PartitioningHint =>
+        // Ignore Hive partition hints in Wvlet and just process the child
+        relation(h.child)
       case p: Project =>
         unary(p, "select", p.selectItems)
       case g: GroupBy =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
@@ -262,6 +262,31 @@ case class Offset(child: Relation, rows: LongLiteral, span: Span) extends Filter
 case class Filter(child: Relation, filterExpr: Expression, span: Span) extends FilteringRelation:
   override def toString: String = s"Filter[${filterExpr}](${child})"
 
+/**
+  * Partition write strategies for ETL operations
+  */
+enum PartitionWriteMode:
+  case HIVE_CLUSTER_BY
+  case HIVE_DISTRIBUTE_BY
+  case HIVE_SORT_BY
+
+/**
+  * Generic partition write options for ETL operations
+  */
+case class PartitionWriteOption(
+    mode: PartitionWriteMode,
+    expressions: List[Expression] = Nil,
+    sortItems: List[SortItem] = Nil
+)
+
+case class PartitioningHint(
+    child: Relation,
+    partitionWriteOptions: List[PartitionWriteOption],
+    span: Span
+) extends FilteringRelation:
+  override def toString: String =
+    s"PartitioningHint[${partitionWriteOptions.mkString(", ")}](${child})"
+
 case class Count(child: Relation, span: Span) extends UnaryRelation with AggSelect:
   override def toString: String = s"Count(${child})"
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/update.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/update.scala
@@ -14,26 +14,21 @@ import scala.collection.immutable.ListMap
 trait Update extends TopLevelStatement with HasTableOrFileName:
   override def relationType: RelationType = EmptyRelationType
 
+object Update:
+  /**
+    * Extract partition write options from a relation if it's a PartitioningHint, and return the
+    * unwrapped child relation and the options.
+    */
+  def extractPartitionOptions(relation: Relation): (Relation, List[PartitionWriteOption]) =
+    relation match
+      case hint: PartitioningHint =>
+        (hint.child, hint.partitionWriteOptions)
+      case other =>
+        (other, Nil)
+
 trait Save extends Update with UnaryRelation
 
 case class SaveOption(key: Identifier, value: Expression, span: Span) extends LeafExpression
-
-/**
-  * Partition write strategies for ETL operations
-  */
-enum PartitionWriteMode:
-  case HIVE_CLUSTER_BY
-  case HIVE_DISTRIBUTE_BY
-  case HIVE_SORT_BY
-
-/**
-  * Generic partition write options for ETL operations
-  */
-case class PartitionWriteOption(
-    mode: PartitionWriteMode,
-    expressions: List[Expression] = Nil,
-    sortItems: List[SortItem] = Nil
-)
 
 case class SaveTo(
     child: Relation,


### PR DESCRIPTION
## Summary

This PR fixes a parser error that occurred when encountering `CLUSTER BY` clauses in subqueries within `WITH` statements. The error was:

```
[SYNTAX_ERROR] Expected R_PAREN, but found CLUSTER (context: SqlParser.scala:2755)
    CLUSTER BY (01K4TWYW5Z1SZPZQMY6MVTJSFP.sql:23:5)
```

## Changes

### Core Implementation
- **Add PartitioningHint relation**: New `FilteringRelation` that preserves Hive-specific partition clauses in the logical plan
- **Move partition definitions**: Relocated `PartitionWriteMode` and `PartitionWriteOption` from `update.scala` to `relation.scala` for broader reuse
- **Enhanced SqlParser**: Updated to handle `CLUSTER BY`, `DISTRIBUTE BY`, and `SORT BY` in SELECT contexts, not just INSERT/CREATE statements

### SQL Generation
- **Database-specific behavior**: Only generates partition clauses for `DBType.Hive`, other databases ignore these hints
- **Updated SqlGenerator**: Added support for rendering partition clauses in SELECT statements
- **Updated WvletGenerator**: Added case to ignore partition hints since Wvlet doesn't support them

### Update Statement Integration  
- **Enhanced INSERT/CREATE**: Modified `InsertInto`, `InsertOverwrite`, and `CreateTableAs` to extract partition hints from child relations
- **Backward compatibility**: Existing code continues to work unchanged

## Test Coverage

Added test case in `spec/sql/hive/with-insert.sql` with the failing query from the error report:

```sql
WITH tag_top_k AS (
  SELECT /* ... */ FROM (
    SELECT /* ... */ FROM table
    CLUSTER BY cdp_customer_id
  ) t
)
INSERT OVERWRITE TABLE target
SELECT /* ... */ FROM tag_top_k;
```

## Benefits

- **Preserves SQL syntax**: The logical plan maintains the original Hive syntax  
- **Database compatibility**: Only generates partition clauses for Hive, other databases ignore them
- **Backward compatibility**: No breaking changes to existing functionality
- **Test coverage**: Prevents regression with comprehensive test case

🤖 Generated with [Claude Code](https://claude.ai/code)