### PR TITLE
internal: Migrate StaticContent + wvlet-http-server deps to uni HTTP types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -446,9 +446,10 @@ lazy val sdkJs = project
   )
   .dependsOn(lang.js)
 
-// JVM-only host for the airframe-http server runtime that wvlet is vendoring in.
-// Files here are ported verbatim from airframe and migrated to uni HTTP types
-// across phases 1–3 of #1662; consumers (wvlet-server) switch over in phase 2.
+// JVM-only host for HTTP server bits that wvlet maintains. Hosts the few
+// pieces uni doesn't ship (e.g. StaticContent) and re-exports uni-netty as a
+// transitive runtime for downstream modules. Part of the airframe→uni
+// migration in #1662 (wvlet-server consumers move over in subsequent PRs).
 lazy val httpServer = project
   .in(file("wvlet-http-server"))
   .settings(
@@ -456,8 +457,8 @@ lazy val httpServer = project
     name := "wvlet-http-server",
     libraryDependencies ++=
       Seq(
-        "org.wvlet.airframe" %% "airframe-http" % AIRFRAME_VERSION,
-        "org.wvlet.uni"      %% "uni"           % UNI_VERSION
+        "org.wvlet.uni" %% "uni"       % UNI_VERSION,
+        "org.wvlet.uni" %% "uni-netty" % UNI_VERSION
       )
   )
 

--- a/plans/2026-05-03-airframe-http-server-to-uni-migration.md
+++ b/plans/2026-05-03-airframe-http-server-to-uni-migration.md
@@ -330,3 +330,65 @@ In the `wvlet/airframe` repository (sources to port):
 
 - `airframe-http-netty/src/main/scala/wvlet/airframe/http/netty/NettyServer.scala`
 - `airframe-http/.jvm/src/main/scala/wvlet/airframe/http/router/HttpRequestDispatcher.scala`
+
+## 7. Major course correction (2026-05-03)
+
+**Critical revision: uni already ships the full HTTP server runtime.**
+The Section 1 / Phase 1b–1d plan to port ~3.3k LOC of airframe-http
+into `wvlet.lang.http.server.*` is **abandoned**. Inspecting Maven
+Central revealed:
+
+- `uni-netty_3` (2026.1.8) publishes a complete Netty server runtime —
+  `NettyServer`, `NettyServerConfig`, `NettyHttpServer`,
+  `RouterHandler`, `RxHttpHandler`, `RxHttpFilter`, `RPCHandler`,
+  `NettyRequestHandler`.
+- `uni_3` already ships the full router stack
+  (`Router, Route, RouteMatcher, RxRouter, RxRouterProvider,
+  ControllerProvider, HttpRequestMapper, ResponseConverter,
+  RouterMacros`) and the full RPC stack (`RPCStatus, RPCException,
+  RPCRoute, RPCRouter, RPCClient, MethodCodec`).
+
+Two simplifying findings the user surfaced:
+
+1. **No `@RPC` annotation needed.** uni's `RPCRouter.of[T]` scans a
+   service trait via Surface; no annotation is required. So the
+   migration drops `wvlet.airframe.http.RPC` from `FrontendApi` /
+   `FileApi` rather than vendor-or-substitute.
+2. **airframe's `Netty.server.withRouter(...).design.bindXxx` chain
+   is just sugar for a regular `Design`.** uni-netty exposes
+   `NettyServerConfig` directly; equivalent wvlet code constructs the
+   config and binds it via uni's `Design` plus lifecycle hooks.
+3. **Codegen.** uni publishes `sbt-uni_sbt2_3` (sbt 2.x) with HTTP
+   codegen. wvlet currently uses sbt 1.11.1, so adopting the uni
+   codegen plugin is gated on a separate sbt 1→2 migration —
+   investigate before Phase 4.
+
+### Revised phase plan
+
+Each phase is one PR. The remaining work shrinks dramatically.
+
+- **Phase 1b (this PR).** Re-vendor `StaticContent` against uni HTTP
+  types (`wvlet.uni.http.{Response, HttpStatus, HttpHeader}`,
+  `wvlet.uni.control.{Control, IO}`, `wvlet.uni.log.LogSupport`).
+  Replace airframe's `wvlet.log.io.Resource.find` with classloader
+  `getResource`. Drop `airframe-http` from `wvlet-http-server` deps;
+  add `uni-netty`. Update `StaticContentTest` to `UniTest` +
+  `wvlet.uni.http.HttpStatus`. Replace literal NUL byte with
+  `path.indexOf(0) >= 0` (avoids any unicode-escape preprocessing
+  that would re-introduce a NUL byte at compile time, while still
+  catching path-null injection).
+- **Phase 2.** Migrate `wvlet-server/WvletServer.scala` and
+  `StaticContentApi.scala` to uni `NettyServer` + uni router/Design.
+  Translate the `Netty.server.withRouter(rxRouter).design...` chain
+  into `Design.newDesign.bindInstance[NettyServerConfig](...)` plus
+  uni-netty lifecycle wiring. Migrate `wvlet-ui-main/WvletUIMain.Http`
+  import. Drop `airframe-http-netty` from `wvlet-server` deps.
+- **Phase 3.** Migrate `wvlet-api` (`FrontendApi`, `FileApi`) to uni
+  router types. Drop `@RPC` annotations entirely; let
+  `RPCRouter.of[T]` discover routes from the trait surface. Verify
+  the JS/Native cross-builds still link.
+- **Phase 4.** Switch RPC codegen from `AirframeHttpPlugin` to uni's
+  HTTP codegen. Predicated on `sbt-uni` having a sbt 1.x build, or on
+  wvlet migrating to sbt 2.x — investigate first.
+- **Phase 5.** Drop `airframe-http` and any remaining airframe HTTP
+  transitive deps from `build.sbt` once Phase 4 lands.

