### PR TITLE
chore: Upgrade to JDK25

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ !matrix.skip }}
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '25'
           cache: sbt
       - name: Install libgc
         if: ${{ !matrix.skip }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '25'
           cache: sbt
       
       - name: Set up Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '25'
           cache: sbt
       - name: Scala 3.x test
         run: ./sbt projectJVM/test
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '25'
           cache: sbt
       - uses: actions/setup-node@v6
         with:
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '25'
           cache: sbt
       - uses: actions/setup-node@v6
         with:
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '25'
           cache: sbt
       - name: Install native dependencies
         run: sudo apt-get update && sudo apt-get install -y libgc-dev

--- a/.github/workflows/typescript-test.yml
+++ b/.github/workflows/typescript-test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '25'
           cache: sbt
       
       - name: Set up Node.js

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '25'
           cache: sbt
       - uses: actions/setup-node@v6
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ test _.output should be """
 
 ## Environment Requirements
 
-- **JDK**: Minimum JDK 17, JDK 24+ required for Trino connector testing
+- **JDK**: Minimum JDK 17, JDK 25+ required for Trino connector testing
 - **Native Builds**: clang, llvm, libstdc++-12-dev, libgc (Boehm GC)
 - **Node.js**: 22+ for UI development and documentation
 - **SBT**: 1.11.1 (specified in project/build.properties)

--- a/build.sbt
+++ b/build.sbt
@@ -349,11 +349,11 @@ lazy val cli = project
         "wvlet" -> "wvlet.lang.cli.WvletMain"
       ),
     packJvmVersionSpecificOpts := {
-      val java24Opts = Seq(
+      val jvmOpts = Seq(
         "--sun-misc-unsafe-memory-access=allow",
         "--enable-native-access=ALL-UNNAMED"
       )
-      Map("wv" -> Map(24 -> java24Opts), "wvlet" -> Map(24 -> java24Opts))
+      Map("wv" -> Map(25 -> jvmOpts), "wvlet" -> Map(25 -> jvmOpts))
     },
     packResourceDir ++= Map(file("wvlet-ui-main/dist") -> "web")
   )


### PR DESCRIPTION
## Summary
- Update all JDK version references from 24 to 25 across the project
- Ensures compatibility with latest Java features and security updates

## Changes
- Update GitHub workflow files to use `java-version: '25'`
- Rename `java24Opts` to `java25Opts` in build.sbt
- Update documentation in CLAUDE.md to reflect JDK25 requirement

## Test plan
- [x] Compilation passes for all JVM targets
- [ ] Monitor CI checks to ensure workflows pass with Java 25
- [ ] Verify Trino connector tests still work with JDK25

Closes #1406

🤖 Generated with [Claude Code](https://claude.com/claude-code)