### PR TITLE
feature: Add headless mode support to avoid jline3 initialization

### DIFF
--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
@@ -83,16 +83,20 @@ class WvletREPLMain(cliOption: WvletGlobalOption, replOpts: WvletREPLOption) ext
           throw StatusCode.FILE_NOT_FOUND.newException(s"File not found: ${f.getAbsolutePath()}")
       }
 
-    val inputScripts = commandInputs.result()
+    val inputScripts  = commandInputs.result()
+    val isInteractive = inputScripts.isEmpty
 
     val design = Design
       .newSilentDesign
-      .bindSingleton[WvletREPL]
+      .bind[WvletREPL]
+      .toProvider { (workEnv: WorkEnv, runner: WvletScriptRunner) =>
+        WvletREPL(workEnv, runner, isInteractive)
+      }
       .bindInstance[Profile](currentProfile)
       .bindInstance[WorkEnv](WorkEnv(path = replOpts.workFolder, logLevel = cliOption.logLevel))
       .bindInstance[WvletScriptRunnerConfig](
         WvletScriptRunnerConfig(
-          interactive = inputScripts.isEmpty,
+          interactive = isInteractive,
           profile = currentProfile,
           catalog = selectedCatalog,
           schema = selectedSchema

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
@@ -9,6 +9,9 @@ import wvlet.lang.api.StatusCode.SYNTAX_ERROR
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.catalog.Profile
+import wvlet.lang.cli.terminal.HeadlessTerminal
+import wvlet.lang.cli.terminal.JLine3Terminal
+import wvlet.lang.cli.terminal.REPLTerminal
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.runner.WvletScriptRunner
 import wvlet.lang.runner.WvletScriptRunnerConfig
@@ -89,9 +92,16 @@ class WvletREPLMain(cliOption: WvletGlobalOption, replOpts: WvletREPLOption) ext
 
     val design = Design
       .newSilentDesign
+      .bind[REPLTerminal]
+      .toProvider { (workEnv: WorkEnv) =>
+        if isInteractive then
+          JLine3Terminal(workEnv)
+        else
+          HeadlessTerminal()
+      }
       .bind[WvletREPL]
-      .toProvider { (workEnv: WorkEnv, runner: WvletScriptRunner) =>
-        WvletREPL(workEnv, runner, isInteractive)
+      .toProvider { (runner: WvletScriptRunner, terminal: REPLTerminal) =>
+        WvletREPL(runner, terminal)
       }
       .bindInstance[Profile](currentProfile)
       .bindInstance[WorkEnv](WorkEnv(path = replOpts.workFolder, logLevel = cliOption.logLevel))

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
@@ -10,6 +10,7 @@ import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.runner.WvletScriptRunner
 import wvlet.lang.runner.WvletScriptRunnerConfig
 import wvlet.lang.runner.connector.DBConnector
 import wvlet.lang.runner.connector.DBConnectorProvider

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/HeadlessTerminal.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/HeadlessTerminal.scala
@@ -1,0 +1,92 @@
+package wvlet.lang.cli.terminal
+
+import scala.io.StdIn
+
+/**
+  * Headless terminal implementation that doesn't use JLine3
+  *
+  * This implementation uses simple stdin/stdout without any interactive features, ensuring JLine3
+  * is never loaded in non-interactive mode.
+  */
+class HeadlessTerminal extends REPLTerminal:
+  private var termWidth  = 120
+  private var termHeight = 40
+  private val history    = new HeadlessHistory()
+
+  override def width: Int  = termWidth
+  override def height: Int = termHeight
+
+  override def setSize(width: Int, height: Int): Unit =
+    termWidth = width
+    termHeight = height
+
+  override def write(s: String): Unit = print(s)
+
+  override def writeln(s: String): Unit = println(s)
+
+  override def flush(): Unit = Console.flush()
+
+  override def clearScreen(): Unit =
+    // No-op in headless mode
+    ()
+
+  override def printAbove(s: String): Unit =
+    // In headless mode, just print normally
+    println(s)
+
+  override def readLine(prompt: String): String =
+    print(prompt)
+    flush()
+    StdIn.readLine()
+
+  override def isRealTerminal: Boolean = false
+
+  override def handleInterrupt(handler: => Unit): Unit =
+    // No-op in headless mode - signal handling happens at JVM level
+    ()
+
+  override def getHistory: REPLHistory = history
+
+  override def executeSpecialCommand(cmd: REPLCommand): Boolean =
+    // Special commands not supported in headless mode
+    false
+
+  override def getBuffer: String =
+    // No buffer in headless mode
+    ""
+
+  override def moveCursor(pos: Int): Unit = ()
+
+  override def getCursorPosition: Int = 0
+
+  override def getBufferLength: Int = 0
+
+  override def getBufferUpToCursor: String = ""
+
+  override def getCurrentChar: Char = '\u0000'
+
+  override def writeToBuffer(s: String): Unit = ()
+
+  override def callWidget(widgetName: String): Unit = ()
+
+  override def redrawLine(): Unit = ()
+
+  override def getOutput: Any = null
+
+  override def close(): Unit =
+    // Nothing to close in headless mode
+    ()
+
+end HeadlessTerminal
+
+/**
+  * Simple in-memory history for headless mode
+  */
+class HeadlessHistory extends REPLHistory:
+  private val entries = scala.collection.mutable.ListBuffer.empty[String]
+
+  override def add(line: String): Unit = entries += line
+
+  override def save(): Unit =
+    // No persistence in headless mode
+    ()

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/HeadlessTerminal.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/HeadlessTerminal.scala
@@ -71,7 +71,11 @@ class HeadlessTerminal extends REPLTerminal:
 
   override def redrawLine(): Unit = ()
 
-  override def getOutput: Any = null
+  override def getOutputWriter: Option[java.io.Writer] = None
+
+  override def writeNewlines(count: Int): Unit =
+    // No-op in headless mode
+    ()
 
   override def close(): Unit =
     // Nothing to close in headless mode

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/JLine3Terminal.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/JLine3Terminal.scala
@@ -1,0 +1,196 @@
+package wvlet.lang.cli.terminal
+
+import org.jline.keymap.KeyMap
+import org.jline.reader.*
+import org.jline.reader.impl.DefaultParser
+import org.jline.reader.impl.DefaultParser.Bracket
+import org.jline.terminal.Terminal.Signal
+import org.jline.terminal.Size
+import org.jline.terminal.Terminal
+import org.jline.terminal.TerminalBuilder
+import org.jline.utils.AttributedString
+import org.jline.utils.InfoCmp
+import wvlet.lang.cli.LocalFileCompleter
+import wvlet.lang.cli.WvletMain
+import wvlet.lang.cli.WvletREPL
+import wvlet.lang.compiler.WorkEnv
+
+import java.io.File
+import scala.jdk.CollectionConverters.*
+
+/**
+  * JLine3-based terminal implementation with full interactive features
+  *
+  * @param workEnv
+  *   Working environment for caching history file
+  */
+class JLine3Terminal(workEnv: WorkEnv) extends REPLTerminal:
+  private val jlineTerminal = TerminalBuilder
+    .builder()
+    .name("wvlet-shell")
+    // Use dumb terminal for sbt testing or non-TTY environments (e.g., Claude Code, CI/CD)
+    // Note: We check TTY env var instead of System.console() == null because System.console()
+    // returns ProxyingConsole (not null) in Java 24+ even in non-TTY environments
+    .dumb(WvletMain.isInSbt || sys.env.get("TTY").isEmpty)
+    .build()
+
+  private val historyFile = new File(workEnv.cacheFolder, ".wv_history")
+
+  private val jlineReader = LineReaderBuilder
+    .builder()
+    .terminal(jlineTerminal)
+    .variable(LineReader.HISTORY_FILE, historyFile.toPath)
+    .parser(new WvletREPL.ReplParser())
+    .completer(LocalFileCompleter(workEnv))
+    // For enabling multiline input
+    .variable(
+      LineReader.SECONDARY_PROMPT_PATTERN,
+      if isRealTerminal then
+        AttributedString(s"%P  ${WvletREPL.Color.GRAY}│${WvletREPL.Color.RESET} ")
+      else
+        ""
+    )
+    .variable(LineReader.INDENTATION, 2)
+    // Coloring keywords
+    .highlighter(new WvletREPL.ReplHighlighter)
+    .build()
+
+  private val history = new JLine3History(jlineReader)
+
+  override def width: Int  = jlineTerminal.getWidth
+  override def height: Int = jlineTerminal.getHeight
+
+  override def setSize(width: Int, height: Int): Unit = jlineTerminal.setSize(Size(width, height))
+
+  override def write(s: String): Unit = jlineTerminal.writer().print(s)
+
+  override def writeln(s: String): Unit = jlineTerminal.writer().println(s)
+
+  override def flush(): Unit = jlineTerminal.flush()
+
+  override def clearScreen(): Unit =
+    jlineTerminal.puts(InfoCmp.Capability.clear_screen)
+    jlineTerminal.flush()
+
+  override def printAbove(s: String): Unit = jlineReader.printAbove(s)
+
+  override def readLine(prompt: String): String = jlineReader.readLine(prompt)
+
+  override def isRealTerminal: Boolean =
+    jlineTerminal.getType != Terminal.TYPE_DUMB && jlineTerminal.getType != Terminal.TYPE_DUMB_COLOR
+
+  override def handleInterrupt(handler: => Unit): Unit = jlineTerminal.handle(
+    Signal.INT,
+    _ => handler
+  )
+
+  override def getHistory: REPLHistory = history
+
+  override def executeSpecialCommand(cmd: REPLCommand): Boolean =
+    // Special commands are handled in WvletREPL
+    // This method provides access to buffer operations
+    cmd match
+      case REPLCommand.MoveToTop =>
+        val buf = jlineReader.getBuffer
+        buf.cursor(0)
+        true
+      case REPLCommand.MoveToEnd =>
+        val buf = jlineReader.getBuffer
+        buf.cursor(buf.length())
+        true
+      case REPLCommand.EnterStatement =>
+        val buf = jlineReader.getBuffer
+        buf.cursor(buf.length())
+        val line = buf.toString
+        if !line.trim.endsWith(";") then
+          buf.write(";")
+          buf.cursor(buf.length())
+        jlineReader.callWidget(LineReader.ACCEPT_LINE)
+        true
+      case _ =>
+        // DescribeLine and SubqueryRun need WvletScriptRunner, handled in WvletREPL
+        false
+
+  override def getBuffer: String = jlineReader.getBuffer.toString
+
+  override def moveCursor(pos: Int): Unit = jlineReader.getBuffer.cursor(pos)
+
+  override def getCursorPosition: Int = jlineReader.getBuffer.cursor()
+
+  override def getBufferLength: Int = jlineReader.getBuffer.length()
+
+  override def getBufferUpToCursor: String = jlineReader.getBuffer.upToCursor()
+
+  override def getCurrentChar: Char = jlineReader.getBuffer.currChar().toChar
+
+  override def writeToBuffer(s: String): Unit = jlineReader.getBuffer.write(s)
+
+  override def callWidget(widgetName: String): Unit = jlineReader.callWidget(widgetName)
+
+  override def redrawLine(): Unit = jlineReader.callWidget(LineReader.REDRAW_LINE)
+
+  override def getOutput: Any = jlineTerminal.output()
+
+  /**
+    * Get access to the JLine3 reader for advanced operations
+    */
+  def getReader: LineReader = jlineReader
+
+  /**
+    * Get access to the JLine3 terminal for advanced operations
+    */
+  def getJLineTerminal: Terminal = jlineTerminal
+
+  /**
+    * Setup interactive mode with key bindings
+    */
+  def setupInteractiveMode(
+      moveToTop: Widget,
+      moveToEnd: Widget,
+      enterStmt: Widget,
+      describeLine: Widget,
+      subqueryRun: Widget
+  ): Unit =
+    // Set the default size when opening a new window or inside sbt console
+    if jlineTerminal.getWidth == 0 || jlineTerminal.getHeight == 0 then
+      jlineTerminal.setSize(Size(120, 40))
+
+    // Add shortcut keys
+    val keyMaps = jlineReader.getKeyMaps().get("main")
+
+    // Clean up some default key bindings
+    jlineReader
+      .getKeyMaps()
+      .values()
+      .asScala
+      .foreach { keyMap =>
+        // Remove ctrl-j (accept line) to enable our custom key bindings
+        keyMap.unbind(KeyMap.ctrl('J'))
+      }
+
+    // Bind shortcut keys Ctrl+J, ... sequence
+    keyMaps.bind(moveToTop, KeyMap.translate("^J^A"))
+    keyMaps.bind(moveToEnd, KeyMap.translate("^J^E"))
+    keyMaps.bind(enterStmt, KeyMap.translate("^J^R"))
+    keyMaps.bind(describeLine, KeyMap.translate("^J^D"))
+    keyMaps.bind(subqueryRun, KeyMap.translate("^J^T"))
+
+    // Load the command history so that we can use ctrl-r (keyword), ctrl+p/n (previous/next) for history search
+    val history = jlineReader.getHistory
+    history.attach(jlineReader)
+
+  end setupInteractiveMode
+
+  override def close(): Unit =
+    jlineReader.getHistory.save()
+    jlineTerminal.close()
+
+end JLine3Terminal
+
+/**
+  * JLine3-based history implementation with file persistence
+  */
+class JLine3History(reader: LineReader) extends REPLHistory:
+  override def add(line: String): Unit = reader.getHistory.add(line)
+
+  override def save(): Unit = reader.getHistory.save()

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/JLine3Terminal.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/JLine3Terminal.scala
@@ -121,7 +121,12 @@ class JLine3Terminal(workEnv: WorkEnv) extends REPLTerminal:
 
   override def getBufferUpToCursor: String = jlineReader.getBuffer.upToCursor()
 
-  override def getCurrentChar: Char = jlineReader.getBuffer.currChar().toChar
+  override def getCurrentChar: Char =
+    val c = jlineReader.getBuffer.currChar()
+    if c == -1 then
+      '\u0000'
+    else
+      c.toChar
 
   override def writeToBuffer(s: String): Unit = jlineReader.getBuffer.write(s)
 
@@ -129,7 +134,12 @@ class JLine3Terminal(workEnv: WorkEnv) extends REPLTerminal:
 
   override def redrawLine(): Unit = jlineReader.callWidget(LineReader.REDRAW_LINE)
 
-  override def getOutput: Any = jlineTerminal.output()
+  override def getOutputWriter: Option[java.io.Writer] = Some(jlineTerminal.writer())
+
+  override def writeNewlines(count: Int): Unit =
+    val writer = jlineTerminal.writer()
+    for i <- 1 until count do
+      writer.write('\n')
 
   /**
     * Get access to the JLine3 reader for advanced operations

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/REPLTerminal.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/REPLTerminal.scala
@@ -1,0 +1,140 @@
+package wvlet.lang.cli.terminal
+
+/**
+  * Terminal abstraction for REPL to avoid loading JLine3 in headless mode
+  */
+trait REPLTerminal extends AutoCloseable:
+  /**
+    * Terminal width in characters
+    */
+  def width: Int
+
+  /**
+    * Terminal height in lines
+    */
+  def height: Int
+
+  /**
+    * Set terminal size (for testing or initial setup)
+    */
+  def setSize(width: Int, height: Int): Unit
+
+  /**
+    * Write a string to the terminal
+    */
+  def write(s: String): Unit
+
+  /**
+    * Write a string followed by newline
+    */
+  def writeln(s: String): Unit
+
+  /**
+    * Flush the terminal output
+    */
+  def flush(): Unit
+
+  /**
+    * Clear the screen
+    */
+  def clearScreen(): Unit
+
+  /**
+    * Print a message above the current line (for interactive terminals)
+    */
+  def printAbove(s: String): Unit
+
+  /**
+    * Read a line of input with the given prompt
+    */
+  def readLine(prompt: String): String
+
+  /**
+    * Whether this is a real terminal (not dumb/headless)
+    */
+  def isRealTerminal: Boolean
+
+  /**
+    * Handle interrupt signal (Ctrl+C)
+    */
+  def handleInterrupt(handler: => Unit): Unit
+
+  /**
+    * Get the command history
+    */
+  def getHistory: REPLHistory
+
+  /**
+    * Execute a special REPL command (like move to top, describe line, etc.) Returns true if the
+    * command was handled, false otherwise
+    */
+  def executeSpecialCommand(cmd: REPLCommand): Boolean
+
+  /**
+    * Get the current input buffer content (for interactive terminals)
+    */
+  def getBuffer: String
+
+  /**
+    * Move cursor in the input buffer to position
+    */
+  def moveCursor(pos: Int): Unit
+
+  /**
+    * Get current cursor position
+    */
+  def getCursorPosition: Int
+
+  /**
+    * Get buffer length
+    */
+  def getBufferLength: Int
+
+  /**
+    * Get buffer content up to cursor
+    */
+  def getBufferUpToCursor: String
+
+  /**
+    * Get current character at cursor
+    */
+  def getCurrentChar: Char
+
+  /**
+    * Write to the current buffer
+    */
+  def writeToBuffer(s: String): Unit
+
+  /**
+    * Call a line reader widget by name
+    */
+  def callWidget(widgetName: String): Unit
+
+  /**
+    * Redraw the current line
+    */
+  def redrawLine(): Unit
+
+  /**
+    * Get terminal output writer (for advanced terminal operations)
+    */
+  def getOutput: Any
+
+end REPLTerminal
+
+/**
+  * REPL command history abstraction
+  */
+trait REPLHistory:
+  def add(line: String): Unit
+  def save(): Unit
+
+/**
+  * Special REPL commands for interactive terminals
+  */
+enum REPLCommand:
+  case MoveToTop
+  case MoveToEnd
+  case EnterStatement
+  case DescribeLine
+  case SubqueryRun

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/REPLTerminal.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/REPLTerminal.scala
@@ -116,9 +116,17 @@ trait REPLTerminal extends AutoCloseable:
   def redrawLine(): Unit
 
   /**
-    * Get terminal output writer (for advanced terminal operations)
+    * Get terminal output writer for advanced operations (JLine3 only)
     */
-  def getOutput: Any
+  def getOutputWriter: Option[java.io.Writer]
+
+  /**
+    * Write blank lines to the terminal output
+    *
+    * @param count
+    *   Number of blank lines to write
+    */
+  def writeNewlines(count: Int): Unit
 
 end REPLTerminal
 


### PR DESCRIPTION
Make `wv -f (query file)` efficient by implementing lazy jline3 initialization.

## Changes

- Add `interactive` parameter to WvletREPL constructor
- Convert `terminal`, `reader`, and `historyFile` to lazy vals
- Guard terminal setup to only initialize in interactive mode
- Update `close()` to only close terminal if initialized
- Modify `runStmt()` to use stdout in headless mode
- Update WvletREPLMain to pass interactive flag

This eliminates unnecessary terminal, LineReader, history, parser, completer, highlighter, and key binding initialization when running non-interactive commands.

Fixes #1420

Generated with [Claude Code](https://claude.ai/code)