### PR TITLE
fix: Enable AT keyword as table alias for SQL compatibility

### DIFF
--- a/spec/sql/basic/at-alias.sql
+++ b/spec/sql/basic/at-alias.sql
@@ -1,0 +1,36 @@
+-- Test cases for AT keyword used as table alias
+-- Based on the MAP alias test pattern
+
+-- Simple table alias
+SELECT * FROM VALUES (1, 'test') as t(id, name), VALUES (2, 'at') at (id2, name2)
+
+-- AT with explicit AS keyword  
+SELECT * FROM VALUES (1, 'test') AS at
+
+-- AT in JOIN clauses (the main issue)
+SELECT * FROM VALUES (1, 'alice') t(id, name) 
+LEFT JOIN VALUES (1, 'profile') AT ON (t.id = AT.id)
+
+-- AT in complex subqueries
+SELECT * FROM (SELECT * FROM VALUES (1, 'test') at) sub
+
+-- AT in RIGHT JOIN
+SELECT * FROM VALUES (1, 'alice') t(id, name) 
+RIGHT JOIN VALUES (2, 'profile') at ON (t.id = at.id)
+
+-- AT in INNER JOIN  
+SELECT * FROM VALUES (1, 'alice') t(id, name) 
+INNER JOIN VALUES (1, 'profile') at ON (t.id = at.id)
+
+-- Multiple JOINs with AT
+SELECT * FROM VALUES (1, 'alice') t(id, name) 
+LEFT JOIN VALUES (1, 'profile') at ON (t.id = at.id)
+LEFT JOIN VALUES (1, 'settings') s ON (t.id = s.id)
+
+-- AT as column alias in field access
+SELECT at.id, at.name FROM VALUES (1, 'test') at
+
+-- Mixed case with both AT TIME ZONE and AT as alias 
+-- (verify both contexts work)
+SELECT at.id, TIMESTAMP '2023-01-01 12:00:00' AT TIME ZONE 'UTC' as utc_time
+FROM VALUES (1, 'test') at

--- a/spec/sql/basic/at-alias.sql
+++ b/spec/sql/basic/at-alias.sql
@@ -27,10 +27,16 @@ SELECT * FROM VALUES (1, 'alice') t(id, name)
 LEFT JOIN VALUES (1, 'profile') at ON (t.id = at.id)
 LEFT JOIN VALUES (1, 'settings') s ON (t.id = s.id)
 
--- AT as column alias in field access
+-- AT as table alias in field access
 SELECT at.id, at.name FROM VALUES (1, 'test') at
 
 -- Mixed case with both AT TIME ZONE and AT as alias 
 -- (verify both contexts work)
 SELECT at.id, TIMESTAMP '2023-01-01 12:00:00' AT TIME ZONE 'UTC' as utc_time
 FROM VALUES (1, 'test') at
+
+-- AT as a column alias
+SELECT id AS at FROM VALUES (1) t(id)
+
+-- AT as a column alias for a literal
+SELECT 123 AS at

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlToken.scala
@@ -399,6 +399,7 @@ object SqlToken:
     SqlToken.TIMESTAMP,
     SqlToken.DECIMAL,
     SqlToken.MAP, // MAP can be used as a table/column alias
+    SqlToken.AT,  // AT can be used as a table/column alias
     SqlToken.JSON,
     // JSON object modifiers
     SqlToken.ABSENT,


### PR DESCRIPTION
## Summary
- Fix SQL parser error when using 'at' as table alias in JOIN clauses
- Enable AT as non-reserved keyword while preserving AT TIME ZONE functionality  
- Add comprehensive test coverage for AT alias usage

## Problem
The SQL parser failed with `[SYNTAX_ERROR] Expected R_PAREN, but found AT` when encountering AT as a table alias:
```sql
LEFT JOIN t_54ee8 AT ON (t_90d92.f_2d5bb = t_75347.f_f0bcf)
```

## Root Cause
AT was defined as a reserved keyword for AT TIME ZONE expressions but wasn't included in the `nonReservedKeywords` set, preventing it from being used as an identifier/alias.

## Solution
1. **Add AT to nonReservedKeywords** in `SqlToken.scala` 
2. **Preserve existing functionality** - AT TIME ZONE expressions continue to work
3. **Comprehensive test cases** in `spec/sql/basic/at-alias.sql`

## Compatibility
✅ AT TIME ZONE expressions still work correctly  
✅ AT can now be used as unquoted table alias  
✅ All 66 SQL parser tests pass

## Test plan
- [x] AT as simple table alias: `SELECT * FROM users at`
- [x] AT with explicit AS: `SELECT * FROM users AS at`  
- [x] AT in JOIN clauses: `LEFT JOIN profiles at ON (...)`
- [x] AT in complex subqueries
- [x] Mixed contexts: both AT TIME ZONE and AT alias in same query
- [x] All existing SQL parser tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)