### PR TITLE
build(deps): Update website to use prismjs-wvlet 2026.1.1

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,7 +13,7 @@
         "@docusaurus/preset-classic": "^3.9.2",
         "@docusaurus/theme-mermaid": "^3.9.2",
         "@mdx-js/react": "^3.1.1",
-        "@wvlet/prismjs-wvlet": "^2025.1.24",
+        "@wvlet/prismjs-wvlet": "^2026.1.1",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^19.0.0",
@@ -5517,9 +5517,9 @@
       }
     },
     "node_modules/@wvlet/prismjs-wvlet": {
-      "version": "2025.1.24",
-      "resolved": "https://registry.npmjs.org/@wvlet/prismjs-wvlet/-/prismjs-wvlet-2025.1.24.tgz",
-      "integrity": "sha512-QmOxn+0WJYyEF0zYusCQ4M4i3cC6kRDqsuN0lIKkh6FTj8GgiEfFZXgwrPjYR78y2xFKdrHJy7Gd3h8tYJyx+w==",
+      "version": "2026.1.1",
+      "resolved": "https://registry.npmjs.org/@wvlet/prismjs-wvlet/-/prismjs-wvlet-2026.1.1.tgz",
+      "integrity": "sha512-gVq2ivExD3PCc8GtAFYls/AiaJfNRk9XFKODdcmbo5oeRY/kCYQlnG1qOjCdn4eHyXisNcrm+V4nxLFS78f0yA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "prismjs": "^1.29.0"

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
     "@docusaurus/preset-classic": "^3.9.2",
     "@docusaurus/theme-mermaid": "^3.9.2",
     "@mdx-js/react": "^3.1.1",
-    "@wvlet/prismjs-wvlet": "^2025.1.24",
+    "@wvlet/prismjs-wvlet": "^2026.1.1",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- Update website dependency from `@wvlet/prismjs-wvlet@^2025.1.24` to `@wvlet/prismjs-wvlet@^2026.1.1`
- This enables syntax highlighting for `flow` and `stage` keywords on the documentation site

## Test plan
- [ ] CI passes
- [ ] Website builds successfully
- [ ] Flow/stage syntax is properly highlighted on https://wvlet.org/wvlet/docs/syntax/flow/

🤖 Generated with [Claude Code](https://claude.com/claude-code)