### PR TITLE
feature: `wvlet run` — compile + execute against DuckDB on all three platforms

### DIFF
--- a/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
+++ b/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
@@ -1,16 +1,18 @@
 package wvlet.lang.cli
 
+import wvlet.lang.compiler.analyzer.duckdb.DuckDB
+import wvlet.lang.compiler.analyzer.duckdb.QueryResultPrinter
 import wvlet.uni.cli.launcher.argument
 import wvlet.uni.cli.launcher.command
 import wvlet.uni.cli.launcher.option
 import wvlet.uni.log.LogSupport
 
 /**
-  * Cross-platform wvlet CLI surface — `version`, `compile`, `to_wvlet`.
+  * Cross-platform wvlet CLI surface — `version`, `compile`, `to_wvlet`, `run`.
   *
   * Each platform (JVM, Node.js, Native) wires its own `main` that reads argv and dispatches through
-  * `Launcher.of[WvletCli]`. The JVM `wvlet-cli` module additionally exposes `run` and `ui`
-  * subcommands via its own subclass.
+  * `Launcher.of[WvletCli]`. The JVM `wvlet-cli` module additionally exposes `ui` and the REPL via
+  * its own entry point.
   */
 class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
 
@@ -22,6 +24,25 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
 
   @command(description = "Convert SQL to wvlet flow-style query")
   def to_wvlet(opt: WvletCliCompileOption): Unit = println(WvletCliCompiler(opt).generateWvlet)
+
+  @command(description = "Compile and execute a wvlet query against DuckDB")
+  def run(opt: WvletCliRunOption): Unit =
+    if !DuckDB.canExecute then
+      throw new UnsupportedOperationException(
+        "DuckDB execution is not available on this platform. " +
+          "Ensure libduckdb is installed and discoverable, or set WVLET_LIBDUCKDB."
+      )
+    val sql    = WvletCliCompiler(opt.toCompileOption).generateSQL
+    val result = DuckDB.execute(sql)
+    val output =
+      opt.format.toLowerCase match
+        case "csv" =>
+          QueryResultPrinter.toCsv(result)
+        case "box" | "" =>
+          QueryResultPrinter.toBox(result)
+        case other =>
+          throw new IllegalArgumentException(s"Unknown --format: ${other} (supported: box, csv)")
+    print(output)
 
 end WvletCli
 
@@ -40,3 +61,22 @@ case class WvletCliCompileOption(
     @option(prefix = "-t,--target", description = "Target database type (duckdb, trino, ...)")
     targetDBType: Option[String] = None
 )
+
+case class WvletCliRunOption(
+    @option(prefix = "-w", description = "Working folder")
+    workFolder: String = ".",
+    @option(prefix = "-f,--file", description = "Read a query from the given file")
+    file: Option[String] = None,
+    @argument(description = "query")
+    query: Option[String] = None,
+    @option(prefix = "-t,--target", description = "Target database type (always duckdb for `run`)")
+    targetDBType: Option[String] = None,
+    @option(prefix = "--format", description = "Output format: box (default), csv")
+    format: String = "box"
+):
+  def toCompileOption: WvletCliCompileOption = WvletCliCompileOption(
+    workFolder = workFolder,
+    file = file,
+    query = query,
+    targetDBType = targetDBType
+  )

--- a/wvlet-lang/.js/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/Koffi.scala
+++ b/wvlet-lang/.js/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/Koffi.scala
@@ -13,8 +13,12 @@ import scala.scalajs.js.annotation.JSImport
   *
   * Only the bits we actually use are surfaced here; the full koffi API is much larger.
   */
+// koffi is a CommonJS package; under `ModuleKind.ESModule` consumers (like wvlet-cli-core.js)
+// the CJS module's exports surface as the ES module's DEFAULT export. Using
+// `JSImport.Default` here makes the facade work under both CommonJSModule (langJS tests)
+// and ESModule (the cli-node bundle).
 @js.native
-@JSImport("koffi", JSImport.Namespace)
+@JSImport("koffi", JSImport.Default)
 private[duckdb] object Koffi extends js.Object:
 
   /**
@@ -50,7 +54,7 @@ end KoffiLib
   * rather than getting auto-stringified to JS).
   */
 @js.native
-@JSImport("koffi", JSImport.Namespace)
+@JSImport("koffi", JSImport.Default)
 private[duckdb] object KoffiOps extends js.Object:
   def decode(value: js.Any, offset: Int, `type`: js.Any): js.Any = js.native
   def decode(value: js.Any, `type`: js.Any): js.Any              = js.native


### PR DESCRIPTION
## Summary

Closes the loop on the cross-platform DuckDB.execute work (#1705, #1706). The shared `WvletCli` now has a `run` subcommand: compile a wvlet query (file or inline) → execute against an in-memory DuckDB → print the result.

```
$ wvlet run "from [[1,'a'],[2,'b']] as t(id,label)"
┌────┬───────┐
│ id │ label │
├────┼───────┤
│ 1  │ a     │
│ 2  │ b     │
└────┴───────┘

$ wvlet run --format csv "from [[1,'a'],[2,'b']] as t(id,label)"
id,label
1,a
2,b
```

Same command works identically on:

| Platform | Invocation |
|----------|------------|
| JVM      | `cliCoreJVM/Compile/run run "..."` (or eventually the unified `wvlet` binary) |
| Node     | `node sdks/cli-node/lib/main.js run "..."` |
| Native   | `wvc run "..."` |

## What's added

- `WvletCli.run(opt: WvletCliRunOption): Unit` — single @command using `DuckDB.execute(sql)` + `QueryResultPrinter`
- `WvletCliRunOption` — same fields as `WvletCliCompileOption` plus `--format box|csv`
- Pre-flight `canExecute` check with a clear "install libduckdb / set WVLET_LIBDUCKDB" message when the backend isn't available

## Drive-by fix: koffi import under ESModule

The `Koffi` Scala.js facade was using `@JSImport("koffi", JSImport.Namespace)`, which works under `ModuleKind.CommonJSModule` (langJS tests) but breaks under `ModuleKind.ESModule` (cli-node bundle): Node's CJS→ESM interop surfaces the CommonJS module's exports under `.default`, not as named namespace members. Switching both `Koffi` and `KoffiOps` to `JSImport.Default` makes the facade work in both module kinds.

Without this fix, `DuckDB.canExecute` was reporting `false` on the ESModule bundle because `koffi.load is not a function`. End-to-end-tested the cli-node bundle to confirm.

## Test results

- langJVM: 1413 / 1413
- langJS:  1393 / 1393
- langNative: 1392 / 1392

End-to-end smoke tests pass on all three platforms (box + csv format).

## Out of scope (clean follow-ups)

- `--format json` (small)
- DATE / TIMESTAMP / DECIMAL chunk readers (currently throw NOT_IMPLEMENTED on JS/Native — CAST workaround works today)
- Trino HTTP client (you flagged this is "single page of code" — would open cross-platform remote execution)

## Test plan
- [x] `langJVM/test`: 1413/1413 pass
- [x] `langJS/test`: 1393/1393 pass
- [x] `langNative/test`: 1392/1392 pass
- [x] JVM run: `cliCoreJVM/Compile/run run "select 1+1 as two"` prints box ✓
- [x] Node run: `node sdks/cli-node/lib/main.js run "..."` (box + csv) ✓
- [x] Native run: `wvc run "..."` (box + csv) ✓
- [x] `scalafmtCheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)