### PR TITLE
internal: Migrate wvlet-server runtime + RPC client to uni-netty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scala.scalanative.build.Mode
 import scala.scalanative.build.NativeConfig
 
 val AIRFRAME_VERSION = "2026.1.6"
-val UNI_VERSION      = "2026.1.8"
+val UNI_VERSION      = "2026.1.9"
 
 val AIRSPEC_VERSION        = AIRFRAME_VERSION
 val TRINO_VERSION          = "476"
@@ -470,18 +470,21 @@ lazy val server = project
     libraryDependencies ++=
       Seq(
         // For redirecting slf4j logs to airframe-log
-        "org.slf4j"           % "slf4j-jdk14"         % "2.0.17",
-        "org.wvlet.airframe" %% "airframe-launcher"   % AIRFRAME_VERSION,
-        "org.wvlet.airframe" %% "airframe-http-netty" % AIRFRAME_VERSION
+        "org.slf4j"           % "slf4j-jdk14"       % "2.0.17",
+        "org.wvlet.airframe" %% "airframe-launcher" % AIRFRAME_VERSION
+        // airframe-http-netty dropped in #1662 phase 2: the server runtime
+        // now uses uni-netty, pulled transitively from wvlet-http-server.
       ),
     reStart / baseDirectory := (ThisBuild / baseDirectory).value
   )
   .dependsOn(api.jvm, client.jvm, runner, httpServer, testUtil % Test)
 
+// Hand-written uni-RPC clients live in wvlet-client/{shared,jvm,js}/src/main/scala. The
+// AirframeHttpPlugin codegen was dropped in #1662 phase 2; client surface preserved via the
+// FrontendRPC shim that wraps the per-service clients.
 lazy val client = crossProject(JVMPlatform, JSPlatform)
   .in(file("wvlet-client"))
-  .enablePlugins(AirframeHttpPlugin)
-  .settings(buildSettings, airframeHttpClients := Seq("wvlet.lang.api.v1.frontend:rpc:FrontendRPC"))
+  .settings(buildSettings)
   .dependsOn(api)
 
 import org.scalajs.linker.interface.OutputPatterns

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -7,11 +7,11 @@ ThisBuild / libraryDependencySchemes ++=
   )
 
 // ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
-val AIRFRAME_VERSION = "2026.1.6"
 
-addSbtPlugin("org.scalameta"      % "sbt-scalafmt"  % "2.6.0")
-addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo" % "0.13.1")
-addSbtPlugin("org.wvlet.airframe" % "sbt-airframe"  % AIRFRAME_VERSION)
+addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.6.0")
+addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo" % "0.13.1")
+// sbt-airframe (AirframeHttpPlugin) dropped in #1662 phase 2: RPC client codegen
+// was replaced with hand-written uni-RPC clients under wvlet-client/{shared,jvm,js}.
 
 // For IntelliJ IDEA
 addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.4")

--- a/wvlet-api/src/main/scala/wvlet/lang/api/v1/frontend/FileApi.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/v1/frontend/FileApi.scala
@@ -1,11 +1,9 @@
 package wvlet.lang.api.v1.frontend
 
-import wvlet.airframe.http.RPC
-import wvlet.airframe.http.RxRouter
-import wvlet.airframe.http.RxRouterProvider
+import wvlet.uni.http.router.RxRouter
+import wvlet.uni.http.router.RxRouterProvider
 import wvlet.lang.api.v1.io.FileEntry
 
-@RPC
 trait FileApi:
   import FileApi.*
 

--- a/wvlet-api/src/main/scala/wvlet/lang/api/v1/frontend/FrontendApi.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/v1/frontend/FrontendApi.scala
@@ -13,9 +13,8 @@
  */
 package wvlet.lang.api.v1.frontend
 
-import wvlet.airframe.http.RPC
-import wvlet.airframe.http.RxRouter
-import wvlet.airframe.http.RxRouterProvider
+import wvlet.uni.http.router.RxRouter
+import wvlet.uni.http.router.RxRouterProvider
 import wvlet.uni.util.ElapsedTime
 import wvlet.uni.util.ULID
 import wvlet.lang.BuildInfo
@@ -24,7 +23,6 @@ import wvlet.lang.api.v1.query.QueryInfo
 import wvlet.lang.api.v1.query.QueryRequest
 import wvlet.lang.api.v1.query.QuerySelection
 
-@RPC
 trait FrontendApi:
   import FrontendApi.*
 

