### PR TITLE
Add LSP server for Wvlet VS Code extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2551,7 +2551,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -5764,7 +5763,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6721,6 +6719,84 @@
         "monaco-editor": ">=0.33.0"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "dev": true,
@@ -6993,14 +7069,505 @@
     },
     "vscode-wvlet": {
       "name": "wvlet",
-      "version": "2025.2.1",
+      "version": "2025.3.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "vscode-languageclient": "^9.0.1",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.12"
+      },
       "devDependencies": {
         "@types/vscode": "^1.104.0",
-        "@vscode/vsce": "^3.7.1"
+        "@vscode/vsce": "^3.7.1",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.9.0"
       },
       "engines": {
         "vscode": "^1.104.0"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "vscode-wvlet/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "wvlet-ui-main": {

--- a/sdks/typescript/lib/main.d.ts
+++ b/sdks/typescript/lib/main.d.ts
@@ -16,6 +16,20 @@ export interface WvletJSType {
    * @returns The version string
    */
   getVersion(): string;
+
+  /**
+   * Analyze a Wvlet source and return diagnostics as JSON
+   * @param content The Wvlet source code
+   * @returns JSON array of diagnostics
+   */
+  analyzeDiagnostics(content: string): string;
+
+  /**
+   * Extract document symbols from a Wvlet source as JSON
+   * @param content The Wvlet source code
+   * @returns JSON array of symbols
+   */
+  getDocumentSymbols(content: string): string;
 }
 
 export const WvletJS: WvletJSType;

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -97,3 +97,28 @@ export class CompilationError extends Error {
     this.name = 'CompilationError';
   }
 }
+
+/**
+ * LSP diagnostic from the Wvlet compiler
+ */
+export interface LspDiagnostic {
+  line: number;
+  column: number;
+  endLine: number;
+  endColumn: number;
+  message: string;
+  severity: string;
+  statusCode: string;
+}
+
+/**
+ * LSP document symbol from the Wvlet compiler
+ */
+export interface LspSymbol {
+  name: string;
+  kind: number;
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}

--- a/vscode-wvlet/.gitignore
+++ b/vscode-wvlet/.gitignore
@@ -1,0 +1,3 @@
+out/
+node_modules/
+*.vsix

--- a/vscode-wvlet/.vscodeignore
+++ b/vscode-wvlet/.vscodeignore
@@ -1,4 +1,5 @@
 node_modules/
+src/
 *.log
 npm-debug.log*
 .DS_Store
@@ -6,4 +7,6 @@ npm-debug.log*
 .gitignore
 *.vsix
 package-lock.json
+tsconfig.json
+esbuild.js
 ../**

--- a/vscode-wvlet/esbuild.js
+++ b/vscode-wvlet/esbuild.js
@@ -1,0 +1,46 @@
+const esbuild = require('esbuild');
+
+const isWatch = process.argv.includes('--watch');
+
+/** @type {import('esbuild').BuildOptions} */
+const extensionConfig = {
+  entryPoints: ['src/extension.ts'],
+  bundle: true,
+  outfile: 'out/extension.js',
+  external: ['vscode'],
+  format: 'cjs',
+  platform: 'node',
+  target: 'node18',
+  sourcemap: true,
+};
+
+/** @type {import('esbuild').BuildOptions} */
+const serverConfig = {
+  entryPoints: ['src/server.ts'],
+  bundle: true,
+  outfile: 'out/server.js',
+  format: 'cjs',
+  platform: 'node',
+  target: 'node18',
+  sourcemap: true,
+};
+
+async function build() {
+  if (isWatch) {
+    const extCtx = await esbuild.context(extensionConfig);
+    const srvCtx = await esbuild.context(serverConfig);
+    await Promise.all([extCtx.watch(), srvCtx.watch()]);
+    console.log('Watching for changes...');
+  } else {
+    await Promise.all([
+      esbuild.build(extensionConfig),
+      esbuild.build(serverConfig),
+    ]);
+    console.log('Build complete.');
+  }
+}
+
+build().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/vscode-wvlet/package.json
+++ b/vscode-wvlet/package.json
@@ -2,10 +2,11 @@
   "name": "wvlet",
   "displayName": "Wvlet",
   "description": "Wvlet query language support for Visual Studio Code",
