### PR TITLE
feature: Add native Windows build to CI

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -51,11 +51,6 @@ jobs:
             name: linux
             suffix: so
             skip: false
-# TODO Need some tweaks to run sbt on Windows
-#          - os: windows-latest
-#            arch: x64
-#            name: windows
-#            suffix: dll
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -114,10 +109,54 @@ jobs:
         with:
           name: ${{ matrix.name }}-${{ matrix.arch }}
           path: wvc-lib/target/scala-${{ env.SCALA_VERSION }}/libwvlet.${{ matrix.suffix }}
+
+  build_windows:
+    name: Build native on Windows
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: sbt
+      - name: Install sbt
+        run: |
+          choco install sbt --version=1.10.11 -y
+      - name: Install LLVM and Clang
+        run: |
+          choco install llvm -y
+      - name: Install Boehm GC
+        run: |
+          # Download and extract Boehm GC for Windows
+          Invoke-WebRequest -Uri "https://github.com/pshved/libatomic_ops-release/releases/download/v7.8.0/libatomic_ops-7.8.0.zip" -OutFile "libatomic_ops.zip"
+          Expand-Archive -Path "libatomic_ops.zip" -DestinationPath "C:\libatomic_ops"
+          # For now, we'll try building without pre-installed gc and see what happens
+          # Scala Native on Windows might handle this differently
+      - name: Set SCALA_VERSION env
+        run: |
+          $scalaVersion = Get-Content SCALA_VERSION -Raw
+          $scalaVersion = $scalaVersion.Trim()
+          echo "SCALA_VERSION=$scalaVersion" >> $env:GITHUB_ENV
+          echo "SCALA_VERSION: $scalaVersion"
+        shell: pwsh
+      - name: Build native binary
+        run: |
+          sbt wvcLib/nativeLinkReleaseFast
+        shell: cmd
+      - name: Upload native binary
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-x64
+          path: wvc-lib/target/scala-${{ env.SCALA_VERSION }}/libwvlet.dll
+
   collect_artifact:
     name: Collect wvc dll
     runs-on: ubuntu-latest
-    needs: build_native
+    needs: [build_native, build_windows]
+    if: ${{ always() }}
     steps:
       - name: Merge artifacts
         uses: actions/upload-artifact/merge@v6

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -120,8 +120,10 @@ jobs:
         include:
           - os: windows-latest
             arch: x64
+            target_triple: x86_64-pc-windows-msvc
           - os: windows-11-arm
             arch: arm64
+            target_triple: aarch64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -149,9 +151,12 @@ jobs:
           $scalaVersion = $scalaVersion.Trim()
           echo "SCALA_VERSION=$scalaVersion" >> $env:GITHUB_ENV
           echo "SCALA_VERSION: $scalaVersion"
+          # Set target triple for Scala Native
+          echo "SCALANATIVE_TARGET_TRIPLE=${{ matrix.target_triple }}" >> $env:GITHUB_ENV
         shell: pwsh
       - name: Build native binary
         run: |
+          echo "Target triple: %SCALANATIVE_TARGET_TRIPLE%"
           sbt wvcLib/nativeLinkReleaseFast
         shell: cmd
       - name: Upload native binary

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -138,10 +138,10 @@ jobs:
       - name: Install LLVM and Clang
         run: |
           choco install llvm -y
-      - name: Install native dependencies (Boehm GC, zlib)
+      - name: Install native dependencies (Boehm GC, zlib, OpenSSL)
         run: |
           $triplet = if ("${{ matrix.arch }}" -eq "arm64") { "arm64-windows" } else { "x64-windows" }
-          vcpkg install bdwgc:$triplet zlib:$triplet
+          vcpkg install bdwgc:$triplet zlib:$triplet openssl:$triplet
           echo "C_INCLUDE_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\include" >> $env:GITHUB_ENV
           echo "VCPKG_LIB_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib" >> $env:GITHUB_ENV
         shell: pwsh

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -137,7 +137,19 @@ jobs:
           choco install sbt -y
       - name: Install LLVM and Clang
         run: |
-          choco install llvm -y
+          if ("${{ matrix.arch }}" -eq "arm64") {
+            # Chocolatey LLVM package doesn't support ARM64, download directly
+            $llvmVersion = "19.1.7"
+            $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvmVersion/LLVM-$llvmVersion-woa64.exe"
+            Write-Host "Downloading LLVM $llvmVersion for ARM64..."
+            Invoke-WebRequest -Uri $url -OutFile "llvm-installer.exe"
+            Write-Host "Installing LLVM..."
+            Start-Process -FilePath ".\llvm-installer.exe" -ArgumentList "/S","/D=C:\Program Files\LLVM" -Wait
+            echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
+          } else {
+            choco install llvm -y
+          }
+        shell: pwsh
       - name: Install native dependencies (Boehm GC, zlib, OpenSSL)
         run: |
           $triplet = if ("${{ matrix.arch }}" -eq "arm64") { "arm64-windows" } else { "x64-windows" }

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -142,11 +142,12 @@ jobs:
         run: |
           $triplet = if ("${{ matrix.arch }}" -eq "arm64") { "arm64-windows" } else { "x64-windows" }
           vcpkg install bdwgc:$triplet zlib:$triplet
