### PR TITLE
Add AI-verifiability benchmark corpus

### DIFF
--- a/spec/benchmark/q1-filter-aggregate.wv
+++ b/spec/benchmark/q1-filter-aggregate.wv
@@ -1,0 +1,27 @@
+-- Q1: Simple Filter + Aggregate (⭐)
+-- Business question: How many active orders per customer, with total spend?
+--
+-- Verifiability advantage: Wvlet flows top-to-bottom (filter → group → aggregate → filter),
+-- matching execution order. Named aggregation results (`total_spend`) are reused directly
+-- in the post-aggregation filter, avoiding SQL's HAVING duplication of expressions.
+
+from [
+  [1, 'C001', 'active',  500],
+  [2, 'C001', 'active',  800],
+  [3, 'C002', 'active',  300],
+  [4, 'C002', 'active',  900],
+  [5, 'C003', 'active',  200],
+  [6, 'C003', 'cancelled', 400],
+  [7, 'C001', 'active', 1200],
+  [8, 'C004', 'active',  100]
+] as orders(order_id, customer_id, status, amount)
+where status = 'active'
+group by customer_id
+agg
+  order_count = _.count,
+  total_spend = amount.sum
+where total_spend > 1000
+order by total_spend desc
+
+test _.columns should be ['customer_id', 'order_count', 'total_spend']
+test _.size should be 2

--- a/spec/benchmark/q2-join-derived.wv
+++ b/spec/benchmark/q2-join-derived.wv
@@ -1,0 +1,30 @@
+-- Q2: Multi-table Join with Derived Column (⭐⭐)
+-- Business question: For each order, show customer name, product name, and line total with discount.
+--
+-- Verifiability advantage: Wvlet's linear flow (join → filter → derive → select) reads top-to-bottom.
+-- `add` explicitly separates the derived column from source columns, making the calculation
+-- independently auditable. SQL inlines the expression in SELECT alongside source columns.
+
+from [
+  [1, 101, 201, 2, 50.00, 0.1, '2025-03-01'],
+  [2, 102, 202, 1, 30.00, null, '2025-02-15'],
+  [3, 101, 203, 3, 20.00, 0.2, '2025-03-10'],
+  [4, 103, 201, 1, 50.00, 0.0, '2024-12-01']
+] as orders(order_id, customer_id, product_id, quantity, unit_price, discount, order_date)
+join [
+  [101, 'Alice'],
+  [102, 'Bob'],
+  [103, 'Carol']
+] as customers(id, customer_name) on orders.customer_id = customers.id
+join [
+  [201, 'Widget'],
+  [202, 'Gadget'],
+  [203, 'Gizmo']
+] as products(id, product_name) on orders.product_id = products.id
+where order_date >= '2025-01-01'
+add line_total = quantity * unit_price * (1 - coalesce(discount, 0))
+select customer_name, product_name, quantity, unit_price, line_total
+order by line_total desc
+
+test _.columns should be ['customer_name', 'product_name', 'quantity', 'unit_price', 'line_total']
+test _.size should be 3

--- a/spec/benchmark/q3-window.wv
+++ b/spec/benchmark/q3-window.wv
@@ -1,0 +1,29 @@
+-- Q3: Window Functions — Ranking + Running Total (⭐⭐⭐)
+-- Business question: For each customer, rank orders by amount and show running cumulative total.
+--
+-- Verifiability advantage: `add` isolates window computations from source columns, making it
+-- immediately clear what's computed vs. what's from the source. The filter appears before
+-- the window functions, matching execution order. SQL embeds window functions in SELECT
+-- alongside plain columns, requiring careful parsing to distinguish them.
+
+from [
+  [1, 'C001', 100, 'completed', '2025-01-10'],
+  [2, 'C001', 250, 'completed', '2025-01-15'],
+  [3, 'C001', 150, 'completed', '2025-01-20'],
+  [4, 'C002', 300, 'completed', '2025-01-12'],
+  [5, 'C002', 200, 'completed', '2025-01-18'],
+  [6, 'C002', 100, 'pending',   '2025-01-25']
+] as orders(order_id, customer_id, amount, status, order_date)
+where status = 'completed'
+add
+  rank = row_number() over (partition by customer_id order by amount desc),
+  cumulative_total = sum(amount) over (
+    partition by customer_id
+    order by order_date
+    rows[,0]
+  )
+select customer_id, order_id, amount, rank, cumulative_total
+order by customer_id, rank
+
+test _.columns should be ['customer_id', 'order_id', 'amount', 'rank', 'cumulative_total']
+test _.size should be 5