--- a/wvlet-client/shared/src/main/scala/wvlet/lang/api/v1/frontend/FrontendRPC.scala
+++ b/wvlet-client/shared/src/main/scala/wvlet/lang/api/v1/frontend/FrontendRPC.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.api.v1.frontend
+
+import wvlet.lang.api.v1.frontend.client.{FileApiClient, FrontendApiClient}
+import wvlet.uni.http.{HttpAsyncClient, HttpSyncClient}
+
+/**
+  * Aggregated RPC entry point that wraps the per-service uni-RPC clients into a single client
+  * object with a stable consumer surface (`FrontendRPC.RPCSyncClient`, `.RPCAsyncClient`,
+  * `.FrontendApi`, `.FileApi`). Replaces the airframe-codegen'd FrontendRPC dropped in #1662 phase 2.
+  *
+  * The shape preserves the previous `client.FrontendApi.method(...)` and
+  * `client.FileApi.method(...)` access pattern so consumers don't need to learn two clients.
+  */
+object FrontendRPC:
+
+  def newRPCSyncClient(http: HttpSyncClient): RPCSyncClient    = new RPCSyncClient(http)
+  def newRPCAsyncClient(http: HttpAsyncClient): RPCAsyncClient = new RPCAsyncClient(http)
+
+  class RPCSyncClient(val http: HttpSyncClient) extends AutoCloseable:
+    val FrontendApi: FrontendApiClient.SyncClient = new FrontendApiClient.SyncClient(http)
+    val FileApi: FileApiClient.SyncClient         = new FileApiClient.SyncClient(http)
+    override def close(): Unit                    = http.close()
+  end RPCSyncClient
+
+  class RPCAsyncClient(val http: HttpAsyncClient) extends AutoCloseable:
+    val FrontendApi: FrontendApiClient.AsyncClient = new FrontendApiClient.AsyncClient(http)
+    val FileApi: FileApiClient.AsyncClient         = new FileApiClient.AsyncClient(http)
+    override def close(): Unit                     = http.close()
+  end RPCAsyncClient
+
+end FrontendRPC

--- a/wvlet-client/shared/src/main/scala/wvlet/lang/api/v1/frontend/client/FileApiClient.scala
+++ b/wvlet-client/shared/src/main/scala/wvlet/lang/api/v1/frontend/client/FileApiClient.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.api.v1.frontend.client
+
+import wvlet.lang.api.v1.frontend.FileApi
+import wvlet.lang.api.v1.frontend.FileApi.{FileRequest, SaveFileRequest}
+import wvlet.lang.api.v1.io.FileEntry
+import wvlet.uni.http.*
+import wvlet.uni.http.rpc.RPCClient
+import wvlet.uni.rx.Rx
+import wvlet.uni.surface.Surface
+
+/**
+  * Hand-written RPC client for [[FileApi]]. Same shape as uni's codegen output — see
+  * [[FrontendApiClient]] for rationale.
+  */
+object FileApiClient:
+  private val rpc = RPCClient.build(Surface.of[FileApi], Surface.methodsOf[FileApi])
+
+  class SyncClient(client: HttpSyncClient):
+    def listFiles(request: FileRequest): List[FileEntry] = rpc.callSync(
+      client,
+      "listFiles",
+      Seq(request)
+    )
+
+    def getFile(request: FileRequest): FileEntry = rpc.callSync(client, "getFile", Seq(request))
+    def getPath(request: FileRequest): List[FileEntry] = rpc.callSync(
+      client,
+      "getPath",
+      Seq(request)
+    )
+
+    def readFile(request: FileRequest): FileEntry = rpc.callSync(client, "readFile", Seq(request))
+    def saveFile(request: SaveFileRequest): Unit  = rpc.callSync(client, "saveFile", Seq(request))
+  end SyncClient
+
+  class AsyncClient(client: HttpAsyncClient):
+    def listFiles(request: FileRequest): Rx[List[FileEntry]] = rpc.callAsync(
+      client,
+      "listFiles",
+      Seq(request)
+    )
+
+    def getFile(request: FileRequest): Rx[FileEntry] = rpc.callAsync(
+      client,
+      "getFile",
+      Seq(request)
+    )
+
+    def getPath(request: FileRequest): Rx[List[FileEntry]] = rpc.callAsync(
+      client,
+      "getPath",
+      Seq(request)
+    )
+
+    def readFile(request: FileRequest): Rx[FileEntry] = rpc.callAsync(
+      client,
+      "readFile",
+      Seq(request)
+    )
+
+    def saveFile(request: SaveFileRequest): Rx[Unit] = rpc.callAsync(
+      client,
+      "saveFile",
+      Seq(request)
+    )
+
+  end AsyncClient
+
+end FileApiClient

