### PR TITLE
feature: Add support for Trino DESCRIBE OUTPUT statement

### DIFF
--- a/spec/sql/trino/describe-output.sql
+++ b/spec/sql/trino/describe-output.sql
@@ -1,0 +1,11 @@
+-- Test basic DESCRIBE OUTPUT statement
+DESCRIBE OUTPUT my_statement;
+
+-- Test DESCRIBE OUTPUT with complex statement name
+DESCRIBE OUTPUT complex_prepared_stmt;
+
+-- Test DESCRIBE OUTPUT with quoted identifier
+DESCRIBE OUTPUT "quoted_stmt";
+
+-- Test DESCRIBE OUTPUT with underscored identifier
+DESCRIBE OUTPUT prepared_stmt_with_underscores;

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -596,12 +596,24 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
             unexpected(name, "Statement name for DESCRIBE INPUT cannot be a numeric literal.")
           case _ =>
             DescribeInput(name, spanFrom(t))
+      case SqlToken.OUTPUT =>
+        consume(SqlToken.OUTPUT)
+        val name = identifier()
+        name match
+          case _: Wildcard =>
+            unexpected(name, "Statement name for DESCRIBE OUTPUT cannot be a wildcard (*).")
+          case _: DigitIdentifier =>
+            unexpected(name, "Statement name for DESCRIBE OUTPUT cannot be a numeric literal.")
+          case _ =>
+            DescribeOutput(name, spanFrom(t))
       case _ =>
         unexpected(
           lookaheadTokenData,
           s"Unsupported DESCRIBE target: ${lookaheadTokenData
-              .token}. Only DESCRIBE INPUT is currently supported."
+              .token}. Only DESCRIBE INPUT and DESCRIBE OUTPUT are currently supported."
         )
+
+  end describe
 
   def queryOrUpdate(): LogicalPlan =
     val t = scanner.lookAhead()

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -586,26 +586,23 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
     val t                  = consume(SqlToken.DESCRIBE)
     val lookaheadTokenData = scanner.lookAhead()
     lookaheadTokenData.token match
-      case SqlToken.INPUT =>
-        consume(SqlToken.INPUT)
-        val name = identifier()
+      case token @ (SqlToken.INPUT | SqlToken.OUTPUT) =>
+        consume(token)
+        val name     = identifier()
+        val tokenStr = token.str.toUpperCase
         name match
           case _: Wildcard =>
-            unexpected(name, "Statement name for DESCRIBE INPUT cannot be a wildcard (*).")
+            unexpected(name, s"Statement name for DESCRIBE ${tokenStr} cannot be a wildcard (*).")
           case _: DigitIdentifier =>
-            unexpected(name, "Statement name for DESCRIBE INPUT cannot be a numeric literal.")
+            unexpected(
+              name,
+              s"Statement name for DESCRIBE ${tokenStr} cannot be a numeric literal."
+            )
           case _ =>
-            DescribeInput(name, spanFrom(t))
-      case SqlToken.OUTPUT =>
-        consume(SqlToken.OUTPUT)
-        val name = identifier()
-        name match
-          case _: Wildcard =>
-            unexpected(name, "Statement name for DESCRIBE OUTPUT cannot be a wildcard (*).")
-          case _: DigitIdentifier =>
-            unexpected(name, "Statement name for DESCRIBE OUTPUT cannot be a numeric literal.")
-          case _ =>
-            DescribeOutput(name, spanFrom(t))
+            if token == SqlToken.INPUT then
+              DescribeInput(name, spanFrom(t))
+            else
+              DescribeOutput(name, spanFrom(t))
       case _ =>
         unexpected(
           lookaheadTokenData,

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -204,6 +204,7 @@ enum SqlToken(val tokenType: TokenType, val str: String):
   case FOR            extends SqlToken(Keyword, "for")
   case DESCRIBE       extends SqlToken(Keyword, "describe")
   case INPUT          extends SqlToken(Keyword, "input")
+  case OUTPUT         extends SqlToken(Keyword, "output")
 
   // DDL entity types (non-reserved so they can be used as table names)
   case CATALOG   extends SqlToken(Keyword, "catalog")
@@ -377,6 +378,7 @@ object SqlToken:
     SqlToken.STATEMENT,
     SqlToken.FUNCTIONS,
     SqlToken.INPUT,
+    SqlToken.OUTPUT,
     // Data types - non-reserved so they can be used as column names
     SqlToken.DATE,
     SqlToken.TIME,

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/commands.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/commands.scala
@@ -13,3 +13,4 @@ case class ExecuteExpr(expr: Expression, span: Span)    extends Command
 case class ExplainPlan(child: LogicalPlan, span: Span)  extends Command
 case class UseSchema(schema: QualifiedName, span: Span) extends Command
 case class DescribeInput(name: NameExpr, span: Span)    extends Command
+case class DescribeOutput(name: NameExpr, span: Span)   extends Command

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -258,7 +258,7 @@ class QueryExecutor(
               )
       case d: DescribeInput =>
         // For now, just return empty result since DESCRIBE INPUT is mainly for parsing validation
-        // In a full implementation, this would query the prepared statement metadata
+        // In a full implementation, this would query the prepared statement input metadata
         workEnv.info(s"DESCRIBE INPUT ${d.name.fullName}")
         QueryResult.empty
       case d: DescribeOutput =>

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -261,6 +261,11 @@ class QueryExecutor(
         // In a full implementation, this would query the prepared statement metadata
         workEnv.info(s"DESCRIBE INPUT ${d.name.fullName}")
         QueryResult.empty
+      case d: DescribeOutput =>
+        // For now, just return empty result since DESCRIBE OUTPUT is mainly for parsing validation
+        // In a full implementation, this would query the prepared statement output metadata
+        workEnv.info(s"DESCRIBE OUTPUT ${d.name.fullName}")
+        QueryResult.empty
     end match
 
   end executeCommand


### PR DESCRIPTION
## Summary

- Add support for parsing `DESCRIBE OUTPUT statement_name` syntax 
- Implement basic execution handling for DESCRIBE OUTPUT commands
- Add comprehensive test coverage for the new functionality

## Changes Made

### Parser Updates
- **SqlToken.scala**: Added `OUTPUT` token as non-reserved keyword
- **SqlParser.scala**: Extended `describe()` method to handle both INPUT and OUTPUT cases
- **commands.scala**: Added `DescribeOutput` case class extending Command

### Execution Support  
- **QueryExecutor.scala**: Added placeholder handling for DescribeOutput commands

### Testing
- **describe-output.sql**: Added comprehensive test cases covering basic usage, quoted identifiers, and complex statement names

## Test Results

All tests pass successfully:
- ✅ New DESCRIBE OUTPUT parsing tests
- ✅ Existing DESCRIBE INPUT functionality (regression test)
- ✅ Combined prepare-and-describe scenarios
- ✅ Code formatting compliance

## Implementation Notes

This adds parser support for Trino's `DESCRIBE OUTPUT` statement, which is used to examine the output columns of prepared statements. The current implementation provides a placeholder execution path that can be extended with actual metadata querying in the future.

The syntax supported:
```sql
DESCRIBE OUTPUT statement_name;
DESCRIBE OUTPUT "quoted_statement";
DESCRIBE OUTPUT complex_prepared_stmt;
```

🤖 Generated with [Claude Code](https://claude.ai/code)