### PR TITLE
fix: Skip collect_artifact when no native builds ran

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -212,7 +212,8 @@ jobs:
     name: Collect wvc dll
     runs-on: ubuntu-latest
     needs: [build_native, build_windows]
-    if: ${{ always() }}
+    # Only run if at least one upstream job succeeded (skip when all are skipped or failed)
+    if: ${{ always() && (needs.build_native.result == 'success' || needs.build_windows.result == 'success') }}
     steps:
       - name: Merge artifacts
         uses: actions/upload-artifact/merge@v6


### PR DESCRIPTION
## Summary
- Fixed `collect_artifact` job failing when no native builds were executed
- Added condition to only run when at least one upstream job (`build_native` or `build_windows`) succeeded

## Details
The `collect_artifact` job was configured with `if: ${{ always() }}` which caused it to run even when the upstream build jobs were skipped (due to no source changes detected by paths-filter). This resulted in the `upload-artifact/merge` action failing because there were no artifacts to merge.

The fix changes the condition to:
```yaml
if: ${{ always() && (needs.build_native.result == 'success' || needs.build_windows.result == 'success') }}
```

This ensures the job only runs when at least one build job actually succeeded and produced artifacts.

## Test plan
- [x] Verify workflow syntax is valid
- [ ] CI should skip collect_artifact step when PR has no changes matching the paths-filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)