--- a/spec/benchmark/q4-multi-step.wv
+++ b/spec/benchmark/q4-multi-step.wv
@@ -1,0 +1,41 @@
+-- Q4: Multi-step Aggregation — Aggregate → Classify → Re-aggregate (⭐⭐⭐⭐)
+-- Business question: Classify customers into tiers based on purchase behavior, then summarize tiers.
+--
+-- Verifiability advantage: Single continuous flow (filter → aggregate → classify → re-aggregate)
+-- vs SQL's two CTEs + final query. Each step can be debugged mid-pipeline by truncating.
+-- No CTE naming overhead — the flow itself is the structure.
+
+from [
+  [1, 'C001', 500, 'completed', '2025-01-05'],
+  [2, 'C001', 800, 'completed', '2025-01-10'],
+  [3, 'C001', 200, 'completed', '2025-01-15'],
+  [4, 'C002', 3000, 'completed', '2025-01-08'],
+  [5, 'C002', 4000, 'completed', '2025-01-12'],
+  [6, 'C002', 3500, 'completed', '2025-01-20'],
+  [7, 'C003', 150, 'completed', '2025-01-03'],
+  [8, 'C004', 6000, 'completed', '2025-01-02'],
+  [9, 'C004', 5000, 'completed', '2025-01-09'],
+  [10, 'C004', 4500, 'cancelled', '2025-01-15']
+] as orders(order_id, customer_id, amount, status, order_date)
+where status = 'completed'
+group by customer_id
+agg
+  purchase_count = _.count,
+  total_spend = amount.sum
+add tier = case
+  when total_spend >= 10000 and purchase_count >= 3 then 'platinum'
+  when total_spend >= 5000 and purchase_count >= 2 then 'gold'
+  when total_spend >= 1000 then 'silver'
+  else 'bronze'
+group by tier
+agg
+  customer_count = _.count,
+  avg_spend = total_spend.avg
+order by case tier
+  when 'platinum' then 1
+  when 'gold' then 2
+  when 'silver' then 3
+  else 4
+
+test _.columns should be ['tier', 'customer_count', 'avg_spend']
+test _.size should be 4

--- a/spec/benchmark/q5-reconciliation.wv
+++ b/spec/benchmark/q5-reconciliation.wv
@@ -1,10 +1,10 @@
 -- Q5: Multi-Source Reconciliation (⭐⭐⭐⭐⭐)
 -- Business question: Find revenue discrepancies between orders and payments systems.
 --
