### PR TITLE
fix: Use release-drafter autolabeler sub-action for PR labeling

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,8 +1,8 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-# Releases are produced by .github/workflows/release.yml; this config is only
-# used by the autolabeler in .github/workflows/issue-labeler.yml.
-disable-releaser: true
+# This config is consumed by the autolabeler in
+# .github/workflows/issue-labeler.yml. Actual releases are produced by
+# .github/workflows/release.yml.
 categories:
   - title: '🔥 Breaking Changes'
     labels:

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -21,9 +21,11 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # Runs only pull-request labeler. Releaser is disabled via
-      # disable-releaser in .github/release-drafter.yml (releases are
-      # produced separately by .github/workflows/release.yml).
-      - uses: release-drafter/release-drafter@v7
+      # Use the dedicated autolabeler sub-action. The top-level
+      # release-drafter/release-drafter@v7 action is the drafter (creates
+      # GitHub releases) and requires contents: write; we only want
+      # autolabeling here. Releases are produced by
+      # .github/workflows/release.yml.
+      - uses: release-drafter/release-drafter/autolabeler@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to #1643. That PR tried to disable the releaser via a `disable-releaser: true` config option, but in release-drafter v7 that key is **not honored** — the drafter still calls the create-release API and fails with `Resource not accessible by integration` because the workflow only grants `pull-requests: write`.

Verified post-merge of #1643 on a rerun of the labeler:

```
Config fetched on remote "wvlet/wvlet@refs/heads/main".
Creating new release...
##[error]Resource not accessible by integration
```

So even though the config change landed on `main`, the labeler kept failing.

### Real fix

In v7, release-drafter ships a dedicated autolabeler sub-action: `release-drafter/release-drafter/autolabeler@v7`. Its description: *"Automatically labels pull requests based on your configuration."* It only writes labels — no release-creation step, no `contents: write` requirement.

This PR:
- Switches `.github/workflows/issue-labeler.yml` to the autolabeler sub-action.
- Removes the now-unused `disable-releaser: true` from `.github/release-drafter.yml` (the v7 drafter doesn't read it; the autolabeler doesn't need it).

### Verification

The PR's own `pull_request` labeler run **passes** with the new sub-action — log shows `Running for event "pull_request.opened"` and `Found label for title: 'bug'`, no release-creation attempt.

The `pull_request_target` labeler still fails on this PR, because GitHub runs `pull_request_target` workflows from the **base ref** (`main`) for security — so it executes the old workflow file with the drafter. After merge, both events run the new workflow and both should pass on subsequent PRs.

Tag-triggered release behavior (`.github/workflows/release.yml` → `gh release create`) is unaffected.

## Test plan

- [x] `pull_request` labeler passes on this PR (autolabeler sub-action, no release attempt).
- [ ] After merge, `pull_request_target` labeler also passes on subsequent PRs.
- [ ] Autolabels (`bug`, `internal`, `dependencies`, etc.) still applied per `.github/release-drafter.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)