### PR TITLE
feature: Add Windows cross-compilation using Nix to CI

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -112,10 +112,15 @@ jobs:
           name: ${{ matrix.name }}-${{ matrix.arch }}
           path: wvc-lib/target/scala-${{ env.SCALA_VERSION }}/libwvlet.${{ matrix.suffix }}
   # Windows cross-compilation using Nix with MinGW-w64 toolchain
+  # Currently disabled due to LLVM CodeViewDebug crash when cross-compiling for Windows.
+  # The crash occurs in CodeViewDebug::beginModule() and cannot be worked around with
+  # compile flags like -g0 since LLVM initializes CodeView based on target triple.
+  # See: https://github.com/llvm/llvm-project/issues/61039
+  # Enable when LLVM fixes this issue or when native Windows runners are available.
   build_windows:
     name: Cross build for Windows
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ needs.changes.outputs.src == 'true' && false }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -111,6 +111,10 @@ jobs:
         with:
           name: ${{ matrix.name }}-${{ matrix.arch }}
           path: wvc-lib/target/scala-${{ env.SCALA_VERSION }}/libwvlet.${{ matrix.suffix }}
+  # Windows cross-compilation using Nix with MinGW-w64 toolchain
+  # Currently disabled due to LLVM CodeViewDebug crash when cross-compiling for Windows:
+  # https://github.com/llvm/llvm-project/issues/61039
+  # Enable when LLVM fixes this issue or when building natively on Windows runners
   build_windows:
     name: Cross build for Windows
     needs: changes
@@ -121,10 +125,10 @@ jobs:
         include:
           - arch: x64
             target: windows-x64
-            skip: false
+            skip: true  # LLVM CodeViewDebug crash - see comment above
           - arch: arm64
             target: windows-arm64
-            skip: false
+            skip: true  # LLVM CodeViewDebug crash - see comment above
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -28,6 +28,8 @@ jobs:
               - '**.conf'
               - '**.wv'
               - SCALA_VERSION
+              - 'flake.nix'
+              - 'nix/**'
   build_native:
     name: Cross build with Scala Native
     needs: changes
@@ -51,11 +53,6 @@ jobs:
             name: linux
             suffix: so
             skip: false
-# TODO Need some tweaks to run sbt on Windows
-#          - os: windows-latest
-#            arch: x64
-#            name: windows
-#            suffix: dll
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -114,10 +111,50 @@ jobs:
         with:
           name: ${{ matrix.name }}-${{ matrix.arch }}
           path: wvc-lib/target/scala-${{ env.SCALA_VERSION }}/libwvlet.${{ matrix.suffix }}
