### PR TITLE
feature: Add task-oriented syntax for flow definitions (Phase 1)

### DIFF
--- a/spec/basic/flow-task-syntax.wv
+++ b/spec/basic/flow-task-syntax.wv
@@ -1,0 +1,95 @@
+-- Test task-oriented flow syntax (Phase 1)
+
+-- Stage with config block
+flow ConfiguredStage = {
+  stage extract with {
+    retries: 3
+    timeout: 5m
+    retry_delay: 1s
+    backoff: 'exponential'
+  } = from source
+  stage transform = from extract | select *
+}
+;
+
+-- Stage with trigger condition
+flow TriggerFlow = {
+  stage primary with { retries: 3 } = from source
+  stage fallback if primary.failed = from backup
+  stage cleanup if primary.done = from primary | select *
+}
+;
+
+-- Complex trigger conditions
+flow ComplexTriggerFlow = {
+  stage a = from source
+  stage b = from source
+  stage alert if a.failed or b.failed = from source | select 'alert'
+}
+;
+
+-- Flow with schedule config
+flow ScheduledFlow with {
+  schedule: cron('0 2 * * *')
+  timezone: 'UTC'
+  concurrency: 1
+} = {
+  stage extract = from source | select *
+}
+;
+
+-- Flow dependency
+flow DependentFlow depends on ScheduledFlow = {
+  stage report = from warehouse | select *
+}
+;
+
+-- Flow with error trigger
+flow RecoveryFlow if ScheduledFlow.failed = {
+  stage alert = from source | select 'error'
+}
+;
+
+-- Duration literals
+flow DurationTest = {
+  stage test with {
+    timeout: 100ms
+    retry_delay: 30s
+    max_delay: 5m
+    heartbeat: 2h
+    cooldown: 1d
+  } = from source | select *
+}
+;
+
+-- Stage trigger with AND
+flow TriggerAndFlow = {
+  stage a = from source
+  stage b = from source
+  stage c if a.done and b.done = from source | select 'both done'
+}
+;
+
+-- Stage trigger with OR and AND combined
+flow TriggerCombinedFlow = {
+  stage a = from source
+  stage b = from source
+  stage c = from source
+  stage d if a.failed or (b.done and c.done) = from source | select *
+}
+;
+
+-- Backward compatibility - flows without new syntax
+flow BackwardCompatible = {
+  stage entry = from users
+  stage output = from entry | select name
+}
+;
+
+-- Flow with both parameters and config
+flow ParameterizedWithConfig(segment: string) with {
+  schedule: cron('0 0 * * *')
+} = {
+  stage entry = from users | where segment_id = segment
+}
+;

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -458,6 +458,17 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
         // the full relation (including 'from' clause), so we only output the body.
         // Use flattenWithPipes to output stage body inline with explicit pipes,
         // avoiding parsing ambiguity with newline-as-implicit-pipe inside flows.
+        val trigger =
+          s.trigger match
+            case Some(t) =>
+              wl("if", triggerExpr(t))
+            case None =>
+              empty
+        val config =
+          if s.config.isEmpty then
+            empty
+          else
+            wl("with", "{") + nest(linebreak + configItems(s.config)) + linebreak + "}"
         val deps =
           if s.dependsOn.isEmpty then
             empty
@@ -465,7 +476,7 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
             wl("depends on", cl(s.dependsOn.map(d => expr(d))))
         val body = s.body.map(b => flattenWithPipes(relation(b))).getOrElse(empty)
         code(s) {
-          group(wl("stage", text(s.name.name), "=", deps, body))
+          group(wl("stage", text(s.name.name), trigger, config, "=", deps, body))
         }
       case r: FlowRoute =>
         val prev     = relation(r.child)
@@ -607,12 +618,25 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
               paren(cl(p.params.map(x => expr(x))))
           group(wl("def", text(p.name.name) + params, "=")) + nest(linebreak + relation(p.body))
         case f: FlowDef =>
+          val dependency =
+            f.dependency match
+              case Some(DependsOnFlow(flowName, _)) =>
+                wl("depends", "on", expr(flowName))
+              case Some(FlowStatePredicate(flowName, stateName, _)) =>
+                wl("if", expr(flowName) + "." + stateName)
+              case None =>
+                empty
           val params =
             if f.params.isEmpty then
               empty
             else
               paren(cl(f.params.map(x => expr(x))))