--- Verifiability advantage: `subtotal` is computed once with `agg` and reused by name
--- (single source of truth), while SQL repeats the expression 3 times. Mid-pipeline
--- debugging lets you truncate at any step to verify intermediate results. Named columns
--- (`discrepancy_type`) are reused in the filter, avoiding SQL's expression re-derivation.
+-- Verifiability advantage: Derived columns like `discrepancy` and `discrepancy_type` are computed
+-- in sequence and reused in subsequent steps (e.g., `discrepancy_type` in the `where` clause).
+-- This avoids repeating complex expressions, a common issue in SQL. Mid-pipeline debugging lets
+-- you truncate at any step to verify intermediate results.
 
 val order_totals(order_id, customer_id, expected_total) = [
   [1, 'C001', 145.80],

--- a/spec/benchmark/q5-reconciliation.wv
+++ b/spec/benchmark/q5-reconciliation.wv
@@ -1,0 +1,39 @@
+-- Q5: Multi-Source Reconciliation (⭐⭐⭐⭐⭐)
+-- Business question: Find revenue discrepancies between orders and payments systems.
+--
+-- Verifiability advantage: `subtotal` is computed once with `agg` and reused by name
+-- (single source of truth), while SQL repeats the expression 3 times. Mid-pipeline
+-- debugging lets you truncate at any step to verify intermediate results. Named columns
+-- (`discrepancy_type`) are reused in the filter, avoiding SQL's expression re-derivation.
+
+val order_totals(order_id, customer_id, expected_total) = [
+  [1, 'C001', 145.80],
+  [2, 'C002', 69.00],
+  [3, 'C003', 102.60],
+  [4, 'C004', 96.00]
+]
+
+val payment_totals(pt_order_id, paid_total, payment_count) = [
+  [1, 145.00, 1],
+  [2, 60.00, 1],
+  [3, 102.60, 1],
+  [4, 90.00, 1]
+]
+
+-- Join order totals with payments and classify discrepancies
+from order_totals
+left join payment_totals on order_id = pt_order_id
+add
+  paid = coalesce(paid_total, 0),
+  discrepancy = expected_total - coalesce(paid_total, 0)
+add discrepancy_type = case
+  when paid_total is null then 'no_payment'
+  when abs(discrepancy) < 0.01 then 'match'
+  when paid < expected_total then 'underpaid'
+  when paid > expected_total then 'overpaid'
+select order_id, customer_id, expected_total, paid, discrepancy, discrepancy_type
+where discrepancy_type != 'match'
+order by abs(discrepancy) desc
+
+test _.columns should be ['order_id', 'customer_id', 'expected_total', 'paid', 'discrepancy', 'discrepancy_type']
+test _.size should be 3

--- a/spec/sql/benchmark/q1-filter-aggregate.sql
+++ b/spec/sql/benchmark/q1-filter-aggregate.sql
@@ -1,0 +1,20 @@
+-- Q1: Simple Filter + Aggregate
+-- Business question: How many active orders per customer, with total spend?
+SELECT
+  customer_id,
+  COUNT(*) AS order_count,
+  SUM(amount) AS total_spend
+FROM (VALUES
+  (1, 'C001', 'active',  500),
+  (2, 'C001', 'active',  800),
+  (3, 'C002', 'active',  300),
+  (4, 'C002', 'active',  900),
+  (5, 'C003', 'active',  200),
+  (6, 'C003', 'cancelled', 400),
+  (7, 'C001', 'active', 1200),
+  (8, 'C004', 'active',  100)
+) AS orders(order_id, customer_id, status, amount)
+WHERE status = 'active'
+GROUP BY customer_id
+HAVING SUM(amount) > 1000
+ORDER BY total_spend DESC;

--- a/spec/sql/benchmark/q2-join-derived.sql
+++ b/spec/sql/benchmark/q2-join-derived.sql
@@ -1,0 +1,26 @@
+-- Q2: Multi-table Join with Derived Column
+-- Business question: For each order, show customer name, product name, and line total with discount.
+SELECT
+  c.name AS customer_name,
+  p.name AS product_name,
+  o.quantity,
+  o.unit_price,
+  o.quantity * o.unit_price * (1 - COALESCE(o.discount, 0)) AS line_total
+FROM (VALUES
+  (1, 101, 201, 2, 50.00, 0.1, '2025-03-01'),
+  (2, 102, 202, 1, 30.00, null, '2025-02-15'),
+  (3, 101, 203, 3, 20.00, 0.2, '2025-03-10'),
+  (4, 103, 201, 1, 50.00, 0.0, '2024-12-01')
+) AS o(order_id, customer_id, product_id, quantity, unit_price, discount, order_date)
+JOIN (VALUES
+  (101, 'Alice'),
+  (102, 'Bob'),
+  (103, 'Carol')
+) AS c(id, name) ON o.customer_id = c.id
+JOIN (VALUES
+  (201, 'Widget'),
+  (202, 'Gadget'),
+  (203, 'Gizmo')
+) AS p(id, name) ON o.product_id = p.id
+WHERE o.order_date >= '2025-01-01'
+ORDER BY line_total DESC;

--- a/spec/sql/benchmark/q3-window.sql
+++ b/spec/sql/benchmark/q3-window.sql
@@ -1,0 +1,22 @@
+-- Q3: Window Functions — Ranking + Running Total
+-- Business question: For each customer, rank orders by amount and show running cumulative total.
+SELECT
+  customer_id,
+  order_id,
+  amount,
+  ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY amount DESC) AS rank,
+  SUM(amount) OVER (
+    PARTITION BY customer_id
+    ORDER BY order_date
+    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+  ) AS cumulative_total
+FROM (VALUES
+  (1, 'C001', 100, 'completed', '2025-01-10'),
+  (2, 'C001', 250, 'completed', '2025-01-15'),
+  (3, 'C001', 150, 'completed', '2025-01-20'),
+  (4, 'C002', 300, 'completed', '2025-01-12'),
+  (5, 'C002', 200, 'completed', '2025-01-18'),
+  (6, 'C002', 100, 'pending',   '2025-01-25')
+) AS orders(order_id, customer_id, amount, status, order_date)
+WHERE status = 'completed'
+ORDER BY customer_id, rank;