--- a/wvlet-http-server/src/main/scala/wvlet/lang/http/server/static/StaticContent.scala
+++ b/wvlet-http-server/src/main/scala/wvlet/lang/http/server/static/StaticContent.scala
@@ -11,18 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Ported verbatim from airframe-http/.jvm/.../wvlet/airframe/http/StaticContent.scala
-// (#1662, phase 1a). Imports still consume airframe-http types; phase 3 swaps
-// them to wvlet.uni.http.* once the rest of the server runtime is in place.
 package wvlet.lang.http.server.static
 
 import java.io.{File, IOException}
 import java.net.URL
-import wvlet.airframe.control.Control
-import wvlet.airframe.http.HttpMessage.Response
-import wvlet.airframe.http.{Http, HttpStatus}
-import wvlet.log.LogSupport
-import wvlet.log.io.{IOUtil, Resource}
+import wvlet.uni.control.{Control, IO}
+import wvlet.uni.http.{HttpHeader, HttpStatus, Response}
+import wvlet.uni.log.LogSupport
 
 import java.nio.file.Paths
 import scala.annotation.tailrec
@@ -69,9 +64,17 @@ object StaticContent extends LogSupport:
         None
 
   case class ClasspathResource(basePath: String) extends ResourceType:
-    override def find(relativePath: String): Option[URL] = Resource.find(
-      s"${basePath}/${relativePath}"
-    )
+    override def find(relativePath: String): Option[URL] =
+      // ClassLoader.getResource rejects leading slashes, so normalize the
+      // joined path to match airframe Resource.find semantics where callers
+      // could pass either "/static" or "static" or even an empty basePath.
+      val resourcePath = s"${basePath}/${relativePath}".dropWhile(_ == '/')
+      val cl           = Option(Thread.currentThread().getContextClassLoader).getOrElse(
+        getClass.getClassLoader
+      )
+      Option(cl.getResource(resourcePath)).orElse(
+        Option(getClass.getClassLoader.getResource(resourcePath))
+      )
 
   private def isSafeRelativePath(path: String): Boolean =
     @tailrec
@@ -86,7 +89,7 @@ object StaticContent extends LogSupport:
         loop(pos + 1, path.tail)
 
     // Check for null characters
-    if path.contains("\u0000") then
+    if path.indexOf(0) >= 0 then
       false
     else if path.startsWith("/") || path.isEmpty || path.contains("//") then
       false
