### PR TITLE
feature: Enable wvlet-labs project in IntelliJ IDEA

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -518,6 +518,8 @@ lazy val labs = project
   .settings(
     buildSettings,
     noPublish,
+    // Override noPublish setting to allow IDEA import
+    ideSkipProject := false,
     name := "wvlet-labs",
     libraryDependencies ++=
       Seq(


### PR DESCRIPTION
## Summary
- Override `ideSkipProject := false` for the wvlet-labs project to enable IntelliJ IDEA import
- Maintains `noPublish` configuration while allowing IDE integration
- Labs project is now available in IntelliJ IDEA for development

## Test plan
- [x] Verify labs project compiles successfully
- [x] Confirm IDEA module files are generated (.idea/modules/wvlet/wvlet-labs/)
- [x] Check that noPublish settings remain intact
- [ ] Test opening project in IntelliJ IDEA to verify labs module is visible

🤖 Generated with [Claude Code](https://claude.ai/code)