### PR TITLE
feature: Add Nix flake for cross-compilation of Scala Native

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767116409,
+        "narHash": "sha256-5vKw92l1GyTnjoLzEagJy5V5mDFck72LiQWZSOnSicw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cad22e7d996aea55ecab064e84834289143e44a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,193 @@
+{
+  description = "Wvlet Scala Native cross-compilation environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      # Supported build host systems
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      # Import target configurations
+      targets = import ./nix/targets.nix;
+    in
+    flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          # Allow unfree packages if needed (e.g., for some native tools)
+          config.allowUnfree = true;
+        };
+
+        # Import the package builder
+        mkWvcLib = import ./nix/mkWvcLib.nix {
+          inherit pkgs system;
+          inherit (pkgs) lib stdenv;
+        };
+
+        # Common development dependencies (run on host)
+        commonDevInputs = with pkgs; [
+          # JVM for SBT
+          jdk21
+          # Build tools
+          sbt
+          git  # Use nixpkgs git instead of Apple Git (avoids FamilyDisplayName warning)
+          # Native toolchain
+          llvmPackages.clang
+          llvmPackages.lld
+          llvmPackages.llvm
+          # Required libraries for native build
+          boehmgc
+          openssl
+          pkg-config
+        ];
+
+        # Create a dev shell for a specific cross-compilation target
+        mkCrossDevShell = { targetName, targetConfig }:
+          let
+            crossPkgs =
+              if targetConfig.crossSystem == null then
+                pkgs  # Native build
+              else
+                import nixpkgs {
+                  inherit system;
+                  crossSystem = targetConfig.crossSystem;
+                };
+
+            # Get cross-compiled dependencies
+            crossBoehmgc = crossPkgs.boehmgc;
+            crossOpenssl = crossPkgs.openssl;
+
+            # Determine the correct clang/lld for cross-compilation
+            crossClang =
+              if targetConfig.crossSystem == null then
+                "${pkgs.llvmPackages.clang}/bin/clang"
+              else
+                "${crossPkgs.stdenv.cc}/bin/${targetConfig.llvmTriple}-cc";
+
+            crossClangpp =
+              if targetConfig.crossSystem == null then
+                "${pkgs.llvmPackages.clang}/bin/clang++"
+              else
+                "${crossPkgs.stdenv.cc}/bin/${targetConfig.llvmTriple}-c++";
+
+            crossLld =
+              if targetConfig.crossSystem == null then
+                "${pkgs.llvmPackages.lld}/bin/ld.lld"
+              else if targetConfig.useLd64 or false then
+                "${pkgs.llvmPackages.lld}/bin/ld64.lld"
+              else
+                "${pkgs.llvmPackages.lld}/bin/ld.lld";
+
+          in pkgs.mkShell {
+            name = "wvlet-cross-${targetName}";
+
+            nativeBuildInputs = commonDevInputs ++ (
+              if targetConfig.crossSystem != null then
+                [ crossPkgs.stdenv.cc ]
+              else
+                []
+            );
+
+            buildInputs =
+              if targetConfig.crossSystem == null then
+                [ pkgs.boehmgc pkgs.openssl ]
+              else
+                [ crossBoehmgc crossOpenssl ];
+
+            shellHook = ''
+              echo "Wvlet cross-compilation shell for ${targetName}"
+              echo "Target triple: ${targetConfig.llvmTriple}"
+
+              # Scala Native environment variables
+              export SCALANATIVE_CLANG="${crossClang}"
+              export SCALANATIVE_CLANGPP="${crossClangpp}"
+              export SCALANATIVE_LLD="${crossLld}"
+              export SCALANATIVE_TARGET_TRIPLE="${targetConfig.llvmTriple}"
+
+              ${if targetConfig.crossSystem != null then ''
+                export SCALANATIVE_SYSROOT="${crossPkgs.stdenv.cc.libc}"
+                export CROSS_GC_INCLUDE="${crossBoehmgc.dev}/include"
+                export CROSS_GC_LIB="${crossBoehmgc}/lib"
+                export CROSS_OPENSSL_INCLUDE="${crossOpenssl.dev}/include"
+                export CROSS_OPENSSL_LIB="${crossOpenssl.out}/lib"
+                # Set library paths for cross-compilation
+                export LIBRARY_PATH="${crossBoehmgc}/lib:${crossOpenssl.out}/lib:${crossPkgs.zlib}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+                export C_INCLUDE_PATH="${crossBoehmgc.dev}/include:${crossOpenssl.dev}/include:${crossPkgs.zlib.dev}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+              '' else ''
+                # Set library paths for native build - prioritize Nix packages over Homebrew
+                export LIBRARY_PATH="${pkgs.boehmgc}/lib:${pkgs.openssl.out}/lib:${pkgs.zlib}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+                export C_INCLUDE_PATH="${pkgs.boehmgc.dev}/include:${pkgs.openssl.dev}/include:${pkgs.zlib.dev}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+              ''}
+
+              echo ""
+              echo "Environment variables set:"
+              echo "  SCALANATIVE_CLANG=$SCALANATIVE_CLANG"
+              echo "  SCALANATIVE_CLANGPP=$SCALANATIVE_CLANGPP"
+              echo "  SCALANATIVE_LLD=$SCALANATIVE_LLD"
+              echo "  SCALANATIVE_TARGET_TRIPLE=$SCALANATIVE_TARGET_TRIPLE"
+              echo "  LIBRARY_PATH=$LIBRARY_PATH"
+              ${if targetConfig.crossSystem != null then ''
+                echo "  SCALANATIVE_SYSROOT=$SCALANATIVE_SYSROOT"
+              '' else ""}
+              echo ""
+              echo "Run: ./sbt wvcLib/nativeLink"
+            '';
+          };
+
+        # Filter targets based on current host system
+        availableTargets = pkgs.lib.filterAttrs (name: config:
+          # Check if this target can be built from the current host
+          builtins.elem system config.buildHosts
+        ) targets;
+
+      in {
+        # Dev shells for each target
+        devShells = {
+          # Default shell for native development
+          default = pkgs.mkShell {
+            name = "wvlet-dev";
+            nativeBuildInputs = commonDevInputs;
+            buildInputs = [ pkgs.boehmgc pkgs.openssl pkgs.zlib ];
+
+            shellHook = ''
+              echo "Wvlet development shell"
+              echo "Available cross-compilation targets: ${builtins.concatStringsSep ", " (builtins.attrNames availableTargets)}"
+              echo ""
+
+              # Set library paths - prioritize Nix packages over Homebrew
+              export LIBRARY_PATH="${pkgs.boehmgc}/lib:${pkgs.openssl.out}/lib:${pkgs.zlib}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+              export C_INCLUDE_PATH="${pkgs.boehmgc.dev}/include:${pkgs.openssl.dev}/include:${pkgs.zlib.dev}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+
+              # Set macOS deployment target to current version
+              export MACOSX_DEPLOYMENT_TARGET="15.0"
+
+              # Force linker to search our paths first
+              export NIX_ENFORCE_NO_NATIVE="1"
+
+              echo "LIBRARY_PATH=$LIBRARY_PATH"
+              echo "MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET"
+              echo ""
+              echo "Enter a cross-compilation shell with:"
+              echo "  nix develop .#<target-name>"
+              echo ""
+            '';
+          };
+        } // pkgs.lib.mapAttrs (name: config:
+          mkCrossDevShell { targetName = name; targetConfig = config; }
+        ) availableTargets;
+
+        # Packages (to be implemented - for now just expose shell)
+        packages = {
+          # TODO: Add actual package derivations
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -166,11 +166,10 @@
               export LIBRARY_PATH="${pkgs.boehmgc}/lib:${pkgs.openssl.out}/lib:${pkgs.zlib}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
               export C_INCLUDE_PATH="${pkgs.boehmgc.dev}/include:${pkgs.openssl.dev}/include:${pkgs.zlib.dev}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
 
-              # Set macOS deployment target to current version
-              export MACOSX_DEPLOYMENT_TARGET="15.0"
-
-              # Force linker to search our paths first
-              export NIX_ENFORCE_NO_NATIVE="1"
+              ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+                # Set macOS deployment target to a compatible version
+                export MACOSX_DEPLOYMENT_TARGET="${pkgs.stdenv.hostPlatform.darwinMinVersion}"
+              ''}
 
               echo "LIBRARY_PATH=$LIBRARY_PATH"
               echo "MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET"

