### PR TITLE
internal: Drop airspec dep — every test is on UniTest now

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ import scala.scalanative.build.NativeConfig
 val AIRFRAME_VERSION = "2026.1.6"
 val UNI_VERSION      = "2026.1.9"
 
-val AIRSPEC_VERSION        = AIRFRAME_VERSION
 val TRINO_VERSION          = "476"
 val AWS_SDK_VERSION        = "2.20.146"
 val SCALAJS_DOM_VERSION    = "2.8.1"
@@ -33,15 +32,11 @@ val buildSettings = Seq[Setting[?]](
   libraryDependencies ++=
     Seq(
       // https://users.scala-lang.org/t/scala-js-with-3-7-0-package-scala-contains-object-and-package-with-same-name-caps/10786/5
-      "org.scala-lang"      %% "scala3-library" % scalaVersion.value,
-      "org.wvlet.airframe" %%% "airspec"        % AIRSPEC_VERSION % Test,
-      "org.wvlet.uni"      %%% "uni-test"       % UNI_VERSION     % Test
+      "org.scala-lang" %% "scala3-library" % scalaVersion.value,
+      // airspec dropped: every test in the tree now extends UniTest / WvletDITest.
+      "org.wvlet.uni"  %%% "uni-test"       % UNI_VERSION     % Test
     ),
-  testFrameworks ++=
-    Seq(
-      new TestFramework("wvlet.airspec.Framework"),
-      new TestFramework("wvlet.uni.test.Framework")
-    ),
+  testFrameworks += new TestFramework("wvlet.uni.test.Framework"),
   // Don't use pipelining as it tends to slowdown the build
   usePipelining := false
 )


### PR DESCRIPTION
## Summary

Audit: **zero** \`extends AirSpec\` and **zero** \`import wvlet.airspec\` left across the source tree. The earlier per-module migrations to \`UniTest\` / \`WvletDITest\` are complete. This PR drops:

- the \`airspec\` dependency from \`buildSettings\`,
- the \`AIRSPEC_VERSION\` constant (was just an alias for \`AIRFRAME_VERSION\`),
- the \`wvlet.airspec.Framework\` \`TestFramework\` registration.

Only \`wvlet.uni.test.Framework\` remains.

After this PR there are zero remaining \`org.wvlet.airframe\` deps in \`build.sbt\` and zero \`import wvlet.airframe\` (or \`wvlet.airspec\` / \`wvlet.log\`) imports in any wvlet module's source path. Closes the airframe→uni migration tracked in #1662.

## Test plan

- [x] \`./sbt projectJVM/Test/compile\`
- [x] \`./sbt projectJS/test\`
- [x] \`./sbt projectNative/Test/compile\`
- [x] \`./sbt scalafmtAll\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)