### PR TITLE
feature: Accelerate ParseQuery with multi-threaded parallel processing

### DIFF
--- a/wvlet-labs/src/main/scala/wvlet/lang/labs/ParseQuery.scala
+++ b/wvlet-labs/src/main/scala/wvlet/lang/labs/ParseQuery.scala
@@ -166,7 +166,7 @@ class ParseQuery() extends LogSupport:
             // Thread-safe counters and timing
             val queryCount = new AtomicInteger(0)
             val errorCount = new AtomicInteger(0)
-            val startTime = System.nanoTime()
+            val startTime  = System.nanoTime()
 
             // Create error log file in target folder
             val queryLogFileName = java.nio.file.Paths.get(queryLogFile).getFileName.toString
@@ -224,9 +224,13 @@ class ParseQuery() extends LogSupport:
 
               val finalQueryCount = queryCount.get()
               val finalErrorCount = errorCount.get()
-              val endTime = System.nanoTime()
+              val endTime         = System.nanoTime()
               val durationSeconds = (endTime - startTime) / 1_000_000_000.0
-              val queriesPerSecond = if durationSeconds > 0 then finalQueryCount / durationSeconds else 0.0
+              val queriesPerSecond =
+                if durationSeconds > 0 then
+                  finalQueryCount / durationSeconds
+                else
+                  0.0
               val queriesPerMinute = queriesPerSecond * 60.0
 
               if finalErrorCount > 0 then
@@ -237,12 +241,13 @@ class ParseQuery() extends LogSupport:
                   (finalErrorCount.toDouble / finalQueryCount * 100)
                 else
                   0.0
-              
+
               info(
                 f"Final: ${finalQueryCount}%,d queries, ${finalErrorCount}%,d failed (${errorRate}%.3f%% error rate)"
               )
               info(
-                f"Performance: ${Count.succinct(queriesPerMinute.toLong)} queries/min (${Count.succinct(queriesPerSecond.toLong)} queries/sec, ${durationSeconds}%.1fs total)"
+                f"Performance: ${Count.succinct(queriesPerMinute.toLong)} queries/min (${Count
+                    .succinct(queriesPerSecond.toLong)} queries/sec, ${durationSeconds}%.1fs total)"
               )
             }
           }

--- a/wvlet-labs/src/main/scala/wvlet/lang/labs/ParseQuery.scala
+++ b/wvlet-labs/src/main/scala/wvlet/lang/labs/ParseQuery.scala
@@ -129,15 +129,10 @@ class ParseQuery() extends LogSupport:
       @argument(description = "query log parquet file, with database and sql parameters")
       queryLogFile: String,
       @option(prefix = "-p,--parallelism", description = "Number of parallel threads")
-      parallelism: Int = Runtime.getRuntime.availableProcessors(),
-      @option(
-        prefix = "--error-sampling",
-        description = "Error sampling rate (1 = log all errors, 10 = log every 10th error)"
-      )
-      errorSampling: Int = 10
+      parallelism: Int = Runtime.getRuntime.availableProcessors()
   ): Unit =
     info(s"Reading query logs from ${queryLogFile}")
-    info(s"Using parallelism: ${parallelism} threads, error sampling: 1/${errorSampling}")
+    info(s"Using parallelism: ${parallelism} threads")
 
     // Use DuckDB JDBC to read the parquet file
     Class.forName("org.duckdb.DuckDBDriver")


### PR DESCRIPTION
## Summary
- Add parallel processing to ParseQuery.scala using Airframe's Parallel utility
- Implement batch processing with configurable batch size and parallelism options
- Use thread-safe counters and synchronized error writing for concurrent execution
- Maintain streaming DB reading while processing batches in parallel

## Performance Improvements
- Expected 3-8x speedup depending on CPU cores
- Default batch size: 1000 queries per batch
- Default parallelism: CPU core count
- Configurable via `--batch-size` and `--parallelism` options

## Technical Changes
- Added `QueryRecord` case class for batch processing
- Imported `Parallel` from `wvlet.airframe.control`
- Replaced sequential parsing loop with batch collection + parallel processing
- Added `AtomicInteger` counters for thread-safe counting
- Added `processBatch` method with `Parallel.run` for concurrent execution
- Maintained streaming results from DuckDB to prevent OOM

## Test plan
- [x] Compile successfully with `./sbt "labs/compile"`
- [x] Format code with `./sbt scalafmtAll`
- [ ] Test with sample query log file to verify functionality
- [ ] Measure performance improvement compared to sequential version
- [ ] Verify error logging accuracy remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)