### PR TITLE
fix: Resolve compilation warnings in SqlGenerator

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -629,14 +629,11 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
             s.size match
               case Rows(n) =>
                 text(s"${n}")
-              case Percentage(p) if dbType == Trino =>
-                // Trino: TABLESAMPLE BERNOULLI(5) - integer percentage
-                text(p.toString.stripSuffix(".0"))
               case Percentage(p) if dbType == DBType.DuckDB =>
                 // DuckDB: TABLESAMPLE BERNOULLI(5%) - percentage with % sign
                 text(s"${p.toString.stripSuffix(".0")}%")
               case Percentage(p) =>
-                // Default for other databases - use percentage without % sign (Trino style)
+                // Default for other databases (including Trino) - percentage without % sign
                 text(p.toString.stripSuffix(".0"))
               case PercentageExpr(e) =>
                 expr(e)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -292,8 +292,8 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
                   None
               val whereClause = e.where.map(w => wl("where", expr(w)))
               wl("execute", expr(e.command), params, whereClause)
-            case _ =>
-              unsupportedNode(s"alter table ${op.nodeName}", d.span)
+            case null =>
+              unsupportedNode(s"alter table operation (null)", d.span)
 
         group(
           wl(
@@ -635,6 +635,9 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
               case Percentage(p) if dbType == DBType.DuckDB =>
                 // DuckDB: TABLESAMPLE BERNOULLI(5%) - percentage with % sign
                 text(s"${p.toString.stripSuffix(".0")}%")
+              case Percentage(p) =>
+                // Default for other databases - use percentage without % sign (Trino style)
+                text(p.toString.stripSuffix(".0"))
               case PercentageExpr(e) =>
                 expr(e)
 


### PR DESCRIPTION
## Summary
This PR fixes two Scala 3 compilation warnings in `SqlGenerator.scala` that were reported in issue #1436:

1. **Line 295**: Unreachable case warning in AlterTableOps pattern match
   - Changed `case _ =>` to `case null =>` to properly handle null values
   - Eliminates "Unreachable case except for null" warning

2. **Line 629**: Non-exhaustive match warning for SamplingSize
   - Added catch-all case for `Percentage(p)` when dbType is neither Trino nor DuckDB
   - Uses Trino-style percentage format (without % sign) as default behavior
   - Ensures pattern match is exhaustive

## Changes
- Modified `wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala`

## Testing
- ✅ Compilation passes without warnings
- ✅ All tests pass (`langJVM/test`: 1362 passed, 0 failed)
- ✅ Code formatted with `scalafmtAll`

## Impact
- No behavioral changes
- Maintains backward compatibility
- Follows existing code patterns

Fixes #1436

🤖 Generated with [Claude Code](https://claude.com/claude-code)