--- a/nix/mkWvcLib.nix
+++ b/nix/mkWvcLib.nix
@@ -1,0 +1,113 @@
+# Package derivation builder for wvcLib
+#
+# This module provides functions to build wvcLib as a Nix package.
+# Note: Building Scala/SBT projects in Nix requires special handling
+# for dependency fetching. For now, this provides the structure for
+# future implementation.
+
+{ pkgs, lib, stdenv, system }:
+
+let
+  targets = import ./targets.nix;
+
+  # Create a derivation for building wvcLib for a specific target
+  mkWvcLibPackage = { targetName, targetConfig, src }:
+    let
+      crossPkgs =
+        if targetConfig.crossSystem == null then
+          pkgs
+        else
+          import <nixpkgs> {
+            inherit system;
+            crossSystem = targetConfig.crossSystem;
+          };
+
+      crossBoehmgc = crossPkgs.boehmgc;
+      crossOpenssl = crossPkgs.openssl;
+
+    in stdenv.mkDerivation {
+      pname = "wvcLib-${targetName}";
+      version = "0.1.0";  # TODO: Extract from build.sbt
+
+      inherit src;
+
+      nativeBuildInputs = with pkgs; [
+        jdk21
+        sbt
+        llvmPackages.clang
+        llvmPackages.lld
+      ] ++ lib.optionals (targetConfig.crossSystem != null) [
+        crossPkgs.stdenv.cc
+      ];
+
+      buildInputs = [
+        crossBoehmgc
+        crossOpenssl
+      ];
+
+      # SBT needs a writable home directory
+      HOME = "/tmp/sbt-home";
+
+      # Environment variables for Scala Native
+      SCALANATIVE_TARGET_TRIPLE = targetConfig.llvmTriple;
+
+      buildPhase = ''
+        mkdir -p $HOME
+
+        # Set up cross-compilation environment
+        export SCALANATIVE_CLANG="${if targetConfig.crossSystem == null
+          then "${pkgs.llvmPackages.clang}/bin/clang"
+          else "${crossPkgs.stdenv.cc}/bin/${targetConfig.llvmTriple}-cc"}"
+
+        export SCALANATIVE_CLANGPP="${if targetConfig.crossSystem == null
+          then "${pkgs.llvmPackages.clang}/bin/clang++"
+          else "${crossPkgs.stdenv.cc}/bin/${targetConfig.llvmTriple}-c++"}"
+
+        export SCALANATIVE_LLD="${pkgs.llvmPackages.lld}/bin/${if targetConfig.useLd64 or false then "ld64.lld" else "ld.lld"}"
+
+        ${lib.optionalString (targetConfig.crossSystem != null) ''
+          export SCALANATIVE_SYSROOT="${crossPkgs.stdenv.cc.libc}"
+          export CROSS_GC_INCLUDE="${crossBoehmgc.dev}/include"
+          export CROSS_GC_LIB="${crossBoehmgc}/lib"
+        ''}
+
+        # Run SBT build
+        ./sbt wvcLib/nativeLink
+      '';
+
+      installPhase = ''
+        mkdir -p $out/lib
+
+        # Copy the built library
+        cp wvlet-native-lib/target/scala-*/libwvlet.${targetConfig.libSuffix} $out/lib/ || true
+
+        # Copy headers if available
+        if [ -d wvc-lib/include ]; then
+          mkdir -p $out/include
+          cp -r wvc-lib/include/* $out/include/
+        fi
+      '';
+
+      meta = with lib; {
+        description = "Wvlet native library for ${targetName}";
+        homepage = "https://github.com/wvlet/wvlet";
+        license = licenses.asl20;
+        platforms = targetConfig.buildHosts;
+      };
+    };
+
+in {
+  inherit mkWvcLibPackage;
+
+  # Convenience function to build all available targets for the current system
+  buildAllTargets = src:
+    lib.mapAttrs (name: config:
+      mkWvcLibPackage {
+        targetName = name;
+        targetConfig = config;
+        inherit src;
+      }
+    ) (lib.filterAttrs (name: config:
+      builtins.elem system config.buildHosts
+    ) targets);
+}

--- a/nix/mkWvcLib.nix
+++ b/nix/mkWvcLib.nix
@@ -45,8 +45,8 @@ let
         crossOpenssl
       ];
 
-      # SBT needs a writable home directory
-      HOME = "/tmp/sbt-home";
+      # SBT needs a writable home directory (use relative path for sandboxed isolation)
+      HOME = "./.sbt-home";
 
       # Environment variables for Scala Native
       SCALANATIVE_TARGET_TRIPLE = targetConfig.llvmTriple;
@@ -79,7 +79,7 @@ let
         mkdir -p $out/lib
 
         # Copy the built library
-        cp wvlet-native-lib/target/scala-*/libwvlet.${targetConfig.libSuffix} $out/lib/ || true
+        cp $(find wvc-lib/target -type f -name "libwvlet.${targetConfig.libSuffix}") $out/lib/
 
         # Copy headers if available
         if [ -d wvc-lib/include ]; then

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -1,0 +1,69 @@
+# Target platform configurations for Scala Native cross-compilation
+#
+# Each target defines:
+# - llvmTriple: The LLVM target triple for Scala Native
+# - crossSystem: nixpkgs cross-compilation system config (null for native)
+# - buildHosts: List of systems that can build this target
+# - libSuffix: File extension for shared libraries
+# - useLd64: Whether to use ld64.lld (macOS) instead of ld.lld
+
+{
+  # macOS ARM64 - native build only on macOS ARM
+  darwin-arm64 = {
+    llvmTriple = "aarch64-apple-darwin";
+    crossSystem = null;  # Native build only
+    buildHosts = [ "aarch64-darwin" ];
+    libSuffix = "dylib";
+    useLd64 = true;
+  };
+
+  # Linux ARM64 - native on ARM, cross from x86_64
+  linux-arm64 = {
+    llvmTriple = "aarch64-unknown-linux-gnu";
+    crossSystem = {
+      config = "aarch64-unknown-linux-gnu";
+      system = "aarch64-linux";
+    };
+    buildHosts = [ "aarch64-linux" "x86_64-linux" ];
+    libSuffix = "so";
+    useLd64 = false;
+  };
+
+  # Linux x86_64 - native on x86_64, cross from ARM
+  linux-x64 = {
+    llvmTriple = "x86_64-unknown-linux-gnu";
+    crossSystem = {
+      config = "x86_64-unknown-linux-gnu";
+      system = "x86_64-linux";
+    };
+    buildHosts = [ "x86_64-linux" "aarch64-linux" ];
+    libSuffix = "so";
+    useLd64 = false;
+  };
+
+  # Windows ARM64 - cross from Linux only
+  windows-arm64 = {
+    llvmTriple = "aarch64-w64-mingw32";
+    crossSystem = {
+      config = "aarch64-w64-mingw32";
+      libc = "msvcrt";
+    };
+    buildHosts = [ "x86_64-linux" "aarch64-linux" ];
+    libSuffix = "dll";
+    useLd64 = false;
+    isWindows = true;
+  };
+
+  # Windows x86_64 - cross from Linux only
+  windows-x64 = {
+    llvmTriple = "x86_64-w64-mingw32";
+    crossSystem = {
+      config = "x86_64-w64-mingw32";
+      libc = "msvcrt";
+    };
+    buildHosts = [ "x86_64-linux" "aarch64-linux" ];
+    libSuffix = "dll";
+    useLd64 = false;
+    isWindows = true;
+  };
+}


