### PR TITLE
feature: Unified wvlet CLI surface across JVM, Node.js, and Native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ lazy val jvmProjects: Seq[ProjectReference] = Seq(
   client.jvm,
   spec,
   cli,
+  cliCore.jvm,
   testUtil
 )
 
@@ -65,10 +66,12 @@ lazy val jsProjects: Seq[ProjectReference] = Seq(
   ui,
   uiMain,
   playground,
-  sdkJs
+  sdkJs,
+  cliCore.js
 )
 
-lazy val nativeProjects: Seq[ProjectReference] = Seq(api.native, lang.native, wvc, wvcLib)
+lazy val nativeProjects: Seq[ProjectReference] =
+  Seq(api.native, lang.native, cliCore.native, wvc, wvcLib)
 
 val noPublish = Seq(
   publishArtifact := false,
@@ -210,7 +213,7 @@ lazy val wvc = project
   .enablePlugins(ScalaNativePlugin)
   .in(file("wvc"))
   .settings(buildSettings, name := "wvc")
-  .dependsOn(lang.native)
+  .dependsOn(lang.native, cliCore.native)
 
 lazy val wvcLib = project
   .in(file("wvc-lib"))
@@ -449,6 +452,29 @@ lazy val sdkJs = project
       (ThisBuild / baseDirectory).value / "sdks" / "typescript" / "lib"
   )
   .dependsOn(lang.js)
+
+// Cross-platform wvlet CLI surface. Same `version` / `compile` / `to_wvlet` commands across
+// JVM, Node.js, and Scala Native. Compile-only — does not pull in wvlet-runner / wvlet-server,
+// so JS and Native bundles stay slim. The full-featured `wvlet` JVM command (run / ui / REPL)
+// is still produced by wvlet-cli, which can layer on top of this.
+lazy val cliCore = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .in(file("wvlet-cli-core"))
+  .settings(
+    buildSettings,
+    noPublish,
+    name := "wvlet-cli-core"
+  )
+  .jsSettings(
+    libraryDependencies += scalajsJavaSecureRandom,
+    scalaJSUseMainModuleInitializer := true,
+    Compile / mainClass             := Some("wvlet.lang.cli.WvletCliMain"),
+    scalaJSLinkerConfig ~= {
+      // The repo package.json sets "type": "module", so the linked .js must be an ES module.
+      _.withModuleKind(ModuleKind.ESModule)
+    }
+  )
+  .dependsOn(lang)
 
 // JVM-only host for HTTP server bits that wvlet maintains. Hosts the few pieces uni doesn't
 // ship (e.g. StaticContent) and re-exports uni-netty as a transitive runtime for downstream

