### PR TITLE
doc: Add task-oriented syntax design for wvlet flow

### DIFF
--- a/plans/2025-01-25-task-oriented-syntax.md
+++ b/plans/2025-01-25-task-oriented-syntax.md
@@ -29,9 +29,113 @@ Design syntax extensions for wvlet's flow language to support task management fe
 
 ---
 
-## Syntax Design Ideas
+## Execution Model
 
-### Idea 1: Stage Configuration with `with` Clause
+### Stage States
+
+Each stage has a well-defined execution state:
+
+```
+pending → running → success
+                  ↘ failed → retrying → success
+                           ↘ failed (exhausted)
+                  ↘ skipped
+                  ↘ cancelled
+```
+
+| State | Description |
+|-------|-------------|
+| `pending` | Waiting for dependencies |
+| `running` | Currently executing |
+| `success` | Completed successfully |
+| `failed` | Execution failed (may retry) |
+| `retrying` | Retrying after failure |
+| `skipped` | Skipped due to upstream failure or trigger rule |
+| `cancelled` | Cancelled by user or parent flow |
+
+### Dependency Rules
+
+Stages form a DAG based on:
+1. **Data dependencies**: `from stage_name` creates an edge
+2. **Control dependencies**: `depends on stage_name` creates an edge without data flow
+3. **Failure dependencies**: `on_failure: stage_name` creates a conditional edge (runs only if source fails)
+
+### Trigger Rules
+
+Determine when a stage executes based on upstream states:
+
+| Rule | Description |
+|------|-------------|
+| `all_success` | Run only if ALL upstream stages succeeded (default) |
+| `one_success` | Run if AT LEAST ONE upstream succeeded |
+| `none_failed` | Run if NO upstream failed (success or skipped) |
+| `all_done` | Run after all upstreams complete (any state) |
+| `always` | Always run regardless of upstream state |
+
+---
+
+## Type System Extensions
+
+### Duration Literals
+
+Introduce typed duration literals (not strings):
+
+```wv
+-- Duration literal syntax: number followed by unit
+5m      -- 5 minutes
+30s     -- 30 seconds
+2h      -- 2 hours
+1d      -- 1 day
+100ms   -- 100 milliseconds
+```
+
+Duration units: `ms`, `s`, `m`, `h`, `d`
+
+### Backoff Strategy Enum
+
+```wv
+-- Backoff strategies are keywords, not strings
+backoff: constant     -- Fixed delay
+backoff: linear       -- Linearly increasing delay
+backoff: exponential  -- Exponentially increasing delay (default)
+```
+
+---
+
+## Grammar Rules
+
+### Config Block Syntax
+
+Use only `with { }` block syntax (no `[ ]` shorthand to avoid parsing ambiguity):
+
+```
+stage_def := "stage" IDENT [config_block] "=" stage_body
+
+config_block := "with" "{" config_items "}"
+
+config_items := (config_item NEWLINE)*
+
+config_item := IDENT ":" config_value
+
+config_value := INTEGER           -- retries: 3
+              | DURATION          -- timeout: 5m
+              | BACKOFF_STRATEGY  -- backoff: exponential
+              | TRIGGER_RULE      -- trigger: all_success
+              | IDENT             -- on_failure: fallback_stage
+```
+
+### Precedence
+
+1. `with { }` binds to the immediately preceding `stage` name
+2. `=` separates config from stage body
+3. `|` chains operations within stage body
+4. `->` is a flow operator (jump), not used in config
+
+---
+
+## Syntax Design
+
+### Core Syntax: Stage Configuration (v1 Scope)
 
 Extend stages with task configuration using `with { }` block:
 
