### PR TITLE
feature: npm package for Node.js wvlet CLI (@wvlet/cli)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,7 @@ on:
         type: choice
         options:
           - typescript-sdk
+          - cli-node
           - highlightjs-wvlet
           - prismjs-wvlet
       version:
@@ -77,6 +78,61 @@ jobs:
 
       - name: Publish to NPM
         working-directory: sdks/typescript
+        run: pnpm publish --no-git-checks --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-cli-node:
+    name: Publish @wvlet/cli (Node.js) to NPM
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.package == 'cli-node')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+          cache: sbt
+
+      - uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Build wvlet-cli-core JS bundle
+        run: ./sbt "cliCoreJS/fullLinkJS"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Set version from tag
+        if: github.event_name == 'push'
+        working-directory: sdks/cli-node
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed 's/refs\/tags\/v//')
+          pnpm version $VERSION --no-git-tag-version
+
+      - name: Set version from input
+        if: github.event_name == 'workflow_dispatch'
+        working-directory: sdks/cli-node
+        run: |
+          pnpm version ${{ inputs.version }} --no-git-tag-version
+
+      - name: Publish to NPM
+        working-directory: sdks/cli-node
         run: pnpm publish --no-git-checks --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -472,7 +472,14 @@ lazy val cliCore = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     scalaJSLinkerConfig ~= {
       // The repo package.json sets "type": "module", so the linked .js must be an ES module.
       _.withModuleKind(ModuleKind.ESModule)
-    }
+    },
+    // Link directly into the npm package layout. `bin/wvlet.js` imports `lib/main.js`, so
+    // `pnpm run build` (which calls `./sbt cliCoreJS/fullLinkJS`) drops the bundle straight
+    // into the publishable folder.
+    Compile / fastLinkJS / scalaJSLinkerOutputDirectory :=
+      (ThisBuild / baseDirectory).value / "sdks" / "cli-node" / "lib",
+    Compile / fullLinkJS / scalaJSLinkerOutputDirectory :=
+      (ThisBuild / baseDirectory).value / "sdks" / "cli-node" / "lib"
   )
   .dependsOn(lang)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,8 @@ importers:
         specifier: ^5.47.1
         version: 5.47.1
 
+  sdks/cli-node: {}
+
   sdks/typescript:
     devDependencies:
       '@types/node':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
   - 'highlightjs-wvlet'
   - 'prismjs-wvlet'
   - 'sdks/typescript'
+  - 'sdks/cli-node'

--- a/sdks/cli-node/.gitignore
+++ b/sdks/cli-node/.gitignore
@@ -1,0 +1,3 @@
+lib/
+node_modules/
+*.tgz

--- a/sdks/cli-node/README.md
+++ b/sdks/cli-node/README.md
@@ -1,0 +1,36 @@
+# @wvlet/cli
+
+The wvlet command-line compiler for Node.js. Compile `.wv` flow-style queries to SQL without a JVM.
+
+## Install
+
+```bash
+npm install -g @wvlet/cli
+```
+
+Requires Node.js 20+.
+
+## Usage
+
+```bash
+wvlet version
+wvlet compile -f query.wv > query.sql
+wvlet compile -t trino "from x select a, b"
+wvlet to_wvlet "select a, b from x where c > 10"
+```
+
+This package ships the same `version` / `compile` / `to_wvlet` subcommands as the JVM `wvlet` binary and the Scala Native `wvc` binary. JVM-only features (`run`, `ui`, REPL) are not available in this Node distribution.
+
+## Building from source
+
+```bash
+# In this folder:
+pnpm run build       # produces lib/main.js (production, ~6 MB)
+pnpm run build:dev   # produces lib/main.js (dev, ~10 MB, faster)
+```
+
+The build invokes `./sbt cliCoreJS/{fullLinkJS,fastLinkJS}` from the repo root, which links the Scala.js compiler bundle into `lib/`.
+
+## License
+
+Apache-2.0

--- a/sdks/cli-node/bin/wvlet.js
+++ b/sdks/cli-node/bin/wvlet.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+// Thin shebang wrapper. Importing `lib/main.js` triggers the Scala.js main module
+// initializer, which reads `process.argv` and dispatches through the wvlet CLI launcher.
+import "../lib/main.js";

--- a/sdks/cli-node/package.json
+++ b/sdks/cli-node/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@wvlet/cli",
+  "version": "0.0.0",
+  "description": "wvlet command-line compiler for Node.js — compile .wv flow-style queries to SQL",
+  "type": "module",
+  "bin": {
+    "wvlet": "./bin/wvlet.js"
+  },
+  "scripts": {
+    "build:scalajs": "cd ../.. && ./sbt cliCoreJS/fullLinkJS",
+    "build:scalajs:dev": "cd ../.. && ./sbt cliCoreJS/fastLinkJS",
+    "build": "pnpm run build:scalajs",
+    "prepublishOnly": "pnpm run build"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "README.md"
+  ],
+  "keywords": [
+    "wvlet",
+    "sql",
+    "query",
+    "compiler",
+    "cli"
+  ],
+  "author": "wvlet.org",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wvlet/wvlet.git",
+    "directory": "sdks/cli-node"
+  },
+  "bugs": {
+    "url": "https://github.com/wvlet/wvlet/issues"
+  },
+  "homepage": "https://wvlet.org/",
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Makes the unified Node.js CLI from #1688 actually distributable. Users can now (after this lands and is tagged):

```bash
npm install -g @wvlet/cli
wvlet compile -f foo.wv > foo.sql
```

`sdks/cli-node/` mirrors the existing TypeScript SDK layout:
- `package.json` — declares `"bin": { "wvlet": "./bin/wvlet.js" }`, scoped name `@wvlet/cli`, ESM
- `bin/wvlet.js` — shebang wrapper; `import "../lib/main.js"` triggers the Scala.js main module initializer, which reads `process.argv` and dispatches through the unified `WvletCli` launcher
- `lib/` (gitignored) — generated by `./sbt cliCoreJS/fullLinkJS`

## Build wiring

- `build.sbt`: `cliCoreJS`'s `fastLinkJS` / `fullLinkJS` outputs now go directly into `sdks/cli-node/lib/`, so `pnpm --filter @wvlet/cli run build` produces a publishable folder.
- `.github/workflows/npm-publish.yml`: new `publish-cli-node` job that fires on `v*.*.*` tags and adds `cli-node` to the manual workflow dispatch package list. Mirrors `publish-typescript-sdk` with provenance + scoped public access.
- `pnpm-workspace.yaml`: registers `sdks/cli-node`.

## Verified locally

```bash
$ ./bin/wvlet.js version
wvlet 2026.1.1+139-...

$ ./bin/wvlet.js compile "from x select a, b"
-- wvlet version=...
select a, b
from x

$ ./bin/wvlet.js to_wvlet "select a from x where b > 10"
from x
where b > 10
select a
```

Bundle size: **5.9 MB optimized / 10 MB dev**.

## Test plan
- [x] `./sbt cliCoreJS/fullLinkJS` emits into `sdks/cli-node/lib/main.js`
- [x] `./bin/wvlet.js {version,compile,to_wvlet}` work end-to-end
- [x] `pnpm install` registers the workspace cleanly
- [x] `scalafmtCheck` clean
- [x] `cliCoreJVM/compile`, `cliCoreJS/compile`, `cliCoreNative/compile` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)