### PR TITLE
build(deps): Update prismjs-wvlet to 2026.1.1

### DIFF
--- a/prismjs-wvlet/package-lock.json
+++ b/prismjs-wvlet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wvlet/prismjs-wvlet",
-  "version": "2025.1.13",
+  "version": "2026.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wvlet/prismjs-wvlet",
-      "version": "2025.1.13",
+      "version": "2026.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^30.1.1",

--- a/prismjs-wvlet/package.json
+++ b/prismjs-wvlet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wvlet/prismjs-wvlet",
-  "version": "2025.1.13",
+  "version": "2026.1.1",
   "description": "Wvlet language support for Prism.js syntax highlighting",
   "main": "components/prism-wvlet.js",
   "browser": "dist/prism-wvlet.min.js",


### PR DESCRIPTION
## Summary
- Update prismjs-wvlet package version from 2025.1.13 to 2026.1.1

This updates the package version in preparation for npm publishing. After the new version is published to npm, the website dependency should be updated separately.

## Test plan
- [x] prismjs-wvlet build passes
- [x] prismjs-wvlet tests pass (14 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)