### PR TITLE
internal: Migrate wvlet-cli/wvlet-runner utilities from airframe to uni

### DIFF
--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
@@ -1,8 +1,8 @@
 package wvlet.lang.cli
 
-import wvlet.airframe.control.Control
 import wvlet.airframe.launcher.argument
 import wvlet.airframe.launcher.option
+import wvlet.uni.control.Control
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.v1.query.QuerySelection
 import wvlet.lang.catalog.Profile

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletMain.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletMain.scala
@@ -1,8 +1,8 @@
 package wvlet.lang.cli
 
-import wvlet.airframe.Design
 import wvlet.airframe.launcher.Launcher
 import wvlet.airframe.launcher.command
+import wvlet.uni.design.Design
 import wvlet.lang.BuildInfo
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.cli.WvletMain.isInSbt

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPL.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPL.scala
@@ -20,11 +20,11 @@ import org.jline.terminal.Terminal
 import org.jline.utils.AttributedString
 import org.jline.utils.AttributedStringBuilder
 import org.jline.utils.AttributedStyle
-import wvlet.airframe.control.Shell
-import wvlet.airframe.control.ThreadUtil
-import wvlet.airframe.log.AnsiColorPalette
-import wvlet.airframe.metrics.Count
-import wvlet.airframe.metrics.ElapsedTime
+import wvlet.uni.io.IO
+import wvlet.uni.log.AnsiColorPalette
+import wvlet.uni.util.Count
+import wvlet.uni.util.ElapsedTime
+import wvlet.uni.util.ThreadUtil
 import wvlet.lang.api.LinePosition
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
@@ -274,7 +274,7 @@ class WvletREPL(runner: WvletScriptRunner, terminal: REPLTerminal)
           case "help" =>
             println(helpMessage)
           case "git" | "gh" =>
-            Shell.exec(trimmedLine)
+            IO.run(trimmedLine)
           case "clip" =>
             lastOutput match
               case Some(output) =>

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
@@ -1,10 +1,10 @@
 package wvlet.lang.cli
 
-import wvlet.airframe.Design
 import wvlet.airframe.launcher.Launcher
 import wvlet.airframe.launcher.argument
 import wvlet.airframe.launcher.command
 import wvlet.airframe.launcher.option
+import wvlet.uni.design.Design
 import wvlet.lang.api.StatusCode.SYNTAX_ERROR
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
@@ -17,8 +17,8 @@ import wvlet.lang.runner.WvletScriptRunner
 import wvlet.lang.runner.WvletScriptRunnerConfig
 import wvlet.lang.runner.connector.DBConnector
 import wvlet.lang.runner.connector.DBConnectorProvider
+import wvlet.uni.io.IO
 import wvlet.uni.log.LogSupport
-import wvlet.log.io.IOUtil
 
 import java.io.File
 
