### PR TITLE
internal: Drop unused airframe deps after #1678

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,15 @@ val buildSettings = Seq[Setting[?]](
   usePipelining := false
 )
 
+// uni-core's JS compat$ references java.security.SecureRandom (uni#TBD). The Scala.js linker
+// needs the scalajs-java-securerandom polyfill on the classpath to resolve it. airframe's JS
+// jars used to make this reachable transitively; once they're dropped we declare it explicitly
+// on every JS-targeting module that ends up touching uni's randomness or ULID code paths.
+// Hard-coded artifact name (sjs1_2.13) because Scala.js 1.x publishes this only against the
+// Scala 2.13 binary ABI; %%% would not resolve under Scala 3.
+val scalajsJavaSecureRandom: ModuleID =
+  "org.scala-js" % "scalajs-java-securerandom_sjs1_2.13" % "1.0.0"
+
 lazy val jvmProjects: Seq[ProjectReference] = Seq(
   api.jvm,
   httpServer,
@@ -106,6 +115,7 @@ lazy val api = crossProject(JVMPlatform, JSPlatform, NativePlatform)
         "org.wvlet.uni" %%% "uni" % UNI_VERSION
       )
   )
+  .jsSettings(libraryDependencies += scalajsJavaSecureRandom)
 
 def generateWvletLib(path: File, packageName: String, className: String): String = {
   val srcDir      = path
@@ -190,6 +200,7 @@ lazy val lang = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       ((ThisBuild / baseDirectory).value / "spec" ** "*.wv").get ++
         ((ThisBuild / baseDirectory).value / "wvlet-stdlib" ** "*.wv").get
   )
+  .jsSettings(libraryDependencies += scalajsJavaSecureRandom)
   .dependsOn(api)
 
 val specRunnerSettings = Seq(
@@ -484,6 +495,7 @@ lazy val server = project
 lazy val client = crossProject(JVMPlatform, JSPlatform)
   .in(file("wvlet-client"))
   .settings(buildSettings)
+  .jsSettings(libraryDependencies += scalajsJavaSecureRandom)
   .dependsOn(api)
 
 import org.scalajs.linker.interface.OutputPatterns

--- a/build.sbt
+++ b/build.sbt
@@ -101,8 +101,9 @@ lazy val api = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     buildInfoPackage := "wvlet.lang",
     libraryDependencies ++=
       Seq(
-        "org.wvlet.airframe" %%% "airframe-http" % AIRFRAME_VERSION,
-        "org.wvlet.uni"      %%% "uni"           % UNI_VERSION
+        // airframe-http dropped: wvlet-api source no longer references any
+        // airframe.http types after the @RPC + RxRouter migration in #1678.
+        "org.wvlet.uni" %%% "uni" % UNI_VERSION
       )
   )
 
@@ -467,8 +468,9 @@ lazy val server = project
     libraryDependencies ++=
       Seq(
         // For redirecting slf4j logs to airframe-log
-        "org.slf4j"           % "slf4j-jdk14"       % "2.0.17",
-        "org.wvlet.airframe" %% "airframe-launcher" % AIRFRAME_VERSION
+        "org.slf4j" % "slf4j-jdk14" % "2.0.17"
+        // airframe-launcher dropped: wvlet-server uses wvlet.uni.cli.launcher.@option
+        // already and no source references the airframe launcher.
         // airframe-http-netty dropped in #1662 phase 2: the server runtime
         // now uses uni-netty, pulled transitively from wvlet-http-server.
       ),
@@ -500,7 +502,9 @@ lazy val ui = project
     libraryDependencies ++=
       Seq(
         "org.wvlet.airframe" %%% "airframe"         % AIRFRAME_VERSION,
-        "org.wvlet.airframe" %%% "airframe-http"    % AIRFRAME_VERSION,
+        // airframe-http dropped: only airframe-rx-html is actually consumed from the
+        // airframe stack here. Migration off airframe-rx-html itself waits on uni
+        // shipping an rx-html replacement.
         "org.wvlet.airframe" %%% "airframe-rx-html" % AIRFRAME_VERSION,
         "org.wvlet.uni"      %%% "uni"              % UNI_VERSION,
         "org.scala-js"       %%% "scalajs-dom"      % SCALAJS_DOM_VERSION

--- a/wvlet-server/src/main/scala/wvlet/lang/server/FileApiImpl.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/FileApiImpl.scala
@@ -3,8 +3,8 @@ package wvlet.lang.server
 import wvlet.lang.api.v1.frontend.FileApi
 import wvlet.lang.api.v1.io.FileEntry
 import wvlet.lang.compiler.WorkEnv
+import wvlet.uni.control.IO
 import wvlet.uni.log.LogSupport
-import wvlet.log.io.IOUtil
 
 class FileApiImpl(workEnv: WorkEnv) extends FileApi with LogSupport:
 
@@ -61,7 +61,7 @@ class FileApiImpl(workEnv: WorkEnv) extends FileApi with LogSupport:
       if !f.exists() then
         None
       else
-        Some(IOUtil.readAsString(f))
+        Some(IO.readAsString(f))
     )
 
   override def saveFile(request: FileApi.SaveFileRequest): Unit = ???

