### PR TITLE
internal: Bump UNI_VERSION to 2026.1.6 and migrate ConnectorCatalog to Weaver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scala.scalanative.build.Mode
 import scala.scalanative.build.NativeConfig
 
 val AIRFRAME_VERSION = "2026.1.6"
-val UNI_VERSION      = "2026.1.5"
+val UNI_VERSION      = "2026.1.6"
 
 val AIRSPEC_VERSION        = AIRFRAME_VERSION
 val TRINO_VERSION          = "476"

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorCatalog.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorCatalog.scala
@@ -15,7 +15,6 @@ package wvlet.lang.runner.connector
 
 import com.github.benmanes.caffeine.cache.CacheLoader
 import com.github.benmanes.caffeine.cache.Caffeine
-import wvlet.airframe.codec.MessageCodec
 import wvlet.lang.api.StatusCode
 import wvlet.lang.catalog.Catalog.TableName
 import wvlet.lang.catalog.Catalog
@@ -25,6 +24,8 @@ import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.runner.ThreadManager
 import wvlet.lang.runner.ThreadUtil
 import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import java.util.concurrent.TimeUnit
 import scala.jdk.CollectionConverters.*
@@ -38,7 +39,8 @@ class ConnectorCatalog(
 ) extends Catalog
     with LogSupport:
 
-  private val tableDefCodec = MessageCodec.of[List[Catalog.TableDef]]
+  private given Weaver[Catalog.TableDef] = Weaver.of[Catalog.TableDef]
+  private val tableDefCodec               = summon[Weaver[List[Catalog.TableDef]]]
 
   private val tablesInSchemaCache = Caffeine
     .newBuilder()

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorCatalog.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorCatalog.scala
@@ -40,7 +40,7 @@ class ConnectorCatalog(
     with LogSupport:
 
   private given Weaver[Catalog.TableDef] = Weaver.of[Catalog.TableDef]
-  private val tableDefCodec               = summon[Weaver[List[Catalog.TableDef]]]
+  private val tableDefCodec              = summon[Weaver[List[Catalog.TableDef]]]
 
   private val tablesInSchemaCache = Caffeine
     .newBuilder()


### PR DESCRIPTION
## Summary

uni 2026.1.6 ships **wvlet/uni#517** (fix for `Weaver.fromSurface` self-recursive types via fixpoint pre-registration) — that was Gap E filed during the 2026.1.5 bump in #1640. With it landed, the last `MessageCodec` use in wvlet-runner main code can move to `Weaver`.

## Changes

- **build.sbt**: \`UNI_VERSION\` 2026.1.5 → 2026.1.6
- **\`ConnectorCatalog.scala\`**:
  - Drop \`wvlet.airframe.codec.MessageCodec\` import
  - Add \`Weaver\` + \`PrimitiveWeaver.given\` imports
  - \`MessageCodec.of[List[Catalog.TableDef]]\` → \`summon[Weaver[List[Catalog.TableDef]]]\` with an explicit \`given Weaver[Catalog.TableDef] = Weaver.of[Catalog.TableDef]\`. Derivation walks through the case-class fields and the new Surface-fallback handles \`DataType\` (which has self-recursive \`typeParams: List[DataType]\`).

## Still parked

**Gap F** — \`AirframeSession.init\` throws \"Missing controller. Add FrontendApiImpl to the design\" when \`WvletMain.ui\` is invoked via uni's launcher (uni-launcher works correctly thanks to uni#512; the failure is downstream in airframe-http-netty's controller discovery). Same path under airframe-launcher succeeds. Needs a minimal repro before filing — likely an interaction between airframe.surface and uni.surface registration ordering. wvlet-cli launcher imports therefore stay on \`wvlet.airframe.launcher.*\` for now.

## Test plan

- [x] \`./sbt projectJVM/Test/compile\` — green
- [x] \`./sbt cli/test\` — 81/81
- [x] \`./sbt \"runner/testOnly *RunnerSpecBasic\"\` — 122/122 (1 pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)