### PR TITLE
fix: Correct keyword classification logic in SqlToken and WvletToken

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/DataTypeParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/DataTypeParser.scala
@@ -113,7 +113,7 @@ class DataTypeParser(scanner: WvletScanner) extends LogSupport:
       case s if s.isStringLiteral && t.str.toLowerCase == "null" =>
         consumeToken()
         NullType
-      case token if token.isIdentifier || token.isReservedKeyword =>
+      case token if token.isIdentifier || token.isKeyword =>
         val id       = consume(t.token)
         val typeName = id.str.toLowerCase
         typeName match

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -3404,7 +3404,7 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
   def reserved(): Identifier =
     val t = consumeToken()
     t.token match
-      case token if token.isReservedKeyword =>
+      case token if token.isKeyword =>
         UnquotedIdentifier(t.str, spanFrom(t))
       case _ =>
         unexpected(t)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -4,9 +4,12 @@ import TokenType.*
 
 enum SqlToken(val tokenType: TokenType, val str: String):
   import SqlToken.*
-  def isIdentifier: Boolean      = tokenType == Identifier || isNonReservedKeyword
-  def isLiteral: Boolean         = tokenType == Literal
-  def isReservedKeyword: Boolean = tokenType == Keyword
+  def isIdentifier: Boolean = tokenType == Identifier || isNonReservedKeyword
+  def isLiteral: Boolean    = tokenType == Literal
+  def isKeyword: Boolean    = tokenType == Keyword
+  def isReservedKeyword: Boolean =
+    tokenType == Keyword && !SqlToken.nonReservedKeywords.contains(this)
+
   def isNonReservedKeyword: Boolean =
     tokenType == Keyword && SqlToken.nonReservedKeywords.contains(this)
 
