### PR TITLE
internal: Migrate wvlet-cli launcher imports to uni

### DIFF
--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
@@ -1,7 +1,7 @@
 package wvlet.lang.cli
 
-import wvlet.airframe.launcher.argument
-import wvlet.airframe.launcher.option
+import wvlet.uni.cli.launcher.argument
+import wvlet.uni.cli.launcher.option
 import wvlet.uni.control.Control
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.v1.query.QuerySelection

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletGlobalOption.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletGlobalOption.scala
@@ -1,15 +1,13 @@
 package wvlet.lang.cli
 
-import wvlet.airframe.launcher.option
 import wvlet.lang.BuildInfo
 import wvlet.lang.api.StatusCode
+import wvlet.uni.cli.launcher.option
 import wvlet.uni.log.LogLevel
 import wvlet.uni.log.LogSupport
 import wvlet.uni.log.Logger
 
 case class WvletGlobalOption(
-    @option(prefix = "-h,--help", description = "Display help message", isHelp = true)
-    displayHelp: Boolean = false,
     @option(prefix = "--version", description = "Display the version")
     displayVersion: Boolean = false,
     @option(prefix = "--debug", description = "Enable debug log")

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletMain.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletMain.scala
@@ -1,7 +1,7 @@
 package wvlet.lang.cli
 
-import wvlet.airframe.launcher.Launcher
-import wvlet.airframe.launcher.command
+import wvlet.uni.cli.launcher.Launcher
+import wvlet.uni.cli.launcher.command
 import wvlet.uni.design.Design
 import wvlet.lang.BuildInfo
 import wvlet.lang.api.WvletLangException

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletREPLMain.scala
@@ -1,9 +1,9 @@
 package wvlet.lang.cli
 
-import wvlet.airframe.launcher.Launcher
-import wvlet.airframe.launcher.argument
-import wvlet.airframe.launcher.command
-import wvlet.airframe.launcher.option
+import wvlet.uni.cli.launcher.Launcher
+import wvlet.uni.cli.launcher.argument
+import wvlet.uni.cli.launcher.command
+import wvlet.uni.cli.launcher.option
 import wvlet.uni.design.Design
 import wvlet.lang.api.StatusCode.SYNTAX_ERROR
 import wvlet.lang.api.StatusCode


### PR DESCRIPTION
## Summary

Closes **Gap F**. Swaps \`wvlet.airframe.launcher.*\` → \`wvlet.uni.cli.launcher.*\` in the four wvlet-cli files that were pinned to airframe in #1635.

- \`WvletMain.scala\` — \`Launcher\`, \`@command\`
- \`WvletREPLMain.scala\` — \`Launcher\`, \`@command\`, \`@option\`, \`@argument\`
- \`WvletCompiler.scala\` — \`@option\`, \`@argument\`
- \`WvletGlobalOption.scala\` — \`@option\`. Drops the \`displayHelp\` field with \`isHelp = true\` — uni's launcher treats \`-h\`/\`--help\` as built-in via \`LauncherConfig.helpPrefixes\`, so no field is needed.

## Why now

Gap F was the \"Missing controller. Add FrontendApiImpl to the design\" failure inside \`AirframeSession.init\` when \`WvletMain.ui\` was invoked via uni-launcher (uni 2026.1.5). The failure does **not reproduce** against uni 2026.1.6, which has both the launcher fix from uni#512 (Gap D) and the abstract-type Weaver fallback from uni#513 (Gap C). I re-applied the swap on a fresh branch off \`origin/main\` and ran \`cli/test\` — all 81 tests pass, including \`WvletMainTest.\"start server test\"\` which previously triggered the NPE → \"Missing controller\" cascade.

This finishes the wvlet-cli migration. wvlet-cli is now zero-airframe.

## Test plan

- [x] \`./sbt projectJVM/Test/compile\` — green
- [x] \`./sbt cli/test\` — 81/81 (incl. \`start server test\`)
- [x] \`./sbt \"runner/testOnly *RunnerSpecBasic\"\` — 122/122 (1 pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)