### PR TITLE
fix: Use bash shell for listing wheels on Windows

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -208,6 +208,7 @@ jobs:
         run: |
           echo "Available wheels:"
           ls -la dist/
+        shell: bash
       
       - name: Install wheel
         run: |


### PR DESCRIPTION
## Summary
- Fixed Windows test failure in Python SDK workflow by adding `shell: bash` to the "List available wheels" step

## Details
The `ls -la dist/` command failed on Windows because:
- GitHub Actions defaults to PowerShell on Windows
- PowerShell's `ls` alias (Get-ChildItem) doesn't support the `-la` flag

Error from CI:
```
A parameter cannot be found that matches parameter name 'la'.
```

## Test plan
- [ ] CI should pass on all platforms including Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)