+  build_windows:
+    name: Cross build for Windows
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            target: windows-x64
+            skip: false
+          - arch: arm64
+            target: windows-arm64
+            skip: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        if: ${{ !matrix.skip }}
+      - name: Install Nix
+        if: ${{ !matrix.skip }}
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Setup Nix cache
+        if: ${{ !matrix.skip }}
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Set SCALA_VERSION env
+        if: ${{ !matrix.skip }}
+        run: |
+          SCALA_VERSION=$(cat SCALA_VERSION)
+          echo SCALA_VERSION: $SCALA_VERSION
+          echo "SCALA_VERSION=$SCALA_VERSION" >> $GITHUB_ENV
+      - name: Build Windows DLL
+        if: ${{ !matrix.skip }}
+        run: |
+          nix develop .#${{ matrix.target }} --command ./sbt 'wvcLib/nativeLinkReleaseFast'
+      - name: Upload Windows DLL
+        if: ${{ !matrix.skip }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-${{ matrix.arch }}
+          path: wvc-lib/target/scala-${{ env.SCALA_VERSION }}/libwvlet.dll
   collect_artifact:
     name: Collect wvc dll
     runs-on: ubuntu-latest
-    needs: build_native
+    needs: [build_native, build_windows]
     steps:
       - name: Merge artifacts
         uses: actions/upload-artifact/merge@v6

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -112,9 +112,6 @@ jobs:
           name: ${{ matrix.name }}-${{ matrix.arch }}
           path: wvc-lib/target/scala-${{ env.SCALA_VERSION }}/libwvlet.${{ matrix.suffix }}
   # Windows cross-compilation using Nix with MinGW-w64 toolchain
-  # Currently disabled due to LLVM CodeViewDebug crash when cross-compiling for Windows:
-  # https://github.com/llvm/llvm-project/issues/61039
-  # Enable when LLVM fixes this issue or when building natively on Windows runners
   build_windows:
     name: Cross build for Windows
     needs: changes
@@ -125,32 +122,24 @@ jobs:
         include:
           - arch: x64
             target: windows-x64
-            skip: true  # LLVM CodeViewDebug crash - see comment above
           - arch: arm64
             target: windows-arm64
-            skip: true  # LLVM CodeViewDebug crash - see comment above
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        if: ${{ !matrix.skip }}
       - name: Install Nix
-        if: ${{ !matrix.skip }}
         uses: DeterminateSystems/nix-installer-action@main
       - name: Setup Nix cache
-        if: ${{ !matrix.skip }}
         uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Set SCALA_VERSION env
-        if: ${{ !matrix.skip }}
         run: |
           SCALA_VERSION=$(cat SCALA_VERSION)
           echo SCALA_VERSION: $SCALA_VERSION
           echo "SCALA_VERSION=$SCALA_VERSION" >> $GITHUB_ENV
       - name: Build Windows DLL
-        if: ${{ !matrix.skip }}
         run: |
           nix develop .#${{ matrix.target }} --command ./sbt 'wvcLib/nativeLinkReleaseFast'
       - name: Upload Windows DLL
-        if: ${{ !matrix.skip }}
         uses: actions/upload-artifact@v6
         with:
           name: windows-${{ matrix.arch }}

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,12 @@ def applyNixCrossSettings(config: NativeConfig): NativeConfig = {
     .map(_.split(":").filter(_.nonEmpty).map(p => s"-L$p").toSeq)
     .getOrElse(Seq.empty)
 
+  // Also add -B flags to help clang find CRT files (crtbeginS.o, etc.)
+  // -B tells clang to add a path to its search list for executables, libraries, and data files
+  val crtSearchPaths = libraryPath
+    .map(_.split(":").filter(_.nonEmpty).map(p => s"-B$p").toSeq)
+    .getOrElse(Seq.empty)
+
   // Convert C_INCLUDE_PATH to -I flags
   val includePathOpts = cIncludePath
     .map(_.split(":").filter(_.nonEmpty).map(p => s"-I$p").toSeq)
@@ -58,6 +64,7 @@ def applyNixCrossSettings(config: NativeConfig): NativeConfig = {
 
   val extraLinkOpts =
     searchPathsFirst ++
+    crtSearchPaths ++   // -B flags to find CRT files (crtbeginS.o, etc.)
     libraryPathOpts ++  // Put Nix library paths first
     sysroot.map(s => s"--sysroot=$s").toSeq ++
     gcLib.map(l => s"-L$l").toSeq ++

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,12 @@ def applyNixCrossSettings(config: NativeConfig): NativeConfig = {
     includePathOpts
 
   // On macOS, use -search_paths_first to prioritize -L paths over default paths
-  val searchPathsFirst = if (scala.util.Properties.isMac) Seq("-Wl,-search_paths_first") else Seq.empty
+  // Check target triple for cross-compilation, fall back to host OS for native builds
+  val isMacOSTarget = triple match {
+    case Some(t) => t.contains("darwin") || t.contains("apple")
+    case None    => scala.util.Properties.isMac
+  }
+  val searchPathsFirst = if (isMacOSTarget) Seq("-Wl,-search_paths_first") else Seq.empty
 
   val extraLinkOpts =
     searchPathsFirst ++

--- a/build.sbt
+++ b/build.sbt
@@ -56,15 +56,8 @@ def applyNixCrossSettings(config: NativeConfig): NativeConfig = {
   }
   val searchPathsFirst = if (isMacOSTarget) Seq("-Wl,-search_paths_first") else Seq.empty
 
-  // Check if targeting Windows (mingw)
-  val isWindowsTarget = triple.exists(t => t.contains("mingw") || t.contains("windows"))
-  // Disable debug info for Windows cross-compilation to avoid LLVM CodeViewDebug crash
-  // See: https://github.com/llvm/llvm-project/issues/61039
-  val windowsDebugWorkaround = if (isWindowsTarget) Seq("-g0") else Seq.empty
-
   // Apply sysroot and library paths for cross-compilation
   val extraCompileOpts =
-    windowsDebugWorkaround ++
     sysroot.map(s => s"--sysroot=$s").toSeq ++
     gcInclude.map(i => s"-I$i").toSeq ++
     includePathOpts

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
             # Get cross-compiled dependencies
             crossBoehmgc = crossPkgs.boehmgc;
             crossOpenssl = crossPkgs.openssl;
+            crossGlibc = crossPkgs.stdenv.cc.libc;
 
             # Determine the correct clang/lld for cross-compilation
             # Always use clang for Scala Native (it passes clang-specific flags like -target)
@@ -129,14 +130,15 @@
               export SCALANATIVE_TARGET_TRIPLE="${targetConfig.llvmTriple}"
 
               ${if targetConfig.crossSystem != null then ''
-                export SCALANATIVE_SYSROOT="${crossPkgs.stdenv.cc.libc}"
+                export SCALANATIVE_SYSROOT="${crossGlibc}"
                 export CROSS_GC_INCLUDE="${crossBoehmgc.dev}/include"
                 export CROSS_GC_LIB="${crossBoehmgc}/lib"
                 export CROSS_OPENSSL_INCLUDE="${crossOpenssl.dev}/include"
                 export CROSS_OPENSSL_LIB="${crossOpenssl.out}/lib"
                 # Set library paths for cross-compilation
                 export LIBRARY_PATH="${crossBoehmgc}/lib:${crossOpenssl.out}/lib:${crossPkgs.zlib}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
-                export C_INCLUDE_PATH="${crossBoehmgc.dev}/include:${crossOpenssl.dev}/include:${crossPkgs.zlib.dev}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+                # Include glibc headers for cross-compilation (needed when using unwrapped clang)
+                export C_INCLUDE_PATH="${crossGlibc.dev}/include:${crossBoehmgc.dev}/include:${crossOpenssl.dev}/include:${crossPkgs.zlib.dev}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
               '' else ''
                 # Set library paths for native build - prioritize Nix packages over Homebrew
                 export LIBRARY_PATH="${pkgs.boehmgc}/lib:${pkgs.openssl.out}/lib:${pkgs.zlib}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"

--- a/flake.nix
+++ b/flake.nix
@@ -81,9 +81,6 @@
             # The unwrapped clang works with Scala Native's --target flag
             useUnwrappedClang = isWindowsTarget || (isDarwinHost && targetConfig.crossSystem != null);
 
-            # Detect if we're cross-compiling from Darwin to a non-Darwin target
-            # In this case, we need to override os.name to prevent macOS-specific linker flags
-            isDarwinToNonDarwinCross = isDarwinHost && targetConfig.crossSystem != null && !(targetConfig.useLd64 or false);
 
             crossClang =
               if targetConfig.crossSystem == null then
@@ -171,13 +168,7 @@
                 echo "  SCALANATIVE_SYSROOT=$SCALANATIVE_SYSROOT"
               '' else ""}
               echo ""
-              ${if isDarwinToNonDarwinCross then ''
-                echo "Run: ./sbt -Dos.name=linux wvcLib/nativeLink"
-                echo ""
-                echo "Note: -Dos.name=linux is required to prevent macOS-specific linker flags"
-              '' else ''
-                echo "Run: ./sbt wvcLib/nativeLink"
-              ''}
+              echo "Run: ./sbt wvcLib/nativeLink"
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -98,10 +98,12 @@
               else
                 "${crossPkgs.stdenv.cc}/bin/${targetConfig.llvmTriple}-c++";
 
+            # Select the appropriate linker based on target
+            # - ld64.lld for macOS (useLd64 = true)
+            # - lld-link for Windows
+            # - ld.lld for Linux/ELF
             crossLld =
-              if targetConfig.crossSystem == null then
-                "${pkgs.llvmPackages.lld}/bin/ld.lld"
-              else if targetConfig.useLd64 or false then
+              if targetConfig.useLd64 or false then
                 "${pkgs.llvmPackages.lld}/bin/ld64.lld"
               else if isWindowsTarget then
                 "${pkgs.llvmPackages.lld}/bin/lld-link"

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -9,8 +9,9 @@
 
 {
   # macOS ARM64 - native build only on macOS ARM
+  # Use arm64-apple-darwin to match Nix's clang wrapper expectations
   darwin-arm64 = {
-    llvmTriple = "aarch64-apple-darwin";
+    llvmTriple = "arm64-apple-darwin";
     crossSystem = null;  # Native build only
     buildHosts = [ "aarch64-darwin" ];
     libSuffix = "dylib";

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -45,14 +45,14 @@
     useLd64 = false;
   };
 
-  # Windows ARM64 - cross from Linux or macOS
+  # Windows ARM64 - cross from Linux only
   windows-arm64 = {
     llvmTriple = "aarch64-w64-mingw32";
     crossSystem = {
       config = "aarch64-w64-mingw32";
       libc = "msvcrt";
     };
-    buildHosts = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+    buildHosts = [ "x86_64-linux" "aarch64-linux" ];
     libSuffix = "dll";
     useLd64 = false;
     isWindows = true;

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -17,30 +17,29 @@
     useLd64 = true;
   };
 
-  # Linux ARM64 - native on ARM, cross from x86_64 Linux
-  # Note: Cross-compilation from macOS doesn't work because Scala Native
-  # passes host-specific linker flags (e.g., -search_paths_first) to the
-  # cross-linker, which doesn't understand them.
+  # Linux ARM64 - native on ARM, cross from x86_64 Linux or macOS
+  # Note: Cross-compilation from macOS requires -Dos.name=linux to prevent
+  # macOS-specific linker flags from being passed to the cross-linker.
   linux-arm64 = {
     llvmTriple = "aarch64-unknown-linux-gnu";
     crossSystem = {
       config = "aarch64-unknown-linux-gnu";
       system = "aarch64-linux";
     };
-    buildHosts = [ "aarch64-linux" "x86_64-linux" ];
+    buildHosts = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" ];
     libSuffix = "so";
     useLd64 = false;
   };
 
-  # Linux x86_64 - native on x86_64, cross from ARM Linux
-  # Note: Cross-compilation from macOS doesn't work (same reason as above)
+  # Linux x86_64 - native on x86_64, cross from ARM Linux or macOS
+  # Note: Cross-compilation from macOS requires -Dos.name=linux (same as above)
   linux-x64 = {
     llvmTriple = "x86_64-unknown-linux-gnu";
     crossSystem = {
       config = "x86_64-unknown-linux-gnu";
       system = "x86_64-linux";
     };
-    buildHosts = [ "x86_64-linux" "aarch64-linux" ];
+    buildHosts = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
     libSuffix = "so";
     useLd64 = false;
   };

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -17,26 +17,30 @@
     useLd64 = true;
   };
 
-  # Linux ARM64 - native on ARM, cross from x86_64 Linux or macOS
+  # Linux ARM64 - native on ARM, cross from x86_64 Linux
+  # Note: Cross-compilation from macOS doesn't work because Scala Native
+  # passes host-specific linker flags (e.g., -search_paths_first) to the
+  # cross-linker, which doesn't understand them.
   linux-arm64 = {
     llvmTriple = "aarch64-unknown-linux-gnu";
     crossSystem = {
       config = "aarch64-unknown-linux-gnu";
       system = "aarch64-linux";
     };
-    buildHosts = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" ];
+    buildHosts = [ "aarch64-linux" "x86_64-linux" ];
     libSuffix = "so";
     useLd64 = false;
   };
 
-  # Linux x86_64 - native on x86_64, cross from ARM Linux or macOS
+  # Linux x86_64 - native on x86_64, cross from ARM Linux
+  # Note: Cross-compilation from macOS doesn't work (same reason as above)
   linux-x64 = {
     llvmTriple = "x86_64-unknown-linux-gnu";
     crossSystem = {
       config = "x86_64-unknown-linux-gnu";
       system = "x86_64-linux";
     };
-    buildHosts = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+    buildHosts = [ "x86_64-linux" "aarch64-linux" ];
     libSuffix = "so";
     useLd64 = false;
   };

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -45,14 +45,14 @@
     useLd64 = false;
   };
 
-  # Windows ARM64 - cross from Linux only (macOS has LLVM CodeViewDebug crash)
+  # Windows ARM64 - cross from Linux or macOS
   windows-arm64 = {
     llvmTriple = "aarch64-w64-mingw32";
     crossSystem = {
       config = "aarch64-w64-mingw32";
       libc = "msvcrt";
     };
-    buildHosts = [ "x86_64-linux" "aarch64-linux" ];
+    buildHosts = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
     libSuffix = "dll";
     useLd64 = false;
     isWindows = true;

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -48,11 +48,7 @@
   # Windows ARM64 - cross from Linux only
   windows-arm64 = {
     llvmTriple = "aarch64-w64-mingw32";
-    crossSystem = {
-      config = "aarch64-w64-mingw32";
-      libc = "msvcrt";
-    };
-    buildHosts = [ "x86_64-linux" "aarch64-linux" ];
+    buildHosts = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
     libSuffix = "dll";
     useLd64 = false;
     isWindows = true;

--- a/nix/targets.nix
+++ b/nix/targets.nix
@@ -17,31 +17,31 @@
     useLd64 = true;
   };
 
-  # Linux ARM64 - native on ARM, cross from x86_64
+  # Linux ARM64 - native on ARM, cross from x86_64 Linux or macOS
   linux-arm64 = {
     llvmTriple = "aarch64-unknown-linux-gnu";
     crossSystem = {
       config = "aarch64-unknown-linux-gnu";
       system = "aarch64-linux";
     };
-    buildHosts = [ "aarch64-linux" "x86_64-linux" ];
+    buildHosts = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" ];
     libSuffix = "so";
     useLd64 = false;
   };
 
-  # Linux x86_64 - native on x86_64, cross from ARM
+  # Linux x86_64 - native on x86_64, cross from ARM Linux or macOS
   linux-x64 = {
     llvmTriple = "x86_64-unknown-linux-gnu";
     crossSystem = {
       config = "x86_64-unknown-linux-gnu";
       system = "x86_64-linux";
     };
-    buildHosts = [ "x86_64-linux" "aarch64-linux" ];
+    buildHosts = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
     libSuffix = "so";
     useLd64 = false;
   };
 
-  # Windows ARM64 - cross from Linux only
+  # Windows ARM64 - cross from Linux only (macOS has LLVM CodeViewDebug crash)
   windows-arm64 = {
     llvmTriple = "aarch64-w64-mingw32";
     crossSystem = {
@@ -54,7 +54,7 @@
     isWindows = true;
   };
 
-  # Windows x86_64 - cross from Linux only
+  # Windows x86_64 - cross from Linux only (macOS has LLVM CodeViewDebug crash)
   windows-x64 = {
     llvmTriple = "x86_64-w64-mingw32";
     crossSystem = {


### PR DESCRIPTION
## Summary
- Add Nix-based Windows cross-compilation infrastructure to native.yml
- Add `build_windows` job using DeterminateSystems Nix installer
- Configure MinGW-w64 toolchain via flake.nix for Windows x64 and ARM64
- Use unwrapped clang for Windows targets (MinGW GCC doesn't understand clang flags)
- Add flake.nix and nix/** to path filters for change detection
- Add glibc headers to C_INCLUDE_PATH for cross-compilation

### Cross-compilation status

| From → To | Linux ARM64 | Linux x64 | Windows | macOS |
|-----------|-------------|-----------|---------|-------|
| **Linux x64** | ✅ Works | Native | ⏸️ LLVM bug | ❌ |
| **Linux ARM64** | Native | ✅ Works | ⏸️ LLVM bug | ❌ |
| **macOS ARM64** | ❌ Linker flags | ❌ Linker flags | ⏸️ LLVM bug | Native |

**Known limitations:**
- **Windows cross-compilation disabled** (`skip: true`) due to [LLVM CodeViewDebug crash](https://github.com/llvm/llvm-project/issues/61039). The infrastructure is ready and can be enabled once LLVM fixes this issue.
- **macOS→Linux cross-compilation not possible** because Scala Native passes host-specific linker flags (e.g., `-search_paths_first`) to the cross-linker.

## Test plan
- [x] CI passes for native builds (macOS, Linux)
- [x] Windows jobs complete (skipped due to LLVM bug)
- [ ] Verify Windows cross-build works when LLVM is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)