### PR TITLE
internal: Migrate wvlet-labs/ParseQuery off airframe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -585,8 +585,8 @@ lazy val labs = project
     name           := "wvlet-labs",
     libraryDependencies ++=
       Seq(
-        "org.wvlet.airframe" %% "airframe-launcher" % AIRFRAME_VERSION,
-        "org.duckdb"          % "duckdb_jdbc"       % DUCKDB_JDBC_VERSION
+        // airframe-launcher dropped: ParseQuery uses wvlet.uni.cli.launcher (#1662 phase 7).
+        "org.duckdb" % "duckdb_jdbc" % DUCKDB_JDBC_VERSION
       )
   )
   .dependsOn(lang.jvm)

--- a/wvlet-labs/src/main/scala/wvlet/lang/labs/ParseQuery.scala
+++ b/wvlet-labs/src/main/scala/wvlet/lang/labs/ParseQuery.scala
@@ -1,21 +1,20 @@
 package wvlet.lang.labs
 
-import wvlet.uni.log.LogSupport
-import wvlet.airframe.launcher.*
-
-import java.io.FileWriter
-import java.io.PrintWriter
-import wvlet.airframe.codec.MessageCodec
-import wvlet.airframe.control.Control
-import wvlet.airframe.control.Parallel
-import wvlet.airframe.metrics.Count
-import wvlet.airframe.metrics.ElapsedTime
+import org.duckdb.DuckDBDriver
 import wvlet.lang.compiler.parser.ParserPhase
 import wvlet.lang.compiler.CompileResult
 import wvlet.lang.compiler.Context
-import org.duckdb.DuckDBDriver
+import wvlet.uni.cli.launcher.*
+import wvlet.uni.control.Control
+import wvlet.uni.log.LogSupport
+import wvlet.uni.util.Count
+import wvlet.uni.util.ElapsedTime
+import wvlet.uni.weaver.Weaver
 
+import java.io.FileWriter
+import java.io.PrintWriter
 import java.util.Properties
+import java.util.concurrent.{ArrayBlockingQueue, Executors, ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 import scala.io.AnsiColor
 
@@ -50,7 +49,7 @@ object ParseQuery extends LogSupport:
 // Test command for parsing queries in batch
 class ParseQuery() extends LogSupport:
 
-  private val codec                    = MessageCodec.of[QueryErrorRecord]
+  private val codec                    = Weaver.of[QueryErrorRecord]
   private val PROGRESS_REPORT_INTERVAL = 10000
 
   private def writeErrorRecord(
@@ -184,10 +183,13 @@ class ParseQuery() extends LogSupport:
                   .lang
                   .compiler
                   .CompilerOptions(
-                    phases = wvlet.lang.compiler.Compiler.parseOnlyPhases,
                     sourceFolders = List("target/test"),
-                    workEnv = wvlet.lang.compiler.WorkEnv(".", logLevel = wvlet.log.LogLevel.INFO)
-                  )
+                    workEnv = wvlet
+                      .lang
+                      .compiler
+                      .WorkEnv(".", logLevel = wvlet.uni.log.LogLevel.INFO)
+                  ),
+                phases = wvlet.lang.compiler.Compiler.parseOnlyPhases
               )
 
             // Thread-safe counters and timing
@@ -220,32 +222,43 @@ class ParseQuery() extends LogSupport:
                       sql = rs.getString("sql")
                     )
 