--- a/spec/sql/benchmark/q4-multi-step.sql
+++ b/spec/sql/benchmark/q4-multi-step.sql
@@ -1,0 +1,48 @@
+-- Q4: Multi-step Aggregation — Aggregate → Classify → Re-aggregate
+-- Business question: Classify customers into tiers based on purchase behavior, then summarize tiers.
+WITH recent_purchases AS (
+  SELECT
+    customer_id,
+    COUNT(*) AS purchase_count,
+    SUM(amount) AS total_spend
+  FROM (VALUES
+    (1, 'C001', 500, 'completed', '2025-01-05'),
+    (2, 'C001', 800, 'completed', '2025-01-10'),
+    (3, 'C001', 200, 'completed', '2025-01-15'),
+    (4, 'C002', 3000, 'completed', '2025-01-08'),
+    (5, 'C002', 4000, 'completed', '2025-01-12'),
+    (6, 'C002', 3500, 'completed', '2025-01-20'),
+    (7, 'C003', 150, 'completed', '2025-01-03'),
+    (8, 'C004', 6000, 'completed', '2025-01-02'),
+    (9, 'C004', 5000, 'completed', '2025-01-09'),
+    (10, 'C004', 4500, 'cancelled', '2025-01-15')
+  ) AS orders(order_id, customer_id, amount, status, order_date)
+  WHERE status = 'completed'
+  GROUP BY customer_id
+),
+tiered_customers AS (
+  SELECT
+    customer_id,
+    purchase_count,
+    total_spend,
+    CASE
+      WHEN total_spend >= 10000 AND purchase_count >= 3 THEN 'platinum'
+      WHEN total_spend >= 5000 AND purchase_count >= 2 THEN 'gold'
+      WHEN total_spend >= 1000 THEN 'silver'
+      ELSE 'bronze'
+    END AS tier
+  FROM recent_purchases
+)
+SELECT
+  tier,
+  COUNT(*) AS customer_count,
+  AVG(total_spend) AS avg_spend
+FROM tiered_customers
+GROUP BY tier
+ORDER BY
+  CASE tier
+    WHEN 'platinum' THEN 1
+    WHEN 'gold' THEN 2
+    WHEN 'silver' THEN 3
+    ELSE 4
+  END;

--- a/spec/sql/benchmark/q5-reconciliation.sql
+++ b/spec/sql/benchmark/q5-reconciliation.sql
@@ -1,0 +1,40 @@
+-- Q5: Multi-Source Reconciliation
+-- Business question: Find revenue discrepancies between orders and payments systems.
+-- Note: The subtotal expression SUM(quantity * unit_price * (1 - COALESCE(discount, 0)))
+-- would be repeated 3 times in a real SQL query (for subtotal, tax_amount, expected_total).
+-- This version uses pre-computed totals for clarity.
+WITH order_totals(order_id, customer_id, expected_total) AS (
+  VALUES
+    (1, 'C001', 145.80),
+    (2, 'C002', 69.00),
+    (3, 'C003', 102.60),
+    (4, 'C004', 96.00)
+),
+payment_totals(pt_order_id, paid_total, payment_count) AS (
+  VALUES
+    (1, 145.00, 1),
+    (2, 60.00, 1),
+    (3, 102.60, 1),
+    (4, 90.00, 1)
+)
+SELECT
+  ot.order_id,
+  ot.customer_id,
+  ot.expected_total,
+  COALESCE(pt.paid_total, 0) AS paid,
+  ot.expected_total - COALESCE(pt.paid_total, 0) AS discrepancy,
+  CASE
+    WHEN pt.pt_order_id IS NULL THEN 'no_payment'
+    WHEN ABS(ot.expected_total - pt.paid_total) < 0.01 THEN 'match'
+    WHEN pt.paid_total < ot.expected_total THEN 'underpaid'
+    WHEN pt.paid_total > ot.expected_total THEN 'overpaid'
+  END AS discrepancy_type
+FROM order_totals ot
+LEFT JOIN payment_totals pt ON ot.order_id = pt.pt_order_id
+WHERE CASE
+    WHEN pt.pt_order_id IS NULL THEN 'no_payment'
+    WHEN ABS(ot.expected_total - pt.paid_total) < 0.01 THEN 'match'
+    WHEN pt.paid_total < ot.expected_total THEN 'underpaid'
+    WHEN pt.paid_total > ot.expected_total THEN 'overpaid'
+  END != 'match'
+ORDER BY ABS(ot.expected_total - COALESCE(pt.paid_total, 0)) DESC;

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/RunnerSpec.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/RunnerSpec.scala
@@ -128,6 +128,10 @@ class RunnerSpecSqlBasic
       )
     )
 
+class RunnerSpecBenchmark extends RunnerSpec("spec/benchmark")
+
+class RunnerSpecSqlBenchmark extends RunnerSpec("spec/sql/benchmark")
+
 class RunnerSpecSqlTPCH extends RunnerSpec("spec/sql/tpc-h", parseOnly = true, prepareTPCH = true)
 
 class RunnerSpecSqlTPCDS


### PR DESCRIPTION
## Summary
- Add `spec/benchmark/` with 5 Wvlet queries of increasing complexity (filter+aggregate, join+derived, window functions, multi-step aggregation, multi-source reconciliation)
- Add matching `spec/sql/benchmark/` SQL equivalents (DuckDB-compatible)
- Add `RunnerSpecBenchmark` and `RunnerSpecSqlBenchmark` test classes
- Each query demonstrates a specific verifiability advantage of Wvlet over SQL, documented in comments

## Test plan
- [x] All 5 `.wv` benchmark specs compile and run with assertions passing
- [x] All 5 `.sql` benchmark specs parse and run successfully
- [x] `./sbt "runner/testOnly *RunnerSpecBenchmark"` passes
- [x] `./sbt "runner/testOnly *RunnerSpecSqlBenchmark"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)