### PR TITLE
doc: Add guidance for SQL specs to use VALUES expressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ For testing SqlParser, use `spec/sql/basic` directory:
 - `spec/sql/basic`: SQL-parser tests (.sql files) 
 - `spec/sql/tpc-h`: TPC-H benchmark queries
 
+In SQL specs, use VALUES expr to avoid referencing non-existing tables as it will be tested against DuckDB.
+
 - **Embedded Assertions**: `.wv` files contain `test` statements for validation
 - **SpecRunner**: Core engine that compiles and executes .wv files as test cases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ For testing SqlParser, use `spec/sql/basic` directory:
 - `spec/sql/basic`: SQL-parser tests (.sql files) 
 - `spec/sql/tpc-h`: TPC-H benchmark queries
 
-In SQL specs, use VALUES expr to avoid referencing non-existing tables as it will be tested against DuckDB.
+In SQL specs, use `VALUES` expressions to avoid referencing non-existing tables, as these specs are tested against DuckDB.
 
 - **Embedded Assertions**: `.wv` files contain `test` statements for validation
 - **SpecRunner**: Core engine that compiles and executes .wv files as test cases


### PR DESCRIPTION
## Summary
- Add guidance note in CLAUDE.md for SQL spec testing to use VALUES expressions
- This helps avoid referencing non-existing tables since SQL specs are tested against DuckDB

## Test plan
- [x] Documentation update only - no code changes required
- [x] Verified the guidance is clear and actionable

🤖 Generated with [Claude Code](https://claude.ai/code)