### PR DESCRIPTION
## Summary

- Add Nix flake infrastructure for reproducible cross-compilation of Scala Native projects
- Define 5 target platforms: macOS ARM64, Linux ARM64/x64, Windows ARM64/x64
- Update build.sbt to read Nix-provided environment variables for cross-toolchain configuration
- Remove macOS Intel target (Apple no longer sells Intel Macs)

## Changes

### New Files
- `flake.nix` - Main Nix flake with dev shells for each target
- `flake.lock` - Locked nixpkgs dependencies
- `nix/targets.nix` - Target platform configurations with LLVM triples
- `nix/mkWvcLib.nix` - Package derivation builder template

### Modified Files
- `build.sbt` - Added `applyNixCrossSettings()` function to read environment variables:
  - `LIBRARY_PATH` → `-L` flags
  - `C_INCLUDE_PATH` → `-I` flags
  - `SCALANATIVE_CLANG/CLANGPP/LLD` → toolchain paths
  - `MACOSX_DEPLOYMENT_TARGET` → macOS version
  - `-Wl,-search_paths_first` for correct library ordering on macOS

## Usage

```bash
# Enter development shell
nix develop

# Enter cross-compilation shell for specific target
nix develop .#darwin-arm64
nix develop .#linux-arm64
nix develop .#linux-x64
nix develop .#windows-x64
nix develop .#windows-arm64

# Build wvcLib
./sbt wvcLib/nativeLink
```

## Test plan

- [x] Verify `nix flake show` lists all targets
- [x] Verify `nix develop` provides JDK 21, SBT, Clang/LLVM
- [x] Verify `./sbt wvcLib/nativeLink` builds without version mismatch warnings
- [ ] Test cross-compilation on Linux CI runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)