### PR TITLE
fix: Add support for SHOW CATALOGS with LIKE clause in Trino

### DIFF
--- a/spec/sql/trino/show-catalogs.sql
+++ b/spec/sql/trino/show-catalogs.sql
@@ -1,0 +1,11 @@
+-- Test SHOW CATALOGS without LIKE clause
+SHOW CATALOGS;
+
+-- Test SHOW CATALOGS with LIKE clause  
+SHOW CATALOGS LIKE 'td-presto';
+
+-- Test SHOW CATALOGS with LIKE clause and wildcard pattern
+SHOW CATALOGS LIKE '%catalog%';
+
+-- Test SHOW CATALOGS with LIKE clause and simple pattern
+SHOW CATALOGS LIKE 'system';

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -748,12 +748,11 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
           group(wl("from", "information_schema.schemata"))
         )
         val queryWithFilter =
-          s.likePattern match
-            case Some(pattern) =>
-              val filterClause = group(wl("where", "catalog_name", "like", expr(pattern)))
-              baseQuery :+ filterClause
-            case None =>
-              baseQuery
+          baseQuery ++
+            s.likePattern
+              .map { pattern =>
+                group(wl("where", "catalog_name", "like", expr(pattern)))
+              }
         val sql = lines(queryWithFilter :+ group(wl("order by", "name")))
         selectExpr(sql)
       case s: Show if s.showType == ShowType.columns =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1756,12 +1756,10 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
               Show(tpe, in, None, spanFrom(t))
             case ShowType.catalogs =>
               val likePattern =
-                scanner.lookAhead().token match
-                  case SqlToken.LIKE =>
-                    consume(SqlToken.LIKE)
-                    Some(expression())
-                  case _ =>
-                    None
+                if consumeIfExist(SqlToken.LIKE) then
+                  Some(expression())
+                else
+                  None
               Show(ShowType.catalogs, EmptyName, likePattern, spanFrom(t))
             case ShowType.columns =>
               // Handle "SHOW COLUMNS FROM table" syntax

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -347,21 +347,21 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
               case _ =>
                 EmptyName
 
-          val s = Show(ShowType.valueOf(name.leafName), inExpr, spanFrom(t))
+          val s = Show(ShowType.valueOf(name.leafName), inExpr, None, spanFrom(t))
           val q = queryBlock(s)
           Query(q, spanFrom(t))
         case ShowType.catalogs =>
-          val s = Show(ShowType.valueOf(name.leafName), NameExpr.EmptyName, spanFrom(t))
+          val s = Show(ShowType.valueOf(name.leafName), NameExpr.EmptyName, None, spanFrom(t))
           val q = queryBlock(s)
           Query(q, spanFrom(t))
         case ShowType.functions =>
-          val s = Show(ShowType.functions, NameExpr.EmptyName, spanFrom(t))
+          val s = Show(ShowType.functions, NameExpr.EmptyName, None, spanFrom(t))
           val q = queryBlock(s)
           Query(q, spanFrom(t))
         case ShowType.createView =>
           // For Wvlet parser, we'll handle this as a simple show with the view name
           val viewName = nameExpression()
-          val s        = Show(ShowType.createView, viewName, spanFrom(t))
+          val s        = Show(ShowType.createView, viewName, None, spanFrom(t))
           val q        = queryBlock(s)
           Query(q, spanFrom(t))
         case ShowType.query =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
@@ -1051,7 +1051,9 @@ enum ShowType:
   case functions
   case createView
 
-case class Show(showType: ShowType, inExpr: NameExpr, span: Span) extends Relation with LeafPlan:
+case class Show(showType: ShowType, inExpr: NameExpr, likePattern: Option[Expression], span: Span)
+    extends Relation
+    with LeafPlan:
   override def relationType: RelationType =
     showType match
       case ShowType.models =>


### PR DESCRIPTION
## Summary
- Fix queryOrUpdate method to handle SHOW and USE statements when used in EXPLAIN/PREPARE contexts
- Add comprehensive support for SHOW CATALOGS LIKE 'pattern' syntax 
- Update Show case class to include optional likePattern parameter
- Update SQL generator to generate proper WHERE clauses for LIKE filtering

## Changes Made
1. **SqlParser.scala**: Added SHOW and USE cases to queryOrUpdate method
2. **relation.scala**: Added likePattern parameter to Show case class
3. **SqlParser.scala**: Updated show() method to parse LIKE clause for catalogs
4. **SqlGenerator.scala**: Added WHERE clause generation for LIKE patterns
5. **show-catalogs.sql**: Added comprehensive test cases

## Test plan
- [x] Created test file with SHOW CATALOGS syntax variants
- [x] Verified parsing works for both with and without LIKE clause
- [x] Confirmed SQL generation produces correct WHERE clauses
- [x] All tests pass: `./sbt "langJVM/testOnly *SqlParserTrinoSpec -- spec:sql:trino:show-catalogs.sql"`

Fixes the syntax error: `[SYNTAX_ERROR] Unexpected token: <SHOW> 'SHOW'` when using SHOW CATALOGS in certain contexts.

🤖 Generated with [Claude Code](https://claude.ai/code)