### PR TITLE
internal: Migrate wvlet-server utility imports to uni

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,8 @@ lazy val api = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     libraryDependencies ++=
       Seq(
         "org.wvlet.airframe" %%% "airframe-http"    % AIRFRAME_VERSION,
-        "org.wvlet.airframe" %%% "airframe-metrics" % AIRFRAME_VERSION
+        "org.wvlet.airframe" %%% "airframe-metrics" % AIRFRAME_VERSION,
+        "org.wvlet.uni"      %%% "uni"              % UNI_VERSION
       )
   )
 

--- a/wvlet-server/src/main/scala/wvlet/lang/server/FrontendApiImpl.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/FrontendApiImpl.scala
@@ -1,12 +1,11 @@
 package wvlet.lang.server
 
-import wvlet.airframe.metrics.ElapsedTime
-import wvlet.airframe.ulid.ULID
 import wvlet.lang.api.v1.frontend.FrontendApi.*
 import wvlet.lang.api.v1.io.FileEntry
 import wvlet.lang.api.v1.query.QueryInfo
 import wvlet.lang.api.v1.query.QueryRequest
 import wvlet.lang.api.v1.frontend.FrontendApi
+import wvlet.airframe.metrics.ElapsedTime
 import wvlet.lang.compiler.WorkEnv
 import wvlet.uni.log.LogSupport
 

--- a/wvlet-server/src/main/scala/wvlet/lang/server/QueryService.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/QueryService.scala
@@ -1,7 +1,5 @@
 package wvlet.lang.server
 
-import wvlet.airframe.control.ThreadUtil
-import wvlet.airframe.ulid.ULID
 import wvlet.lang.api.SourceLocation
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
@@ -17,8 +15,10 @@ import wvlet.lang.api.v1.query.QueryStatus.RUNNING
 import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.runner.QueryExecutor
 import wvlet.lang.runner.WvletScriptRunner
+import wvlet.airframe.ulid.ULID
 import wvlet.lang.runner.connector.DBConnector
 import wvlet.uni.log.LogSupport
+import wvlet.uni.util.ThreadUtil
 
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap

--- a/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
@@ -2,16 +2,10 @@ package wvlet.lang.server
 
 import org.jline.nativ.OSInfo
 import wvlet.airframe.Design
-import wvlet.airframe.control.Control.withResource
-import wvlet.airframe.control.Control
-import wvlet.airframe.control.Shell
 import wvlet.airframe.http.netty.Netty
 import wvlet.airframe.http.netty.NettyServer
 import wvlet.airframe.http.Http
 import wvlet.airframe.http.RxRouter
-import wvlet.airframe.launcher.Launcher
-import wvlet.airframe.launcher.command
-import wvlet.airframe.launcher.option
 import wvlet.lang.api.v1.frontend.FrontendRPC
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.OS
@@ -21,6 +15,10 @@ import wvlet.lang.runner.connector.DBConnector
 import wvlet.lang.runner.connector.DBConnectorProvider
 import wvlet.lang.runner.QueryExecutor
 import wvlet.lang.runner.WvletScriptRunnerConfig
+import wvlet.uni.cli.launcher.option
+import wvlet.uni.control.Control
+import wvlet.uni.control.Control.withResource
+import wvlet.uni.io.IO
 import wvlet.uni.log.LogSupport
 import wvlet.log.io.IOUtil
 
@@ -67,7 +65,7 @@ object WvletServer extends LogSupport:
         warn(s"--quit-immediately is set. The server will quit immediately after starting.")
         if OS.isMacOS && openBrowser then
           // Open the web browser
-          Shell.exec(s"open http://localhost:${config.port}")
+          IO.run(s"open http://localhost:${config.port}")
         server.awaitTermination()
     }
 

--- a/wvlet-server/src/main/scala/wvlet/lang/server/WvletServerMain.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/WvletServerMain.scala
@@ -1,10 +1,8 @@
 package wvlet.lang.server
 
-import wvlet.airframe.http.netty.NettyServer
-import wvlet.airframe.launcher.Launcher
-import wvlet.airframe.launcher.command
-import wvlet.airframe.launcher.option
 import wvlet.lang.compiler.WorkEnv
+import wvlet.uni.cli.launcher.Launcher
+import wvlet.uni.cli.launcher.command
 import wvlet.uni.log.LogLevel
 import wvlet.uni.log.LogSupport
 


### PR DESCRIPTION
## Summary

Easy-swap migration for **wvlet-server**: \`control\` / \`launcher\` / \`Shell\` → uni equivalents. Same pattern shipped for wvlet-cli (#1651) and wvlet-runner (#1635, #1641, #1642).

### \`WvletServer.scala\`
- \`wvlet.airframe.control.{Control, Control.withResource}\` → \`wvlet.uni.control.*\`
- \`wvlet.airframe.control.Shell.exec(cmd)\` → \`wvlet.uni.io.IO.run(cmd)\`
- \`wvlet.airframe.launcher.option\` → \`wvlet.uni.cli.launcher.option\`
- Drop dead \`Launcher\` / \`command\` imports

### \`WvletServerMain.scala\`
- \`wvlet.airframe.launcher.{Launcher, command}\` → \`wvlet.uni.cli.launcher.*\`
- Drop dead \`NettyServer\` / \`option\` imports

### \`QueryService.scala\`
- \`wvlet.airframe.control.ThreadUtil\` → \`wvlet.uni.util.ThreadUtil\`

### \`build.sbt\`
- Add \`uni\` dep to the \`wvlet-api\` crossProject (was airframe-only)

## Not in scope — for the upcoming airframe-http migration PR

- \`airframe.Design\` — coupled to \`airframe-http-netty\`'s \`Netty.server.design\`
- \`airframe.http.{RxRouter, Http, netty.{Netty, NettyServer}}\`
- \`airframe.ulid.ULID\` and \`airframe.metrics.ElapsedTime\` in wvlet-api types (\`FrontendApi.QueryInfoRequest\`, \`ServerStatus.upTime\`) — wire-typed by the airframe-http RPC codegen, must stay airframe until the whole RPC chain moves
- \`airframe.http.StaticContent\` (\`StaticContentApi\`)
- \`log.io.IOUtil.unusedPort\` in \`WvletServer.testDesign\`

## Test plan

- [x] \`./sbt projectJVM/Test/compile\` — green
- [x] \`./sbt projectJS/Test/compile\` — green
- [x] \`./sbt projectNative/Test/compile\` — green
- [x] \`./sbt server/test\` — 6/6
- [x] \`./sbt cli/test\` — 81/81

🤖 Generated with [Claude Code](https://claude.com/claude-code)