@@ -187,21 +190,22 @@ case class StaticContent(resourcePaths: List[StaticContent.ResourceType] = List.
 
   def apply(relativePath: String): Response =
     if !isSafeRelativePath(relativePath) then
-      Http.response(HttpStatus.Forbidden_403)
+      Response(HttpStatus.Forbidden_403)
     else
       find(relativePath)
         .map { uri =>
           val mediaType = findContentType(relativePath)
           // Read the resource file as binary
           Control.withResource(uri.openStream()) { in =>
-            IOUtil.readFully(in) { content =>
-              // TODO cache control (e.g., max-age, last-updated)
-              Http.response(HttpStatus.Ok_200).withContent(content).withContentType(mediaType)
-            }
+            val content = IO.readFully(in)
+            // TODO cache control (e.g., max-age, last-updated)
+            Response(HttpStatus.Ok_200)
+              .withBytesContent(content)
+              .setHeader(HttpHeader.ContentType, mediaType)
           }
         }
         .getOrElse {
-          Http.response(HttpStatus.NotFound_404)
+          Response(HttpStatus.NotFound_404)
         }
 
 end StaticContent

--- a/wvlet-http-server/src/main/scala/wvlet/lang/http/server/static/StaticContent.scala
+++ b/wvlet-http-server/src/main/scala/wvlet/lang/http/server/static/StaticContent.scala
@@ -65,16 +65,16 @@ object StaticContent extends LogSupport:
 
   case class ClasspathResource(basePath: String) extends ResourceType:
     override def find(relativePath: String): Option[URL] =
-      // ClassLoader.getResource rejects leading slashes, so normalize the
-      // joined path to match airframe Resource.find semantics where callers
-      // could pass either "/static" or "static" or even an empty basePath.
-      val resourcePath = s"${basePath}/${relativePath}".dropWhile(_ == '/')
-      val cl           = Option(Thread.currentThread().getContextClassLoader).getOrElse(
-        getClass.getClassLoader
-      )
-      Option(cl.getResource(resourcePath)).orElse(
-        Option(getClass.getClassLoader.getResource(resourcePath))
-      )
+      // Match airframe Resource.find: callers may pass leading slashes ("/static"),
+      // trailing slashes ("static/"), or an empty basePath. ClassLoader.getResource
+      // rejects leading slashes and many loaders mishandle "//", so collapse the
+      // joined path into a clean "a/b/c" before lookup.
+      val resourcePath = s"${basePath}/${relativePath}".split("/").filter(_.nonEmpty).mkString("/")
+      val tccl         = Option(Thread.currentThread().getContextClassLoader)
+      val ownLoader    = Option(getClass.getClassLoader)
+      tccl
+        .flatMap(cl => Option(cl.getResource(resourcePath)))
+        .orElse(ownLoader.flatMap(cl => Option(cl.getResource(resourcePath))))
 
   private def isSafeRelativePath(path: String): Boolean =
     @tailrec

--- a/wvlet-http-server/src/test/scala/wvlet/lang/http/server/static/StaticContentTest.scala
+++ b/wvlet-http-server/src/test/scala/wvlet/lang/http/server/static/StaticContentTest.scala
@@ -13,15 +13,14 @@
  */
 package wvlet.lang.http.server.static
 
-import wvlet.airframe.http.HttpStatus
-import wvlet.airspec.AirSpec
+import wvlet.uni.http.HttpStatus
+import wvlet.uni.test.UniTest
 
 /**
-  * Unit-level smoke test for the verbatim port from airframe (#1662 phase 1a). Exercises the helper
-  * directly — Netty-backed integration tests live in the airframe source and are deferred until
-  * later phases of #1662.
+  * Smoke test for the static-content helper. Exercises the StaticContent helper directly via
+  * classpath lookup; Netty-backed integration is covered by uni-netty.
   */
-class StaticContentTest extends AirSpec:
+class StaticContentTest extends UniTest:
 
   // Resolve via classpath so the test runs from any working directory and
   // doesn't fail on Windows checkouts where text fixtures may be CRLF-converted.
@@ -31,8 +30,9 @@ class StaticContentTest extends AirSpec:
     val resp = content("hello.txt")
     resp.status shouldBe HttpStatus.Ok_200
     // Normalize line endings so a Windows checkout with autocrlf doesn't break the assertion.
-    resp.contentString.replace("\r\n", "\n") shouldBe "hello\n"
-    resp.contentType shouldBe Some("text/plain")
+    val body = resp.contentAsString.getOrElse("").replace("\r\n", "\n")
+    body shouldBe "hello\n"
+    resp.header("Content-Type") shouldBe Some("text/plain")
   }
 
   test("404 on missing file") {
@@ -45,3 +45,17 @@ class StaticContentTest extends AirSpec:
     content("/etc/passwd").status shouldBe HttpStatus.Forbidden_403
     content("foo//bar").status shouldBe HttpStatus.Forbidden_403
   }