@@ -39,8 +143,8 @@ Extend stages with task configuration using `with { }` block:
 flow DataPipeline = {
   stage extract with {
     retries: 3
-    timeout: '5m'
-    retry_delay: '1s'
+    timeout: 5m
+    retry_delay: 1s
     backoff: exponential
   } = from api_source | fetch_data()
 
@@ -48,120 +152,94 @@ flow DataPipeline = {
 
   stage load with {
     retries: 5
-    timeout: '10m'
-    heartbeat: '30s'
+    timeout: 10m
+    heartbeat: 30s
   } = from transform | save to warehouse
 }
 ```
 
-**Properties (inspired by Temporal):**
-- `retries` - max retry attempts (0 = no retry, default)
-- `timeout` - start-to-close timeout
-- `schedule_timeout` - schedule-to-close timeout (total including retries)
-- `retry_delay` - initial retry interval
-- `backoff` - `constant`, `linear`, `exponential`
-- `max_retry_delay` - cap on backoff delay
-- `heartbeat` - heartbeat interval for long-running stages
+**Stage-level properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `retries` | Int | 0 | Max retry attempts |
+| `timeout` | Duration | none | Start-to-close timeout |
+| `retry_delay` | Duration | 1s | Initial retry delay |
+| `backoff` | Enum | exponential | Backoff strategy |
+| `max_retry_delay` | Duration | none | Cap on backoff delay |
+| `heartbeat` | Duration | none | Heartbeat interval for long-running stages |
 
 ---
 
-### Idea 2: Activity-Style Stage Separation
+### Error Handling with Trigger Rules
 
-Separate orchestration (`flow`) from execution (`activity`):
-
-```wv
--- Define reusable activities with default configs
-activity fetch_api with {
-  retries: 3
-  timeout: '30s'
-  backoff: exponential
-}
-
-activity send_email with {
-  retries: 2
-  timeout: '10s'
-}
-
--- Flow uses activities (orchestration only)
-flow CustomerOnboarding = {
-  stage fetch = from customer_id | fetch_api(endpoint: '/users')
-  stage welcome = from fetch | send_email(template: 'welcome')
-}
-```
-
-**Benefits:**
-- Reusable retry/timeout configs
-- Clear separation of concerns (Temporal pattern)
-- Activities can be shared across flows
-
----
-
-### Idea 3: Inline vs Block Configuration
-
-Support both compact and verbose syntax:
-
-```wv
-flow Pipeline = {
-  -- Compact: single property
-  stage fast [timeout: '1m'] = from source
-
-  -- Compact: multiple properties
-  stage reliable [retries: 3, backoff: exponential] = from fast
-
-  -- Block: complex configuration
-  stage critical with {
-    retries: 5
-    timeout: '10m'
-    retry_delay: '5s'
-    backoff: exponential
-    max_retry_delay: '2m'
-    on_failure: skip
-  } = from reliable | process()
-}
-```
-
----
-
-### Idea 4: Error Handling and Fallback
-
-Explicit error handling inspired by Temporal's non-retryable errors:
+Explicit error handling with clear dependency semantics:
 
 ```wv
 flow ResilientPipeline = {
   stage primary with {
     retries: 3
-    on_failure: fallback_stage
   } = from source | call_primary_api()
 
-  stage fallback_stage = from source | call_backup_api()
+  -- Runs only if primary fails (after all retries exhausted)
+  stage fallback with {
+    on_failure: primary   -- creates conditional dependency edge
+  } = from source | call_backup_api()
 
+  -- Runs if either primary or fallback succeeds
   stage continue with {
-    trigger: one_success  -- run if either primary or fallback succeeds
-  } = merge primary, fallback_stage | process()
+    trigger: one_success
+  } = from primary, fallback | process()
 }
 ```
 
-**Trigger rules (from Airflow):**
-- `all_success` - all upstream stages succeeded (default)
-- `one_success` - at least one upstream succeeded
-- `none_failed` - no upstream failed (includes skipped)
-- `always` - run regardless of upstream state
+**Semantics:**
+- `on_failure: stage_name` creates an edge that activates only when the named stage fails
+- The fallback stage receives the same input as the failed stage (via `from source`)
+- `trigger: one_success` allows downstream to proceed if any upstream succeeded
 
 ---
 
-### Idea 5: Child Flow Invocation with Policies
+### Flow-Level Configuration
 
-Support child workflow patterns with parent close policies:
+Flow-level properties apply to the entire flow:
+
+```wv
+flow DailyETL with {
+  schedule: cron('0 2 * * *')  -- 2 AM daily
+  timezone: 'UTC'
+  concurrency: 1               -- max concurrent executions
+} = {
+  stage extract = from source | fetch_daily_data()
+  stage transform = from extract | clean_and_normalize()
+  stage load = from transform | save to warehouse
+}
+```
+
+**Flow-level properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `schedule` | Schedule | Cron or interval schedule |
+| `timezone` | String | Timezone for schedule |
+| `concurrency` | Int | Max concurrent flow executions |
+| `timeout` | Duration | Total flow timeout |
+
+---
+
+### Child Flow Invocation
+
+Use `call` keyword for explicit child flow invocation:
 
 ```wv
 flow ParentFlow = {
   stage setup = from config | initialize()
 
-  -- Invoke child flow with policy
+  -- Invoke child flow with explicit call syntax
   stage child with {
-    parent_close: abandon  -- or: terminate, request_cancel
-    timeout: '1h'
-  } = from setup | -> ChildFlow(param: _.value)
+    timeout: 1h
+    parent_close: abandon  -- terminate | request_cancel | abandon
+  } = call ChildFlow(param: setup.value)
 
   stage cleanup = from child | finalize()
 }
