### PR TITLE
fix: Complete pattern match for ShowType in WvletParser to eliminate exhaustivity warning

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -350,12 +350,11 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
           val s = Show(ShowType.valueOf(name.leafName), inExpr, None, spanFrom(t))
           val q = queryBlock(s)
           Query(q, spanFrom(t))
-        case ShowType.catalogs =>
+        case ShowType.catalogs | ShowType.functions | ShowType.createTable | ShowType.createSchema |
+            ShowType.createMaterializedView | ShowType.createFunction | ShowType.grants | ShowType
+              .stats | ShowType.branches | ShowType.currentRoles | ShowType.roleGrants | ShowType
+              .session =>
           val s = Show(ShowType.valueOf(name.leafName), NameExpr.EmptyName, None, spanFrom(t))
-          val q = queryBlock(s)
-          Query(q, spanFrom(t))
-        case ShowType.functions =>
-          val s = Show(ShowType.functions, NameExpr.EmptyName, None, spanFrom(t))
           val q = queryBlock(s)
           Query(q, spanFrom(t))
         case ShowType.createView =>


### PR DESCRIPTION
## Summary

- Fixed pattern match exhaustivity warning in `WvletParser.scala:339` by adding missing ShowType cases
- Added support for `createTable`, `createSchema`, `createMaterializedView`, `createFunction`, `grants`, `stats`, `branches`, `currentRoles`, `roleGrants`, and `session` show types
- Grouped new cases with existing `catalogs` and `functions` handling (simple show without IN clause)

## Changes Made

- Modified `showExpr()` method in `WvletParser.scala` to handle all ShowType enum values
- Treated new cases as simple show operations without IN clause support, consistent with `catalogs` and `functions`
- Eliminated compiler warning: "Pattern Match Exhaustivity Warning" that would fail on the missing cases

## Test plan

- [x] Compiled successfully without warnings
- [x] Code formatted with scalafmt
- [ ] Verify CI passes all tests
- [ ] Confirm no regression in show statement functionality

🤖 Generated with [Claude Code](https://claude.ai/code)