### PR TITLE
doc: Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![wvlet](logos/wvlet-banner-300.png)
 
+[![](https://deepwiki.com/badge.svg)](https://deepwiki.com/wvlet/wvlet)
+
 Wvlet, pronounced as weave-let, is a new cross-SQL flow-style query language for functional data modeling and interactive data exploration. Wvlet works with various types of SQL-based database engines, including [DuckDB](https://duckdb.org/), [Trino](https://trino.io/), [Hive](https://hive.apache.org/), etc.
 
 - [Documentation](https://wvlet.org/wvlet/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![wvlet](logos/wvlet-banner-300.png)
 
-[![](https://deepwiki.com/badge.svg)](https://deepwiki.com/wvlet/wvlet)
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/wvlet/wvlet)
 
 Wvlet, pronounced as weave-let, is a new cross-SQL flow-style query language for functional data modeling and interactive data exploration. Wvlet works with various types of SQL-based database engines, including [DuckDB](https://duckdb.org/), [Trino](https://trino.io/), [Hive](https://hive.apache.org/), etc.
 


### PR DESCRIPTION
Added DeepWiki badge to README.md as requested in issue #1441.

The badge has been placed after the banner image at the top of the README.

Fixes #1441

Generated with [Claude Code](https://claude.ai/code)