-  "version": "2025.2.1",
+  "version": "2025.3.0",
   "engines": {
     "vscode": "^1.104.0"
   },
+  "main": "./out/extension.js",
   "categories": [
     "Programming Languages"
   ],
@@ -48,12 +49,21 @@
       }
     ]
   },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1",
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.12"
+  },
   "devDependencies": {
     "@types/vscode": "^1.104.0",
-    "@vscode/vsce": "^3.7.1"
+    "@vscode/vsce": "^3.7.1",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.9.0"
   },
   "scripts": {
-    "package": "vsce package"
+    "compile": "node esbuild.js",
+    "watch": "node esbuild.js --watch",
+    "package": "npm run compile && vsce package"
   },
   "author": "Wvlet Team",
   "license": "Apache-2.0"

--- a/vscode-wvlet/src/extension.ts
+++ b/vscode-wvlet/src/extension.ts
@@ -1,0 +1,43 @@
+import * as path from 'path';
+import { ExtensionContext } from 'vscode';
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind,
+} from 'vscode-languageclient/node';
+
+let client: LanguageClient | undefined;
+
+export function activate(context: ExtensionContext): void {
+  const serverModule = context.asAbsolutePath(path.join('out', 'server.js'));
+
+  const serverOptions: ServerOptions = {
+    run: { module: serverModule, transport: TransportKind.ipc },
+    debug: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+      options: { execArgv: ['--nolazy', '--inspect=6009'] },
+    },
+  };
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [{ scheme: 'file', language: 'wvlet' }],
+  };
+
+  client = new LanguageClient(
+    'wvletLanguageServer',
+    'Wvlet Language Server',
+    serverOptions,
+    clientOptions
+  );
+
+  client.start();
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  if (!client) {
+    return undefined;
+  }
+  return client.stop();
+}