-          group(wl("flow", text(f.name.name) + params, "= {")) +
+          val config =
+            if f.config.isEmpty then
+              empty
+            else
+              wl("with", "{") + nest(linebreak + configItems(f.config)) + linebreak + "}"
+          group(wl("flow", text(f.name.name), dependency, params, config, "= {")) +
             nest(linebreak + lines(f.stages.map(s => relation(s)))) + linebreak + "}"
         case t: ShowQuery =>
           group(wl("show", "query", expr(t.name)))
@@ -732,8 +756,12 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
         case i: IntervalLiteral =>
           val s = StringLiteral.fromString(i.stringValue, i.span)
           expr(s) + text(":interval")
+        case d: DurationLiteral =>
+          text(d.stringValue)
         case g: GenericLiteral =>
           text(s"${g.value.stringValue}:${g.literalType.typeName}")
+        case c: ConfigItem =>
+          wl(expr(c.key) + ":", expr(c.value))
         case l: Literal =>
           text(l.stringValue)
         case bq: BackquoteInterpolatedIdentifier =>
@@ -939,5 +967,24 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
         nameExpr(t.name.toExpr)
       case other =>
         expr(e.sqlExpr)
+
+  /**
+    * Generate code for a list of config items.
+    */
+  private def configItems(items: List[ConfigItem])(using sc: SyntaxContext): Doc = lines(
+    items.map(item => group(wl(expr(item.key) + ":", expr(item.value))))
+  )
+
+  /**
+    * Generate code for a stage trigger expression.
+    */
+  private def triggerExpr(t: StageTrigger)(using sc: SyntaxContext): Doc =
+    t match
+      case StatePredicate(stageName, stateName, _) =>
+        expr(stageName) + text(".") + text(stateName)
+      case TriggerAnd(left, right, _) =>
+        triggerExpr(left) + text(" and ") + triggerExpr(right)
+      case TriggerOr(left, right, _) =>
+        triggerExpr(left) + text(" or ") + triggerExpr(right)
 
 end WvletGenerator

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -539,14 +539,12 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         while scanner.lookAhead().token != WvletToken.R_BRACE do
           val startOffset = scanner.lookAhead().offset
           val la          = scanner.lookAhead()
-          la.token match
-            case WvletToken.IDENTIFIER | _ if la.token.isNonReservedKeyword =>
-              val key = identifierSingle()
-              consume(WvletToken.COLON)
-              val value = configValue()
-              items += ConfigItem(key, value, key.span.extendTo(value.span))
-            case _ =>
-              ()
+          // Check if token can start a config item (identifier or non-reserved keyword)
+          if la.token == WvletToken.IDENTIFIER || la.token.isNonReservedKeyword then
+            val key = identifierSingle()
+            consume(WvletToken.COLON)
+            val value = configValue()
+            items += ConfigItem(key, value, key.span.extendTo(value.span))
           // Skip optional separators (semicolons or commas)
           while scanner.lookAhead().token == WvletToken.SEMICOLON ||
             scanner.lookAhead().token == WvletToken.COMMA

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
@@ -285,3 +285,45 @@ case class FlowJump(child: Relation, targetFlow: NameExpr, span: Span) extends U
   * Example: `end()`
   */
 case class FlowEnd(child: Relation, span: Span) extends UnaryFlowOp
