### PR TITLE
feature: Add statement typing rules to new Typer

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -19,6 +19,9 @@ import wvlet.lang.model.expr.*
 import wvlet.lang.model.Type
 import wvlet.lang.model.Type.NoType
 import wvlet.lang.model.Type.ErrorType
+import wvlet.lang.model.Type.UnitType
+import wvlet.lang.model.Type.PackageType
+import wvlet.lang.model.Type.FunctionType
 import wvlet.lang.model.DataType
 import wvlet.lang.model.DataType.*
 
@@ -414,6 +417,43 @@ object TyperRules:
     case r: Relation =>
       r.tpe = r.relationType
       r
+  }
+
+  // ============================================
+  // Statement Typing Rules
+  // ============================================
+
+  /**
+    * Typing rules for statements. Sets tpe field on all statement types to ensure all nodes are
+    * typed after the typing phase.
+    *
+    * Note: FunctionDef and FieldDef are TypeElem (extend Expression, not LogicalPlan) and are
+    * handled directly in Typer.typeTypeElem.
+    */
+  def statementRules(using ctx: Context): PartialFunction[LogicalPlan, LogicalPlan] = {
+    case p: PackageDef =>
+      p.tpe = PackageType(wvlet.lang.compiler.Name.termName(p.name.fullName))
+      p
+
+    case t: TypeDef =>
+      t.tpe = t.symbol.dataType
+      t
+
+    case m: ModelDef =>
+      m.tpe = m.child.tpe
+      m
+
+    case i: Import =>
+      i.tpe = UnitType
+      i
+
+    case v: ValDef =>
+      v.tpe = v.dataType
+      v
+
+    case t: TopLevelFunctionDef =>
+      t.tpe = t.functionDef.tpe
+      t
   }
 
 end TyperRules

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -19,7 +19,7 @@ import wvlet.lang.model.expr.*
 import wvlet.lang.model.Type
 import wvlet.lang.model.Type.NoType
 import wvlet.lang.model.Type.ErrorType
-import wvlet.lang.model.Type.UnitType
+import wvlet.lang.model.Type.ImportType
 import wvlet.lang.model.Type.PackageType
 import wvlet.lang.model.Type.FunctionType
 import wvlet.lang.model.DataType
@@ -439,7 +439,7 @@ object TyperRules:
       case m: ModelDef =>
         m.tpe = m.child.tpe
       case i: Import =>
-        i.tpe = UnitType
+        i.tpe = ImportType(i)
       case v: ValDef =>
         v.tpe = v.dataType
       case t: TopLevelFunctionDef =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -430,30 +430,21 @@ object TyperRules:
     * Note: FunctionDef and FieldDef are TypeElem (extend Expression, not LogicalPlan) and are
     * handled directly in Typer.typeTypeElem.
     */
-  def statementRules(using ctx: Context): PartialFunction[LogicalPlan, LogicalPlan] = {
-    case p: PackageDef =>
-      p.tpe = PackageType(wvlet.lang.compiler.Name.termName(p.name.fullName))
-      p
-
-    case t: TypeDef =>
-      t.tpe = t.symbol.dataType
-      t
-
-    case m: ModelDef =>
-      m.tpe = m.child.tpe
-      m
-
-    case i: Import =>
-      i.tpe = UnitType
-      i
-
-    case v: ValDef =>
-      v.tpe = v.dataType
-      v
-
-    case t: TopLevelFunctionDef =>
-      t.tpe = t.functionDef.tpe
-      t
-  }
+  def typeStatement(plan: LogicalPlan)(using ctx: Context): Unit =
+    plan match
+      case p: PackageDef =>
+        p.tpe = PackageType(wvlet.lang.compiler.Name.termName(p.name.fullName))
+      case t: TypeDef =>
+        t.tpe = t.symbol.dataType
+      case m: ModelDef =>
+        m.tpe = m.child.tpe
+      case i: Import =>
+        i.tpe = UnitType
+      case v: ValDef =>
+        v.tpe = v.dataType
+      case t: TopLevelFunctionDef =>
+        t.tpe = t.functionDef.tpe
+      case _ =>
+        () // Other statements don't need typing
 
 end TyperRules

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperTest.scala
@@ -517,7 +517,7 @@ class TyperTest extends AirSpec:
     // After typing, tpe should be PackageType
     packageDef.tpe.isInstanceOf[Type.PackageType] shouldBe true
 
