### PR TITLE
feature: --profile / -p on the cross-platform CLI

### DIFF
--- a/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
+++ b/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
@@ -1,5 +1,6 @@
 package wvlet.lang.cli
 
+import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.analyzer.duckdb.DuckDB
 import wvlet.lang.compiler.analyzer.duckdb.QueryResult
 import wvlet.lang.compiler.analyzer.duckdb.QueryResultPrinter
@@ -43,7 +44,14 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
     print(output)
 
   private def executeAgainst(sql: String, opt: WvletCliRunOption): QueryResult =
-    opt.targetDBType.map(_.toLowerCase).getOrElse("duckdb") match
+    val profile = opt.profile.flatMap(Profile.getProfile)
+    // Effective backend: --target wins, then profile.type, then "duckdb".
+    val backend = opt
+      .targetDBType
+      .orElse(profile.map(_.`type`))
+      .map(_.toLowerCase)
+      .getOrElse("duckdb")
+    backend match
       case "duckdb" =>
         if !DuckDB.canExecute then
           throw new UnsupportedOperationException(
@@ -52,20 +60,45 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
           )
         DuckDB.execute(sql)
       case "trino" =>
+        // CLI flags override the matching profile field; missing host is a hard error since
+        // there's no sensible default. `--https` (a Boolean flag) can't distinguish "user passed
+        // false" from "user didn't pass it", so the profile setting only applies when the flag
+        // was left at the default `false`.
         val host = opt
           .host
-          .getOrElse(throw new IllegalArgumentException("--host is required for --target=trino"))
+          .orElse(profile.flatMap(_.host))
+          .getOrElse(
+            throw new IllegalArgumentException(
+              "Trino host is required — pass --host or set 'host' on the profile"
+            )
+          )
+        val useHttps =
+          if opt.useHttps then
+            true
+          else
+            profile.flatMap(_.useHttps).getOrElse(false)
         val cfg = TrinoConfig(
           host = host,
-          port = opt.port.getOrElse(8080),
-          user = opt.user.getOrElse("wvlet"),
-          catalog = opt.catalog,
-          schema = opt.schema,
-          useHttps = opt.useHttps
+          port = opt
+            .port
+            .orElse(profile.flatMap(_.port))
+            .getOrElse(
+              if useHttps then
+                443
+              else
+                8080
+            ),
+          user = opt.user.orElse(profile.flatMap(_.user)).getOrElse("wvlet"),
+          catalog = opt.catalog.orElse(profile.flatMap(_.catalog)),
+          schema = opt.schema.orElse(profile.flatMap(_.schema)),
+          useHttps = useHttps
         )
         Trino.execute(sql, cfg)
       case other =>
         throw new IllegalArgumentException(s"Unsupported --target for `run`: ${other}")
+    end match
+
+  end executeAgainst
 
 end WvletCli
 
