### PR TITLE
doc: Update PyPI README to reflect Windows support

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -195,7 +195,8 @@ Platform | Architecture | Status
 Linux    | x86_64      | ✅ Supported
 Linux    | aarch64     | ✅ Supported
 macOS    | arm64       | ✅ Supported
-Windows  | x86_64      | 🔄 Planned
+Windows  | x86_64      | ✅ Supported
+Windows  | arm64       | ✅ Supported
 
 
 ## Performance


### PR DESCRIPTION
## Summary
- Update the platform support table in Python SDK README to show Windows x86_64 and arm64 as supported
- Previously Windows x86_64 was marked as "🔄 Planned" and arm64 was missing

## Test plan
- [ ] Verify README renders correctly on PyPI after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)