### PR TITLE
internal: Migrate wvc + wvlet-sdk-js MessageCodec to Weaver

### DIFF
--- a/wvc/src/main/scala/wvlet/lang/native/WvcLib.scala
+++ b/wvc/src/main/scala/wvlet/lang/native/WvcLib.scala
@@ -1,7 +1,8 @@
 package wvlet.lang.native
 
-import wvlet.airframe.codec.MessageCodec
 import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.api.SourceLocation
 import wvlet.lang.api.LinePosition
@@ -38,7 +39,7 @@ object WvcLib extends LogSupport:
   def compile_main(argJson: CString): Int =
     try
       val json = fromCString(argJson)
-      val args = MessageCodec.of[Array[String]].fromJson(json)
+      val args = summon[Weaver[Array[String]]].fromJson(json)
       WvcMain.main(args)
       0
     catch
@@ -57,7 +58,7 @@ object WvcLib extends LogSupport:
   def compile_query(argJson: CString): CString =
     try
       val json     = fromCString(argJson)
-      val args     = MessageCodec.of[Array[String]].fromJson(json)
+      val args     = summon[Weaver[Array[String]]].fromJson(json)
       val (sql, _) = WvcMain.compileWvletQuery(args)
       toCString(sql)
     catch
@@ -79,7 +80,7 @@ object WvcLib extends LogSupport:
   def compile_query_json(argJson: CString): CString =
     try
       val json = fromCString(argJson)
-      val args = MessageCodec.of[Array[String]].fromJson(json)
+      val args = summon[Weaver[Array[String]]].fromJson(json)
 
       val response =
         try
@@ -119,7 +120,7 @@ object WvcLib extends LogSupport:
             CompileResponse(success = false, error = Some(error))
 
       // Convert response to JSON
-      val responseJson = MessageCodec.of[CompileResponse].toJson(response)
+      val responseJson = Weaver.of[CompileResponse].toJson(response)
       toCString(responseJson)
     catch
       case e: Throwable =>
@@ -137,7 +138,7 @@ object WvcLib extends LogSupport:
           )
         )
         // Use MessageCodec for consistent JSON formatting
-        val errorJson = MessageCodec.of[CompileResponse].toJson(errorResponse)
+        val errorJson = Weaver.of[CompileResponse].toJson(errorResponse)
         toCString(errorJson)
 
 end WvcLib

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -2,7 +2,6 @@ package wvlet.lang.sdk.js
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.*
-import wvlet.airframe.codec.MessageCodec
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Compiler
 import wvlet.lang.compiler.CompilerOptions
@@ -19,6 +18,8 @@ import wvlet.lang.api.v1.compile.ErrorLocation
 import wvlet.lang.BuildInfo
 import wvlet.lang.compiler.parser.ParserPhase
 import wvlet.lang.model.plan.*
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import scala.collection.mutable.ListBuffer
 
@@ -41,7 +42,7 @@ object WvletJS:
   @JSExport
   def compile(query: String, options: String = "{}"): String =
     try
-      val opts = MessageCodec.of[CompileOptions].fromJson(options)
+      val opts = Weaver.of[CompileOptions].fromJson(options)
 
       // Create compiler with options
       val targetDB =
@@ -69,7 +70,7 @@ object WvletJS:
 
       val response = CompileResponse(success = true, sql = Some(sql))
 
-      MessageCodec.of[CompileResponse].toJson(response)
+      Weaver.of[CompileResponse].toJson(response)
     catch
       case e: WvletLangException =>
         val locationOpt =
@@ -98,7 +99,7 @@ object WvletJS:
 
         val response = CompileResponse(success = false, error = Some(error))
 
-        MessageCodec.of[CompileResponse].toJson(response)
+        Weaver.of[CompileResponse].toJson(response)
 
       case e: Throwable =>
         val error = CompileError(
@@ -108,7 +109,7 @@ object WvletJS:
 
         val response = CompileResponse(success = false, error = Some(error))
 
-        MessageCodec.of[CompileResponse].toJson(response)
+        Weaver.of[CompileResponse].toJson(response)
 
   /**
     * Get the version of the Wvlet compiler
@@ -178,7 +179,8 @@ object WvletJS:
           )
     end try
 
-    MessageCodec.of[List[LspDiagnostic]].toJson(diagnostics.toList)
+    given Weaver[LspDiagnostic] = Weaver.of[LspDiagnostic]
+    summon[Weaver[List[LspDiagnostic]]].toJson(diagnostics.toList)
 
   end analyzeDiagnostics
 
@@ -243,7 +245,8 @@ object WvletJS:
 
     extractSymbols(inputUnit.unresolvedPlan)
 
-    MessageCodec.of[List[LspSymbol]].toJson(symbols.toList)
+    given Weaver[LspSymbol] = Weaver.of[LspSymbol]
+    summon[Weaver[List[LspSymbol]]].toJson(symbols.toList)
 
   end getDocumentSymbols
 


### PR DESCRIPTION
## Summary

Drops the last airframe-codec usage in **wvc** (Scala Native) and **wvlet-sdk-js** (Scala.js).

### \`WvcLib.scala\`
- \`MessageCodec.of[Array[String]]\` → \`summon[Weaver[Array[String]]]\` (uses \`PrimitiveWeaver.given\` for \`Array\` support)
- \`MessageCodec.of[CompileResponse]\` → \`Weaver.of[CompileResponse]\`

### \`WvletJS.scala\`
- \`MessageCodec.of[CompileOptions]\` → \`Weaver.of[CompileOptions]\`
- \`MessageCodec.of[CompileResponse]\` → \`Weaver.of[CompileResponse]\`
- \`MessageCodec.of[List[LspDiagnostic]]\` → \`summon[…]\` with explicit \`given Weaver[LspDiagnostic] = Weaver.of[LspDiagnostic]\` (collection codec needs a per-element Weaver)
- \`MessageCodec.of[List[LspSymbol]]\` → same pattern

## Not in scope: wvlet-labs

\`wvlet-labs/.../ParseQuery.scala\` is intentionally **not** migrated — it depends on \`wvlet.airframe.control.Parallel\` (no uni equivalent), plus \`airframe-launcher\` and metrics. Will revisit if uni gains \`Parallel\` or if labs is dropped from the codebase.

## Test plan

- [x] \`./sbt projectJVM/Test/compile\` — green
- [x] \`./sbt projectJS/Test/compile\` — green
- [x] \`./sbt projectNative/Test/compile\` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)