### PR TITLE
feature: Add pre-scanning and context-aware typing to new typer

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -146,7 +146,7 @@ object Typer extends Phase("typer") with LogSupport:
         val modelCtx = ctx.newContext(m.symbol)
         // Register parameters in input type
         val paramTypes = m.params.map(p => NamedType(p.name, p.dataType))
-        val inputType = SchemaType(
+        val inputType  = SchemaType(
           parent = None,
           typeName = Name.typeName(s"${m.name.name}_params"),
           columnTypes = paramTypes
@@ -186,17 +186,13 @@ object Typer extends Phase("typer") with LogSupport:
     elem match
       case f: FunctionDef =>
         // Add function args to input type
-        val argTypes = f.args.map(arg => NamedType(arg.name, arg.dataType))
+        val argTypes      = f.args.map(arg => NamedType(arg.name, arg.dataType))
         val inputWithArgs =
           ctx.inputType match
             case st: SchemaType =>
               st.copy(columnTypes = st.columnTypes ++ argTypes)
             case _ =>
-              SchemaType(
-                parent = None,
-                typeName = Name.NoTypeName,
-                columnTypes = argTypes
-              )
+              SchemaType(parent = None, typeName = Name.NoTypeName, columnTypes = argTypes)
         val funcCtx   = ctx.withInputType(inputWithArgs)
         val typedExpr = f.expr.map(e => typeExpression(e)(using funcCtx))
         f.copy(expr = typedExpr)


### PR DESCRIPTION
## Summary
- Implement two-phase typing approach following Scala 3's pattern
- Phase 1: Pre-scan to register symbols (TypeDef, ModelDef) for forward references
- Phase 2: Context-aware typing with proper scope management

## Changes
- **Typer.scala**: Add pre-scanning phase and context-aware `typePlan` with scope changes
  - `preScan()`: Register symbols before typing
  - `typePlan()`: Handle PackageDef, TypeDef, ModelDef with proper scope nesting
  - `typeRelation()`: Propagate input type through relational operators
  - `typeTypeElem()`: Type function/field definitions with input context
- **TyperTest.scala**: Add tests for TyperState and Context propagation

## Test Results
- All 24 TyperTest tests pass
- All 1386 langJVM tests pass (no regressions)

## Related Issues
- Addresses #392 (Redesign Typer)
- Builds on #1472 (TyperState in Context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)