--- a/vscode-wvlet/src/server.ts
+++ b/vscode-wvlet/src/server.ts
@@ -1,0 +1,215 @@
+import {
+  createConnection,
+  TextDocuments,
+  Diagnostic,
+  DiagnosticSeverity,
+  ProposedFeatures,
+  InitializeParams,
+  InitializeResult,
+  TextDocumentSyncKind,
+  DocumentSymbol,
+  SymbolKind,
+  Range,
+  Position,
+} from 'vscode-languageserver/node';
+
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+// Interface for the Scala.js WvletJS module
+interface WvletJSModule {
+  WvletJS: {
+    compile(query: string, options?: string): string;
+    getVersion(): string;
+    analyzeDiagnostics(content: string): string;
+    getDocumentSymbols(content: string): string;
+  };
+}
+
+interface LspDiagnostic {
+  line: number;
+  column: number;
+  endLine: number;
+  endColumn: number;
+  message: string;
+  severity: string;
+  statusCode: string;
+}
+
+interface LspSymbol {
+  name: string;
+  kind: number;
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}
+
+// Create the LSP connection
+const connection = createConnection(ProposedFeatures.all);
+
+// Create a text document manager
+const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
+
+// Cached reference to the Scala.js compiler module
+let wvletModule: WvletJSModule | null = null;
+let moduleLoadFailed = false;
+
+async function getWvletJS(): Promise<WvletJSModule | null> {
+  if (wvletModule) {
+    return wvletModule;
+  }
+  if (moduleLoadFailed) {
+    return null;
+  }
+  try {
+    // Dynamic import of the Scala.js ESModule output
+    wvletModule = await import('../../sdks/typescript/lib/main.js');
+    connection.console.log(
+      `Wvlet compiler loaded (version: ${wvletModule!.WvletJS.getVersion()})`
+    );
+    return wvletModule;
+  } catch (e) {
+    moduleLoadFailed = true;
+    connection.console.error(
+      `Failed to load Wvlet compiler: ${e instanceof Error ? e.message : String(e)}`
+    );
+    return null;
+  }
+}
+
+connection.onInitialize((_params: InitializeParams): InitializeResult => {
+  return {
+    capabilities: {
+      textDocumentSync: TextDocumentSyncKind.Incremental,
+      documentSymbolProvider: true,
+    },
+  };
+});
+
+connection.onInitialized(async () => {
+  // Pre-load the compiler module
+  await getWvletJS();
+});
+
+// Debounce map for document validation
+const validationTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function scheduleValidation(document: TextDocument): void {
+  const uri = document.uri;
+
+  // Clear existing timer for this document
+  const existing = validationTimers.get(uri);
+  if (existing) {
+    clearTimeout(existing);
+  }
+
+  // Schedule validation after 300ms debounce
+  validationTimers.set(
+    uri,
+    setTimeout(async () => {
+      validationTimers.delete(uri);
+      await validateDocument(document);
+    }, 300)
+  );
+}
+
+async function validateDocument(document: TextDocument): Promise<void> {
+  const module = await getWvletJS();
+  if (!module) {
+    return;
+  }
+
+  const diagnostics: Diagnostic[] = [];
+
+  try {
+    const resultJson = module.WvletJS.analyzeDiagnostics(document.getText());
+    const lspDiagnostics: LspDiagnostic[] = JSON.parse(resultJson);
+
+    for (const d of lspDiagnostics) {
+      // Convert from 1-based (Wvlet) to 0-based (LSP)
+      const range: Range = {
+        start: Position.create(d.line - 1, d.column - 1),
+        end: Position.create(d.endLine - 1, d.endColumn - 1),
+      };
+
+      const severity =
+        d.severity === 'warning'
+          ? DiagnosticSeverity.Warning
+          : DiagnosticSeverity.Error;
+
+      diagnostics.push({
+        range,
+        message: d.message,
+        severity,
+        source: 'wvlet',
+        code: d.statusCode,
+      });
+    }
+  } catch (e) {
+    connection.console.error(
+      `Validation error: ${e instanceof Error ? e.message : String(e)}`
+    );
+  }
+
+  connection.sendDiagnostics({ uri: document.uri, diagnostics });
+}
+
+connection.onDocumentSymbol(async (params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) {
+    return [];
+  }
+
+  const module = await getWvletJS();
+  if (!module) {
+    return [];
+  }
+
+  try {
+    const resultJson = module.WvletJS.getDocumentSymbols(document.getText());
+    const lspSymbols: LspSymbol[] = JSON.parse(resultJson);
+
+    return lspSymbols.map((s): DocumentSymbol => {
+      // Convert from 1-based (Wvlet) to 0-based (LSP)
+      const range: Range = {
+        start: Position.create(s.startLine - 1, s.startColumn - 1),
+        end: Position.create(s.endLine - 1, s.endColumn - 1),
+      };
+
+      return {
+        name: s.name,
+        kind: s.kind as SymbolKind,
+        range,
+        selectionRange: range,
+      };
+    });
+  } catch (e) {
+    connection.console.error(
+      `Document symbol error: ${e instanceof Error ? e.message : String(e)}`
+    );
+    return [];
+  }
+});
+
+// Validate on open and change
+documents.onDidOpen((event) => {
+  scheduleValidation(event.document);
+});
+
+documents.onDidChangeContent((event) => {
+  scheduleValidation(event.document);
+});
+
+// Clear diagnostics when a document is closed
+documents.onDidClose((event) => {
+  const timer = validationTimers.get(event.document.uri);
+  if (timer) {
+    clearTimeout(timer);
+    validationTimers.delete(event.document.uri);
+  }
+  connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+});
+
+// Listen on the connection
+documents.listen(connection);
+connection.listen();