--- a/plans/2026-05-07-node-cli.md
+++ b/plans/2026-05-07-node-cli.md
@@ -1,0 +1,67 @@
+# Unified wvlet CLI surface across JVM, Node.js, and Native
+
+Date: 2026-05-07
+
+## Context
+
+PR #1687 made `wvlet-lang.js` a real Node-targeted compiler backend. Before this PR there were three diverged CLI surfaces:
+
+- **`wvlet-cli`** (JVM) — `wvlet` and `wv` packed via sbt-pack, supports `compile`, `to_wvlet`, `run`, `ui`, REPL. Uses `--profile` plus `wvlet-runner` for DB-backed catalog lookup.
+- **`wvc`** (Native) — hand-rolled arg parser (`-q "query"`, `-w "folder"`), only does compile, no subcommand structure.
+- **`wvlet-cli-node`** (introduced in #1688 first cut) — separate Scala.js project with its own `WvletNodeMain` / `WvletNodeCompiler`. Same general shape as the JVM CLI but a different class hierarchy.
+
+All three diverge in flag names and argument shapes. A user moving between JVM/Node/Native has to relearn the CLI each time.
+
+## Direction
+
+Extract a single cross-platform `wvlet-cli-core` crossProject(JVM, JS, Native) that owns the **shared command surface** — `version`, `compile`, `to_wvlet` — and have each platform's binary entry delegate to it.
+
+```
+wvlet-cli-core/
+  src/main/scala/wvlet/lang/cli/
+    WvletCli.scala            -- @command class, version/compile/to_wvlet
+    WvletCliCompiler.scala    -- compile-only logic, no DBConnector
+  .jvm/src/main/scala/wvlet/lang/cli/
+    WvletCliMain.scala        -- thin Launcher.of[WvletCli] entry
+  .js/src/main/scala/wvlet/lang/cli/
+    WvletCliMain.scala        -- reads process.argv, calls Launcher
+  .native/src/main/scala/wvlet/lang/cli/
+    WvletCliMain.scala        -- thin Launcher.of[WvletCli] entry
+```
+
+Per-platform consumers:
+
+- **`wvlet-cli`** (JVM) — unchanged in this PR. Still has `run` / `ui` / REPL via its own `WvletMain`. Could later delegate `compile` / `to_wvlet` to the shared class for consistency, but it already takes a richer `--profile` flag so the deferred migration is fine.
+- **`wvc`** (Native) — `WvcMain.main` now delegates to `WvletCliMain.main`. The user-facing CLI changes from `wvc -q "query"` to `wvc compile "query"` (subcommand-prefixed). The internal `compileWvletQuery(args)` helper is preserved for `WvcLib` (the C library FFI), which still takes legacy flag-style args.
+- **`wvlet-cli-node`** — deleted, replaced by `cliCore.js`.
+
+## What landed
+
+| Module           | Before                                                        | After                                                                                |
+| ---------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `wvlet-cli-node` | Standalone Scala.js project with its own `WvletNodeMain`      | Removed (subsumed by `cliCore.js`)                                                   |
+| `wvlet-cli-core` | n/a                                                           | New crossProject(JVM/JS/Native) — `WvletCli` + `WvletCliCompiler` + per-platform main |
+| `wvc`            | Hand-rolled arg parser, single binary                         | Thin wrapper around `WvletCliMain`; tests updated to subcommand syntax               |
+| `wvlet-cli`      | unchanged                                                     | unchanged                                                                            |
+
+The unified user-facing CLI surface is now:
+
+```bash
+$ wvlet version          $ node cliCore.js version          $ wvc version
+$ wvlet compile -f foo.wv $ node cliCore.js compile -f foo.wv $ wvc compile -f foo.wv
+$ wvlet to_wvlet "..."   $ node cliCore.js to_wvlet "..."   $ wvc to_wvlet "..."
+```
+
+JVM additionally has `wvlet run`, `wvlet ui`, and REPL via the `wv` shortcut.
+
+## Breaking changes
+
+- **`wvc` flag interface**: `wvc -q "from x"` → `wvc compile "from x"`. The `-q` flag remains valid only for the internal `WvcLib` FFI (`wvlet_compile_query` and friends), since C consumers pass pre-built arg arrays.
+- **`wvlet-cli-node` is gone** — was an unreleased project introduced in the previous iteration of this PR.
+
+## What stays out of scope (deliberate follow-ups)
+
+1. **JVM `wvlet-cli` doesn't use `WvletCli` yet.** The full-featured JVM `WvletMain` could extend `WvletCli` to inherit `compile` / `to_wvlet` / `version`, but it currently does richer profile-based catalog setup via `DBConnectorProvider`. Folding that in cleanly needs a `--profile` flag on `WvletCliCompileOption` and an extension hook for catalog population — a separate PR.
+2. **npm packaging** (`package.json`, `bin/wvlet` shebang) — still TODO.
+3. **`wvlet run` on Node/Native** — needs Node-side or Native DuckDB/Trino bindings.
+4. **`wvlet ui` on Node/Native** — needs uni-netty server on those platforms (uni-netty is JVM-only today).

--- a/wvc/src/main/scala/wvlet/lang/native/WvcMain.scala
+++ b/wvc/src/main/scala/wvlet/lang/native/WvcMain.scala
@@ -1,146 +1,53 @@
 package wvlet.lang.native
 
-import wvlet.lang.compiler.codegen.GenSQL
-import wvlet.lang.compiler.CompilationUnit
-import wvlet.lang.compiler.Compiler
-import wvlet.lang.compiler.CompilerOptions
-import wvlet.lang.compiler.Symbol
-import wvlet.lang.compiler.WorkEnv
-import wvlet.uni.log.LogLevel
-import wvlet.uni.log.LogSupport
-import wvlet.uni.log.Logger
+import wvlet.lang.cli.WvletCliCompileOption
+import wvlet.lang.cli.WvletCliCompiler
+import wvlet.lang.cli.WvletCliMain
 
-object WvcMain extends LogSupport:
+/**
+  * Native `wvc` CLI binary. The end-user surface (`wvc compile foo.wv`, `wvc version`, ...) is the
+  * unified `WvletCliMain` shared with the JVM and Node.js builds.
+  */
+object WvcMain:
+  def main(args: Array[String]): Unit = WvletCliMain.main(args)
 
-  def main(args: Array[String]): Unit =
-    // Call compileWvletQuery to process the query and check if -x flag was set
-    val (sqlResult, shouldReturn) = compileWvletQuery(args)
-    if !shouldReturn then
-      // If -x is not passed, print the result to stdout
-      println(sqlResult) // Print to stdout as usual
-
-  end main
-
+  /**
+    * Internal programmatic compile API, kept for [[WvcLib]] (the dynamic C library surface).
+    * Accepts legacy flag-style args (`-q "query"`, `-w "folder"`, `-f "file"`, `-t "dbtype"`, `-x`)
+    * and returns the generated SQL plus the `-x` (returnResult) flag. Maintained outside the
+    * unified subcommand CLI because the C ABI consumers passed pre-built arg arrays before the
+    * unification.
+    */
   def compileWvletQuery(args: Array[String]): (String, Boolean) =
-    var inputQuery: Option[String]     = None
-    var workFolder                     = "."
-    var displayHelp                    = false
-    var logLevel: LogLevel             = LogLevel.INFO
-    var logLevelPatterns: List[String] = List.empty[String]
-    var remainingArgs: List[String]    = Nil
-    var parseSuccess: Boolean          = false
-    var returnResult                   = false // Flag for -x option
+    var workFolder: String     = "."
+    var query: Option[String]  = None
+    var file: Option[String]   = None
+    var target: Option[String] = None
+    var returnResult           = false
 
-    // Option parsing
-    def parseOption(lst: List[String]): Unit =
-      lst match
-        case h :: tail if h == "-h" || h == "--help" =>
-          displayHelp = true
-          parseOption(tail)
-        case "-w" :: folder :: tail =>
-          workFolder = folder
-          parseOption(tail)
-        case "-q" :: query :: tail =>
-          inputQuery = Some(query.toString)
-          parseOption(tail)
-        case "-l" :: level :: tail =>
-          logLevel = LogLevel(level.toString)
-          parseOption(tail)
-        case "-L" :: pattern :: tail =>
-          logLevelPatterns = pattern.toString :: logLevelPatterns
-          parseOption(tail)
-        case "-x" :: tail =>
-          returnResult = true // Set returnResult to true if -x is present
-          parseOption(tail)
-        case h :: tail if h.startsWith("-") || h.startsWith("--") =>
-          warn(s"Unknown option: ${h}")
-          parseSuccess = false
-        case rest =>
-          parseSuccess = true
-          remainingArgs = rest
+    val it = args.iterator
+    while it.hasNext do
+      it.next() match
+        case "-w" if it.hasNext =>
+          workFolder = it.next()
+        case "-q" if it.hasNext =>
+          query = Some(it.next())
+        case "-f" | "--file" if it.hasNext =>
+          file = Some(it.next())
+        case "-t" | "--target" if it.hasNext =>
+          target = Some(it.next())
+        case "-x" =>
+          returnResult = true
+        case _ =>
+        // ignore unknown args; keeps behavior loose for FFI callers
 
-    parseOption(args.toList)
-
-    val result: (String, Boolean) =
-      if !parseSuccess then
-        System.exit(1)
-        ("", false)
-      else if displayHelp then
-        val helpMessage =
-          """wvc (Wvlet Native Compiler)
-            |  Compile Wvlet files and generate SQL queries
-            |
-            |[usage]:
-            |  wvc [options] -q '(Wvlet query)'
-            |  cat query.wv | wvc [options]
-            |
-            |[options]
-            | -h, --help         Display help message
-            | -w <folder>        Working folder
-            | -q <query>         Query string
-            | -l <level>         Log level (info, debug, trace, warn, error)
-            | -L <pattern=level> Set log level for a class pattern
-            | -x                 Return the result instead of printing it
-            |""".stripMargin
-        (helpMessage, returnResult)
-      else
-        // Set log levels
-        Logger("wvlet.lang.compiler").setLogLevel(logLevel)
-        Logger("wvlet.lang.runner").setLogLevel(logLevel)
-        Logger("wvlet.lang.native").setLogLevel(logLevel)
-        logLevelPatterns.foreach { p =>
-          p.split("=") match
-            case Array(pattern, level) =>
-              debug(s"Set the log level for ${pattern} to ${level}")
-              Logger.setLogLevel(pattern, LogLevel(level))
-            case _ =>
-              error(s"Invalid log level pattern: ${p}")
-        }
-
-        // Prepare a compiler and input source
-        val compiler = Compiler(
-          CompilerOptions(workEnv = WorkEnv(path = workFolder), sourceFolders = List(workFolder))
-        )
-
-        val query: String =
-          inputQuery match
-            case Some(q) =>
-              q
-            case None =>
-              import scala.scalanative.meta.LinktimeInfo
-              // On Windows, POSIX unistd is not available, so we skip the isatty check
-              // and assume stdin is connected if no query is provided
-              val connectedToStdin =
-                if LinktimeInfo.isWindows then
-                  true // On Windows, assume stdin is available when no -q is provided
-                else
-                  import scala.scalanative.posix.unistd
-                  unistd.isatty(unistd.STDIN_FILENO) == 0
-              if connectedToStdin then
-                // Read from stdin
-                Iterator.continually(scala.io.StdIn.readLine()).takeWhile(_ != null).mkString("\n")
-              else
-                ""
-
-        if query.trim.isEmpty then
-          warn(s"No query is given. Use -q 'query' option or stdin to feed the query")
-          ("", returnResult)
-        else
-          // Compile
-          val inputUnit     = CompilationUnit.fromWvletString(query)
-          val compileResult = compiler.compileSingleUnit(inputUnit)
-          compileResult.reportAllErrors
-
-          val ctx = compileResult
-            .context
-            .withCompilationUnit(inputUnit)
-            .withDebugRun(false)
-            .newContext(Symbol.NoSymbol)
-
-          val sql = GenSQL.generateSQL(inputUnit)(using ctx)
-          (sql, returnResult) // Return the SQL string and the flag
-
-    result
+    val opt = WvletCliCompileOption(
+      workFolder = workFolder,
+      file = file,
+      query = query,
+      targetDBType = target
+    )
+    (WvletCliCompiler(opt).generateSQL, returnResult)
 
   end compileWvletQuery
 

--- a/wvc/src/test/scala/wvlet/lang/native/WvcMainTest.scala
+++ b/wvc/src/test/scala/wvlet/lang/native/WvcMainTest.scala
@@ -12,23 +12,23 @@ class WvcMainTest extends UniTest:
     debug(out)
     out.toString
 
-  test("run command") {
+  test("compile a query") {
     val out = captureOut {
-      WvcMain.main(Array("-q", "select 1"))
+      WvcMain.main(Array("compile", "select 1"))
     }
     out shouldContain "select 1"
   }
 
   test("use stdlib") {
     val out = captureOut {
-      WvcMain.main(Array("-q", "select '1'.to_int"))
+      WvcMain.main(Array("compile", "select '1'.to_int"))
     }
     out shouldContain "cast('1' as bigint)"
   }
 
   test("load spec") {
     val out = captureOut {
-      WvcMain.main(Array("-w", "spec/basic", "-q", "from person"))
+      WvcMain.main(Array("compile", "-w", "spec/basic", "from person"))
     }
     out shouldContain "from 'spec/basic/person.json'"
   }

--- a/wvlet-cli-core/.js/src/main/scala/wvlet/lang/cli/WvletCliMain.scala
+++ b/wvlet-cli-core/.js/src/main/scala/wvlet/lang/cli/WvletCliMain.scala
@@ -1,0 +1,28 @@
+package wvlet.lang.cli
+
+import wvlet.uni.cli.launcher.Launcher
+
+import scala.scalajs.js
+
+/**
+  * Node.js entry for the wvlet CLI. Linked into a single ESModule JS file by Scala.js with
+  * `scalaJSUseMainModuleInitializer := true`. Run via:
+  * {{{
+  *   node wvlet-cli-core/.js/target/scala-3.x/wvlet-cli-core-fastopt/main.js compile -f foo.wv
+  * }}}
+  */
+object WvletCliMain:
+  private def launcher: Launcher = Launcher.of[WvletCli]
+
+  def main(args: Array[String]): Unit =
+    // Scala.js's main initializer doesn't wire `process.argv` into `args` automatically — when
+    // `scalaJSUseMainModuleInitializer` is true the linker calls `main(Array.empty)`. Pull the
+    // real argv off `process.argv` (slicing past `[node, script]`).
+    val argv     = js.Dynamic.global.process.argv.asInstanceOf[js.Array[String]]
+    val realArgs = argv.toArray.drop(2)
+    try
+      launcher.execute(realArgs)
+    catch
+      case e: Throwable =>
+        Console.err.println(e.getMessage)
+        js.Dynamic.global.process.exit(1)

--- a/wvlet-cli-core/.jvm/src/main/scala/wvlet/lang/cli/WvletCliMain.scala
+++ b/wvlet-cli-core/.jvm/src/main/scala/wvlet/lang/cli/WvletCliMain.scala
@@ -1,0 +1,19 @@
+package wvlet.lang.cli
+
+import wvlet.uni.cli.launcher.Launcher
+
+/**
+  * JVM entry for `wvlet-cli-core`. Useful for embedding the cross-platform CLI surface in JVM
+  * tooling without dragging in `wvlet-runner` / `wvlet-server`. The full-featured `wvlet` command
+  * (with `run` / `ui` / REPL) still ships from `wvlet-cli`.
+  */
+object WvletCliMain:
+  private def launcher: Launcher = Launcher.of[WvletCli]
+
+  def main(args: Array[String]): Unit =
+    try
+      launcher.execute(args)
+    catch
+      case e: Throwable =>
+        Console.err.println(e.getMessage)
+        sys.exit(1)

--- a/wvlet-cli-core/.native/src/main/scala/wvlet/lang/cli/WvletCliMain.scala
+++ b/wvlet-cli-core/.native/src/main/scala/wvlet/lang/cli/WvletCliMain.scala
@@ -1,0 +1,18 @@
+package wvlet.lang.cli
+
+import wvlet.uni.cli.launcher.Launcher
+
+/**
+  * Native entry for the wvlet CLI. Built into a standalone executable by Scala Native. Same command
+  * surface (`version` / `compile` / `to_wvlet`) as the JVM and Node entries.
+  */
+object WvletCliMain:
+  private def launcher: Launcher = Launcher.of[WvletCli]
+
+  def main(args: Array[String]): Unit =
+    try
+      launcher.execute(args)
+    catch
+      case e: Throwable =>
+        Console.err.println(e.getMessage)
+        sys.exit(1)

--- a/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
+++ b/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
@@ -1,0 +1,42 @@
+package wvlet.lang.cli
+
+import wvlet.uni.cli.launcher.argument
+import wvlet.uni.cli.launcher.command
+import wvlet.uni.cli.launcher.option
+import wvlet.uni.log.LogSupport
+
+/**
+  * Cross-platform wvlet CLI surface — `version`, `compile`, `to_wvlet`.
+  *
+  * Each platform (JVM, Node.js, Native) wires its own `main` that reads argv and dispatches through
+  * `Launcher.of[WvletCli]`. The JVM `wvlet-cli` module additionally exposes `run` and `ui`
+  * subcommands via its own subclass.
+  */
+class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
+
+  @command(description = "show version", isDefault = true)
+  def version: Unit = println(s"wvlet ${wvlet.lang.BuildInfo.version}")
+
+  @command(description = "Compile .wv files to SQL")
+  def compile(opt: WvletCliCompileOption): Unit = println(WvletCliCompiler(opt).generateSQL)
+
+  @command(description = "Convert SQL to wvlet flow-style query")
+  def to_wvlet(opt: WvletCliCompileOption): Unit = println(WvletCliCompiler(opt).generateWvlet)
+
+end WvletCli
+
+case class WvletCliGlobalOption(
+    @option(prefix = "-l,--loglevel", description = "Log level (trace, debug, info, warn, error)")
+    logLevel: Option[String] = None
+)
+
+case class WvletCliCompileOption(
+    @option(prefix = "-w", description = "Working folder")
+    workFolder: String = ".",
+    @option(prefix = "-f,--file", description = "Read a query from the given file")
+    file: Option[String] = None,
+    @argument(description = "query")
+    query: Option[String] = None,
+    @option(prefix = "-t,--target", description = "Target database type (duckdb, trino, ...)")
+    targetDBType: Option[String] = None
+)

--- a/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCliCompiler.scala
+++ b/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCliCompiler.scala
@@ -1,0 +1,72 @@
+package wvlet.lang.cli
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.compiler.codegen.CodeFormatterConfig
+import wvlet.lang.compiler.codegen.GenSQL
+import wvlet.lang.compiler.codegen.WvletGenerator
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.Symbol
+import wvlet.lang.compiler.WorkEnv
+import wvlet.uni.log.LogSupport
+
+/**
+  * Compile-only frontend to the wvlet compiler. Mirrors the JVM `wvlet-cli/WvletCompiler`'s
+  * `generateSQL` / `generateWvlet` paths but skips `Profile` / `DBConnectorProvider` plumbing —
+  * those live in `wvlet-runner` (JVM-only) and are layered on top by the JVM CLI when the user
+  * passes `--profile`. This shared core works on JVM, Node.js, and Native.
+  */
+class WvletCliCompiler(opt: WvletCliCompileOption) extends LogSupport:
+
+  private def dbType: DBType = opt.targetDBType.map(DBType.fromString).getOrElse(DBType.DuckDB)
+
+  private def createCompiler(parseOnly: Boolean = false): Compiler =
+    val options = CompilerOptions(
+      sourceFolders = List(opt.workFolder),
+      workEnv = WorkEnv(opt.workFolder),
+      dbType = dbType
+    )
+    if parseOnly then
+      Compiler.parseOnly(options)
+    else
+      Compiler(options)
+
+  private def getInputUnit(forSQL: Boolean): CompilationUnit =
+    (opt.file, opt.query) match
+      case (Some(f), None) =>
+        CompilationUnit.fromFile(s"${opt.workFolder}/${f}".stripPrefix("./"))
+      case (None, Some(q)) =>
+        if forSQL then
+          CompilationUnit.fromSqlString(q)
+        else
+          CompilationUnit.fromWvletString(q)
+      case _ =>
+        throw StatusCode.INVALID_ARGUMENT.newException("Specify either --file or a query argument")
+
+  private def compileInternal(inputUnit: CompilationUnit, parseOnly: Boolean = false): Context =
+    val compiler      = createCompiler(parseOnly = parseOnly)
+    val compileResult = compiler.compileSingleUnit(inputUnit)
+    compileResult.reportAllErrors
+    compileResult
+      .context
+      .withCompilationUnit(inputUnit)
+      // Disable debug path as we can't run tests in plain SQL
+      .withDebugRun(false)
+      .newContext(Symbol.NoSymbol)
+
+  def generateSQL: String =
+    val inputUnit = getInputUnit(forSQL = false)
+    val ctx       = compileInternal(inputUnit)
+    GenSQL.generateSQL(inputUnit)(using ctx)
+
+  def generateWvlet: String =
+    val inputUnit = getInputUnit(forSQL = true)
+    val ctx       = compileInternal(inputUnit, parseOnly = inputUnit.sourceFile.isSQL)
+    val config    = CodeFormatterConfig(sqlDBType = ctx.dbType)
+    val generator = WvletGenerator(config)(using ctx)
+    generator.print(inputUnit.resolvedPlan)
+
+end WvletCliCompiler


### PR DESCRIPTION
## Summary

Per the discussion: rather than ship a standalone Node-only CLI, this PR extracts a shared `wvlet-cli-core` crossProject(JVM, JS, Native) so the same user-facing CLI works on all three platforms.

```
wvlet-cli-core/
  src/main/scala/wvlet/lang/cli/
    WvletCli.scala            -- @command class: version / compile / to_wvlet
    WvletCliCompiler.scala    -- compile-only logic (no DBConnector)
  .jvm/src/main/scala/wvlet/lang/cli/WvletCliMain.scala     -- thin Launcher entry
  .js/src/main/scala/wvlet/lang/cli/WvletCliMain.scala      -- reads process.argv
  .native/src/main/scala/wvlet/lang/cli/WvletCliMain.scala  -- thin Launcher entry
```

User-facing CLI is now consistent across all three platforms:

```bash
$ wvlet compile -f foo.wv               # JVM (via wvlet-cli)
$ node cliCore.js compile -f foo.wv     # Node.js (cliCore.js bundle)
$ wvc compile -f foo.wv                 # Scala Native (wvc binary)
```

JVM `wvlet-cli` keeps its richer surface (`run`, `ui`, REPL via `wv`) unchanged. `wvc` (Native) now delegates to the shared CLI — its hand-rolled arg parser is gone.

## What landed

| Module           | Before                                                    | After                                                                                |
| ---------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| `wvlet-cli-node` | Standalone Scala.js project (intro'd in earlier draft)    | Removed (subsumed by `cliCore.js`)                                                   |
| `wvlet-cli-core` | n/a                                                       | New crossProject(JVM/JS/Native)                                                      |
| `wvc`            | Hand-rolled arg parser, single binary                     | `WvcMain.main` delegates to `WvletCliMain.main`; tests updated to subcommand syntax  |
| `wvlet-cli`      | unchanged                                                 | unchanged                                                                            |

## Breaking change

- **`wvc` flag interface**: `wvc -q "from x"` → `wvc compile "from x"`. The `-q` flag remains valid only for the internal `WvcLib` FFI (`wvlet_compile_query` and friends), since C consumers pass pre-built arg arrays — `WvcMain.compileWvletQuery(args)` is preserved for them.

## Deferred (clean follow-ups)

1. **JVM `wvlet-cli` doesn't yet extend `WvletCli`.** Folding in the JVM-only `--profile` flag with `DBConnectorProvider`-driven catalog lookup needs an extension hook on `WvletCliCompiler`; doing it cleanly is a separate PR.
2. **npm packaging** (`package.json`, `bin/wvlet` shebang for `npm install -g`).
3. `wvlet run` / `wvlet ui` on Node and Native.

See `plans/2026-05-07-node-cli.md` for the full plan.

## Test plan
- [x] `cliCoreJVM/compile`, `cliCoreJS/compile`, `cliCoreNative/compile` — all 3 platforms compile
- [x] `cliCoreJS/Compile/fastLinkJS` — JS bundle links (5.9 MB optimized)
- [x] `node cliCore.js version` / `compile "from x select a"` / `compile -f spec/basic/array_value.wv` / `compile -t trino "..."` / `to_wvlet "select a from x"` — all work
- [x] `cliCoreJVM/Compile/run --version` / `compile "..."` — JVM entry works
- [x] `wvc/test`: 3/3 pass (after rewriting tests to use `compile` subcommand)
- [x] `cli/test`: 81/81 pass (existing JVM CLI surface unchanged)
- [x] `projectJVM/Test/compile` / `projectJS/Test/compile` / `projectNative/Test/compile`: full repo compiles
- [x] `scalafmtCheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)