### PR TITLE
internal: Bump UNI_VERSION to 2026.1.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scala.scalanative.build.Mode
 import scala.scalanative.build.NativeConfig
 
 val AIRFRAME_VERSION = "2026.1.6"
-val UNI_VERSION      = "2026.1.4"
+val UNI_VERSION      = "2026.1.5"
 
 val AIRSPEC_VERSION        = AIRFRAME_VERSION
 val TRINO_VERSION          = "476"


### PR DESCRIPTION
## Summary

Plain dependency bump. Picks up:

- **wvlet/uni#512** — launcher: recursively build nested config-class method args (closes Gap D from #1635)
- **wvlet/uni#513** — Weaver: auto-derive for fields with abstract types via Surface fallback (closes Gap C from #1635)

No source changes — both fixes are picked up transitively.

## Why not also re-migrate cli launcher / ConnectorCatalog now?

Tried; uncovered two new uni gaps. Will file and attempt again once they ship:

- **Gap E** — \`Weaver.fromSurface\` throws \`IllegalStateException: Recursive update\` for self-recursive types like \`Catalog.TableDef → DataType\` (\`typeParams: List[DataType]\`).
- **Gap F** — \`AirframeSession.init\` fails with \"Missing controller. Add FrontendApiImpl to the design\" when \`WvletMain.ui\` is invoked via uni's launcher; same path works under airframe-launcher. Suspected Surface registration ordering between airframe.surface and uni.surface. Needs minimal repro before filing.

## Test plan

- [x] \`./sbt projectJVM/Test/compile\` — green
- [x] \`./sbt cli/test\` — 81/81
- [x] \`./sbt \"runner/testOnly *RunnerSpecBasic\"\` — 122/122 (1 pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)