@@ -92,13 +125,18 @@ case class WvletCliRunOption(
     file: Option[String] = None,
     @argument(description = "query")
     query: Option[String] = None,
+    @option(prefix = "-p,--profile", description = "Profile name from ~/.wvlet/profiles.json")
+    profile: Option[String] = None,
     @option(prefix = "-t,--target", description = "Backend: duckdb (default) or trino")
     targetDBType: Option[String] = None,
     @option(prefix = "--format", description = "Output format: box (default), csv")
     format: String = "box",
-    @option(prefix = "--host", description = "Trino coordinator host (target=trino only)")
+    @option(prefix = "--host", description = "Trino coordinator host (overrides profile)")
     host: Option[String] = None,
-    @option(prefix = "--port", description = "Trino coordinator port (default 8080)")
+    @option(
+      prefix = "--port",
+      description = "Trino coordinator port (default 443 with --https, else 8080)"
+    )
     port: Option[Int] = None,
     @option(prefix = "--user", description = "Trino user (default 'wvlet')")
     user: Option[String] = None,

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/Profile.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/Profile.scala
@@ -24,8 +24,6 @@ import wvlet.lang.compiler.DBType
 import wvlet.uni.log.LogSupport
 import wvlet.uni.io.IO
 
-import java.io.File
-
 case class Profile(
     name: String,
     `type`: String,
@@ -35,6 +33,7 @@ case class Profile(
     port: Option[Int] = None,
     catalog: Option[String] = None,
     schema: Option[String] = None,
+    useHttps: Option[Boolean] = None,
     properties: Map[String, Any] = Map.empty
 ):
   def dbType: DBType                                 = DBType.fromString(`type`)
@@ -96,15 +95,23 @@ object Profile extends LogSupport:
 
   end getProfile
 
-  def getProfile(profile: String): Option[Profile] =
-    val configDir = sys.props("user.home") + "/.wvlet"
+  def getProfile(profile: String): Option[Profile] = getProfile(profile, defaultConfigDir)
+
+  /**
+    * Test-friendly overload that takes an explicit config directory instead of resolving
+    * `${HOME}/.wvlet`. Production code calls the single-arg version.
+    */
+  def getProfile(profile: String, configDir: String): Option[Profile] =
     resolveConfigPath(configDir) match
       case Some(configPath) =>
         readProfileConfig(configPath).profiles.find(_.name == profile)
       case None =>
         None
 
-  end getProfile
+  // Resolves `~/.wvlet` via uni's cross-platform `IO.homeDirectory`. JVM reads
+  // `System.getProperty("user.home")`, Node uses `os.homedir()`, Native uses libc's
+  // `getpwuid`/`HOME` fallback — so the profile config lives in the same place across all three.
+  private def defaultConfigDir: String = s"${IO.homeDirectory}/.wvlet"
 
   // Returns the path of the first profile config file found, or None when
   // no config exists at all.
@@ -115,11 +122,11 @@ object Profile extends LogSupport:
   // against DuckDB. Force the user to convert before any query runs.
   private def resolveConfigPath(configDir: String): Option[String] =
     val candidates = Seq("profiles.json", "profiles.jsonc")
-    val found = candidates.iterator.map(name => s"${configDir}/${name}").find(p => File(p).isFile)
+    val found      = candidates.iterator.map(name => s"${configDir}/${name}").find(IO.isFile)
     found.orElse {
       Seq("profiles.yml", "profiles.yaml")
         .map(name => s"${configDir}/${name}")
-        .find(p => File(p).isFile)
+        .find(IO.isFile)
         .foreach { path =>
           throw StatusCode
             .INVALID_ARGUMENT
@@ -132,7 +139,7 @@ object Profile extends LogSupport:
     }
 
   private def readProfileConfig(configPath: String): ProfileConfig =
-    val rawText  = IO.readString(IO.path(configPath))
+    val rawText  = IO.readString(configPath)
     val parsed   = JSON.parse(rawText)
     val expanded = expandEnvVarsInStrings(parsed, configPath)
     Weaver.of[ProfileConfig].fromJSONValue(expanded)


### PR DESCRIPTION
## Summary

Make `wvlet run -p <profile>` work on JVM, Node.js, and Native. The JVM `wvlet` binary already supported `--profile`; the cross-platform `wvlet-cli-core` didn't because `Profile.scala` lived in `.jvm/src/main/scala` and used `java.io.File` + `sys.props(\"user.home\")`.

### What changed

- **`Profile.scala` moved to shared `src/main/scala`** — `java.io.File.isFile` → `IO.isFile`, `sys.props(\"user.home\")` → `IO.homeDirectory`. JVM behavior unchanged (uni's JVM `homeDirectory` reads the same system property); Node uses `os.homedir()`; Native uses libc.
- **`useHttps: Option[Boolean]` added to `Profile`** so HTTPS can be declared once in the profile config instead of repeated on every command line.
- **`getProfile(name, configDir)` overload** for tests + non-default config locations.
- **`--profile,-p` flag** on `WvletCliRunOption`. Resolution rules:
  - Backend: `--target` > `profile.type` > `\"duckdb\"`
  - Host / port / user / catalog / schema / useHttps: CLI flag > profile field > built-in default
  - Port autoderives from scheme: `443` when `useHttps`, else `8080`

### Design note

The user flagged that as wvlet matures into a cross-database language (a single query can reference multiple data sources), a single `--profile` becomes restrictive. This PR keeps `--profile` as a soft default — every value is overrideable on the command line, and the underlying `Profile.getProfile` API stays orthogonal to the CLI, so future federated-query work doesn't have to peel back this layer.

### Verification

- 12/12 `ProfileTest` still pass (existing mock via `sys.props(\"user.home\")` works because uni's JVM `homeDirectory` reads the same property)
- Live-tested against `api-presto.treasuredata.com` via a temp profile with `\"useHttps\": true`, `\"user\": \"\$TD_API_KEY_7060\"`, `\"catalog\": \"td\"` — env-var expansion, useHttps, and catalog all flow through to `Trino.execute`
- All 3 platforms compile (`langJVM` / `langJS` / `langNative` and `cliCore*`)

## Test plan

- [x] `langJVM/testOnly *ProfileTest *TrinoTest *DuckDBExecuteTest` — 21/21 green
- [x] Compile `cliCoreJVM` / `cliCoreJS` / `cliCoreNative`
- [x] Live smoke against TD with a temp profile
- [ ] CI passes
- [ ] Manual `wvlet run -p <profile> 'select 1'` on JVM after packing

🤖 Generated with [Claude Code](https://claude.com/claude-code)