--- a/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
@@ -25,7 +25,6 @@ import wvlet.uni.http.{
 }
 import wvlet.uni.log.LogSupport
 import wvlet.uni.rx.Rx
-import wvlet.log.io.IOUtil
 
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -204,7 +203,9 @@ object WvletServer extends LogSupport:
 
   end design
 
-  def testDesign: Design = design(WvletServerConfig(port = IOUtil.unusedPort)).bindProvider {
+  // Bind port = 0 so the design's unusedPortFrom helper acquires whichever local
+  // port the OS hands back — same effect the dropped airframe IOUtil.unusedPort had.
+  def testDesign: Design = design(WvletServerConfig(port = 0)).bindProvider {
     (server: NettyHttpServer) =>
       // Force the JVM HTTP channel factory before constructing the client.
       // HttpCompat (which auto-registers the factory) is package-private, so we

--- a/wvlet-ui-main/src/main/scala/wvlet/lang/ui/WvletUIMain.scala
+++ b/wvlet-ui-main/src/main/scala/wvlet/lang/ui/WvletUIMain.scala
@@ -14,9 +14,9 @@
 package wvlet.lang.ui
 
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.*
-import wvlet.airframe.Design
 import wvlet.airframe.rx.Rx
 import wvlet.airframe.rx.RxVar
+import wvlet.uni.design.Design
 import wvlet.uni.http.Http
 import wvlet.lang.api.v1.frontend.FrontendRPC
 import wvlet.lang.api.v1.query.QueryError
@@ -44,7 +44,7 @@ object WvletUIMain extends LogSupport:
     .map { status =>
       info(s"Connected to the server: ${status}")
       val frame = MainFrame()
-      // Let Airframe DI design build UI components for WvletEditor
+      // Let the uni Design build UI components for WvletEditor
       val editor = design.newSession.build[WvletEditor]
       frame(editor).renderTo("main")
     }


### PR DESCRIPTION
## Summary

Cleanup PR following #1678 (wvlet-server runtime + RPC client migration to uni-netty). Three build deps were declared but no longer referenced from any source:

- **\`wvlet-api\`** drops \`airframe-http\` — the \`@RPC\` + RxRouter migration removed every \`wvlet.airframe.http\` import.
- **\`wvlet-server\`** drops \`airframe-launcher\` — the option-annotation surface is \`wvlet.uni.cli.launcher\` already; nothing else referenced it.
- **\`wvlet-ui\`** drops \`airframe-http\` — only \`airframe-rx-html\` was actually consumed; that migration waits on uni shipping an \`rx-html\` replacement.

Two source-side follow-ups required by the dep drops:

- \`WvletServer.testDesign\` and \`FileApiImpl\` swap \`wvlet.log.io.IOUtil\` (previously transitive via airframe-launcher) for \`wvlet.uni.control.IO\`. \`testDesign\` now passes \`port = 0\` so the existing \`unusedPortFrom\` helper acquires whatever local port the OS hands back — same effect \`IOUtil.unusedPort\` had.
- \`WvletUIMain\` swaps \`wvlet.airframe.Design\` for \`wvlet.uni.design.Design\`. uni \`Design\` works on Scala.js and supports the same \`bindSingleton\` / \`bindInstance\` / \`newSession.build[T]\` surface this file uses.

Refs #1662.

## Test plan

- [x] \`./sbt projectJVM/Test/compile\`
- [x] \`./sbt projectJS/Test/compile\`
- [x] \`./sbt projectNative/Test/compile\`
- [x] \`./sbt server/test\` — 7/7 pass
- [x] \`./sbt scalafmtAll\` clean

## Out of scope

- \`wvlet-labs/ParseQuery.scala\` still uses \`airframe-launcher\` + \`airframe-codec\` + \`airframe-control.Parallel\` + \`airframe-metrics\`. Migrating it touches several airframe APIs uni doesn't have one-line replacements for; better as its own PR.
- The \`airframe-rx-html\` ecosystem (\`wvlet-ui\`, \`wvlet-ui-main\`) blocks on uni shipping an \`rx-html\` replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)