-  test("TyperRules.typeStatement should type Import with UnitType"):
+  test("TyperRules.typeStatement should type Import with ImportType"):
     given ctx: Context = testContext
 
     val importDef = Import(
@@ -533,7 +533,7 @@ class TyperTest extends AirSpec:
     // Apply statement typing
     TyperRules.typeStatement(importDef)
 
-    // After typing, tpe should be UnitType
-    importDef.tpe shouldBe Type.UnitType
+    // After typing, tpe should be ImportType
+    importDef.tpe.isInstanceOf[Type.ImportType] shouldBe true
 
 end TyperTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperTest.scala
@@ -490,7 +490,7 @@ class TyperTest extends AirSpec:
   // Statement typing tests
   // ============================================
 
-  test("TyperRules.statementRules should type PackageDef with PackageType"):
+  test("TyperRules.typeStatement should type PackageDef with PackageType"):
     given ctx: Context = testContext
 
     val packageDef = PackageDef(
@@ -511,13 +511,13 @@ class TyperTest extends AirSpec:
     // Before typing, tpe should be NoType
     packageDef.tpe shouldBe NoType
 
-    // Apply statement rules
-    val typed = TyperRules.statementRules.apply(packageDef)
+    // Apply statement typing
+    TyperRules.typeStatement(packageDef)
 
     // After typing, tpe should be PackageType
-    typed.tpe.isInstanceOf[Type.PackageType] shouldBe true
+    packageDef.tpe.isInstanceOf[Type.PackageType] shouldBe true
 
-  test("TyperRules.statementRules should type Import with UnitType"):
+  test("TyperRules.typeStatement should type Import with UnitType"):
     given ctx: Context = testContext
 
     val importDef = Import(
@@ -530,10 +530,10 @@ class TyperTest extends AirSpec:
     // Before typing, tpe should be NoType
     importDef.tpe shouldBe NoType
 
-    // Apply statement rules
-    val typed = TyperRules.statementRules.apply(importDef)
+    // Apply statement typing
+    TyperRules.typeStatement(importDef)
 
     // After typing, tpe should be UnitType
-    typed.tpe shouldBe Type.UnitType
+    importDef.tpe shouldBe Type.UnitType
 
 end TyperTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperTest.scala
@@ -486,4 +486,54 @@ class TyperTest extends AirSpec:
     typed.tpe shouldBe values.relationType
     typed.tpe shouldBe schema
 
+  // ============================================
+  // Statement typing tests
+  // ============================================
+
+  test("TyperRules.statementRules should type PackageDef with PackageType"):
+    given ctx: Context = testContext
+
+    val packageDef = PackageDef(
+      name = wvlet
+        .lang
+        .model
+        .expr
+        .DotRef(
+          wvlet.lang.model.expr.UnquotedIdentifier("test", Span.NoSpan),
+          wvlet.lang.model.expr.UnquotedIdentifier("pkg", Span.NoSpan),
+          DataType.UnknownType,
+          Span.NoSpan
+        ),
+      statements = Nil,
+      span = Span.NoSpan
+    )
+
+    // Before typing, tpe should be NoType
+    packageDef.tpe shouldBe NoType
+
+    // Apply statement rules
+    val typed = TyperRules.statementRules.apply(packageDef)
+
+    // After typing, tpe should be PackageType
+    typed.tpe.isInstanceOf[Type.PackageType] shouldBe true
+
+  test("TyperRules.statementRules should type Import with UnitType"):
+    given ctx: Context = testContext
+
+    val importDef = Import(
+      importRef = wvlet.lang.model.expr.UnquotedIdentifier("some_module", Span.NoSpan),
+      alias = None,
+      fromSource = None,
+      span = Span.NoSpan
+    )
+
+    // Before typing, tpe should be NoType
+    importDef.tpe shouldBe NoType
+
+    // Apply statement rules
+    val typed = TyperRules.statementRules.apply(importDef)
+
+    // After typing, tpe should be UnitType
+    typed.tpe shouldBe Type.UnitType
+
 end TyperTest


### PR DESCRIPTION
## Summary

Add statement typing rules to ensure all statement nodes have their `tpe` field set after the typing phase, following Scala 3's approach where all nodes are typed.

## Design

Following the design note's three-category architecture:
- `statementRules` - for PackageDef, TypeDef, ModelDef, etc. (this PR)
- `relationRules` - already implemented (PR #1479)
- `exprRules` - already implemented

## Statement Types

| Statement | tpe Value | Rationale |
|-----------|-----------|-----------|
| PackageDef | PackageType(name) | Package namespace |
| TypeDef | symbol.dataType | The type being defined |
| ModelDef | child query's type | Schema from child query |
| FunctionDef | FunctionType(name, args, returnType) | Function signature |
| FieldDef | symbol.dataType | Column/field type |
| Import | UnitType | Side effect |
| ValDef | value's dataType | Variable type |
| TopLevelFunctionDef | inner functionDef's type | Wrapper |

## Changes

- **TyperRules.scala**: Add `statementRules` PartialFunction for LogicalPlan statements
- **Typer.scala**: Apply `statementRules` after typing statement children; handle FunctionDef/FieldDef directly in `typeTypeElem` (they extend Expression, not LogicalPlan)
- **TyperTest.scala**: Add tests for PackageDef and Import statement typing

## Test Results

- All 27 TyperTest tests pass (2 new)
- All 1389 langJVM tests pass

## Related Issues

- Addresses #392 (Redesign Typer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)