--- a/wvlet-client/shared/src/main/scala/wvlet/lang/api/v1/frontend/client/FrontendApiClient.scala
+++ b/wvlet-client/shared/src/main/scala/wvlet/lang/api/v1/frontend/client/FrontendApiClient.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.api.v1.frontend.client
+
+import wvlet.lang.api.v1.frontend.FrontendApi
+import wvlet.lang.api.v1.frontend.FrontendApi.{QueryInfoRequest, QueryResponse, ServerStatus}
+import wvlet.lang.api.v1.query.{QueryInfo, QueryRequest}
+import wvlet.uni.http.*
+import wvlet.uni.http.rpc.RPCClient
+import wvlet.uni.rx.Rx
+import wvlet.uni.surface.Surface
+
+/**
+  * Hand-written RPC client for [[FrontendApi]]. Mirrors the shape of
+  * `wvlet.uni.http.codegen.client.RPCClientGenerator` output so it can be regenerated later by
+  * uni's codegen without affecting consumers. Replaces the previous airframe-codegen'd FrontendRPC.
+  */
+object FrontendApiClient:
+  private val rpc = RPCClient.build(Surface.of[FrontendApi], Surface.methodsOf[FrontendApi])
+
+  class SyncClient(client: HttpSyncClient):
+    def status: ServerStatus = rpc.callSync(client, "status", Seq.empty)
+    def submitQuery(request: QueryRequest): QueryResponse = rpc.callSync(
+      client,
+      "submitQuery",
+      Seq(request)
+    )
+
+    def getQueryInfo(request: QueryInfoRequest): QueryInfo = rpc.callSync(
+      client,
+      "getQueryInfo",
+      Seq(request)
+    )
+
+  end SyncClient
+
+  class AsyncClient(client: HttpAsyncClient):
+    def status: Rx[ServerStatus] = rpc.callAsync(client, "status", Seq.empty)
+    def submitQuery(request: QueryRequest): Rx[QueryResponse] = rpc.callAsync(
+      client,
+      "submitQuery",
+      Seq(request)
+    )
+
+    def getQueryInfo(request: QueryInfoRequest): Rx[QueryInfo] = rpc.callAsync(
+      client,
+      "getQueryInfo",
+      Seq(request)
+    )
+
+  end AsyncClient
+
+end FrontendApiClient

--- a/wvlet-server/src/main/scala/wvlet/lang/server/StaticContentApi.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/StaticContentApi.scala
@@ -1,12 +1,15 @@
 package wvlet.lang.server
 
-import wvlet.airframe.http.Endpoint
-import wvlet.airframe.http.HttpMessage
-import wvlet.airframe.http.StaticContent
+import wvlet.lang.http.server.static.StaticContent
+import wvlet.uni.http.{ContentType, Response}
 import wvlet.uni.log.LogSupport
 
 import java.io.File
 
+// Serves static UI assets from ${prog.home}/web. Wired as a fallback handler in WvletServer
+// rather than as an @Endpoint-annotated controller: uni's path matcher supports :param
+// placeholders but not airframe's /*path splat, so a single catch-all controller endpoint
+// isn't expressible. WvletServer composes RPC routing with a serve()-based fallback below.
 class StaticContentApi extends LogSupport:
   private val baseDir = sys.props.getOrElse("prog.home", ".")
   trace(s"current directory: ${new File(".").getAbsolutePath}")
@@ -14,9 +17,11 @@ class StaticContentApi extends LogSupport:
 
   private val content = StaticContent.fromDirectory(s"${baseDir}/web")
 
-  @Endpoint(path = "/*path")
-  def staticContent(path: String): HttpMessage.Response =
-    if path.isEmpty then
-      content("index.html").withContentType("text/html")
+  def serve(path: String): Response =
+    val key = path.stripPrefix("/")
+    if key.isEmpty then
+      content("index.html").withContentType(ContentType.TextHtml)
     else
-      content(path)
+      content(key)
+
+end StaticContentApi

--- a/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
@@ -1,28 +1,33 @@
 package wvlet.lang.server
 
 import org.jline.nativ.OSInfo
-import wvlet.airframe.Design
-import wvlet.airframe.http.netty.Netty
-import wvlet.airframe.http.netty.NettyServer
-import wvlet.airframe.http.Http
-import wvlet.airframe.http.RxRouter
-import wvlet.lang.api.v1.frontend.FrontendRPC
+import wvlet.lang.api.v1.frontend.{FileApi, FrontendApi, FrontendRPC}
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.OS
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.runner.connector.duckdb.DuckDBConnector
-import wvlet.lang.runner.connector.DBConnector
-import wvlet.lang.runner.connector.DBConnectorProvider
-import wvlet.lang.runner.QueryExecutor
-import wvlet.lang.runner.WvletScriptRunnerConfig
+import wvlet.lang.runner.connector.{DBConnector, DBConnectorProvider}
+import wvlet.lang.runner.{QueryExecutor, WvletScriptRunnerConfig}
 import wvlet.uni.cli.launcher.option
-import wvlet.uni.control.Control
 import wvlet.uni.control.Control.withResource
 import wvlet.uni.io.IO
