### PR TITLE
internal: Port JDBCCodec into wvlet-runner; drop airframe-codec from runner

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -387,9 +387,8 @@ lazy val runner = project
     Test / javaOptions ++= Seq("--enable-native-access=ALL-UNNAMED"),
     libraryDependencies ++=
       Seq(
-        "org.jline"                     % "jline"             % "4.0.13",
-        "org.wvlet.airframe"           %% "airframe-launcher" % AIRFRAME_VERSION,
-        "com.github.ben-manes.caffeine" % "caffeine"          % "3.2.3",
+        "org.jline"                     % "jline"    % "4.0.13",
+        "com.github.ben-manes.caffeine" % "caffeine" % "3.2.3",
         "org.apache.arrow"              % "arrow-vector"      % "19.0.0",
         "org.duckdb"                    % "duckdb_jdbc"       % DUCKDB_JDBC_VERSION,
         "io.trino"                      % "trino-jdbc"        % TRINO_VERSION,

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.lang.runner
 
-import wvlet.airframe.codec.JDBCCodec
 import wvlet.lang.api.v1.query.QuerySelection
+import wvlet.lang.runner.codec.JDBCCodec
 import wvlet.lang.api.LinePosition
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/codec/JDBCCodec.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/codec/JDBCCodec.scala
@@ -1,0 +1,359 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner.codec
+
+import wvlet.uni.log.LogSupport
+import wvlet.uni.msgpack.spi.MessagePack
+import wvlet.uni.msgpack.spi.Packer
+import wvlet.uni.weaver.codec.JSONWeaver
+
+import java.sql.ResultSet
+import java.sql.Types
+
+/**
+  * JDBC ResultSet → MsgPack/JSON codec, ported from wvlet.airframe.codec.JDBCCodec so wvlet can
+  * adjust per-database type quirks (DuckDB, Trino, Snowflake, ...) independently of uni.
+  */
+object JDBCCodec extends LogSupport:
+  def apply(rs: ResultSet): ResultSetCodec = ResultSetCodec(rs)
+
+  class ResultSetCodec(rs: ResultSet):
+    private lazy val md                                        = rs.getMetaData
+    private lazy val columnCount                               = md.getColumnCount
+    private lazy val columnCodecs: IndexedSeq[JDBCColumnCodec] = (1 to columnCount)
+      .map(i => toJDBCColumnCodec(md.getColumnType(i), md.getColumnTypeName(i)))
+      .toIndexedSeq
+
+    private lazy val columnNames = (1 to columnCount).map(i => md.getColumnName(i))
+
+    /**
+      * Encode all ResultSet rows as a JSON array of JSON objects (column name → column value).
+      */
+    def toJson: String = s"[${toJsonSeq.mkString(",")}]"
+
+    /**
+      * Encode each ResultSet row as a JSON object string.
+      */
+    def toJsonSeq: Iterator[String] = mapMsgPackMapRows(JSONWeaver.unweave(_))
+
+    /**
+      * Iterator over rows packed as MsgPack maps.
+      */
+    def mapMsgPackMapRows[U](f: Array[Byte] => U): Iterator[U] =
+      new RStoMsgPackIterator[U](f, packRowAsMap(_))
+
+    /**
+      * Iterator over rows packed as MsgPack arrays.
+      */
+    def mapMsgPackArrayRows[U](f: Array[Byte] => U): Iterator[U] =
+      new RStoMsgPackIterator[U](f, packRowAsArray(_))
+
+    /**
+      * Pack one ResultSet row as a MsgPack map (keys = column names).
+      */
+    def packRowAsMap(p: Packer): Unit =
+      p.packMapHeader(columnCount)
+      var col = 1
+      while col <= columnCount do
+        p.packString(columnNames(col - 1))
+        columnCodecs(col - 1).pack(p, rs, col)
+        col += 1
+
+    /**
+      * Pack one ResultSet row as a MsgPack array.
+      */
+    def packRowAsArray(p: Packer): Unit =
+      p.packArrayHeader(columnCount)
+      var col = 1
+      while col <= columnCount do
+        columnCodecs(col - 1).pack(p, rs, col)
+        col += 1
+
+    private class RStoMsgPackIterator[A](f: Array[Byte] => A, packer: Packer => Unit)
+        extends Iterator[A]:
+      private var hasNextElem: Option[Boolean] = None
+      override def hasNext: Boolean            =
+        hasNextElem match
+          case Some(x) =>
+            x
+          case None =>
+            val x = rs.next()
+            hasNextElem = Some(x)
+            x
+
+      override def next(): A =
+        val p = MessagePack.newPacker()
+        packer(p)
+        hasNextElem = None
+        f(p.toByteArray)
+
+    end RStoMsgPackIterator
+
+  end ResultSetCodec
+
+  def toJDBCColumnCodec(sqlType: Int, typeName: String): JDBCColumnCodec =
+    typeName match
+      // workaround for sqlite-jdbc and the like, which don't carry rich JDBC types
+      case "DATE" =>
+        JDBCDateCodec
+      case "TIME" | "TIME WITH TIME ZONE" =>
+        JDBCTimeCodec
+      case "TIMESTAMP" | "TIMESTAMP WITH TIME ZONE" =>
+        JDBCTimestampCodec
+      case x if x.startsWith("DECIMAL") =>
+        JDBCDecimalCodec
+      case "BIT" =>
+        JDBCBooleanCodec
+      case _ =>
+        sqlType match
+          case Types.BIT | Types.BOOLEAN =>
+            JDBCBooleanCodec
+          case Types.TINYINT | Types.SMALLINT =>
+            JDBCShortCodec
+          case Types.INTEGER =>
+            JDBCIntCodec
+          case Types.BIGINT =>
+            JDBCLongCodec
+          case Types.REAL =>
+            JDBCFloatCodec
+          case Types.FLOAT | Types.DOUBLE =>
+            JDBCDoubleCodec
+          case Types.NUMERIC | Types.DECIMAL =>
+            JDBCStringCodec
+          case Types.CHAR | Types.VARCHAR | Types.LONGNVARCHAR | Types.SQLXML | Types.NCHAR | Types
+                .NVARCHAR | Types.CLOB | Types.ROWID =>
+            JDBCStringCodec
+          case Types.BLOB | Types.BINARY | Types.VARBINARY | Types.LONGVARBINARY =>
+            JDBCBinaryCodec
+          case Types.DATE =>
+            JDBCDateCodec
+          case Types.TIME | Types.TIME_WITH_TIMEZONE =>
+            JDBCTimeCodec
+          case Types.TIMESTAMP | Types.TIMESTAMP_WITH_TIMEZONE =>
+            JDBCTimestampCodec
+          case Types.ARRAY =>
+            JDBCArrayCodec
+          case Types.JAVA_OBJECT =>
+            JDBCJavaObjectCodec
+          case Types.NULL =>
+            JDBCNullCodec
+          case Types.OTHER =>
+            JDBCStringCodec
+          case other =>
+            warn(s"Unsupported JDBC type: ${other}. Assume string type")
+            JDBCStringCodec
+
+  /**
+    * Pack a single column value from a ResultSet row.
+    */
+  trait JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit
+
+  object JDBCBooleanCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getBoolean(colIndex)
+      if rs.wasNull() then
+        p.packNil
+      else
+        p.packBoolean(v)
+
+  object JDBCShortCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getShort(colIndex)
+      if rs.wasNull() then
+        p.packNil
+      else
+        p.packShort(v)
+
+  object JDBCIntCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getInt(colIndex)
+      if rs.wasNull() then
+        p.packNil
+      else
+        p.packInt(v)
+
+  object JDBCLongCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getLong(colIndex)
+      if rs.wasNull() then
+        p.packNil
+      else
+        p.packLong(v)
+
+  object JDBCFloatCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getFloat(colIndex)
+      if rs.wasNull() then
+        p.packNil
+      else
+        p.packFloat(v)
+
+  object JDBCDoubleCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getDouble(colIndex)
+      if rs.wasNull() then
+        p.packNil
+      else
+        p.packDouble(v)
+
+  /** Decimal/Numeric → string preserves precision across drivers. */
+  object JDBCDecimalCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getBigDecimal(colIndex)
+      if rs.wasNull() || v == null then
+        p.packNil
+      else
+        p.packString(v.toString)
+
+  object JDBCStringCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getString(colIndex)
+      if rs.wasNull() || v == null then
+        p.packNil
+      else
+        p.packString(v)
+
+  object JDBCBinaryCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getBytes(colIndex)
+      if rs.wasNull() || v == null then
+        p.packNil
+      else
+        p.packBinaryHeader(v.length)
+        p.writePayload(v)
+
+  object JDBCDateCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getDate(colIndex)
+      if rs.wasNull() || v == null then
+        p.packNil
+      else
+        p.packString(v.toString)
+
+  object JDBCTimeCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getTime(colIndex)
+      if rs.wasNull() || v == null then
+        p.packNil
+      else
+        p.packString(v.toString)
+
+  object JDBCTimestampCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getTimestamp(colIndex)
+      if rs.wasNull() || v == null then
+        p.packNil
+      else
+        p.packString(v.toString)
+
+  object JDBCArrayCodec extends JDBCColumnCodec with LogSupport:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val v = rs.getArray(colIndex)
+      if rs.wasNull() || v == null then
+        p.packNil
+      else
+        packJavaSqlArray(p, v)
+
+    private def packJavaSqlArray(p: Packer, v: java.sql.Array): Unit =
+      val arr: AnyRef = v.getArray
+      arr match
+        case a: Array[String] =>
+          p.packArrayHeader(a.length)
+          a.foreach(s =>
+            if s == null then
+              p.packNil
+            else
+              p.packString(s)
+          )
+        case a: Array[Int] =>
+          p.packArrayHeader(a.length)
+          a.foreach(p.packInt(_))
+        case a: Array[Short] =>
+          p.packArrayHeader(a.length)
+          a.foreach(p.packShort(_))
+        case a: Array[Long] =>
+          p.packArrayHeader(a.length)
+          a.foreach(p.packLong(_))
+        case a: Array[Char] =>
+          p.packArrayHeader(a.length)
+          a.foreach(c => p.packString(c.toString))
+        case a: Array[Byte] =>
+          p.packBinaryHeader(a.length)
+          p.writePayload(a)
+        case a: Array[Float] =>
+          p.packArrayHeader(a.length)
+          a.foreach(p.packFloat(_))
+        case a: Array[Double] =>
+          p.packArrayHeader(a.length)
+          a.foreach(p.packDouble(_))
+        case a: Array[Boolean] =>
+          p.packArrayHeader(a.length)
+          a.foreach(p.packBoolean(_))
+        case a: Array[?] =>
+          p.packArrayHeader(a.length)
+          a.foreach(packAnyRef(p, _))
+        case other =>
+          throw UnsupportedOperationException(
+            s"Reading array type of ${arr.getClass} is not supported: ${arr}"
+          )
+      end match
+
+    end packJavaSqlArray
+
+    private def packAnyRef(p: Packer, v: Any): Unit =
+      v match
+        case null =>
+          p.packNil
+        case s: String =>
+          p.packString(s)
+        case b: Boolean =>
+          p.packBoolean(b)
+        case b: java.lang.Boolean =>
+          p.packBoolean(b.booleanValue)
+        case n: Byte =>
+          p.packByte(n)
+        case n: Short =>
+          p.packShort(n)
+        case n: Int =>
+          p.packInt(n)
+        case n: Long =>
+          p.packLong(n)
+        case n: Float =>
+          p.packFloat(n)
+        case n: Double =>
+          p.packDouble(n)
+        case n: java.lang.Number =>
+          p.packString(n.toString)
+        case bs: Array[Byte] =>
+          p.packBinaryHeader(bs.length)
+          p.writePayload(bs)
+        case other =>
+          // Last-resort: stringify. Matches airframe's JDBCJavaObjectCodec behaviour.
+          p.packString(other.toString)
+
+  end JDBCArrayCodec
+
+  object JDBCJavaObjectCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit =
+      val obj = rs.getObject(colIndex)
+      if rs.wasNull() || obj == null then
+        p.packNil
+      else
+        p.packString(obj.toString)
+
+  object JDBCNullCodec extends JDBCColumnCodec:
+    def pack(p: Packer, rs: ResultSet, colIndex: Int): Unit = p.packNil
+
+end JDBCCodec

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/snowflake/SnowflakeConnectorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/snowflake/SnowflakeConnectorTest.scala
@@ -14,9 +14,9 @@
 package wvlet.lang.runner.connector.snowflake
 
 import wvlet.airframe.Design
-import wvlet.airframe.codec.JDBCCodec.ResultSetCodec
 import wvlet.airspec.AirSpec
 import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.runner.codec.JDBCCodec.ResultSetCodec
 
 /**
   * Tests for SnowflakeConnector

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/CustomMemoryPlugin.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/CustomMemoryPlugin.scala
@@ -25,14 +25,14 @@ import io.trino.spi.connector.*
 import io.trino.spi.function.FunctionProvider
 import io.trino.spi.function.table.ReturnTypeSpecification.DescribedTable
 import io.trino.spi.function.table.*
-import wvlet.airframe.codec.JDBCCodec.ResultSetCodec
-import wvlet.airframe.codec.MessageCodec
-import wvlet.airframe.msgpack.spi.MessagePack
 import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.runner.codec.JDBCCodec.ResultSetCodec
 import wvlet.lang.runner.connector.duckdb.DuckDBConnector
 import wvlet.lang.runner.connector.trino.DuckDBSQLFunction.DuckDBFunctionHandle
 import wvlet.lang.runner.connector.trino.DuckDBSQLFunction.DuckDBQuerySplit
 import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
@@ -389,7 +389,7 @@ object DuckDBSQLFunction extends ConnectorTableFunction with LogSupport:
             debug(s"column types: ${types}")
 
             val json    = ResultSetCodec(rs).toJson
-            val records = MessageCodec.of[Seq[ListMap[String, Any]]].fromJson(json)
+            val records = summon[Weaver[Seq[ListMap[String, Any]]]].fromJson(json)
             debug(s"=== ${records}")
             toPage(columnNames.toIndexedSeq, types.toIndexedSeq, records)
           }

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TableFunctionTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TableFunctionTest.scala
@@ -1,6 +1,6 @@
 package wvlet.lang.runner.connector.trino
 
-import wvlet.airframe.codec.JDBCCodec.ResultSetCodec
+import wvlet.lang.runner.codec.JDBCCodec.ResultSetCodec
 import wvlet.airspec.AirSpec
 
 class TableFunctionTest extends AirSpec:

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TrinoConnectorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TrinoConnectorTest.scala
@@ -14,8 +14,8 @@
 package wvlet.lang.runner.connector.trino
 
 import wvlet.airframe.Design
-import wvlet.airframe.codec.JDBCCodec
-import wvlet.airframe.codec.JDBCCodec.ResultSetCodec
+import wvlet.lang.runner.codec.JDBCCodec
+import wvlet.lang.runner.codec.JDBCCodec.ResultSetCodec
 import wvlet.airframe.control.Control
 import wvlet.airframe.control.Control.withResource
 import wvlet.airspec.AirSpec


### PR DESCRIPTION
## Summary

Removes the last airframe-codec usage in wvlet-runner. JDBC \`ResultSet\` → MsgPack conversion is database-specific (DuckDB / Trino / Snowflake / future Databricks each return slightly different shapes for the same JDBC type), so the codec lives next to the connectors in wvlet-runner rather than in uni — see [wvlet/uni#510](https://github.com/wvlet/uni/issues/510) for the decision.

## Port

New file: \`wvlet-runner/src/main/scala/wvlet/lang/runner/codec/JDBCCodec.scala\`

- Ported from \`wvlet.airframe.codec.JDBCCodec\`, written against uni's \`Packer\` / \`MessagePack\` / \`JSONWeaver\` instead of airframe's \`PrimitiveCodec.*\` and airframe-msgpack.
- Dropped the \`unpack\`/\`MessageContext\` halves of the per-type codecs — wvlet only encodes (\`ResultSet\` → MsgPack → \`ListMap[String, Any]\` via \`Weaver\`).
- Inlined primitive packing (\`p.packInt(v)\` etc.) instead of going through airframe's \`BooleanCodec\` / \`IntCodec\` / … indirection.
- \`toJson\` now delegates to \`JSONWeaver.unweave(msgpack)\` instead of \`JSONCodec.toJson\`.
- Trimmed \`JDBCArrayCodec\`'s fallback case to one \`packAnyRef\` helper that matches airframe's per-element behaviour (string / numeric primitives / byte array; everything else stringified, matching \`JDBCJavaObjectCodec\`).

## Callsite swaps

- \`wvlet-runner/.../QueryExecutor.scala\` — import swap.
- \`wvlet-runner/test/.../trino/{TrinoConnectorTest, TableFunctionTest, CustomMemoryPlugin}.scala\` and \`snowflake/SnowflakeConnectorTest.scala\` — import swaps.
- \`CustomMemoryPlugin\`'s \`MessageCodec.of[Seq[ListMap[String, Any]]].fromJson(json)\` → \`summon[Weaver[Seq[ListMap[String, Any]]]].fromJson(json)\` with \`import PrimitiveWeaver.given\`.

## build.sbt

- Drop \`\"org.wvlet.airframe\" %% \"airframe-launcher\"\` from runner — runner has no source reference to airframe-launcher (cli still uses it directly; this doesn't affect cli's classpath).

## Outstanding

- Gap F (uni-launcher + airframe-http \"Missing controller\") still parks the wvlet-cli launcher swap — separate workstream.
- airframe-codec / airframe-msgpack still appear on wvlet-runner's transitive classpath via cli's airframe-launcher dep, but no wvlet-runner source references them.

## Test plan

- [x] \`./sbt projectJVM/Test/compile\` — green
- [x] \`./sbt cli/test\` — 81/81
- [x] \`./sbt \"runner/testOnly *RunnerSpecBasic\"\` — 122/122 (1 pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)