-              // Process queries in parallel using Parallel.iterate for memory-efficient streaming
-              val results =
-                Parallel.iterate(queryIterator, parallelism = parallelism) { queryRecord =>
-                  val hasError = parseQueryRecord(queryRecord, compiler, errorWriter)
-
-                  // Update counters
-                  queryCount.incrementAndGet()
-                  if hasError then
-                    errorCount.incrementAndGet()
-
-                  // Report progress at regular intervals
-                  val currentQueryCount = queryCount.get()
-                  if currentQueryCount % PROGRESS_REPORT_INTERVAL == 0 then
-                    val currentErrorCount = errorCount.get()
-                    val progressMessage   = formatProgressMessage(
-                      currentQueryCount,
-                      currentErrorCount,
-                      startTimeNanos
-                    )
-                    System.err.print(s"\r${AnsiColor.CYAN}${progressMessage}${AnsiColor.RESET}")
-
-                  hasError
-                }
-
-              // Consume the iterator to trigger parallel processing
-              results.foreach(_ => ()) // Just consume the results
+              // Process queries in parallel with bounded back-pressure. CallerRunsPolicy makes
+              // the producing thread (this loop) execute the task itself when the worker queue
+              // fills up — that throttles ResultSet reads, keeping memory bounded the same way
+              // airframe Parallel.iterate did. Replaces wvlet.airframe.control.Parallel.iterate.
+              val workQueue = ArrayBlockingQueue[Runnable](parallelism * 2)
+              val pool      = ThreadPoolExecutor(
+                parallelism,
+                parallelism,
+                0L,
+                TimeUnit.MILLISECONDS,
+                workQueue,
+                ThreadPoolExecutor.CallerRunsPolicy()
+              )
+              try
+                while queryIterator.hasNext do
+                  val queryRecord = queryIterator.next()
+                  pool.execute { () =>
+                    val hasError = parseQueryRecord(queryRecord, compiler, errorWriter)
+                    queryCount.incrementAndGet()
+                    if hasError then
+                      errorCount.incrementAndGet()
+                    val currentQueryCount = queryCount.get()
+                    if currentQueryCount % PROGRESS_REPORT_INTERVAL == 0 then
+                      val currentErrorCount = errorCount.get()
+                      val progressMessage   = formatProgressMessage(
+                        currentQueryCount,
+                        currentErrorCount,
+                        startTimeNanos
+                      )
+                      System.err.print(s"\r${AnsiColor.CYAN}${progressMessage}${AnsiColor.RESET}")
+                  }
+                pool.shutdown()
+                pool.awaitTermination(Long.MaxValue, TimeUnit.NANOSECONDS)
+              finally
+                if !pool.isTerminated then
+                  pool.shutdownNow()
+              end try
               System.err.println()
 
               val finalQueryCount = queryCount.get()


### PR DESCRIPTION
## Summary

Drops the last \`airframe-launcher\` dep from the build (was \`wvlet-labs\` only). \`ParseQuery\` now consumes uni equivalents end-to-end.

| airframe | uni |
|---|---|
| \`airframe.launcher.{Launcher, @command, @argument, @option}\` | \`wvlet.uni.cli.launcher.*\` |
| \`airframe.codec.MessageCodec.of[T]\` | \`wvlet.uni.weaver.Weaver.of[T]\` (\`toJson\` is the same shape) |
| \`airframe.control.Control\` | \`wvlet.uni.control.Control\` |
| \`airframe.metrics.{Count, ElapsedTime}\` | \`wvlet.uni.util.{Count, ElapsedTime}\` |

uni doesn't ship a \`Parallel.iterate\` equivalent, so it's inlined as a \`ThreadPoolExecutor\` with an \`ArrayBlockingQueue\` and \`CallerRunsPolicy\`. That preserves airframe's bounded back-pressure semantics — the producing thread executes the task itself when the worker queue fills up, throttling JDBC \`ResultSet\` reads and keeping memory bounded for large query logs.

Also touched, both forced by the dep drop:

- \`wvlet.log.LogLevel.INFO\` (transitive via airframe-log, gone with airframe-launcher) → \`wvlet.uni.log.LogLevel.INFO\`.
- \`CompilerOptions(phases = ...)\` → \`Compiler(opts, phases = ...)\`. \`phases\` moved off \`CompilerOptions\` in a recent refactor.

Refs #1662 phase 7. After this PR \`airframe-launcher\` / \`airframe-codec\` / \`airframe-control\` / \`airframe-metrics\` are no longer pulled transitively into any wvlet module's source path. Only \`airspec\` (test framework, gradual replacement by uni-test in progress) remains on the airframe stack.

## Test plan

- [x] \`./sbt projectJVM/Test/compile\`
- [x] \`./sbt projectJS/test\`
- [x] \`./sbt projectNative/Test/compile\`
- [x] \`./sbt scalafmtAll\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)