### PR TITLE
feature: Add support for expressions in TABLESAMPLE clauses

### DIFF
--- a/spec/sql/basic/tablesample.sql
+++ b/spec/sql/basic/tablesample.sql
@@ -33,3 +33,8 @@ SELECT * FROM information_schema.tables USING SAMPLE 10 percent;
 
 -- DuckDB USING SAMPLE with reservoir method
 SELECT * FROM information_schema.tables USING SAMPLE reservoir(10%);
+
+-- Test cases for arithmetic expressions in TABLESAMPLE (should work after fix)
+SELECT * FROM information_schema.tables TABLESAMPLE BERNOULLI ((100 - 10));
+SELECT * FROM information_schema.tables TABLESAMPLE BERNOULLI (50 + 25);
+SELECT * FROM information_schema.tables TABLESAMPLE BERNOULLI (((10)));

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -340,11 +340,25 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
       case s: Sample =>
         val prev = relation(s.child)
         val opts =
-          s.method match
-            case Some(m) =>
-              text(m.toString) + paren(text(s.size.toExpr))
-            case None =>
-              text(s.size.toExpr)
+          s.size match
+            case SamplingSize.Rows(n) =>
+              s.method match
+                case Some(m) =>
+                  text(m.toString) + paren(text(n.toString))
+                case None =>
+                  text(s"${n} rows")
+            case SamplingSize.Percentage(p) =>
+              s.method match
+                case Some(m) =>
+                  text(m.toString) + paren(text(s"${p}%"))
+                case None =>
+                  text(s"${p}%")
+            case SamplingSize.PercentageExpr(e) =>
+              s.method match
+                case Some(m) =>
+                  text(m.toString) + paren(expr(e))
+                case None =>
+                  expr(e)
         prev /
           code(s) {
             group(wl("sample", opts))

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -340,25 +340,22 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
       case s: Sample =>
         val prev = relation(s.child)
         val opts =
-          s.size match
-            case SamplingSize.Rows(n) =>
-              s.method match
-                case Some(m) =>
-                  text(m.toString) + paren(text(n.toString))
-                case None =>
+          val sizeDoc =
+            s.size match
+              case SamplingSize.Rows(n) =>
+                if s.method.isDefined then
+                  text(n.toString)
+                else
                   text(s"${n} rows")
-            case SamplingSize.Percentage(p) =>
-              s.method match
-                case Some(m) =>
-                  text(m.toString) + paren(text(s"${p}%"))
-                case None =>
-                  text(s"${p}%")
-            case SamplingSize.PercentageExpr(e) =>
-              s.method match
-                case Some(m) =>
-                  text(m.toString) + paren(expr(e))
-                case None =>
-                  expr(e)
+              case SamplingSize.Percentage(p) =>
+                text(s"${p}%")
+              case SamplingSize.PercentageExpr(e) =>
+                expr(e)
+          s.method match
+            case Some(m) =>
+              text(m.toString) + paren(sizeDoc)
+            case None =>
+              sizeDoc
         prev /
           code(s) {
             group(wl("sample", opts))

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -343,10 +343,7 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
           val sizeDoc =
             s.size match
               case SamplingSize.Rows(n) =>
-                if s.method.isDefined then
-                  text(n.toString)
-                else
-                  text(s"${n} rows")
+                text(n.toString)
               case SamplingSize.Percentage(p) =>
                 text(s"${p}%")
               case SamplingSize.PercentageExpr(e) =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
@@ -1148,15 +1148,9 @@ enum SamplingMethod:
   case bernoulli
 
 enum SamplingSize:
-  def toExpr: String =
-    this match
-      case Rows(rows) =>
-        rows.toString
-      case Percentage(p) =>
-        s"${p}%"
-
-  case Rows(rows: Long)               extends SamplingSize
-  case Percentage(percentage: Double) extends SamplingSize
+  case Rows(rows: Long)                 extends SamplingSize
+  case Percentage(percentage: Double)   extends SamplingSize
+  case PercentageExpr(expr: Expression) extends SamplingSize
 
 /**
   * Debug operator adds a separate execution path to inspect the input relation.


### PR DESCRIPTION
## Summary

This PR fixes a Trino SQL parsing error that occurred when using complex expressions in TABLESAMPLE clauses, such as `TABLESAMPLE BERNOULLI ((100 - 10))`.

## Problem

The original error:
```
[SYNTAX_ERROR] Unexpected expression: ParenthesizedExpression(Subtract(left:LongLiteral(100,100,[78..81]), right:LongLiteral(10,10,[84..86))),[77..87))
```

This occurred because the SQL parser's `extractNumericValue` method only handled literal values but couldn't process complex expressions like parenthesized arithmetic operations.

## Solution

- **Add `PercentageExpr` case** to `SamplingSize` enum to handle expressions
- **Remove `toExpr` method** from the model for better separation of concerns  
- **Update SqlParser** to use `PercentageExpr` for non-literal expressions
- **Update SqlGenerator** to handle `PercentageExpr` in all database contexts (Trino, DuckDB, etc.)
- **Update WvletGenerator** to handle `PercentageExpr` for Wvlet code generation

## Test Coverage

Added test cases for:
- `TABLESAMPLE BERNOULLI ((100 - 10))`
- `TABLESAMPLE BERNOULLI (50 + 25)` 
- `TABLESAMPLE BERNOULLI (((10)))`

All existing SQL parser tests (185 tests) continue to pass, ensuring no regression.

## Benefits

- **Flexibility**: Now supports any valid SQL expression in TABLESAMPLE clauses
- **Database compatibility**: Works across Trino, DuckDB, and other databases
- **Clean architecture**: Proper separation between model and presentation logic
- **Backward compatibility**: All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)