### PR TITLE
feature: Use Nix for consistent native build environment

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -27,9 +27,11 @@ jobs:
               - '**.sbt'
               - '**.conf'
               - '**.wv'
+              - 'flake.nix'
+              - 'flake.lock'
               - SCALA_VERSION
   build_native:
-    name: Cross build with Scala Native
+    name: Build native on ${{ matrix.name }}-${{ matrix.arch }}
     needs: changes
     if: ${{ needs.changes.outputs.src == 'true' }}
     strategy:
@@ -51,11 +53,6 @@ jobs:
             name: linux
             suffix: so
             skip: false
-# TODO Need some tweaks to run sbt on Windows
-#          - os: windows-latest
-#            arch: x64
-#            name: windows
-#            suffix: dll
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -66,14 +63,18 @@ jobs:
           distribution: 'temurin'
           java-version: '25'
           cache: sbt
-      - name: Install libgc
+      - name: Install Nix
+        if: ${{ !matrix.skip }}
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-24.11
+      - name: Setup Nix build environment
         if: ${{ !matrix.skip }}
         run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            sudo apt-get install libgc-dev
-          elif [[ "${{ runner.os }}" == "macOS" ]]; then
-            brew install bdw-gc
-          fi
+          # Enter Nix CI shell and export environment variables
+          nix develop .#ci --command bash -c 'env' | grep -E '^(LIBRARY_PATH|C_INCLUDE_PATH|MACOSX_DEPLOYMENT_TARGET)=' >> $GITHUB_ENV || true
+          # Also add Nix profile to PATH for clang/lld
+          echo "$(nix develop .#ci --command bash -c 'echo $PATH' | tr ':' '\n' | grep '/nix/store' | head -20 | tr '\n' ':')" >> $GITHUB_PATH
       - name: Set SCALA_VERSION env
         if: ${{ !matrix.skip }}
         run: |

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -68,13 +68,6 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-24.11
-      - name: Setup Nix build environment
-        if: ${{ !matrix.skip }}
-        run: |
-          # Enter Nix CI shell and export environment variables
-          nix develop .#ci --command bash -c 'env' | grep -E '^(LIBRARY_PATH|C_INCLUDE_PATH|MACOSX_DEPLOYMENT_TARGET)=' >> $GITHUB_ENV || true
-          # Also add Nix profile to PATH for clang/lld
-          echo "$(nix develop .#ci --command bash -c 'echo $PATH' | tr ':' '\n' | grep '/nix/store' | head -20 | tr '\n' ':')" >> $GITHUB_PATH
       - name: Set SCALA_VERSION env
         if: ${{ !matrix.skip }}
         run: |
@@ -84,7 +77,7 @@ jobs:
       - name: Build native binary
         if: ${{ !matrix.skip }}
         run: |
-          ./sbt 'wvcLib/nativeLinkReleaseFast'
+          nix develop .#ci --command bash -c './sbt wvcLib/nativeLinkReleaseFast'
       - name: Ad-hoc sign macOS library
         if: ${{ !matrix.skip && runner.os == 'macOS' }}
         run: |

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,99 @@
+{
+  description = "Wvlet Scala Native build environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        # Common build dependencies for Scala Native
+        buildDeps = with pkgs; [
+          # LLVM toolchain
+          llvmPackages.clang
+          llvmPackages.lld
+          llvmPackages.llvm
+          # Required native libraries
+          boehmgc
+          openssl
+          zlib
+          # Build tools
+          pkg-config
+        ];
+
+        # Development dependencies (includes JDK and SBT)
+        devDeps = with pkgs; [
+          jdk21
+          sbt
+          git
+        ];
+
+      in {
+        # Development shell with all dependencies
+        devShells.default = pkgs.mkShell {
+          name = "wvlet-dev";
+          nativeBuildInputs = devDeps ++ buildDeps;
+          buildInputs = with pkgs; [ boehmgc openssl zlib ];
+
+          shellHook = ''
+            echo "Wvlet Scala Native development environment"
+            echo ""
+            echo "Build dependencies:"
+            echo "  clang:   $(clang --version | head -1)"
+            echo "  lld:     $(ld.lld --version | head -1)"
+            echo "  gc:      ${pkgs.boehmgc}"
+            echo "  openssl: ${pkgs.openssl}"
+            echo "  zlib:    ${pkgs.zlib}"
+            echo ""
+
+            # Set library paths for Scala Native
+            export LIBRARY_PATH="${pkgs.boehmgc}/lib:${pkgs.openssl.out}/lib:${pkgs.zlib}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+            export C_INCLUDE_PATH="${pkgs.boehmgc.dev}/include:${pkgs.openssl.dev}/include:${pkgs.zlib.dev}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+
+            ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+              export MACOSX_DEPLOYMENT_TARGET="${pkgs.stdenv.hostPlatform.darwinMinVersion}"
+            ''}
+
+            echo "Environment:"
+            echo "  LIBRARY_PATH=$LIBRARY_PATH"
+            echo "  C_INCLUDE_PATH=$C_INCLUDE_PATH"
+            ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+              echo "  MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET"
+            ''}
+            echo ""
+            echo "Run: ./sbt wvcLib/nativeLink"
+          '';
+        };
+
+        # CI shell - minimal dependencies for GitHub Actions (Java/SBT provided externally)
+        devShells.ci = pkgs.mkShell {
+          name = "wvlet-ci";
+          nativeBuildInputs = buildDeps;
+          buildInputs = with pkgs; [ boehmgc openssl zlib ];
+
+          shellHook = ''
+            # Set library paths for Scala Native
+            export LIBRARY_PATH="${pkgs.boehmgc}/lib:${pkgs.openssl.out}/lib:${pkgs.zlib}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+            export C_INCLUDE_PATH="${pkgs.boehmgc.dev}/include:${pkgs.openssl.dev}/include:${pkgs.zlib.dev}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+
+            ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+              export MACOSX_DEPLOYMENT_TARGET="${pkgs.stdenv.hostPlatform.darwinMinVersion}"
+            ''}
+
+            # Export paths for use in CI scripts
+            echo "LIBRARY_PATH=$LIBRARY_PATH" >> $GITHUB_ENV 2>/dev/null || true
+            echo "C_INCLUDE_PATH=$C_INCLUDE_PATH" >> $GITHUB_ENV 2>/dev/null || true
+            ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+              echo "MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET" >> $GITHUB_ENV 2>/dev/null || true
+            ''}
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

- Replace platform-specific package managers (apt-get, brew) with Nix flakes for installing native build dependencies
- Add `flake.nix` providing consistent LLVM/clang, Boehm GC, OpenSSL, and zlib across all platforms
- Update CI workflow to use `cachix/install-nix-action` and the `ci` dev shell

## Benefits

- **Reproducible builds**: Same dependency versions across all platforms and CI runs
- **Consistent toolchain**: LLVM/clang from nixpkgs instead of varying system versions
- **Simplified maintenance**: Single source of truth for native dependencies

## Dev Shells

The flake provides two shells:
- `nix develop` - Full development environment with JDK, SBT, and all native deps
- `nix develop .#ci` - Minimal CI environment (Java/SBT provided by setup-java action)

## Test plan

- [ ] Verify linux-x64 build passes
- [ ] Verify linux-arm64 build passes (on main push)
- [ ] Verify mac-arm64 build passes (on main push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)