### PR TITLE
fix: Support non-TTY environments in wv CLI (Claude Code, CI/CD)

### DIFF
--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPL.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPL.scala
@@ -50,8 +50,9 @@ class WvletREPL(workEnv: WorkEnv, runner: WvletScriptRunner) extends AutoCloseab
   private val terminal = TerminalBuilder
     .builder()
     .name("wvlet-shell")
-    // Use dumb terminal for sbt testing
-    .dumb(WvletMain.isInSbt)
+    // Use dumb terminal for sbt testing or non-TTY environments (e.g., Claude Code, CI/CD)
+    // When TTY env var is not set, we're not in a real terminal
+    .dumb(WvletMain.isInSbt || sys.env.get("TTY").isEmpty)
     .build()
 
   private val historyFile = new File(workEnv.cacheFolder, ".wv_history")

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPL.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPL.scala
@@ -51,7 +51,8 @@ class WvletREPL(workEnv: WorkEnv, runner: WvletScriptRunner) extends AutoCloseab
     .builder()
     .name("wvlet-shell")
     // Use dumb terminal for sbt testing or non-TTY environments (e.g., Claude Code, CI/CD)
-    // When TTY env var is not set, we're not in a real terminal
+    // Note: We check TTY env var instead of System.console() == null because System.console()
+    // returns ProxyingConsole (not null) in Java 24+ even in non-TTY environments
     .dumb(WvletMain.isInSbt || sys.env.get("TTY").isEmpty)
     .build()
 


### PR DESCRIPTION
## Summary
- Fixes #1370 by detecting non-TTY environments and automatically using dumb terminal mode
- Checks if `TTY` environment variable is set; when not set, uses dumb terminal
- Enables `wv -c` and `wv --file` commands to work in Claude Code, CI/CD, and other non-interactive environments

## Changes
- Modified `WvletREPL.scala` to check `sys.env.get("TTY").isEmpty` condition
- Added this check alongside existing `WvletMain.isInSbt` check to determine when to use dumb terminal

## Test plan
- [x] Tested `wv -c "select 1 as test"` - works without terminal errors
- [x] Tested `wv --file test.wv` - successfully executes queries from file
- [x] Verified behavior in Claude Code environment (non-TTY)
- [x] Build passes with `./sbt cli/packInstall`

🤖 Generated with [Claude Code](https://claude.com/claude-code)