+import wvlet.uni.design.{Design, Session}
+import wvlet.uni.http.netty.{NettyHttpServer, NettyServerConfig, RxHttpHandler}
+import wvlet.uni.http.rpc.{RPCRoute, RPCRouter, RPCStatus}
+import wvlet.uni.http.{
+  Http,
+  HttpHeader,
+  HttpMethod,
+  HttpStatus,
+  JVMHttpChannelFactory,
+  Request,
+  Response
+}
 import wvlet.uni.log.LogSupport
+import wvlet.uni.rx.Rx
+import wvlet.uni.surface.Surface
 import wvlet.log.io.IOUtil
 
-import scala.annotation.tailrec
 import scala.util.Try
 
 case class WvletServerConfig(
@@ -47,15 +52,84 @@ case class WvletServerConfig(
   lazy val workEnv: WorkEnv = WorkEnv(path = workDir)
 
 object WvletServer extends LogSupport:
-  def router: RxRouter = RxRouter.of(
-    RxRouter.of[FrontendApiImpl],
-    RxRouter.of[FileApiImpl],
-    RxRouter.of[StaticContentApi]
-  )
+
+  /**
+    * Multi-service RPC dispatcher. uni-netty's `RPCHandler` only takes a single `RPCRouter`, so
+    * this wraps multiple routers into one `RxHttpHandler` by building a path-keyed lookup. Mirrors
+    * uni-netty `RPCHandler`'s wire format exactly: POST request, JSON `{"request": {...}}` body,
+    * Weaver-encoded JSON response with `RPCStatus` header.
+    */
+  private class MultiRpcHandler(routers: Seq[RPCRouter]) extends RxHttpHandler with LogSupport:
+    private val routeMap: Map[String, (RPCRoute, Any)] =
+      routers.flatMap(r => r.routes.map(route => route.path -> (route, r.instance))).toMap
+
+    override def handle(request: Request): Rx[Response] =
+      if request.method != HttpMethod.POST then
+        Rx.single(
+          RPCStatus
+            .INVALID_REQUEST_U1
+            .newException(s"RPC requires POST method, got: ${request.method}")
+            .toResponse
+        )
+      else
+        routeMap.get(request.path) match
+          case Some((route, instance)) =>
+            handleRPC(request, route, instance)
+          case None =>
+            Rx.single(Response.notFound)
+
+    private def handleRPC(request: Request, route: RPCRoute, instance: Any): Rx[Response] =
+      try
+        val body   = request.content.asString.getOrElse("")
+        val args   = route.codec.decodeParams(body)
+        val result = route.codec.method.call(instance, args*)
+        result match
+          case rx: Rx[?] =>
+            rx.map(v => successResponse(v, route))
+              .recover { case e =>
+                errorResponse(e)
+              }
+          case value =>
+            Rx.single(successResponse(value, route))
+      catch
+        case e: Exception =>
+          warn(s"RPC error on ${request.path}: ${e.getMessage}", e)
+          Rx.single(errorResponse(e))
+
+    private def successResponse(value: Any, route: RPCRoute): Response = Response
+      .ok
+      .addHeader(HttpHeader.XRPCStatus, RPCStatus.SUCCESS_S0.code.toString)
+      .withJsonContent(route.codec.encodeResult(value))
+
+    private def errorResponse(e: Throwable): Response =
+      e match
+        case rpc: wvlet.uni.http.rpc.RPCException =>
+          rpc.toResponse
+        case _ =>
+          RPCStatus.INTERNAL_ERROR_I0.newException(e.getMessage, e).toResponse
+
+  end MultiRpcHandler
+
+  // Wrap an RPC handler with a static-content fallback. uni's path matcher doesn't support
+  // airframe's "/*splat" pattern, so we cannot register a catch-all controller endpoint.
+  // Anything the RPC handler answers with 404 is delegated to StaticContentApi.
+  private def withStaticFallback(
+      rpc: RxHttpHandler,
+      staticContentApi: StaticContentApi
+  ): RxHttpHandler =
+    (request) =>
+      rpc
+        .handle(request)
+        .flatMap { resp =>
+          if resp.status == HttpStatus.NotFound_404 then
+            Rx.single(staticContentApi.serve(request.path))
+          else
+            Rx.single(resp)
+        }
 
   def startServer(config: WvletServerConfig, openBrowser: Boolean = false): Unit = design(config)
     .withProductionMode
-    .build[NettyServer] { server =>
+    .build[NettyHttpServer] { server =>
       info(s"- log file path: ${config.workEnv.logFile}")
       info(s"- error file path: ${config.workEnv.errorFile}")
       info(s"Wvlet UI server started at http://localhost:${config.port}")
@@ -64,7 +138,6 @@ object WvletServer extends LogSupport:
       if !config.quitImmediately then
         warn(s"--quit-immediately is set. The server will quit immediately after starting.")
         if OS.isMacOS && openBrowser then
-          // Open the web browser
           IO.run(s"open http://localhost:${config.port}")
         server.awaitTermination()
     }
@@ -87,12 +160,8 @@ object WvletServer extends LogSupport:
 
   def design(config: WvletServerConfig): Design =
     val port = unusedPortFrom(config.port)
-    Netty
-      .server
-      .withName("wvlet-ui")
-      .withPort(config.port)
-      .withRouter(router)
-      .design
+    Design
+      .newSilentDesign
       .bindInstance[WvletServerConfig](config)
       .bindInstance[WorkEnv](config.workEnv)
       .bindInstance[Profile](
@@ -112,10 +181,39 @@ object WvletServer extends LogSupport:
         )
       }
       .bindSingleton[QueryExecutor]
+      .bindImpl[FrontendApi, FrontendApiImpl]
+      .bindImpl[FileApi, FileApiImpl]
+      .bindSingleton[StaticContentApi]
+      .bindProvider[Session, NettyHttpServer] { (session: Session) =>
+        val frontendApi = session.getInstanceOf(Surface.of[FrontendApi]).asInstanceOf[FrontendApi]
+        val fileApi     = session.getInstanceOf(Surface.of[FileApi]).asInstanceOf[FileApi]
+        val staticApi   = session
+          .getInstanceOf(Surface.of[StaticContentApi])
+          .asInstanceOf[StaticContentApi]
+        val rpc = MultiRpcHandler(
+          Seq(RPCRouter.of[FrontendApi](frontendApi), RPCRouter.of[FileApi](fileApi))
+        )
+        val handler = withStaticFallback(rpc, staticApi)
+        NettyHttpServer(
+          NettyServerConfig().withName("wvlet-ui").withPort(port).withRxHandler(handler)
+        )
+      }
+      .onStart(_.start())
+      .onShutdown(_.stop())
+
+  end design
 
   def testDesign: Design = design(WvletServerConfig(port = IOUtil.unusedPort)).bindProvider {
-    (server: NettyServer) =>
-      FrontendRPC.newRPCSyncClient(Http.client.newSyncClient(server.localAddress))
+    (server: NettyHttpServer) =>
+      // Force the JVM HTTP channel factory before constructing the client.
+      // HttpCompat (which auto-registers the factory) is package-private, so we
+      // can't trigger its static init from outside wvlet.uni.http. Calling
+      // setDefaultChannelFactory directly is idempotent and matches what
+      // HttpCompat would do.
+      Http.setDefaultChannelFactory(JVMHttpChannelFactory)
+      FrontendRPC.newRPCSyncClient(
+        Http.client.withBaseUri(s"http://localhost:${server.localPort}").newSyncClient
+      )
   }
 
 end WvletServer

--- a/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
@@ -25,10 +25,10 @@ import wvlet.uni.http.{
 }
 import wvlet.uni.log.LogSupport
 import wvlet.uni.rx.Rx
-import wvlet.uni.surface.Surface
 import wvlet.log.io.IOUtil
 
 import scala.util.Try
+import scala.util.control.NonFatal
 
 case class WvletServerConfig(
     @option(prefix = "-p,--port", description = "Web UI server port. default:9090")
@@ -92,7 +92,7 @@ object WvletServer extends LogSupport:
           case value =>
             Rx.single(successResponse(value, route))
       catch
-        case e: Exception =>
+        case NonFatal(e) =>
           warn(s"RPC error on ${request.path}: ${e.getMessage}", e)
           Rx.single(errorResponse(e))
 
@@ -132,13 +132,13 @@ object WvletServer extends LogSupport:
     .build[NettyHttpServer] { server =>
       info(s"- log file path: ${config.workEnv.logFile}")
       info(s"- error file path: ${config.workEnv.errorFile}")
-      info(s"Wvlet UI server started at http://localhost:${config.port}")
+      info(s"Wvlet UI server started at http://localhost:${server.localPort}")
       info(s"Press ctrl+c to stop the server")
 
       if !config.quitImmediately then
         warn(s"--quit-immediately is set. The server will quit immediately after starting.")
         if OS.isMacOS && openBrowser then
-          IO.run(s"open http://localhost:${config.port}")
+          IO.run(s"open http://localhost:${server.localPort}")
         server.awaitTermination()
     }
 
@@ -159,16 +159,19 @@ object WvletServer extends LogSupport:
       unusedPortFrom(start, counter + 1)
 
   def design(config: WvletServerConfig): Design =
-    val port = unusedPortFrom(config.port)
+    // Bind the actual port that was acquired so downstream consumers of
+    // WvletServerConfig observe the same port the Netty server is listening on.
+    val port         = unusedPortFrom(config.port)
+    val resolvedConf = config.copy(port = port)
     Design
       .newSilentDesign
-      .bindInstance[WvletServerConfig](config)
-      .bindInstance[WorkEnv](config.workEnv)
+      .bindInstance[WvletServerConfig](resolvedConf)
+      .bindInstance[WorkEnv](resolvedConf.workEnv)
       .bindInstance[Profile](
         Profile.getProfile(
-          config.profile,
-          config.catalog,
-          config.schema,
+          resolvedConf.profile,
+          resolvedConf.catalog,
+          resolvedConf.schema,
           Profile.defaultDuckDBProfile
         )
       )
@@ -185,12 +188,10 @@ object WvletServer extends LogSupport:
       .bindImpl[FileApi, FileApiImpl]
       .bindSingleton[StaticContentApi]
       .bindProvider[Session, NettyHttpServer] { (session: Session) =>
-        val frontendApi = session.getInstanceOf(Surface.of[FrontendApi]).asInstanceOf[FrontendApi]
-        val fileApi     = session.getInstanceOf(Surface.of[FileApi]).asInstanceOf[FileApi]
-        val staticApi   = session
-          .getInstanceOf(Surface.of[StaticContentApi])
-          .asInstanceOf[StaticContentApi]
-        val rpc = MultiRpcHandler(
+        val frontendApi = session.build[FrontendApi]
+        val fileApi     = session.build[FileApi]
+        val staticApi   = session.build[StaticContentApi]
+        val rpc         = MultiRpcHandler(
           Seq(RPCRouter.of[FrontendApi](frontendApi), RPCRouter.of[FileApi](fileApi))
         )
         val handler = withStaticFallback(rpc, staticApi)

--- a/wvlet-server/src/test/scala/wvlet/lang/server/UlidRpcRoundTripTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/UlidRpcRoundTripTest.scala
@@ -1,8 +1,8 @@
 package wvlet.lang.server
 
-import wvlet.airspec.AirSpec
 import wvlet.lang.api.v1.frontend.FrontendRPC
 import wvlet.lang.api.v1.query.QueryRequest
+import wvlet.lang.test.WvletDITest
 import wvlet.uni.util.ULID
 
 /**
@@ -11,18 +11,20 @@ import wvlet.uni.util.ULID
   * airframe-http (phases 0–4 of #1662).
   *
   * Lives in a dedicated spec because `QueryService` is `AutoCloseable`; sharing a spec with
-  * `WvletServerTest` would shut its thread pool down between tests under AirSpec's per-test session
-  * scoping.
+  * `WvletServerTest` would shut its thread pool down between tests under per-test session scoping.
   */
-class UlidRpcRoundTripTest extends AirSpec:
+class UlidRpcRoundTripTest extends WvletDITest:
 
   initDesign:
     _.add(WvletServer.testDesign)
 
-  test("submitQuery returns a parseable ULID over RPC") { (client: FrontendRPC.RPCSyncClient) =>
+  test("submitQuery returns a parseable ULID over RPC") {
+    val client   = dep[FrontendRPC.RPCSyncClient]
     val request  = QueryRequest(query = "select 1")
     val response = client.FrontendApi.submitQuery(request)
 
     response.requestId shouldBe request.requestId
     ULID.isValid(response.queryId.toString) shouldBe true
   }
+
+end UlidRpcRoundTripTest

--- a/wvlet-server/src/test/scala/wvlet/lang/server/WvletServerTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/WvletServerTest.scala
@@ -1,16 +1,18 @@
 package wvlet.lang.server
 
-import wvlet.airspec.AirSpec
 import wvlet.lang.BuildInfo
-import wvlet.lang.api.v1.query.QueryRequest
 import wvlet.lang.api.v1.frontend.FrontendRPC
+import wvlet.lang.test.WvletDITest
 
-class WvletServerTest extends AirSpec:
+class WvletServerTest extends WvletDITest:
 
   initDesign:
     _.add(WvletServer.testDesign)
 
-  test("launch server") { (client: FrontendRPC.RPCSyncClient) =>
-    val status = client.FrontendApi.status()
+  test("launch server") {
+    val client = dep[FrontendRPC.RPCSyncClient]
+    val status = client.FrontendApi.status
     status.version shouldBe BuildInfo.version
   }
+
+end WvletServerTest

--- a/wvlet-ui-main/src/main/scala/wvlet/lang/ui/RxBridge.scala
+++ b/wvlet-ui-main/src/main/scala/wvlet/lang/ui/RxBridge.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.ui
+
+import scala.concurrent.{ExecutionContext, Promise}
+import wvlet.airframe.rx.Rx as AirframeRx
+import wvlet.uni.rx.Rx as UniRx
+
+/**
+  * Lift a one-shot uni-rx `Rx[A]` (what the migrated `FrontendRPC` async client returns) into an
+  * airframe-rx `Rx[A]` so it can be embedded into airframe-rx-html templates via `embedAsNode`. uni
+  * does not yet ship an rx-html replacement; until it does, the UI layer keeps using
+  * `airframe-rx-html` and converts at the RPC boundary here.
+  *
+  * Conversion is one-shot: the bridge subscribes to the uni `Rx` exactly once and forwards the
+  * first emitted value (or failure) to a `Promise`, which is then exposed as an airframe `Rx[A]`
+  * via [[wvlet.airframe.rx.Rx.future]]. This matches RPC call semantics — every method on the
+  * generated client emits one value or one error.
+  */
+object RxBridge:
+  def toAirframe[A](u: UniRx[A])(using ec: ExecutionContext): AirframeRx[A] =
+    val p = Promise[A]()
+    u.recover { case e =>
+        if !p.isCompleted then
+          p.failure(e)
+        // Re-throw: uni's `recover` substitutes a value, but we only need the side effect here.
+        throw e
+      }
+      .tap { a =>
+        if !p.isCompleted then
+          p.success(a)
+      }
+      .run()
+    AirframeRx.future(p.future)
+
+end RxBridge

--- a/wvlet-ui-main/src/main/scala/wvlet/lang/ui/RxBridge.scala
+++ b/wvlet-ui-main/src/main/scala/wvlet/lang/ui/RxBridge.scala
@@ -31,15 +31,13 @@ import wvlet.uni.rx.Rx as UniRx
 object RxBridge:
   def toAirframe[A](u: UniRx[A])(using ec: ExecutionContext): AirframeRx[A] =
     val p = Promise[A]()
-    u.recover { case e =>
-        if !p.isCompleted then
-          p.failure(e)
-        // Re-throw: uni's `recover` substitutes a value, but we only need the side effect here.
-        throw e
-      }
-      .tap { a =>
+    u.tap { a =>
         if !p.isCompleted then
           p.success(a)
+      }
+      .tapOnFailure { e =>
+        if !p.isCompleted then
+          p.failure(e)
       }
       .run()
     AirframeRx.future(p.future)

--- a/wvlet-ui-main/src/main/scala/wvlet/lang/ui/WvletUIMain.scala
+++ b/wvlet-ui-main/src/main/scala/wvlet/lang/ui/WvletUIMain.scala
@@ -15,9 +15,9 @@ package wvlet.lang.ui
 
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.*
 import wvlet.airframe.Design
-import wvlet.airframe.http.Http
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.rx.RxVar
+import wvlet.uni.http.Http
 import wvlet.lang.api.v1.frontend.FrontendRPC
 import wvlet.lang.api.v1.query.QueryError
 import wvlet.lang.ui.component.MainFrame
@@ -28,7 +28,9 @@ import wvlet.uni.log.LogSupport
 object WvletUIMain extends LogSupport:
   def main(args: Array[String]): Unit = render
 
-  private val rpcClient = FrontendRPC.newRPCAsyncClient(Http.client.newJSClient)
+  // The JS HTTP channel factory is auto-installed by wvlet.uni.http.HttpCompat
+  // when the uni module is loaded.
+  private val rpcClient = FrontendRPC.newRPCAsyncClient(Http.client.newAsyncClient)
 
   protected[ui] def design: Design = Design
     .newDesign
@@ -38,7 +40,7 @@ object WvletUIMain extends LogSupport:
 
   def render: Unit = rpcClient
     .FrontendApi
-    .status()
+    .status
     .map { status =>
       info(s"Connected to the server: ${status}")
       val frame = MainFrame()

--- a/wvlet-ui-main/src/main/scala/wvlet/lang/ui/component/editor/FileNav.scala
+++ b/wvlet-ui-main/src/main/scala/wvlet/lang/ui/component/editor/FileNav.scala
@@ -9,9 +9,11 @@ import wvlet.airframe.rx.html.svgAttrs.*
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.rx.RxVar
 import wvlet.uni.util.ULID
+import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.*
 import wvlet.lang.api.v1.frontend.FileApi.FileRequest
 import wvlet.lang.api.v1.frontend.FrontendRPC.RPCAsyncClient
 import wvlet.lang.api.v1.io.FileEntry
+import wvlet.lang.ui.RxBridge
 import wvlet.lang.ui.component.GlobalState.selectedPath
 import wvlet.lang.ui.component.GlobalState
 import wvlet.lang.ui.component.Icon
@@ -88,9 +90,8 @@ class FileNav(rpcClient: RPCAsyncClient) extends RxElement:
     nav(
       cls -> "flex px-2 h-4 text-sm text-gray-400",
       ol(role -> "list", cls -> "flex space-x-4 rounded-md px-1 shadow"),
-      rpcClient
-        .FileApi
-        .getPath(FileRequest(path))
+      RxBridge
+        .toAirframe(rpcClient.FileApi.getPath(FileRequest(path)))
         .map { pathEntries =>
           var parentEntry = FileEntry("", "", true, true, 0, 0)
           val elems       = List.newBuilder[PathElem]

--- a/wvlet-ui-main/src/main/scala/wvlet/lang/ui/component/editor/QueryResultReader.scala
+++ b/wvlet-ui-main/src/main/scala/wvlet/lang/ui/component/editor/QueryResultReader.scala
@@ -1,8 +1,10 @@
 package wvlet.lang.ui.component.editor
 
-import wvlet.airframe.rx.Cancelable
-import wvlet.airframe.rx.Rx
+// Local Rx work runs on uni.rx (the RPC client returns it). RxVar stays on airframe.rx because
+// it's bound into airframe-rx-html UI components downstream — uni doesn't ship an rx-html
+// replacement yet.
 import wvlet.airframe.rx.RxVar
+import wvlet.uni.rx.Rx
 import wvlet.lang.api.v1.frontend.FrontendApi.QueryInfoRequest
 import wvlet.lang.api.v1.frontend.FrontendApi.QueryResponse
 import wvlet.lang.api.v1.frontend.FrontendRPC.RPCAsyncClient


### PR DESCRIPTION
## Summary

Combines what the original migration plan called Phase 2 (runtime swap) and Phase 4 (codegen swap). They turned out to be coupled: airframe-RPC clients and uni-netty servers don't share a wire format, so swapping the runtime alone leaves request/response decoding broken on the client.

Refs #1662. Required uni 2026.1.9 (filed wvlet/uni#536 for the ULID/ElapsedTime `Weaver` gap, wvlet/uni#537 for the related `RouterHandler`/`ResponseConverter` issue).

### Server runtime
- `WvletServer.design` now uses `wvlet.uni.design.Design` with a `bindProvider[Session, NettyHttpServer]` that constructs a Netty server, wraps a custom `MultiRpcHandler` (uni-netty's `RPCHandler` accepts only one `RPCRouter` — we have two services), and chains a static-content fallback because uni's path matcher doesn't support airframe's `\"/*splat\"` pattern. Lifecycle is wired via `.onStart` / `.onShutdown`.
- `StaticContentApi` is no longer a controller; it's a plain helper invoked from the fallback handler.
- `airframe-http-netty` dropped from `wvlet-server` deps; uni-netty pulled transitively from `wvlet-http-server`.
- `testDesign` explicitly calls `Http.setDefaultChannelFactory(JVMHttpChannelFactory)` because the auto-init in uni's `HttpCompat` is package-private and isn't loaded until something inside `wvlet.uni.http` references it.

### RPC codegen
- `sbt-airframe` / `AirframeHttpPlugin` removed from `project/plugin.sbt` and from the `wvlet-client` crossProject.
- Hand-written `FrontendApiClient` and `FileApiClient` under `wvlet-client/shared/src/main/scala/.../client/`, mirroring the shape uni's `RPCClientGenerator` produces (`RPCClient.build` + `SyncClient`/`AsyncClient` inner classes). These can swap to real codegen later when sbt-uni grows a sbt 1.x build.
- `FrontendRPC` kept as a thin shim wrapping the per-service clients so consumers keep their `client.FrontendApi.method(...)` surface.
- `@RPC` annotations removed from `FrontendApi`/`FileApi` traits — uni's `RxRouter` and `RPCRouter` are convention-based.

### JS / cross-platform
- `WvletUIMain.scala` uses uni's HTTP client (`Http.client.newAsyncClient` with the JS fetch factory).
- `QueryResultReader` migrates local `Rx` work to `uni.rx`; `RxVar` stays on `airframe-rx` because it's bound into `airframe-rx-html` UI components that uni doesn't ship a replacement for.
- New `RxBridge.toAirframe` one-shot lifts `uni.rx.Rx[A]` into `airframe.rx.Rx[A]` so RPC results can still be embedded into rx-html templates (FileNav).

## Test plan

- [x] `./sbt projectJVM/Test/compile`
- [x] `./sbt projectJS/Test/compile`
- [x] `./sbt projectNative/Test/compile`
- [x] `./sbt server/test` — 7/7 pass (FileApiImplTest 5/5, UlidRpcRoundTripTest 1/1, WvletServerTest 1/1)
- [x] `./sbt scalafmtAll` clean

## Follow-ups

- The remaining airframe deps (`airframe-rx`, `airframe-rx-html`, `airframe-launcher`, `airframe-codec`) are intentional and tracked in the migration plan. The `airframe-rx`-to-uni-rx sweep across the rest of `wvlet-ui-main` waits on uni shipping an `rx-html` equivalent.
- The hand-written clients can be regenerated by `sbt-uni` once it has a sbt 1.x build (or once we migrate to sbt 2.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)