### PR TITLE
feature: Add support for Trino CREATE TABLE LIKE syntax

### DIFF
--- a/spec/sql/trino/create-table-like-basic.sql
+++ b/spec/sql/trino/create-table-like-basic.sql
@@ -1,0 +1,65 @@
+-- Basic Trino CREATE TABLE LIKE syntax tests (parse-only)
+
+-- Basic LIKE syntax (default is EXCLUDING PROPERTIES)
+CREATE TABLE test_table_basic (
+  LIKE source_table
+);
+
+-- LIKE with explicit EXCLUDING PROPERTIES
+CREATE TABLE test_table_explicit_exclude (
+  LIKE source_table EXCLUDING PROPERTIES
+);
+
+-- LIKE with INCLUDING PROPERTIES
+CREATE TABLE test_table_include_props (
+  LIKE source_table INCLUDING PROPERTIES
+);
+
+-- Mixed columns and LIKE - column before LIKE
+CREATE TABLE test_mixed_before (
+  id BIGINT,
+  LIKE source_table,
+  created_at TIMESTAMP
+);
+
+-- Mixed columns and LIKE - column after LIKE
+CREATE TABLE test_mixed_after (
+  LIKE source_table,
+  processed_at TIMESTAMP
+);
+
+-- CREATE OR REPLACE with LIKE
+CREATE OR REPLACE TABLE test_replace_with_like (
+  LIKE source_table INCLUDING PROPERTIES
+);
+
+-- CREATE TABLE IF NOT EXISTS with LIKE
+CREATE TABLE IF NOT EXISTS test_if_not_exists_like (
+  LIKE source_table
+);
+
+-- LIKE with WITH properties
+CREATE TABLE test_like_with_props (
+  LIKE source_table
+) WITH (
+  format = 'ORC',
+  partitioned_by = ARRAY['date']
+);
+
+-- Multiple LIKE clauses
+CREATE TABLE test_multiple_likes (
+  col1 INT,
+  LIKE table1,
+  col2 VARCHAR(100),
+  LIKE table2 INCLUDING PROPERTIES
+);
+
+-- Qualified table names in LIKE
+CREATE TABLE test_qualified_like (
+  LIKE schema.source_table INCLUDING PROPERTIES
+);
+
+-- Fully qualified table names in LIKE
+CREATE TABLE test_fully_qualified_like (
+  LIKE catalog.schema.source_table
+);

--- a/spec/sql/trino/create-table-like.sql
+++ b/spec/sql/trino/create-table-like.sql
@@ -1,0 +1,85 @@
+-- Trino CREATE TABLE LIKE syntax tests
+
+-- Basic LIKE syntax (default is EXCLUDING PROPERTIES)
+CREATE TABLE test_table_basic (
+  LIKE source_table
+);
+
+-- LIKE with explicit EXCLUDING PROPERTIES
+CREATE TABLE test_table_explicit_exclude (
+  LIKE source_table EXCLUDING PROPERTIES
+);
+
+-- LIKE with INCLUDING PROPERTIES
+CREATE TABLE test_table_include_props (
+  LIKE source_table INCLUDING PROPERTIES
+);
+
+-- Mixed columns and LIKE - column before LIKE
+CREATE TABLE test_mixed_before (
+  id BIGINT,
+  LIKE source_table,
+  created_at TIMESTAMP
+);
+
+-- Mixed columns and LIKE - column after LIKE
+CREATE TABLE test_mixed_after (
+  LIKE source_table,
+  processed_at TIMESTAMP
+);
+
+-- CREATE OR REPLACE with LIKE
+CREATE OR REPLACE TABLE test_replace_with_like (
+  LIKE source_table INCLUDING PROPERTIES
+);
+
+-- CREATE TABLE IF NOT EXISTS with LIKE
+CREATE TABLE IF NOT EXISTS test_if_not_exists_like (
+  LIKE source_table
+);
+
+-- LIKE with WITH properties
+CREATE TABLE test_like_with_props (
+  LIKE source_table
+) WITH (
+  format = 'ORC',
+  partitioned_by = ARRAY['date']
+);
+
+-- LIKE with INCLUDING PROPERTIES and WITH properties
+CREATE TABLE test_like_include_and_with (
+  LIKE source_table INCLUDING PROPERTIES
+) WITH (
+  format = 'PARQUET'
+);
+
+-- CREATE TABLE AS with LIKE
+CREATE TABLE test_like_as_select (
+  LIKE source_table
+) AS SELECT 1 as id, 'test' as name;
+
+-- CREATE TABLE AS with LIKE and WITH properties
+CREATE TABLE test_like_as_select_with_props (
+  LIKE source_table INCLUDING PROPERTIES
+) WITH (
+  bucketed_on = ARRAY['id'],
+  bucket_count = 16
+) AS SELECT 1 as id, 'test' as name;
+
+-- Multiple LIKE clauses (if supported)
+CREATE TABLE test_multiple_likes (
+  col1 INT,
+  LIKE table1,
+  col2 VARCHAR(100),
+  LIKE table2 INCLUDING PROPERTIES
+);
+
+-- Qualified table names in LIKE
+CREATE TABLE test_qualified_like (
+  LIKE schema.source_table INCLUDING PROPERTIES
+);
+
+-- Fully qualified table names in LIKE
+CREATE TABLE test_fully_qualified_like (
+  LIKE catalog.schema.source_table
+);

