### PR TITLE
Enhance interval query documentation with comprehensive examples

### DIFF
--- a/website/docs/syntax/index.md
+++ b/website/docs/syntax/index.md
@@ -288,7 +288,7 @@ One of the major difference from traditional SQL is that wvlet uses single or do
 | `1`, `2`, ...                                         | Refers to 1-origin column index for `order by` clause                                                                                                    |
 | `expr`::`type`                                        | Type cast the value to the target type. Equivalent to cast(`expr` as `type`) in SQL                                                                      |
 | '2025-01-01'::date                                    | Cast the string to a date value                                                                                                                          |
-| '1 year'::interval or '30 days':interval              | Cast the string to an interval value. Supports units: day, days, hour, hours, minute, minutes, second, seconds, month, months, year, years, etc.        |
+| '1 year':interval, '30 days':interval              | Cast the string to an interval value. Supports units: day, days, hour, hours, minute, minutes, second, seconds, month, months, year, years, etc.        |
 
 :::note Type Annotations vs Type Casting
 Single colon `:` is used for **type annotations** in declarations (e.g., `param: int`, `val name: string`), while double colon `::` is used for **runtime type casting** (e.g., `value::int`, `'2025-01-01'::date`).
@@ -1894,11 +1894,11 @@ order by total_revenue desc
 **Time window aggregation:**
 ```wvlet
 val orders(id, order_date, amount) = [
-  ["2025-10-25", "2025-10-25", 100],
-  ["2025-10-24", "2025-10-24", 150],
-  ["2025-10-23", "2025-10-23", 200],
-  ["2025-10-20", "2025-10-20", 75],
-  ["2025-10-18", "2025-10-18", 125]
+  [1, "2025-10-25", 100],
+  [2, "2025-10-24", 150],
+  [3, "2025-10-23", 200],
+  [4, "2025-10-20", 75],
+  [5, "2025-10-18", 125]
 ]
 
 from orders


### PR DESCRIPTION
## Summary

Added comprehensive documentation for interval queries in Wvlet, addressing issue #1346. The documentation now clearly explains:
- How to use the `:interval` type casting syntax
- Supported interval units (day, days, hour, hours, month, months, year, years, etc.)
- Common filtering patterns for time-based queries
- Practical examples for last N days, date ranges, and time window aggregation
- Differences between Wvlet and SQL interval syntax

## Changes

1. **Enhanced type casting table** - Added details about supported interval units
2. **New section: "Interval Queries → Filter by Time Ranges"** with:
   - Basic interval filtering example
   - Complete list of supported interval units
   - Four common filtering patterns with code examples:
     - Last N days filtering
     - Last N hours filtering  
     - Date range filtering with grouping and aggregation
     - Time window aggregation with sample data
   - Tips about `current_date` vs `current_timestamp`
   - Note comparing Wvlet vs SQL interval syntax

## Benefits

- Users can now easily find and understand how to write interval queries
- Comprehensive examples show real-world use cases
- Clear comparison with SQL syntax helps SQL developers transition to Wvlet
- Addresses the feature request in issue #1346 through improved documentation

## Test plan

- [ ] Review documentation renders correctly on the website
- [ ] Verify all code examples are syntactically correct
- [ ] Test the examples in Wvlet REPL/CLI to ensure they work

🤖 Generated with Claude Code