--- a/vscode-wvlet/src/server.ts
+++ b/vscode-wvlet/src/server.ts
@@ -15,33 +15,12 @@ import {
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
-// Interface for the Scala.js WvletJS module
+import type { WvletJSType } from '../../sdks/typescript/lib/main';
+import type { LspDiagnostic, LspSymbol } from '../../sdks/typescript/src/types';
+
+// The Scala.js module exports WvletJS as a named export
 interface WvletJSModule {
-  WvletJS: {
-    compile(query: string, options?: string): string;
-    getVersion(): string;
-    analyzeDiagnostics(content: string): string;
-    getDocumentSymbols(content: string): string;
-  };
-}
-
-interface LspDiagnostic {
-  line: number;
-  column: number;
-  endLine: number;
-  endColumn: number;
-  message: string;
-  severity: string;
-  statusCode: string;
-}
-
-interface LspSymbol {
-  name: string;
-  kind: number;
-  startLine: number;
-  startColumn: number;
-  endLine: number;
-  endColumn: number;
+  WvletJS: WvletJSType;
 }
 
 // Create the LSP connection

--- a/vscode-wvlet/tsconfig.json
+++ b/vscode-wvlet/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./out",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -17,6 +17,10 @@ import wvlet.lang.api.v1.compile.CompileResponse
 import wvlet.lang.api.v1.compile.CompileError
 import wvlet.lang.api.v1.compile.ErrorLocation
 import wvlet.lang.BuildInfo
+import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.model.plan.*
+
+import scala.collection.mutable.ListBuffer
 
 /**
   * JavaScript API for Wvlet compiler. This provides a JSON-based interface similar to the native
@@ -112,9 +116,167 @@ object WvletJS:
   @JSExport
   def getVersion(): String = wvlet.lang.BuildInfo.version
 
+  /**
+    * Analyze a Wvlet source and return diagnostics (errors/warnings) as JSON.
+    * @param content
+    *   The Wvlet source code
+    * @return
+    *   JSON array of diagnostics: [{line, column, endLine, endColumn, message, severity,
+    *   statusCode}]
+    */
+  @JSExport
+  def analyzeDiagnostics(content: String): String =
+    val diagnostics = ListBuffer.empty[LspDiagnostic]
+    try
+      val compiler  = Compiler(CompilerOptions(workEnv = WorkEnv(path = ".")))
+      val inputUnit = CompilationUnit.fromWvletString(content)
+      val result    = compiler.compileSingleUnit(inputUnit)
+      result.reportAllErrors
+    catch
+      case e: WvletLangException =>
+        val loc = e.sourceLocation
+        if loc != SourceLocation.NoSourceLocation then
+          diagnostics +=
+            LspDiagnostic(
+              line = loc.position.line,
+              column = loc.position.column,
+              endLine = loc.position.line,
+              endColumn = loc.position.column,
+              message = e.getMessage,
+              severity = "error",
+              statusCode = e.statusCode.toString
+            )
+        else
+          // Error without location — report at line 1, column 1
+          diagnostics +=
+            LspDiagnostic(
+              line = 1,
+              column = 1,
+              endLine = 1,
+              endColumn = 1,
+              message = e.getMessage,
+              severity = "error",
+              statusCode = e.statusCode.toString
+            )
+      case e: Throwable =>
+        diagnostics +=
+          LspDiagnostic(
+            line = 1,
+            column = 1,
+            endLine = 1,
+            endColumn = 1,
+            message = Option(e.getMessage).getOrElse(e.getClass.getName),
+            severity = "error",
+            statusCode = StatusCode.INTERNAL_ERROR.toString
+          )
+    end try
+
+    MessageCodec.of[List[LspDiagnostic]].toJson(diagnostics.toList)
+
+  end analyzeDiagnostics
+
+  /**
+    * Extract document symbols from a Wvlet source as JSON. Uses parse-only mode for speed.
+    * @param content
+    *   The Wvlet source code
+    * @return
+    *   JSON array of symbols: [{name, kind, startLine, startColumn, endLine, endColumn}]
+    */
+  @JSExport
+  def getDocumentSymbols(content: String): String =
+    val symbols   = ListBuffer.empty[LspSymbol]
+    val inputUnit = CompilationUnit.fromWvletString(content)
+    try
+      inputUnit.unresolvedPlan = ParserPhase.parseOnly(inputUnit)
+    catch
+      case _: Throwable =>
+      // Ignore parse errors — extract whatever symbols we can
+
+    val sourceFile = inputUnit.sourceFile
+    sourceFile.ensureLoaded
+
+    def toSymbol(name: String, kind: Int, span: wvlet.lang.api.Span): LspSymbol =
+      if span.exists then
+        LspSymbol(
+          name = name,
+          kind = kind,
+          startLine = sourceFile.offsetToLine(span.start) + 1,
+          startColumn = sourceFile.offsetToColumn(span.start),
+          endLine = sourceFile.offsetToLine(span.end) + 1,
+          endColumn = sourceFile.offsetToColumn(span.end)
+        )
+      else
+        LspSymbol(
+          name = name,
+          kind = kind,
+          startLine = 1,
+          startColumn = 1,
+          endLine = 1,
+          endColumn = 1
+        )
+
+    def extractSymbols(plan: LogicalPlan): Unit =
+      plan match
+        case pkg: PackageDef =>
+          pkg.statements.foreach(extractSymbols)
+        case m: ModelDef =>
+          symbols += toSymbol(m.name.fullName, LspSymbolKind.Class, m.span)
+        case t: TypeDef =>
+          symbols += toSymbol(t.name.name, LspSymbolKind.Struct, t.span)
+        case f: TopLevelFunctionDef =>
+          symbols += toSymbol(f.functionDef.name.name, LspSymbolKind.Function, f.span)
+        case v: ValDef =>
+          symbols += toSymbol(v.name.name, LspSymbolKind.Variable, v.span)
+        case p: PartialQueryDef =>
+          symbols += toSymbol(p.name.name, LspSymbolKind.Function, p.span)
+        case fl: FlowDef =>
+          symbols += toSymbol(fl.name.name, LspSymbolKind.Function, fl.span)
+        case _ =>
+        // Skip other plan types
+
+    extractSymbols(inputUnit.unresolvedPlan)
+
+    MessageCodec.of[List[LspSymbol]].toJson(symbols.toList)
+
+  end getDocumentSymbols
+
 end WvletJS
 
 /**
   * Compilation options
   */
 case class CompileOptions(target: Option[String] = None, profile: Option[String] = None)
+
+/**
+  * LSP diagnostic representation for JSON serialization
+  */
+case class LspDiagnostic(
+    line: Int,
+    column: Int,
+    endLine: Int,
+    endColumn: Int,
+    message: String,
+    severity: String,
+    statusCode: String
+)
+
+/**
+  * LSP symbol representation for JSON serialization
+  */
+case class LspSymbol(
+    name: String,
+    kind: Int,
+    startLine: Int,
+    startColumn: Int,
+    endLine: Int,
+    endColumn: Int
+)
+
+/**
+  * LSP SymbolKind constants (subset from the LSP specification)
+  */
+object LspSymbolKind:
+  val Class: Int    = 5
+  val Function: Int = 12
+  val Variable: Int = 13
+  val Struct: Int   = 23

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -116,6 +116,26 @@ object WvletJS:
   @JSExport
   def getVersion(): String = wvlet.lang.BuildInfo.version
 
+  // Cached compiler instance for diagnostics (avoids repeated initialization and filesystem scans)
+  private lazy val diagnosticsCompiler = Compiler(CompilerOptions(workEnv = WorkEnv(path = ".")))
+
+  private def makeDiagnostic(
+      line: Int,
+      column: Int,
+      endLine: Int,
+      endColumn: Int,
+      message: String,
+      statusCode: String
+  ): LspDiagnostic = LspDiagnostic(
+    line = line,
+    column = column,
+    endLine = endLine,
+    endColumn = endColumn,
+    message = message,
+    severity = "error",
+    statusCode = statusCode
+  )
+
   /**
     * Analyze a Wvlet source and return diagnostics (errors/warnings) as JSON.
     * @param content
@@ -128,46 +148,33 @@ object WvletJS:
   def analyzeDiagnostics(content: String): String =
     val diagnostics = ListBuffer.empty[LspDiagnostic]
     try
-      val compiler  = Compiler(CompilerOptions(workEnv = WorkEnv(path = ".")))
       val inputUnit = CompilationUnit.fromWvletString(content)
-      val result    = compiler.compileSingleUnit(inputUnit)
+      val result    = diagnosticsCompiler.compileSingleUnit(inputUnit)
       result.reportAllErrors
     catch
       case e: WvletLangException =>
         val loc = e.sourceLocation
         if loc != SourceLocation.NoSourceLocation then
           diagnostics +=
-            LspDiagnostic(
-              line = loc.position.line,
-              column = loc.position.column,
-              endLine = loc.position.line,
-              endColumn = loc.position.column,
-              message = e.getMessage,
-              severity = "error",
-              statusCode = e.statusCode.toString
+            makeDiagnostic(
+              loc.position.line,
+              loc.position.column,
+              loc.position.line,
+              loc.position.column,
+              e.getMessage,
+              e.statusCode.toString
             )
         else
-          // Error without location — report at line 1, column 1
-          diagnostics +=
-            LspDiagnostic(
-              line = 1,
-              column = 1,
-              endLine = 1,
-              endColumn = 1,
-              message = e.getMessage,
-              severity = "error",
-              statusCode = e.statusCode.toString
-            )
+          diagnostics += makeDiagnostic(1, 1, 1, 1, e.getMessage, e.statusCode.toString)
       case e: Throwable =>
         diagnostics +=
-          LspDiagnostic(
-            line = 1,
-            column = 1,
-            endLine = 1,
-            endColumn = 1,
-            message = Option(e.getMessage).getOrElse(e.getClass.getName),
-            severity = "error",
-            statusCode = StatusCode.INTERNAL_ERROR.toString
+          makeDiagnostic(
+            1,
+            1,
+            1,
+            1,
+            Option(e.getMessage).getOrElse(e.getClass.getName),
+            StatusCode.INTERNAL_ERROR.toString
           )
     end try
 


### PR DESCRIPTION
## Summary

- Add LSP server to the VS Code extension using Scala.js + TypeScript shell architecture
- Extend `WvletJS` with `analyzeDiagnostics()` and `getDocumentSymbols()` APIs that compile Wvlet source via the Scala.js compiler and return structured JSON results
- Implement TypeScript LSP server (`vscode-languageserver`) with document sync, diagnostics publishing (300ms debounce), and document symbol provider
- Add VS Code extension client that launches the LSP server via IPC on `.wv` file activation
- Bundle everything with esbuild for distribution

## Architecture

```
VS Code Extension (extension.ts)  ← LSP Client
         ↕ IPC
LSP Server (server.ts)             ← vscode-languageserver (Node.js)
         ↕ calls
WvletJS (Scala.js)                 ← Compiler compiled to JS
```

## Supported LSP Features

| Feature | Status |
|---------|--------|
| Diagnostics (parse/type errors) | ✅ |
| Document Symbols (outline) | ✅ |
| Completion | 🔜 Future |
| Hover | 🔜 Future |
| Go to Definition | 🔜 Future |

## Known Limitations

- **File I/O not available in Scala.js**: The Scala.js platform stubs out all file I/O (`existsFile` always returns `false`), so `from 'file.json'` references will report `FILE_NOT_FOUND` even when the file exists on disk. This will be resolved once the Uni-platform File IO compat layer is implemented.
- Diagnostics report at most one error per file (compiler throws on first error)
- Document symbols require valid syntax (partial parsing not yet supported)

## Test plan

- [x] `sbt sdkJs/fastLinkJS` — Scala.js compilation succeeds
- [x] `npm run compile` (in vscode-wvlet) — esbuild bundles without errors
- [x] Smoke test: `WvletJS.analyzeDiagnostics()` returns correct diagnostics for valid/invalid code
- [x] Smoke test: `WvletJS.getDocumentSymbols()` returns correct symbols for model/function definitions
- [x] VS Code integration test: open `.wv` file, verify diagnostics appear for syntax errors
- [x] VS Code integration test: verify document symbols in outline view

🤖 Generated with [Claude Code](https://claude.com/claude-code)