--- a/spec/sql/trino/original-error-case.sql
+++ b/spec/sql/trino/original-error-case.sql
@@ -1,4 +1,0 @@
--- Test case for the original error from issue
-CREATE TABLE d_bbdde9.t_36c55 (
-   LIKE d_bbdde9.t_1038a
-);

--- a/spec/sql/trino/original-error-case.sql
+++ b/spec/sql/trino/original-error-case.sql
@@ -1,0 +1,4 @@
+-- Test case for the original error from issue
+CREATE TABLE d_bbdde9.t_36c55 (
+   LIKE d_bbdde9.t_1038a
+);

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1601,6 +1601,12 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
           // c.nullable.map(x => text(x.expr)),
           // c.comment.map(x => text(x.expr))
         )
+      case l: LikeTableDef =>
+        if l.includeProperties then
+          wl("like", expr(l.tableName), "including", "properties")
+        else
+          // Default is EXCLUDING PROPERTIES, so we can omit it for cleaner output
+          wl("like", expr(l.tableName))
       case other =>
         unsupportedNode(s"Expression ${other.nodeName}", other.span)
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
@@ -910,13 +910,14 @@ case class ColumnDef(
     with UnaryExpression:
   override def toString: String  = s"${columnName.leafName}:${tpe.wvExpr}"
   override def child: Expression = columnName
+
 //
 //case class ColumnType(tpe: NameExpr, span: Span) extends LeafExpression
 //
-//case class ColumnDefLike(tableName: NameExpr, includeProperties: Boolean, span: Span)
-//    extends TableElement
-//    with UnaryExpression:
-//  override def child: Expression = tableName
+case class LikeTableDef(tableName: NameExpr, includeProperties: Boolean, span: Span)
+    extends TableElement
+    with UnaryExpression:
+  override def child: Expression = tableName
 
 // Aggregation
 trait GroupingKey extends UnaryExpression:

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/ddl.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/ddl.scala
@@ -53,7 +53,7 @@ case class RenameDatabase(database: NameExpr, renameTo: NameExpr, span: Span) ex
 case class CreateTable(
     table: NameExpr,
     ifNotExists: Boolean,
-    tableElems: List[ColumnDef],
+    tableElems: List[TableElement],
     properties: List[(NameExpr, Expression)] = Nil,
     span: Span
 ) extends DDL


### PR DESCRIPTION
## Summary
Implements support for the CREATE TABLE ... LIKE syntax in the Trino SQL parser, which allows creating a new table with the same structure as an existing table.

## Changes Made
- **AST Enhancement**: Added `LikeTableDef` case class to represent LIKE clauses in table definitions
- **Parser Extension**: Modified `tableElems()` to handle LIKE clauses with optional INCLUDING/EXCLUDING PROPERTIES
- **Type System Update**: Changed `CreateTable.tableElems` from `List[ColumnDef]` to `List[TableElement]` 
- **SQL Generation**: Added support for generating LIKE clauses in SQL output
- **Comprehensive Testing**: Added test cases covering various LIKE syntax combinations

## Supported Syntax
- Basic LIKE: `CREATE TABLE t1 (LIKE t2)`
- Properties control: `LIKE t2 INCLUDING PROPERTIES` / `LIKE t2 EXCLUDING PROPERTIES`
- Mixed definitions: `CREATE TABLE t1 (col1 INT, LIKE t2, col2 VARCHAR)`
- Integration with: `CREATE OR REPLACE`, `IF NOT EXISTS`, `WITH` properties, `AS SELECT`

## Test Coverage
- `spec/sql/trino/create-table-like.sql`: Comprehensive syntax tests
- `spec/sql/trino/create-table-like-basic.sql`: Parse-only basic tests  
- `spec/sql/trino/original-error-case.sql`: Original failing case

## Fixes
Resolves the parsing error for:
```sql
CREATE TABLE d_bbdde9.t_36c55 (
   LIKE d_bbdde9.t_1038a
);
```

## Test Plan
- [x] All new test cases pass with `SqlParserTrinoSpec`
- [x] Original error case now parses successfully
- [x] Code formatting applied with `scalafmtAll`
- [x] Compilation verified for `langJVM/Test/compile`

🤖 Generated with [Claude Code](https://claude.ai/code)