### PR TITLE
feature: Make value column optional in unpivot syntax

### DIFF
--- a/spec/basic/unpivot.wv
+++ b/spec/basic/unpivot.wv
@@ -34,3 +34,23 @@ test _.rows = [
   [3, 'cars', 'jun', 600]
 ]
 
+---
+Test optional value column syntax (defaults to "value")
+---
+from [
+ [1, 'electronics', 1, 2, 3],
+ [2, 'clothes', 10, 20, 30]
+] as sales(id, dept, jan, feb, mar)
+unpivot
+  for month in (jan, feb, mar)
+
+test _.columns = ["id", "dept", "month", "value"]
+test _.rows = [
+  [1, 'electronics', 'jan', 1],
+  [1, 'electronics', 'feb', 2],
+  [1, 'electronics', 'mar', 3],
+  [2, 'clothes', 'jan', 10],
+  [2, 'clothes', 'feb', 20],
+  [2, 'clothes', 'mar', 30]
+]
+

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -605,7 +605,7 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
                     "name",
                     expr(u.unpivotKey.unpivotColumnName),
                     "value",
-                    expr(u.unpivotKey.valueColumnName)
+                    expr(u.unpivotKey.getValueColumnName)
                   )
                 )
             )

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -374,7 +374,7 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
             group(
               wl(
                 "unpivot",
-                expr(u.unpivotKey.valueColumnName),
+                expr(u.unpivotKey.getValueColumnName),
                 "for",
                 expr(u.unpivotKey.unpivotColumnName),
                 "in",

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1478,18 +1478,15 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
       val startSpan = scanner.lookAhead().span
       // Check if FOR token appears first (optional value column syntax)
       val (valueColumn, unpivotColumn) =
-        scanner.lookAhead().token match
-          case WvletToken.FOR =>
-            // Optional value column syntax: for (unpivot column) in (...)
-            consume(WvletToken.FOR)
-            val unpivotCol = identifierSingle()
-            (None, unpivotCol)
-          case _ =>
-            // Traditional syntax: (value column) for (unpivot column) in (...)
-            val valueCol = identifierSingle()
-            consume(WvletToken.FOR)
-            val unpivotCol = identifierSingle()
-            (Some(valueCol), unpivotCol)
+        val valueCol =
+          scanner.lookAhead().token match
+            case WvletToken.FOR =>
+              None
+            case _ =>
+              Some(identifierSingle())
+        consume(WvletToken.FOR)
+        val unpivotCol = identifierSingle()
+        (valueCol, unpivotCol)
 
       consume(WvletToken.IN)
       consume(WvletToken.L_PAREN)

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
@@ -623,8 +623,10 @@ case class Unpivot(child: Relation, unpivotKey: UnpivotKey, span: Span) extends 
 
     val nonPivotColumns = inputFields.filterNot(f => unpivotedColumns.contains(f.name.name))
     val valueColumnName = unpivotKey.getValueColumnName
-    val unpivotColumnType: DataType = inputFields
-      .find(f => f.name.name == valueColumnName.fullName)
+    val unpivotColumnType: DataType = unpivotKey
+      .targetColumns
+      .headOption
+      .flatMap(targetCol => inputFields.find(f => f.name.name == targetCol.fullName))
       .map(_.dataType)
       .getOrElse(DataType.UnknownType)
 
@@ -655,7 +657,7 @@ case class UnpivotKey(
   override def children: List[Expression] = Nil
 
   /** Get the value column name, using "value" as default if not specified */
-  def getValueColumnName: Identifier = valueColumnName.getOrElse(Identifier(QName("value"), span))
+  def getValueColumnName: Identifier = valueColumnName.getOrElse(UnquotedIdentifier("value", span))
 
 /**
   * Tradtional SQL aggregation node with SELECT clause


### PR DESCRIPTION
This PR implements optional value column syntax for unpivot operations in flow-style queries.

## Changes

- Modified `UnpivotKey` model to use `Option[Identifier]` for valueColumnName
- Added `getValueColumnName` helper method for default "value" column
- Updated parser to detect and handle optional value column syntax
- Updated SQL generator to use the helper method
- Added test case for optional syntax in spec/basic/unpivot.wv

## New Syntax

```wvlet
# Optional value column (defaults to "value")
unpivot for month in (jan, feb, mar)
```

## Traditional Syntax (still supported)

```wvlet
# Explicit value column name
unpivot sales for month in (jan, feb, mar)
```

Fixes #1331

Generated with [Claude Code](https://claude.ai/code)