+
+  // Match airframe Resource.find semantics: leading slashes on the basePath
+  // and empty basePath should still resolve files relative to the classpath
+  // root. ClassLoader.getResource rejects leading slashes, so the helper has
+  // to normalize.
+  test("normalize basePath with leading slash") {
+    StaticContent.fromResource("/static")("hello.txt").status shouldBe HttpStatus.Ok_200
+  }
+
+  test("empty basePath resolves classpath-rooted relative path") {
+    StaticContent.fromResource("")("static/hello.txt").status shouldBe HttpStatus.Ok_200
+  }
+
+end StaticContentTest

--- a/wvlet-http-server/src/test/scala/wvlet/lang/http/server/static/StaticContentTest.scala
+++ b/wvlet-http-server/src/test/scala/wvlet/lang/http/server/static/StaticContentTest.scala
@@ -46,6 +46,14 @@ class StaticContentTest extends UniTest:
     content("foo//bar").status shouldBe HttpStatus.Forbidden_403
   }
 
+  // Pin the NUL-byte rejection. The implementation uses indexOf(0) so the
+  // source itself stays ASCII; constructing the NUL char at runtime here
+  // keeps the test file ASCII too.
+  test("403 on path with embedded NUL byte") {
+    val nul = 0.toChar.toString
+    content(s"hello${nul}.txt").status shouldBe HttpStatus.Forbidden_403
+  }
+
   // Match airframe Resource.find semantics: leading slashes on the basePath
   // and empty basePath should still resolve files relative to the classpath
   // root. ClassLoader.getResource rejects leading slashes, so the helper has


### PR DESCRIPTION
## Summary

Course-corrects the airframe-http→uni migration plan in #1662: **uni already publishes the full HTTP server runtime** (`uni-netty_3` ships `NettyServer`, `RouterHandler`, etc.; `uni_3` ships the full router + RPC stack). The originally planned ~3.3k-LOC verbatim port of airframe-http into `wvlet-http-server` is therefore **abandoned**. This PR (Phase 1b in the revised plan) starts the consumer-side migration by removing the only file in `wvlet-http-server` that still depended on airframe types.

- `StaticContent` now consumes `wvlet.uni.http.{Response, HttpStatus, HttpHeader}` and `wvlet.uni.control.{Control, IO}` instead of `wvlet.airframe.http.*` / `wvlet.log.io.IOUtil`.
- Classpath lookup uses `ClassLoader.getResource` directly (uni doesn't ship `wvlet.log.io.Resource`), with normalization that keeps airframe `Resource.find` semantics when callers pass leading slashes or an empty basePath.
- The literal NUL byte that previously made git classify the source as binary is replaced with `path.indexOf(0) >= 0`, which avoids the Scala unicode-escape preprocessing that would otherwise re-introduce the NUL at compile time while still catching path-null injection.
- Test moves to `UniTest` and grows two regression cases for the leading-slash / empty-basePath classpath behavior surfaced by codex review.
- `wvlet-http-server` build: drops `airframe-http`, adds `uni-netty`. Downstream `wvlet-server` migration follows in Phase 2.
- Migration plan doc captures the course correction and the revised phase plan that delegates the runtime to uni-netty.

Refs #1662.

## Test plan

- [x] `./sbt httpServer/Test/compile`
- [x] `./sbt httpServer/test` — 5/5 pass (existing 200/404/403, plus new leading-slash and empty-basePath cases)
- [x] `./sbt projectJVM/Test/compile`
- [x] `./sbt scalafmtAll` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)