@@ -171,141 +249,114 @@ flow ChildFlow(param: string) = {
 }
 ```
 
+**Parent close policies:**
+- `terminate` - forcefully stop child when parent closes (default)
+- `request_cancel` - send cancellation request to child
+- `abandon` - let child continue independently
+
 ---
 
-### Idea 6: Signal and Query Handlers
+### Idempotency Keys
 
-Support external interaction with running flows:
+Ensure idempotent execution with explicit key specification:
 
 ```wv
-flow LongRunningProcess = {
-  -- Define signal handlers
-  signal pause = set_paused(true)
-  signal resume = set_paused(false)
-
-  -- Define query handlers
-  query status = current_status()
-  query progress = completed_steps / total_steps
-
-  stage loop with {
-    continue_as_new: 1000  -- reset after 1000 events
-  } = from source | while not_done() | process_batch()
+flow PaymentProcessing = {
+  stage charge with {
+    retries: 3
+    idempotency_key: transaction_id  -- field name from input schema
+  } = from payment_request | process_payment()
 }
 ```
 
+The `idempotency_key` references a field from the stage's input relation schema.
+
 ---
 
-### Idea 7: Saga Pattern for Compensating Actions
+## Future Extensions (Out of Scope for v1)
 
-Support transaction-like semantics with compensation:
+These features are documented for future consideration but not included in the initial implementation:
+
+### Signals and Queries (Temporal Pattern)
 
 ```wv
+-- Future: External interaction with running flows
+flow LongRunning with {
+  signal pause: () -> set_paused(true)
+  signal resume: () -> set_paused(false)
+  query status: () -> current_status()
+} = {
+  stage loop = from source | process_batch()
+}
+```
+
+### Saga Pattern for Compensation
+
+```wv
+-- Future: Transaction-like semantics
 flow BookingFlow = {
   stage book_flight with {
-    compensate: cancel_flight
+    compensate: cancel_flight  -- runs on rollback
   } = from request | reserve_flight()
 
   stage book_hotel with {
     compensate: cancel_hotel
   } = from book_flight | reserve_hotel()
-
-  stage book_car with {
-    compensate: cancel_car
-  } = from book_hotel | reserve_car()
-
-  -- If any stage fails, compensations run in reverse order
 }
 ```
 
----
-
-### Idea 8: Schedule and Cron Support
-
-Define scheduled flow execution:
+### Workflow Versioning
 
 ```wv
-flow DailyETL with {
-  schedule: '0 2 * * *'  -- cron: 2 AM daily
-  timezone: 'UTC'
+-- Future: Versioned flow definitions
+flow OrderProcess with {
+  version: 2
 } = {
-  stage extract = from source | fetch_daily_data()
-  stage transform = from extract | clean_and_normalize()
-  stage load = from transform | save to warehouse
-}
-
--- Or interval-based
-flow HeartbeatCheck with {
-  interval: '5m'
-} = {
-  stage check = from services | health_check()
-  stage alert = from check | where status = 'unhealthy' | send_alert()
-}
-```
-
----
-
-### Idea 9: Idempotency Keys
-
-Ensure idempotent execution:
-
-```wv
-flow PaymentProcessing = {
-  stage charge with {
-    idempotency_key: _.transaction_id  -- use field as idempotency key
-    retries: 3
-  } = from payment_request | process_payment()
-}
-```
-
----
-
-### Idea 10: Workflow Versioning
-
-Support workflow evolution:
-
-```wv
-flow OrderProcess @version(2) = {
-  -- Version 2 adds new validation step
   stage validate = from order | validate_inventory()
   stage process = from validate | process_order()
 }
 
--- Queries can specify version
-from orders | -> OrderProcess @version(1)  -- use old version
+-- Invoke specific version
+stage order = call OrderProcess(version: 1)
+```
+
+### Dynamic Task Mapping
+
+```wv
+-- Future: Fan-out over dynamic inputs
+flow BatchProcess = {
+  stage list_files = from bucket | list_objects()
+
+  stage process_each with {
+    map: list_files.files  -- creates N parallel stages
+  } = from _ | process_file()
+}
 ```
 
 ---
 
-## Recommended Initial Scope
+## Recommended Implementation Phases
 
-For the first implementation, focus on **Idea 1** (Stage Configuration) with core properties:
+### Phase 1: Core Stage Configuration
+- `retries`, `timeout`, `retry_delay`, `backoff` properties
+- Duration literal parsing
+- Backoff strategy enum
+- Basic `with { }` syntax
 
-```wv
-flow ReliablePipeline = {
-  stage load with {
-    retries: 3
-    timeout: '5m'
-    retry_delay: '1s'
-    backoff: exponential
-  } = from source | validate()
+### Phase 2: Trigger Rules and Error Handling
+- Stage state model
+- `trigger` property with rules
+- `on_failure` conditional dependencies
 
-  stage process = from load | transform()
-}
-```
+### Phase 3: Flow-Level Configuration
+- `schedule` and `timezone`
+- `concurrency` limits
+- Flow-level `timeout`
 
-**Core properties for v1:**
-| Property | Type | Description |
-|----------|------|-------------|
-| `retries` | Int | Max retry attempts |
-| `timeout` | Duration | Execution timeout |
-| `retry_delay` | Duration | Initial retry delay |
-| `backoff` | Enum | `constant`, `linear`, `exponential` |
-
-**Future extensions:**
-- Trigger rules and error handling (Idea 4)
-- Child flow policies (Idea 5)
-- Scheduling (Idea 8)
-- Saga pattern (Idea 7)
+### Phase 4: Child Flow Invocation
+- `call` keyword for child flows
+- `parent_close` policy
+- Child flow parameter passing
 
 ---
 
@@ -313,13 +364,16 @@ flow ReliablePipeline = {
 
 1. **Backward compatible** - existing flows work unchanged
 2. **SQL-inspired** - familiar syntax for data engineers
-3. **Composable** - stages can reference other stages naturally
+3. **Explicit over implicit** - clear dependency and execution semantics
 4. **Declarative** - configuration over imperative code
-5. **Deterministic orchestration** - flows coordinate, stages execute (Temporal pattern)
+5. **Type-safe** - duration literals and enums prevent errors
+6. **Unambiguous grammar** - single syntax form, clear precedence
+
+---
 
 ## Open Questions
 
-1. Should `activity` be a separate top-level definition (Idea 2)?
-2. Should we support both `[ ]` and `with { }` syntax (Idea 3)?
-3. How should signals/queries work with wvlet's query model (Idea 6)?
-4. Should versioning be explicit or implicit (Idea 10)?
+1. Should `heartbeat` trigger automatic stage restart or just monitoring?
+2. How should `schedule` interact with manual flow triggers?
+3. Should child flows inherit parent's retry configuration by default?
+4. How to handle circular dependencies in `on_failure` chains?

--- a/plans/2025-01-25-task-oriented-syntax.md
+++ b/plans/2025-01-25-task-oriented-syntax.md
@@ -1,0 +1,325 @@
+# Task-Oriented Syntax Design for Wvlet Flow
+
+## Overview
+
+Design syntax extensions for wvlet's flow language to support task management features found in modern workflow orchestration tools (Temporal, Airflow, Dagster, Prefect).
+
+## Research Summary
+
+### Key Concepts from Workflow Tools
+
+| Concept | Temporal | Airflow | Dagster | Wvlet Flow (Current) |
+|---------|----------|---------|---------|---------------------|
+| Orchestration unit | Workflow | DAG | Job | `flow` |
+| Work unit | Activity | Task/Operator | Op/Asset | `stage` |
+| Composition | Child Workflows | SubDAGs | Nested Jobs | `-> FlowName` (jump) |
+| Branching | Signals/Conditions | BranchOperator | Dynamic outputs | `route { case ... }` |
+| Parallel | Promises/Futures | Parallel tasks | Parallel ops | `fork { ... }` |
+| Fan-in | Promise.all() | TriggerRule | Graph edges | `merge` |
+
+### Temporal's Key Design Patterns
+
+1. **Workflows are deterministic** - orchestration logic only, no side effects
+2. **Activities do the real work** - can be non-deterministic, have retries
+3. **Four timeout types**: start-to-close, schedule-to-close, heartbeat, schedule-to-start
+4. **Retry policies**: initial interval, backoff coefficient, max interval, max attempts
+5. **Parent close policies**: terminate, request_cancel, abandon
+6. **Signals/Queries**: external interaction with running workflows
+7. **Continue-As-New**: reset history for long-running workflows
+
+---
+
+## Syntax Design Ideas
+
+### Idea 1: Stage Configuration with `with` Clause
+
+Extend stages with task configuration using `with { }` block:
+
+```wv
+flow DataPipeline = {
+  stage extract with {
+    retries: 3
+    timeout: '5m'
+    retry_delay: '1s'
+    backoff: exponential
+  } = from api_source | fetch_data()
+
+  stage transform = from extract | normalize()
+
+  stage load with {
+    retries: 5
+    timeout: '10m'
+    heartbeat: '30s'
+  } = from transform | save to warehouse
+}
+```
+
+**Properties (inspired by Temporal):**
+- `retries` - max retry attempts (0 = no retry, default)
+- `timeout` - start-to-close timeout
+- `schedule_timeout` - schedule-to-close timeout (total including retries)
+- `retry_delay` - initial retry interval
+- `backoff` - `constant`, `linear`, `exponential`
+- `max_retry_delay` - cap on backoff delay
+- `heartbeat` - heartbeat interval for long-running stages
+
+---
+
+### Idea 2: Activity-Style Stage Separation
+
+Separate orchestration (`flow`) from execution (`activity`):
+
+```wv
+-- Define reusable activities with default configs
+activity fetch_api with {
+  retries: 3
+  timeout: '30s'
+  backoff: exponential
+}
+
+activity send_email with {
+  retries: 2
+  timeout: '10s'
+}
+
+-- Flow uses activities (orchestration only)
+flow CustomerOnboarding = {
+  stage fetch = from customer_id | fetch_api(endpoint: '/users')
+  stage welcome = from fetch | send_email(template: 'welcome')
+}
+```
+
+**Benefits:**
+- Reusable retry/timeout configs
+- Clear separation of concerns (Temporal pattern)
+- Activities can be shared across flows
+
+---
+
+### Idea 3: Inline vs Block Configuration
+
+Support both compact and verbose syntax:
+
+```wv
+flow Pipeline = {
+  -- Compact: single property
+  stage fast [timeout: '1m'] = from source
+
+  -- Compact: multiple properties
+  stage reliable [retries: 3, backoff: exponential] = from fast
+
+  -- Block: complex configuration
+  stage critical with {
+    retries: 5
+    timeout: '10m'
+    retry_delay: '5s'
+    backoff: exponential
+    max_retry_delay: '2m'
+    on_failure: skip
+  } = from reliable | process()
+}
+```
+
+---
+
+### Idea 4: Error Handling and Fallback
+
+Explicit error handling inspired by Temporal's non-retryable errors:
+
+```wv
+flow ResilientPipeline = {
+  stage primary with {
+    retries: 3
+    on_failure: fallback_stage
+  } = from source | call_primary_api()
+
+  stage fallback_stage = from source | call_backup_api()
+
+  stage continue with {
+    trigger: one_success  -- run if either primary or fallback succeeds
+  } = merge primary, fallback_stage | process()
+}
+```
+
+**Trigger rules (from Airflow):**
+- `all_success` - all upstream stages succeeded (default)
+- `one_success` - at least one upstream succeeded
+- `none_failed` - no upstream failed (includes skipped)
+- `always` - run regardless of upstream state
+
+---
+
+### Idea 5: Child Flow Invocation with Policies
+
+Support child workflow patterns with parent close policies:
+
+```wv
+flow ParentFlow = {
+  stage setup = from config | initialize()
+
+  -- Invoke child flow with policy
+  stage child with {
+    parent_close: abandon  -- or: terminate, request_cancel
+    timeout: '1h'
+  } = from setup | -> ChildFlow(param: _.value)
+
+  stage cleanup = from child | finalize()
+}
+
+flow ChildFlow(param: string) = {
+  stage work = from param | long_running_task()
+}
+```
+
+---
+
+### Idea 6: Signal and Query Handlers
+
+Support external interaction with running flows:
+
+```wv
+flow LongRunningProcess = {
+  -- Define signal handlers
+  signal pause = set_paused(true)
+  signal resume = set_paused(false)
+
+  -- Define query handlers
+  query status = current_status()
+  query progress = completed_steps / total_steps
+
+  stage loop with {
+    continue_as_new: 1000  -- reset after 1000 events
+  } = from source | while not_done() | process_batch()
+}
+```
+
+---
+
+### Idea 7: Saga Pattern for Compensating Actions
+
+Support transaction-like semantics with compensation:
+
+```wv
+flow BookingFlow = {
+  stage book_flight with {
+    compensate: cancel_flight
+  } = from request | reserve_flight()
+
+  stage book_hotel with {
+    compensate: cancel_hotel
+  } = from book_flight | reserve_hotel()
+
+  stage book_car with {
+    compensate: cancel_car
+  } = from book_hotel | reserve_car()
+
+  -- If any stage fails, compensations run in reverse order
+}
+```
+
+---
+
+### Idea 8: Schedule and Cron Support
+
+Define scheduled flow execution:
+
+```wv
+flow DailyETL with {
+  schedule: '0 2 * * *'  -- cron: 2 AM daily
+  timezone: 'UTC'
+} = {
+  stage extract = from source | fetch_daily_data()
+  stage transform = from extract | clean_and_normalize()
+  stage load = from transform | save to warehouse
+}
+
+-- Or interval-based
+flow HeartbeatCheck with {
+  interval: '5m'
+} = {
+  stage check = from services | health_check()
+  stage alert = from check | where status = 'unhealthy' | send_alert()
+}
+```
+
+---
+
+### Idea 9: Idempotency Keys
+
+Ensure idempotent execution:
+
+```wv
+flow PaymentProcessing = {
+  stage charge with {
+    idempotency_key: _.transaction_id  -- use field as idempotency key
+    retries: 3
+  } = from payment_request | process_payment()
+}
+```
+
+---
+
+### Idea 10: Workflow Versioning
+
+Support workflow evolution:
+
+```wv
+flow OrderProcess @version(2) = {
+  -- Version 2 adds new validation step
+  stage validate = from order | validate_inventory()
+  stage process = from validate | process_order()
+}
+
+-- Queries can specify version
+from orders | -> OrderProcess @version(1)  -- use old version
+```
+
+---
+
+## Recommended Initial Scope
+
+For the first implementation, focus on **Idea 1** (Stage Configuration) with core properties:
+
+```wv
+flow ReliablePipeline = {
+  stage load with {
+    retries: 3
+    timeout: '5m'
+    retry_delay: '1s'
+    backoff: exponential
+  } = from source | validate()
+
+  stage process = from load | transform()
+}
+```
+
+**Core properties for v1:**
+| Property | Type | Description |
+|----------|------|-------------|
+| `retries` | Int | Max retry attempts |
+| `timeout` | Duration | Execution timeout |
+| `retry_delay` | Duration | Initial retry delay |
+| `backoff` | Enum | `constant`, `linear`, `exponential` |
+
+**Future extensions:**
+- Trigger rules and error handling (Idea 4)
+- Child flow policies (Idea 5)
+- Scheduling (Idea 8)
+- Saga pattern (Idea 7)
+
+---
+
+## Design Principles
+
+1. **Backward compatible** - existing flows work unchanged
+2. **SQL-inspired** - familiar syntax for data engineers
+3. **Composable** - stages can reference other stages naturally
+4. **Declarative** - configuration over imperative code
+5. **Deterministic orchestration** - flows coordinate, stages execute (Temporal pattern)
+
+## Open Questions
+
+1. Should `activity` be a separate top-level definition (Idea 2)?
+2. Should we support both `[ ]` and `with { }` syntax (Idea 3)?
+3. How should signals/queries work with wvlet's query model (Idea 6)?
+4. Should versioning be explicit or implicit (Idea 10)?


### PR DESCRIPTION
## Summary

Design document for extending wvlet's flow syntax with task management features inspired by Temporal, Airflow, Dagster, and Prefect.

### Key Design Decisions

**Dependency Model:**
| Scope | Success | Error | Cleanup |
|-------|---------|-------|---------|
| **Stage** | `from A` | `if A.failed` | `if A.done` |
| **Flow** | `depends on FlowA` | `if FlowA.failed` | `if FlowA.done` |

**Stage Configuration:**
```wv
stage extract with {
  retries: 3
  timeout: 5m
  retry_delay: 1s
  backoff: exponential
} = from source | fetch_data()
```

**Example Flow:**
```wv
flow Pipeline = {
  stage extract = from 'data.csv' | parse()
  stage transform = from extract | clean()
  stage load = from transform | save()
  
  stage fallback if extract.failed = from backup | recover()
  stage cleanup if load.done = call cleanup_service()
}

flow Reporting depends on Pipeline = {
  stage report = from warehouse | generate()
}

flow Cleanup if Pipeline.done = {
  stage archive = from logs | compress()
}
```

### Design Principles
- **Flow-style**: Reads left-to-right (`if primary.failed`)
- **Clear separation**: `from` for data (stages), `depends on` for flows
- **Minimal syntax**: No redundant keywords
- **SQL-inspired**: Familiar patterns for data engineers

## Test plan
- [x] Design document reviewed with codex
- [ ] Team review and discussion

🤖 Generated with [Claude Code](https://claude.ai/code)