### PR TITLE
build(deps): Bump uni to 2026.1.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scala.scalanative.build.Mode
 import scala.scalanative.build.NativeConfig
 
 val AIRFRAME_VERSION = "2026.1.6"
-val UNI_VERSION      = "2026.1.7"
+val UNI_VERSION      = "2026.1.8"
 
 val AIRSPEC_VERSION        = AIRFRAME_VERSION
 val TRINO_VERSION          = "476"


### PR DESCRIPTION
## Summary

Pulls in the rx-html-related fixes from uni 2026.1.8.

## Test plan

- [x] `./sbt projectJVM/Test/compile`, `projectJS/Test/compile`, `projectNative/Test/compile` — green
- [x] `./sbt server/test` — 7/7 passed (Netty + RPC round-trip incl. `uni.ULID` regression test from #1663)
- [x] `./sbt uiMain/Test/compile` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)