-          $libPath = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib"
+          $vcpkgLibPath = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib"
           echo "C_INCLUDE_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\include" >> $env:GITHUB_ENV
-          echo "LIBRARY_PATH=$libPath" >> $env:GITHUB_ENV
-          # Add to LIB for MSVC linker
-          echo "LIB=$libPath;$env:LIB" >> $env:GITHUB_ENV
+          echo "LIBRARY_PATH=$vcpkgLibPath" >> $env:GITHUB_ENV
+          # Prepend vcpkg lib path to LIB for MSVC linker (keep existing paths)
+          $currentLib = if ($env:LIB) { $env:LIB } else { "" }
+          echo "LIB=$vcpkgLibPath;$currentLib" >> $env:GITHUB_ENV
         shell: pwsh
       - name: Set SCALA_VERSION env
         run: |

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -142,8 +142,11 @@ jobs:
         run: |
           $triplet = if ("${{ matrix.arch }}" -eq "arm64") { "arm64-windows" } else { "x64-windows" }
           vcpkg install bdwgc:$triplet zlib:$triplet
+          $libPath = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib"
           echo "C_INCLUDE_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\include" >> $env:GITHUB_ENV
-          echo "LIBRARY_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib" >> $env:GITHUB_ENV
+          echo "LIBRARY_PATH=$libPath" >> $env:GITHUB_ENV
+          # Add to LIB for MSVC linker
+          echo "LIB=$libPath;$env:LIB" >> $env:GITHUB_ENV
         shell: pwsh
       - name: Set SCALA_VERSION env
         run: |

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -111,10 +111,18 @@ jobs:
           path: wvc-lib/target/scala-${{ env.SCALA_VERSION }}/libwvlet.${{ matrix.suffix }}
 
   build_windows:
-    name: Build native on Windows
+    name: Build native on Windows (${{ matrix.arch }})
     needs: changes
     if: ${{ needs.changes.outputs.src == 'true' }}
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            arch: x64
+          - os: windows-11-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -128,13 +136,6 @@ jobs:
       - name: Install LLVM and Clang
         run: |
           choco install llvm -y
-      - name: Install Boehm GC
-        run: |
-          # Download and extract Boehm GC for Windows
-          Invoke-WebRequest -Uri "https://github.com/pshved/libatomic_ops-release/releases/download/v7.8.0/libatomic_ops-7.8.0.zip" -OutFile "libatomic_ops.zip"
-          Expand-Archive -Path "libatomic_ops.zip" -DestinationPath "C:\libatomic_ops"
-          # For now, we'll try building without pre-installed gc and see what happens
-          # Scala Native on Windows might handle this differently
       - name: Set SCALA_VERSION env
         run: |
           $scalaVersion = Get-Content SCALA_VERSION -Raw
@@ -149,7 +150,7 @@ jobs:
       - name: Upload native binary
         uses: actions/upload-artifact@v6
         with:
-          name: windows-x64
+          name: windows-${{ matrix.arch }}
           path: wvc-lib/target/scala-${{ env.SCALA_VERSION }}/libwvlet.dll
 
   collect_artifact:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -142,8 +142,16 @@ jobs:
         run: |
           $triplet = if ("${{ matrix.arch }}" -eq "arm64") { "arm64-windows" } else { "x64-windows" }
           vcpkg install bdwgc:$triplet zlib:$triplet openssl:$triplet
+          $libDir = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib"
+          # Create symlinks for OpenSSL libraries (Scala Native looks for crypto.lib, vcpkg provides libcrypto.lib)
+          if (Test-Path "$libDir\libcrypto.lib") {
+            Copy-Item "$libDir\libcrypto.lib" "$libDir\crypto.lib"
+          }
+          if (Test-Path "$libDir\libssl.lib") {
+            Copy-Item "$libDir\libssl.lib" "$libDir\ssl.lib"
+          }
           echo "C_INCLUDE_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\include" >> $env:GITHUB_ENV
-          echo "VCPKG_LIB_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib" >> $env:GITHUB_ENV
+          echo "VCPKG_LIB_PATH=$libDir" >> $env:GITHUB_ENV
         shell: pwsh
       - name: Set SCALA_VERSION env
         run: |

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -124,7 +124,7 @@ jobs:
           cache: sbt
       - name: Install sbt
         run: |
-          choco install sbt --version=1.10.11 -y
+          choco install sbt -y
       - name: Install LLVM and Clang
         run: |
           choco install llvm -y

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -136,6 +136,13 @@ jobs:
       - name: Install LLVM and Clang
         run: |
           choco install llvm -y