@@ -81,7 +81,7 @@ class WvletREPLMain(cliOption: WvletGlobalOption, replOpts: WvletREPLOption) ext
       .foreach { file =>
         val f = new File(replOpts.workFolder, file)
         if f.exists() then
-          val contents = IOUtil.readAsString(f)
+          val contents = IO.readString(IO.path(f.getPath))
           commandInputs += contents
         else
           throw StatusCode.FILE_NOT_FOUND.newException(s"File not found: ${f.getAbsolutePath()}")
@@ -92,16 +92,15 @@ class WvletREPLMain(cliOption: WvletGlobalOption, replOpts: WvletREPLOption) ext
 
     val design = Design
       .newSilentDesign
-      .bind[REPLTerminal]
-      .toProvider { (workEnv: WorkEnv) =>
+      .bindProvider[WorkEnv, REPLTerminal] { (workEnv: WorkEnv) =>
         if isInteractive then
           JLine3Terminal(workEnv)
         else
           HeadlessTerminal()
       }
-      .bind[WvletREPL]
-      .toProvider { (runner: WvletScriptRunner, terminal: REPLTerminal) =>
-        WvletREPL(runner, terminal)
+      .bindProvider[WvletScriptRunner, REPLTerminal, WvletREPL] {
+        (runner: WvletScriptRunner, terminal: REPLTerminal) =>
+          WvletREPL(runner, terminal)
       }
       .bindInstance[Profile](currentProfile)
       .bindInstance[WorkEnv](WorkEnv(path = replOpts.workFolder, logLevel = cliOption.logLevel))

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/QueryConverterCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/QueryConverterCommandTest.scala
@@ -3,7 +3,7 @@ package wvlet.lang.cli
 import wvlet.uni.test.UniTest
 import wvlet.lang.compiler.SourceIO
 import wvlet.lang.compiler.VirtualFile
-import wvlet.log.io.IOUtil
+import wvlet.uni.io.IO
 
 import java.io.ByteArrayOutputStream
 
@@ -72,10 +72,10 @@ class QueryConverterCommandTest extends UniTest:
         val sqlFile = sqlFiles.find(_.name == s"${queryName}.sql")
         sqlFile match
           case Some(expectedFile) =>
-            val expectedSQL = IOUtil.readAsString(expectedFile.path)
+            val expectedSQL = IO.readString(IO.path(expectedFile.path))
 
             debug(s"=== Query: ${queryName} ===")
-            val queryContent = IOUtil.readAsString(wvFile.path)
+            val queryContent = IO.readString(IO.path(wvFile.path))
             debug(s"\nInput Wvlet Query: '${queryContent}'")
             debug(s"Generated SQL Output: '${out.trim}'")
 
@@ -142,7 +142,7 @@ class QueryConverterCommandTest extends UniTest:
         val wvFile = wvletFiles.find(_.name == s"${queryName}.wv")
         wvFile match
           case Some(expectedFile) =>
-            val expectedWvlet = IOUtil.readAsString(expectedFile.path)
+            val expectedWvlet = IO.readString(IO.path(expectedFile.path))
             debug(s"Expected Wvlet for ${queryName}: ${expectedWvlet}")
             debug(s"Generated Wvlet: ${out}")
           case None =>

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/InMemoryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/InMemoryExecutor.scala
@@ -15,11 +15,11 @@ package wvlet.lang.runner
 
 import wvlet.lang.compiler.Context
 import wvlet.lang.model.plan.*
-import wvlet.airframe.codec.MessageCodec
-import wvlet.airframe.control.IO
+import wvlet.uni.io.IO
 import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
-import java.io.File
 import scala.collection.immutable.ListMap
 
 object InMemoryExecutor:
@@ -40,8 +40,8 @@ class InMemoryExecutor extends LogSupport:
         warn(s"Test execution is not supported yet: ${t}")
         QueryResult.empty
       case r: FileScan if r.filePath.endsWith(".json") =>
-        val json = IO.readAsString(new File(r.filePath))
+        val json = IO.readString(IO.path(r.filePath))
         trace(json)
-        val codec = MessageCodec.of[Seq[ListMap[String, Any]]]
+        val codec = summon[Weaver[Seq[ListMap[String, Any]]]]
         val data  = codec.fromJson(json)
         TableRows(r.schema, data, data.size)

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -14,7 +14,6 @@
 package wvlet.lang.runner
 
 import wvlet.airframe.codec.JDBCCodec
-import wvlet.airframe.codec.MessageCodec
 import wvlet.lang.api.v1.query.QuerySelection
 import wvlet.lang.api.LinePosition
 import wvlet.lang.api.StatusCode
@@ -39,6 +38,8 @@ import wvlet.lang.runner.connector.DBConnector
 import wvlet.lang.runner.connector.DBConnectorProvider
 import wvlet.uni.log.LogLevel
 import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import java.sql.SQLException
 import scala.collection.immutable.ListMap
@@ -303,7 +304,7 @@ class QueryExecutor(
     import java.io.{BufferedWriter, File, FileOutputStream, FileWriter, OutputStreamWriter}
     import java.sql.ResultSet
     import java.util.zip.GZIPOutputStream
-    import wvlet.airframe.ulid.ULID
+    import wvlet.uni.util.ULID
     import java.nio.file.{Files, Paths}
     import scala.util.Using
 
@@ -330,12 +331,12 @@ class QueryExecutor(
 
     def writeJSONL(rs: ResultSet, out: File): Long =
       var rowCount = 0L
-      val rowCodec = MessageCodec.of[ListMap[String, Any]]
+      val rowCodec = summon[Weaver[ListMap[String, Any]]]
       Using.resource(BufferedWriter(OutputStreamWriter(GZIPOutputStream(FileOutputStream(out))))) {
         w =>
           val codec = JDBCCodec(rs)
           val it    = codec.mapMsgPackMapRows { msgpack =>
-            rowCodec.fromMsgPack(msgpack)
+            rowCodec.unweave(msgpack)
           }
           while it.hasNext do
             val row = it.next()
@@ -435,11 +436,11 @@ class QueryExecutor(
               trace(outputType)
 
               val codec    = JDBCCodec(rs)
-              val rowCodec = MessageCodec.of[ListMap[String, Any]]
+              val rowCodec = summon[Weaver[ListMap[String, Any]]]
               var rowCount = 0
               val it       = codec.mapMsgPackMapRows { msgpack =>
                 if rowCount <= config.rowLimit then
-                  rowCodec.fromMsgPack(msgpack)
+                  rowCodec.unweave(msgpack)
                 else
                   null
               }

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryResult.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryResult.scala
@@ -13,8 +13,9 @@
  */
 package wvlet.lang.runner
 
-import wvlet.airframe.codec.MessageCodec
 import wvlet.lang.api.StatusCode
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 import wvlet.lang.api.SourceLocation
 import wvlet.lang.model.DataType
 import wvlet.lang.model.RelationType
@@ -74,7 +75,7 @@ case class TableRows(schema: RelationType, rows: Seq[ListMap[String, Any]], tota
     extends QueryResult:
   def isTruncated: Boolean = rows.size < totalRows
   def toJsonLines: String  =
-    val codec     = MessageCodec.of[ListMap[String, Any]]
+    val codec     = summon[Weaver[ListMap[String, Any]]]
     val jsonLines = rows
       .map { row =>
         codec.toJson(row)

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/ThreadUtil.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/ThreadUtil.scala
@@ -14,7 +14,7 @@
 package wvlet.lang.runner
 
 import org.apache.arrow.flatbuf.TimeUnit
-import wvlet.airframe.ulid.ULID
+import wvlet.uni.util.ULID
 
 import java.util.concurrent
 import java.util.concurrent.Executors
@@ -33,7 +33,7 @@ object ThreadUtil:
 
 class ThreadManager() extends AutoCloseable:
   private val executor = Executors.newCachedThreadPool(
-    wvlet.airframe.control.ThreadUtil.newDaemonThreadFactory(s"wvlet-task-${ULID.newULID}")
+    wvlet.uni.util.ThreadUtil.newDaemonThreadFactory(s"wvlet-task-${ULID.newULID}")
   )
 
   override def close(): Unit =

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
@@ -14,8 +14,6 @@
 package wvlet.lang.runner
 
 import org.jline.terminal.Terminal
-import wvlet.airframe.control.Control
-import wvlet.airframe.control.Shell
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.api.v1.query.QueryRequest
 import wvlet.lang.api.v1.query.QuerySelection

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/DBConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/DBConnector.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.lang.runner.connector
 
-import wvlet.airframe.control.Control.withResource
+import wvlet.uni.control.Control.withResource
 import DBConnector.*
 import io.trino.jdbc.QueryStats
 import wvlet.lang.catalog.Catalog
@@ -31,9 +31,6 @@ import wvlet.lang.model.DataType
 import wvlet.lang.model.RelationType
 import wvlet.lang.model.plan.LogicalPlan
 import wvlet.lang.model.plan.*
-import wvlet.airframe.codec.JDBCCodec.ResultSetCodec
-import wvlet.airframe.metrics.Count
-import wvlet.airframe.metrics.ElapsedTime
 import wvlet.lang.api.StatusCode
 import wvlet.uni.log.LogSupport
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/duckdb/DuckDBConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/duckdb/DuckDBConnector.scala
@@ -25,9 +25,10 @@ import wvlet.lang.runner.ThreadUtil
 import wvlet.lang.runner.connector.DBConnection
 import wvlet.lang.runner.connector.DBConnector
 import org.duckdb.DuckDBConnection
-import wvlet.airframe.codec.MessageCodec
-import wvlet.airframe.metrics.ElapsedTime
 import wvlet.uni.log.LogSupport
+import wvlet.uni.util.ElapsedTime
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import java.sql.Connection
 import java.sql.DriverManager
@@ -113,7 +114,7 @@ class DuckDBConnector(workEnv: WorkEnv, prepareTPCH: Boolean = false, prepareTPC
   override def listFunctions(catalog: String): List[SQLFunction] =
     val functionList = List.newBuilder[SQLFunction]
 
-    val jsonArrayCodec = MessageCodec.of[Seq[String]]
+    val jsonArrayCodec = summon[Weaver[Seq[String]]]
     runQuery("""select function_name, function_type,
         |parameters::json as parameters, parameter_types::json parameter_types,
         |return_type,

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/snowflake/SnowflakeConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/snowflake/SnowflakeConnector.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.lang.runner.connector.snowflake
 
-import wvlet.airframe.control.Control
 import wvlet.lang.catalog.SQLFunction
+import wvlet.uni.control.Control
 import wvlet.lang.compiler.DBType
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.model.DataType

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
@@ -17,10 +17,10 @@ import io.trino.jdbc.QueryStats
 import io.trino.jdbc.TrinoConnection
 import io.trino.jdbc.TrinoDriver
 import io.trino.jdbc.TrinoStatement
-import wvlet.airframe.control.Control
-import wvlet.airframe.metrics.Count
-import wvlet.airframe.metrics.ElapsedTime
 import wvlet.lang.catalog.SQLFunction
+import wvlet.uni.control.Control
+import wvlet.uni.util.Count
+import wvlet.uni.util.ElapsedTime
 import wvlet.lang.compiler.DBType
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.compiler.query.QueryProgressMonitor

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/TrinoSpec.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/TrinoSpec.scala
@@ -15,8 +15,8 @@ package wvlet.lang.runner
 
 import wvlet.uni.test.UniTest
 import wvlet.lang.api.WvletLangException
-import wvlet.airframe.control.Control
 import wvlet.lang.catalog.Profile
+import wvlet.uni.control.Control
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Compiler
 import wvlet.lang.compiler.CompilerOptions

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/duckdb/DuckDBConnectorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/duckdb/DuckDBConnectorTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.lang.runner.connector.duckdb
 
-import wvlet.airframe.control.Control.withResource
+import wvlet.uni.control.Control.withResource
 import wvlet.lang.compiler.Name
 import wvlet.lang.model.DataType
 import wvlet.lang.model.DataType.NamedType

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TestTrinoServer.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TestTrinoServer.scala
@@ -17,10 +17,9 @@ import io.trino.plugin.deltalake.DeltaLakeConnectorFactory
 import io.trino.plugin.deltalake.DeltaLakePlugin
 import io.trino.plugin.memory.MemoryPlugin
 import io.trino.server.testing.TestingTrinoServer
-import wvlet.airframe.control.Resource
-import wvlet.airframe.ulid.ULID
 import wvlet.uni.log.LogSupport
 import wvlet.uni.log.Logger
+import wvlet.uni.util.ULID
 
 import java.io.File
 import java.nio.file.Files


### PR DESCRIPTION
## Summary

Continues #1634 — swaps airframe utility imports to uni equivalents in
**wvlet-cli** and **wvlet-runner**. Three concrete uni gaps surfaced
during the work; each is locally pinned to airframe and tracked as a
follow-up on the uni side. 17 files, +48 −52.

## What moved to uni (works)

- **Design DI**: `wvlet.airframe.Design` → `wvlet.uni.design.Design`. Constructor injection works. `bind[A].toProvider` rewritten as `bindProvider[…, A]`.
- **Control**: `Control`, `withResource`, `closeResources` → `wvlet.uni.control.*`.
- **Process**: `Shell.exec(line)` → `wvlet.uni.io.IO.run(line)` (REPL).
- **Threads**: `airframe.control.ThreadUtil` → `wvlet.uni.util.ThreadUtil`.
- **Metrics**: `Count`, `ElapsedTime` → `wvlet.uni.util.{Count, ElapsedTime}`.
- **ULID**: `airframe.ulid.ULID` → `wvlet.uni.util.ULID`.
- **Log palette**: `airframe.log.AnsiColorPalette` → `wvlet.uni.log.AnsiColorPalette`.
- **File I/O**: `wvlet.log.io.IOUtil.readAsString` → `wvlet.uni.io.IO.readString(IO.path(…))`.
- **Codec (collections of primitives)**: `MessageCodec.of[T]` → `summon[Weaver[T]]` with `import wvlet.uni.weaver.codec.PrimitiveWeaver.given`. Used in `QueryResult`, `InMemoryExecutor`, `DuckDBConnector`, `QueryExecutor`.
- **Codec method**: `MessageCodec.fromMsgPack` → `Weaver.unweave`.

## Gaps left on airframe (uni follow-ups)

| Gap | What | Location |
|---|---|---|
| **A** | `JDBCCodec(rs).mapMsgPackMapRows{…}` — JDBC ResultSet → MsgPack iterator. uni has no equivalent. | `QueryExecutor.scala:336,437` + 4 test files (`{DuckDB,Snowflake,Trino}ConnectorTest`, `TableFunctionTest`, `CustomMemoryPlugin`) |
| **C** | `Weaver.of[T]` cannot derive when a transitive field is an abstract class (`Catalog.TableDef` → `DataType`). `MessageCodec` handled this via runtime reflection. | `ConnectorCatalog.scala` (table-def cache JSON) |
| **D** | uni's `CommandLauncher.buildMethodArgs` doesn't recursively build nested config-class method parameters — `null` is passed for unmatched complex types. Same recursion already exists for constructor injection (`buildInstanceFromSurface`). Blocks the `@command def f(cfg: SomeConfig)` pattern. | uni `CommandLauncher.scala:169`. Launcher imports therefore stay on `wvlet.airframe.launcher.*` in `WvletMain`, `WvletREPLMain`, `WvletGlobalOption`, `WvletCompiler`; one-line revert once uni ships the fix. |

Issues will be filed against `wvlet/uni` as follow-ups to this PR.

## Test plan

- [x] `./sbt projectJVM/Test/compile` — green
- [x] `./sbt cli/test` — 81/81
- [x] `./sbt "runner/testOnly *RunnerSpecBasic"` — 122/122 (1 pending, pre-existing)
- [x] `./sbt scalafmtAll` — clean
- [ ] CI: Scala 3, Scala.js, Scala Native, Code format, Build Python wheels

🤖 Generated with [Claude Code](https://claude.com/claude-code)