### PR TITLE
fix: Disable release-drafter releaser in PR labeler workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,8 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+# Releases are produced by .github/workflows/release.yml; this config is only
+# used by the autolabeler in .github/workflows/issue-labeler.yml.
+disable-releaser: true
 categories:
   - title: '🔥 Breaking Changes'
     labels:

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -23,5 +23,7 @@ jobs:
     steps:
       # Runs only pull-request labeler
       - uses: release-drafter/release-drafter@v7
+        with:
+          disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -21,9 +21,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # Runs only pull-request labeler
+      # Runs only pull-request labeler. Releaser is disabled via
+      # disable-releaser in .github/release-drafter.yml (releases are
+      # produced separately by .github/workflows/release.yml).
       - uses: release-drafter/release-drafter@v7
-        with:
-          disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The `Update PR labels` job in `.github/workflows/issue-labeler.yml` has been failing on every PR with:

```
##[error]Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
```

Example failure: https://github.com/wvlet/wvlet/actions/runs/25085829453

### Root cause

`release-drafter/release-drafter@v7` runs both autolabeling **and** draft-release creation by default. Creating releases requires `contents: write`, but the workflow intentionally grants only `pull-requests: write` (its comment said *"Runs only pull-request labeler"*). So the autolabel step succeeds, then the implicit draft-release step fails — failing the whole workflow. Releases are produced separately by `.github/workflows/release.yml` (via `gh release create`), so this workflow truly should only autolabel.

### Fix

Set `disable-releaser: true` in `.github/release-drafter.yml`. This is a release-drafter config-file option (not an action input — I tried `with: disable-releaser: true` first and the action emitted `Unexpected input(s) 'disable-releaser'` and still ran the releaser).

### Note on verification

release-drafter fetches its config from the repo's default branch (`main`) via the GitHub API, **not** from the PR checkout. That means the config change cannot be exercised by this PR's own labeler run — `Update PR labels` will continue failing here, and only stop failing on PRs opened after this merges.

## Test plan

- [ ] After merge, the next dependabot/feature PR should show the `Update PR labels` check passing.
- [ ] Autolabels (e.g. `bug`, `internal`, `dependencies`) should still be applied based on the rules in `.github/release-drafter.yml`.
- [ ] Tag-triggered runs of `release.yml` (the actual release pipeline) are unaffected — they don't use release-drafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)