### PR TITLE
doc: Update SDK documentation for Windows support

### DIFF
--- a/website/docs/bindings/index.md
+++ b/website/docs/bindings/index.md
@@ -70,9 +70,9 @@ All language SDKs use the same underlying native library (`libwvlet`) for consis
 |----------|--------|-------|
 | Linux    | ✅     | ✅    |
 | macOS    | ❌     | ✅    |
-| Windows  | 🔄     | 🔄    |
+| Windows  | ✅     | ✅    |
 
-✅ Supported | 🔄 Planned | ❌ Not Supported
+✅ Supported | ❌ Not Supported
 
 ## Contributing
 

--- a/website/docs/bindings/python.md
+++ b/website/docs/bindings/python.md
@@ -263,7 +263,8 @@ print(f"Native: {time.time() - start:.2f}s")
 | Linux    | x86_64      | ✅ Supported |
 | Linux    | aarch64     | ✅ Supported |
 | macOS    | arm64       | ✅ Supported |
-| Windows  | x86_64      | 🔄 Planned |
+| Windows  | x86_64      | ✅ Supported |
+| Windows  | arm64       | ✅ Supported |
 
 
 ## API Reference


### PR DESCRIPTION
## Summary
- Update platform support tables to show Windows x86_64 and ARM64 as supported
- Updated in both `bindings/index.md` and `bindings/python.md`

## Related
- Follows #1492 which added Windows native build support

🤖 Generated with [Claude Code](https://claude.com/claude-code)