+      - name: Install native dependencies (Boehm GC, zlib)
+        run: |
+          $triplet = if ("${{ matrix.arch }}" -eq "arm64") { "arm64-windows" } else { "x64-windows" }
+          vcpkg install bdwgc:$triplet zlib:$triplet
+          echo "C_INCLUDE_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\include" >> $env:GITHUB_ENV
+          echo "LIBRARY_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib" >> $env:GITHUB_ENV
+        shell: pwsh
       - name: Set SCALA_VERSION env
         run: |
           $scalaVersion = Get-Content SCALA_VERSION -Raw

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -142,12 +142,8 @@ jobs:
         run: |
           $triplet = if ("${{ matrix.arch }}" -eq "arm64") { "arm64-windows" } else { "x64-windows" }
           vcpkg install bdwgc:$triplet zlib:$triplet
-          $vcpkgLibPath = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib"
           echo "C_INCLUDE_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\include" >> $env:GITHUB_ENV
-          echo "LIBRARY_PATH=$vcpkgLibPath" >> $env:GITHUB_ENV
-          # Prepend vcpkg lib path to LIB for MSVC linker (keep existing paths)
-          $currentLib = if ($env:LIB) { $env:LIB } else { "" }
-          echo "LIB=$vcpkgLibPath;$currentLib" >> $env:GITHUB_ENV
+          echo "VCPKG_LIB_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib" >> $env:GITHUB_ENV
         shell: pwsh
       - name: Set SCALA_VERSION env
         run: |
@@ -158,9 +154,15 @@ jobs:
           # Set target triple for Scala Native
           echo "SCALANATIVE_TARGET_TRIPLE=${{ matrix.target_triple }}" >> $env:GITHUB_ENV
         shell: pwsh
+      - name: Setup Visual Studio environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
       - name: Build native binary
         run: |
           echo "Target triple: %SCALANATIVE_TARGET_TRIPLE%"
+          set "LIB=%VCPKG_LIB_PATH%;%LIB%"
+          echo "LIB: %LIB%"
           sbt wvcLib/nativeLinkReleaseFast
         shell: cmd
       - name: Upload native binary

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,8 @@ def generateWvletLib(path: File, packageName: String, className: String): String
 
   def resourceDefs: String = wvFiles
     .map { f =>
-      val name = f.relativeTo(srcDir).get.getPath.stripSuffix(".wv").replaceAll("/", "__")
+      // Use replace instead of replaceAll to handle both Unix and Windows path separators
+      val name = f.relativeTo(srcDir).get.getPath.stripSuffix(".wv").replace("/", "__").replace("\\", "__")
 
       val methodName = name.replaceAll("-", "_")
       methodNames += methodName

--- a/build.sbt
+++ b/build.sbt
@@ -206,12 +206,18 @@ lazy val wvcLib = project
     buildSettings,
     name := "wvc-lib",
     nativeConfig ~= { c =>
-      c.withBuildTarget(BuildTarget.libraryDynamic)
+      val baseConfig = c
+        .withBuildTarget(BuildTarget.libraryDynamic)
         // Generates libwvlet.so, libwvlet.dylib, libwvlet.dll
         .withBaseName("wvlet")
         .withSourceLevelDebuggingConfig(_.enableAll) // enable generation of debug information
         // Boehm GC's non-moving behavior helps avoid Segmentation Fault in DLLs
         .withGC(GC.boehm)
+      // Allow overriding target triple via environment variable for cross-compilation
+      sys.env.get("SCALANATIVE_TARGET_TRIPLE") match {
+        case Some(triple) => baseConfig.withTargetTriple(triple)
+        case None         => baseConfig
+      }
     }
   )
   .dependsOn(wvc)

--- a/wvc/src/main/scala/wvlet/lang/native/WvcMain.scala
+++ b/wvc/src/main/scala/wvlet/lang/native/WvcMain.scala
@@ -107,8 +107,15 @@ object WvcMain extends LogSupport:
             case Some(q) =>
               q
             case None =>
-              import scala.scalanative.posix.unistd
-              val connectedToStdin = unistd.isatty(unistd.STDIN_FILENO) == 0
+              import scala.scalanative.meta.LinktimeInfo
+              // On Windows, POSIX unistd is not available, so we skip the isatty check
+              // and assume stdin is connected if no query is provided
+              val connectedToStdin =
+                if LinktimeInfo.isWindows then
+                  true // On Windows, assume stdin is available when no -q is provided
+                else
+                  import scala.scalanative.posix.unistd
+                  unistd.isatty(unistd.STDIN_FILENO) == 0
               if connectedToStdin then
                 // Read from stdin
                 Iterator.continually(scala.io.StdIn.readLine()).takeWhile(_ != null).mkString("\n")


### PR DESCRIPTION
## Summary
- Add native Windows build jobs to CI using Windows runners
- Support both x64 (`windows-latest`) and ARM64 (`windows-11-arm`) architectures
- Install sbt and LLVM via Chocolatey
- Build wvcLib natively on Windows

## Why
Cross-compilation for Windows from Linux/macOS is blocked by an LLVM CodeViewDebug bug (https://github.com/llvm/llvm-project/issues/61039).
Building natively on Windows runners avoids this issue.

## Test plan
- [ ] Verify Windows x64 build completes successfully
- [ ] Verify Windows ARM64 build completes successfully
- [ ] Check that libwvlet.dll is produced
- [ ] Fix any Windows-specific build issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)