@@ -418,7 +421,7 @@ object SqlToken:
   val keywordAndSymbolTable =
     val m = Map.newBuilder[String, SqlToken]
     allKeywordsAndSymbols.foreach {
-      case t: SqlToken if t.isReservedKeyword =>
+      case t: SqlToken if t.isKeyword =>
         m += t.str -> t
         // Support upper-case keywords in SQL
         m += t.str.toUpperCase -> t

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -4,14 +4,12 @@ import TokenType.*
 
 enum SqlToken(val tokenType: TokenType, val str: String):
   import SqlToken.*
-  def isIdentifier: Boolean = tokenType == Identifier || isNonReservedKeyword
-  def isLiteral: Boolean    = tokenType == Literal
-  def isKeyword: Boolean    = tokenType == Keyword
-  def isReservedKeyword: Boolean =
-    tokenType == Keyword && !SqlToken.nonReservedKeywords.contains(this)
+  def isIdentifier: Boolean      = tokenType == Identifier || isNonReservedKeyword
+  def isLiteral: Boolean         = tokenType == Literal
+  def isKeyword: Boolean         = tokenType == Keyword
+  def isReservedKeyword: Boolean = isKeyword && !SqlToken.nonReservedKeywords.contains(this)
 
-  def isNonReservedKeyword: Boolean =
-    tokenType == Keyword && SqlToken.nonReservedKeywords.contains(this)
+  def isNonReservedKeyword: Boolean = isKeyword && SqlToken.nonReservedKeywords.contains(this)
 
   def isOperator: Boolean = tokenType == Op
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -238,7 +238,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
   def reserved(): Identifier = node {
     val t = consumeToken()
     t.token match
-      case token if token.isReservedKeyword =>
+      case token if token.isKeyword =>
         UnquotedIdentifier(t.str, spanFrom(t))
       case _ =>
         unexpected(t)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
@@ -27,14 +27,12 @@ import TokenType.*
 import scala.annotation.switch
 
 enum WvletToken(val tokenType: TokenType, val str: String):
-  def isIdentifier: Boolean = tokenType == Identifier
-  def isLiteral: Boolean    = tokenType == Literal
-  def isKeyword: Boolean    = tokenType == Keyword
-  def isReservedKeyword: Boolean =
-    tokenType == Keyword && !WvletToken.nonReservedKeywords.contains(this)
+  def isIdentifier: Boolean      = tokenType == Identifier
+  def isLiteral: Boolean         = tokenType == Literal
+  def isKeyword: Boolean         = tokenType == Keyword
+  def isReservedKeyword: Boolean = isKeyword && !WvletToken.nonReservedKeywords.contains(this)
 
-  def isNonReservedKeyword: Boolean =
-    tokenType == Keyword && WvletToken.nonReservedKeywords.contains(this)
+  def isNonReservedKeyword: Boolean = isKeyword && WvletToken.nonReservedKeywords.contains(this)
 
   def canStartSelectItem: Boolean =
     tokenType != Keyword || WvletToken.literalStartKeywords.contains(this) ||

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
@@ -27,9 +27,12 @@ import TokenType.*
 import scala.annotation.switch
 
 enum WvletToken(val tokenType: TokenType, val str: String):
-  def isIdentifier: Boolean      = tokenType == Identifier
-  def isLiteral: Boolean         = tokenType == Literal
-  def isReservedKeyword: Boolean = tokenType == Keyword
+  def isIdentifier: Boolean = tokenType == Identifier
+  def isLiteral: Boolean    = tokenType == Literal
+  def isKeyword: Boolean    = tokenType == Keyword
+  def isReservedKeyword: Boolean =
+    tokenType == Keyword && !WvletToken.nonReservedKeywords.contains(this)
+
   def isNonReservedKeyword: Boolean =
     tokenType == Keyword && WvletToken.nonReservedKeywords.contains(this)
 

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/KeywordClassificationTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/KeywordClassificationTest.scala
@@ -57,18 +57,21 @@ class KeywordClassificationTest extends AirSpec:
     identifier.isNonReservedKeyword shouldBe false
   }
 
-  test("should verify all keywords are either reserved or non-reserved") {
+  test("should verify all SqlToken keywords are either reserved or non-reserved") {
     val allSqlKeywords = SqlToken.values.filter(_.isKeyword)
 
     allSqlKeywords.foreach { token =>
       // Each keyword should be either reserved XOR non-reserved, but not both
-      val isReserved    = token.isReservedKeyword
-      val isNonReserved = token.isNonReservedKeyword
+      (token.isReservedKeyword ^ token.isNonReservedKeyword) shouldBe true
+    }
+  }
 
-      if isReserved && isNonReserved then
-        fail(s"SqlToken ${token} is both reserved and non-reserved")
-      else if !isReserved && !isNonReserved then
-        fail(s"SqlToken ${token} is neither reserved nor non-reserved")
+  test("should verify all WvletToken keywords are either reserved or non-reserved") {
+    val allWvletKeywords = WvletToken.values.filter(_.isKeyword)
+
+    allWvletKeywords.foreach { token =>
+      // Each keyword should be either reserved XOR non-reserved, but not both
+      (token.isReservedKeyword ^ token.isNonReservedKeyword) shouldBe true
     }
   }
 

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/KeywordClassificationTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/KeywordClassificationTest.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.parser
+
+import wvlet.airspec.AirSpec
+
+class KeywordClassificationTest extends AirSpec:
+
+  test("SqlToken keyword classification should be mutually exclusive") {
+    // Test reserved keywords
+    val reservedKeyword = SqlToken.SELECT
+    reservedKeyword.isKeyword shouldBe true
+    reservedKeyword.isReservedKeyword shouldBe true
+    reservedKeyword.isNonReservedKeyword shouldBe false
+
+    // Test non-reserved keywords
+    val nonReservedKeyword = SqlToken.IF // IF is in nonReservedKeywords set
+    nonReservedKeyword.isKeyword shouldBe true
+    nonReservedKeyword.isReservedKeyword shouldBe false
+    nonReservedKeyword.isNonReservedKeyword shouldBe true
+
+    // Test non-keywords
+    val identifier = SqlToken.IDENTIFIER
+    identifier.isKeyword shouldBe false
+    identifier.isReservedKeyword shouldBe false
+    identifier.isNonReservedKeyword shouldBe false
+  }
+
+  test("WvletToken keyword classification should be mutually exclusive") {
+    // Test reserved keywords
+    val reservedKeyword = WvletToken.SELECT
+    reservedKeyword.isKeyword shouldBe true
+    reservedKeyword.isReservedKeyword shouldBe true
+    reservedKeyword.isNonReservedKeyword shouldBe false
+
+    // Test non-reserved keywords
+    val nonReservedKeyword = WvletToken.COUNT // COUNT is in nonReservedKeywords set
+    nonReservedKeyword.isKeyword shouldBe true
+    nonReservedKeyword.isReservedKeyword shouldBe false
+    nonReservedKeyword.isNonReservedKeyword shouldBe true
+
+    // Test non-keywords
+    val identifier = WvletToken.IDENTIFIER
+    identifier.isKeyword shouldBe false
+    identifier.isReservedKeyword shouldBe false
+    identifier.isNonReservedKeyword shouldBe false
+  }
+
+  test("should verify all keywords are either reserved or non-reserved") {
+    val allSqlKeywords = SqlToken.values.filter(_.isKeyword)
+
+    allSqlKeywords.foreach { token =>
+      // Each keyword should be either reserved XOR non-reserved, but not both
+      val isReserved    = token.isReservedKeyword
+      val isNonReserved = token.isNonReservedKeyword
+
+      if isReserved && isNonReserved then
+        fail(s"SqlToken ${token} is both reserved and non-reserved")
+      else if !isReserved && !isNonReserved then
+        fail(s"SqlToken ${token} is neither reserved nor non-reserved")
+    }
+  }
+
+  test("should verify SqlToken nonReservedKeywords set matches isNonReservedKeyword") {
+    SqlToken
+      .nonReservedKeywords
+      .foreach { token =>
+        token.isNonReservedKeyword shouldBe true
+        token.isReservedKeyword shouldBe false
+        token.isKeyword shouldBe true
+      }
+  }
+
+  test("should verify WvletToken nonReservedKeywords set matches isNonReservedKeyword") {
+    WvletToken
+      .nonReservedKeywords
+      .foreach { token =>
+        token.isNonReservedKeyword shouldBe true
+        token.isReservedKeyword shouldBe false
+        token.isKeyword shouldBe true
+      }
+  }
+
+end KeywordClassificationTest


### PR DESCRIPTION
## Summary

Fixes the confusing keyword classification logic in SqlToken and WvletToken where `isReservedKeyword` was returning `true` for ALL keywords, causing logical contradictions.

- Fix `isReservedKeyword()` to return `true` only for actually reserved keywords
- Add `isKeyword()` method to check for any keyword (reserved or non-reserved)  
- Update usages throughout codebase to use appropriate methods
- Add comprehensive tests to verify keyword classification logic

## Changes

### Core Logic Fixes
- **SqlToken.isReservedKeyword**: Now returns `tokenType == Keyword && !SqlToken.nonReservedKeywords.contains(this)`
- **SqlToken.isKeyword**: New method that returns `tokenType == Keyword` 
- **WvletToken**: Applied same changes for consistency

### Usage Updates
- **DataTypeParser**: Changed `isReservedKeyword` to `isKeyword` for type name parsing
- **WvletParser.reserved()**: Changed `isReservedKeyword` to `isKeyword` for identifier parsing  
- **SqlParser.reserved()**: Changed `isReservedKeyword` to `isKeyword` for identifier parsing
- **SqlToken.keywordAndSymbolTable**: Changed `isReservedKeyword` to `isKeyword` for case-insensitive keyword support

### Tests
- Added `KeywordClassificationTest` with comprehensive test coverage
- Verifies mutual exclusivity of keyword classification methods
- Ensures all keywords are properly classified as either reserved or non-reserved

## Results

The methods now provide clear, non-overlapping functionality:
- `isKeyword()` - returns true for ANY keyword 
- `isReservedKeyword()` - returns true ONLY for reserved keywords (cannot be used as identifiers)
- `isNonReservedKeyword()` - returns true ONLY for non-reserved keywords (can be used as identifiers)

Previously, non-reserved keywords like `SqlToken.IF` would incorrectly return `true` for both `isReservedKeyword` and `isNonReservedKeyword`. Now they correctly return `false` for `isReservedKeyword` and `true` for `isNonReservedKeyword`.

## Test plan

- [x] All existing tests pass (1,271 tests passing)
- [x] New `KeywordClassificationTest` verifies correct behavior
- [x] Code properly formatted with scalafmt
- [x] No regressions in parser functionality

🤖 Generated with [Claude Code](https://claude.ai/code)