+
+
+/**
+  * FlowDependency represents a dependency relationship between flows.
+  *
+  * Allows flows to depend on other flows, enabling:
+  *   - Sequential flow execution (depends on FlowA)
+  *   - Error handling flows (if FlowA.failed)
+  *
+  * Example:
+  * {{{
+  * flow DependentFlow depends on ScheduledFlow = { ... }
+  * flow RecoveryFlow if ScheduledFlow.failed = { ... }
+  * }}}
+  */
+sealed trait FlowDependency:
+  def span: Span
+
+/**
+  * DependsOnFlow represents a sequential dependency on another flow.
+  *
+  * The current flow will only execute after the referenced flow completes successfully.
+  *
+  * @param flowName
+  *   The name of the flow to depend on
+  * @param span
+  *   Source location
+  */
+case class DependsOnFlow(flowName: NameExpr, span: Span) extends FlowDependency
+
+/**
+  * FlowStatePredicate represents a condition based on another flow's state.
+  *
+  * @param flowName
+  *   The name of the flow to check
+  * @param stateName
+  *   The state to check for ("failed" or "done")
+  * @param span
+  *   Source location
+  */
+case class FlowStatePredicate(flowName: NameExpr, stateName: String, span: Span)
+    extends FlowDependency

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
@@ -286,7 +286,6 @@ case class FlowJump(child: Relation, targetFlow: NameExpr, span: Span) extends U
   */
 case class FlowEnd(child: Relation, span: Span) extends UnaryFlowOp
 
-
 /**
   * FlowDependency represents a dependency relationship between flows.
   *

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
@@ -143,47 +143,6 @@ case class PartialQueryDef(name: TermName, params: List[DefArg], body: Relation,
     extends LanguageStatement
 
 /**
-  * FlowDependency represents a dependency relationship between flows.
-  *
-  * Allows flows to depend on other flows, enabling:
-  *   - Sequential flow execution (depends on FlowA)
-  *   - Error handling flows (if FlowA.failed)
-  *
-  * Example:
-  * {{{
-  * flow DependentFlow depends on ScheduledFlow = { ... }
-  * flow RecoveryFlow if ScheduledFlow.failed = { ... }
-  * }}}
-  */
-sealed trait FlowDependency:
-  def span: Span
-
-/**
-  * DependsOnFlow represents a sequential dependency on another flow.
-  *
-  * The current flow will only execute after the referenced flow completes successfully.
-  *
-  * @param flowName
-  *   The name of the flow to depend on
-  * @param span
-  *   Source location
-  */
-case class DependsOnFlow(flowName: NameExpr, span: Span) extends FlowDependency
-
-/**
-  * FlowStatePredicate represents a condition based on another flow's state.
-  *
-  * @param flowName
-  *   The name of the flow to check
-  * @param stateName
-  *   The state to check for ("failed" or "done")
-  * @param span
-  *   Source location
-  */
-case class FlowStatePredicate(flowName: NameExpr, stateName: String, span: Span)
-    extends FlowDependency
-
-/**
   * FlowDef represents a data flow/workflow definition.
   *
   * A flow is a collection of named stages that define a data pipeline with branching, merging, and


### PR DESCRIPTION
## Summary

Implements Phase 1 of task-oriented syntax extensions for wvlet's flow language as designed in `plans/2025-01-25-task-oriented-syntax.md`:

- **Duration literals** (`5m`, `30s`, `2h`, `1d`, `100ms`) for timeout/delay configuration
- **Stage configuration** with `with { }` blocks for retries, timeouts, backoff settings
- **Stage triggers** with `if` clause (`if primary.failed`, `if a.done and b.done`)
- **Flow-level configuration** with `with { }` blocks for schedule, timezone, concurrency
- **Flow dependencies** (`depends on FlowA`, `if FlowA.failed`)

### New AST Types

- `DurationUnit` enum and `DurationLiteral` for duration values
- `ConfigItem` for key-value configuration pairs  
- `StageTrigger` trait with `StatePredicate`, `TriggerAnd`, `TriggerOr`
- `FlowDependency` trait with `DependsOnFlow`, `FlowStatePredicate`

### Example Syntax

```wv
-- Stage with config and trigger
flow Pipeline with { schedule: cron('0 2 * * *') } = {
  stage extract with { retries: 3; timeout: 5m } = from source
  stage fallback if extract.failed = from backup
  stage cleanup if extract.done = from extract | select *
}

-- Flow dependency
flow DependentFlow depends on Pipeline = {
  stage report = from warehouse | select *
}
```

All changes are backward compatible with existing flow syntax.

## Test plan

- [x] JVM compilation passes
- [x] JS compilation passes
- [x] Code formatted with `scalafmtAll`
- [x] Test spec file added: `spec/basic/flow-task-syntax.wv`

🤖 Generated with [Claude Code](https://claude.ai/code)