### PR TITLE
internal: Drop airframe meta-package dep from wvlet-ui

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -513,10 +513,10 @@ lazy val ui = project
     Test / jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(),
     libraryDependencies ++=
       Seq(
-        "org.wvlet.airframe" %%% "airframe"         % AIRFRAME_VERSION,
-        // airframe-http dropped: only airframe-rx-html is actually consumed from the
-        // airframe stack here. Migration off airframe-rx-html itself waits on uni
-        // shipping an rx-html replacement.
+        // airframe (meta-DI package) and airframe-http already dropped; only
+        // airframe-rx-html is still consumed from the airframe stack here.
+        // Migration off airframe-rx-html itself waits on uni shipping an
+        // rx-html replacement.
         "org.wvlet.airframe" %%% "airframe-rx-html" % AIRFRAME_VERSION,
         "org.wvlet.uni"      %%% "uni"              % UNI_VERSION,
         "org.scala-js"       %%% "scalajs-dom"      % SCALAJS_DOM_VERSION

--- a/wvlet-ui-playground/src/main/scala/wvlet/lang/ui/playground/PlaygroundUI.scala
+++ b/wvlet-ui-playground/src/main/scala/wvlet/lang/ui/playground/PlaygroundUI.scala
@@ -1,9 +1,9 @@
 package wvlet.lang.ui.playground
 
-import wvlet.airframe.Design
 import wvlet.airframe.rx.html.RxElement
-import wvlet.uni.log.LogSupport
 import wvlet.airframe.rx.html.all.*
+import wvlet.uni.design.Design
+import wvlet.uni.log.LogSupport
 import wvlet.lang.ui.component.monaco.EditorBase
 import wvlet.lang.ui.component.Icon
 import wvlet.lang.ui.component.MainFrame


### PR DESCRIPTION
## Summary

The only consumer of \`wvlet.airframe.Design\` in the UI tree (\`WvletUIMain\`) already moved to \`wvlet.uni.design.Design\` in #1680. \`PlaygroundUI\` was the last lingering reference to \`wvlet.airframe.Design\` — migrated to uni's Design here, which is functionally equivalent and works on Scala.js.

The umbrella \`airframe\` package itself is no longer pulled in via \`libraryDependencies\` on \`wvlet-ui\`. Only \`airframe-rx-html\` remains, and that one is blocked on uni shipping an rx-html replacement.

Refs #1662.

## Test plan

- [x] \`./sbt projectJVM/Test/compile\`
- [x] \`./sbt projectJS/test\` — 523/523 pass
- [x] \`./sbt projectNative/Test/compile\`
- [x] \`./sbt scalafmtAll\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)