### PR TITLE
Add -f as shorthand alias for --file option in wv command

### DIFF
--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
@@ -40,7 +40,7 @@ case class WvletREPLOption(
     profile: Option[String] = None,
     @option(prefix = "-c", description = "Run a command and exit")
     commands: List[String] = Nil,
-    @option(prefix = "--file", description = "Run commands in a file and exit")
+    @option(prefix = "-f,--file", description = "Run commands in a file and exit")
     inputFile: Option[String] = None,
     @option(prefix = "-w", description = "Working folder")
     workFolder: String = ".",


### PR DESCRIPTION
## Summary
- Added `-f` as a convenient shorthand alias for the existing `--file` option in the `wv` command
- This matches the pattern already used in the `wvlet` compiler command (`-f,--file`)
- Improves CLI usability by providing a shorter option for frequently used functionality

## Changes
- Modified `WvletREPLOption` in `WvletREPLMain.scala` to accept both `-f` and `--file` prefixes

## Test plan
- [x] Built and installed the wv command with `./sbt "cli/packInstall"`
- [x] Verified `--file` option still works: `wv --file target/test.wv`
- [x] Verified new `-f` option works: `wv -f target/test.wv`
- [x] Both options produced identical output and executed the query successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)