### PR TITLE
feature: PR-A toward dropping trino-jdbc — HTTP-backed SqlConnector view

### DIFF
--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
@@ -23,8 +23,12 @@ import wvlet.uni.util.Count
 import wvlet.uni.util.ElapsedTime
 import wvlet.lang.compiler.DBType
 import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.compiler.analyzer.trino.TrinoConfig as TrinoXPConfig
+import wvlet.lang.compiler.analyzer.trino.TrinoSqlConnector
+import wvlet.lang.compiler.connector.QueryHandle
 import wvlet.lang.compiler.connector.QueryState
 import wvlet.lang.compiler.connector.QueryStats
+import wvlet.lang.compiler.connector.SqlConnector
 import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.model.DataType
 import wvlet.lang.runner.connector.*
@@ -48,6 +52,49 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
     extends DBConnector(DBType.Trino, workEnv)
     with LogSupport:
   private lazy val driver = new TrinoDriver()
+
+  /**
+    * HTTP-backed [[SqlConnector]] view of this Trino instance, exposed as a separate accessor
+    * because [[DBConnector]] and [[SqlConnector]] both declare `execute(sql)` with different return
+    * types (Boolean vs QueryResult) and can't coexist on one class. Built lazily so the JDBC code
+    * path (still the default for `QueryExecutor`'s `runQuery` / `executeUpdate`) doesn't pay any
+    * HTTP setup cost when the caller never asks for it.
+    *
+    * Re-uses the cross-platform `TrinoSqlConnector` from `wvlet-lang` so the runner doesn't
+    * reimplement the protocol. Once `QueryExecutor` migrates to this path (PR-B), we can drop the
+    * JDBC half of `TrinoConnector` and stop dragging in `trino-jdbc`.
+    */
+  lazy val asSqlConnector: SqlConnector = TrinoSqlConnector(toCrossPlatformConfig)
+
+  /**
+    * Bridge the runner's JDBC-shaped [[TrinoConfig]] to the cross-platform variant in `wvlet-lang`.
+    * `hostAndPort` collapses host + port into a single string for the JDBC URL; the cross-platform
+    * shape wants them separate, with the port autoderived from the scheme when missing. `password`
+    * is currently dropped on the HTTP path — auth on the cross-platform connector is `X-Trino-User`
+    * only until the auth story (Basic/JWT) lands.
+    */
+  private def toCrossPlatformConfig: TrinoXPConfig =
+    val parts        = config.hostAndPort.split(":", 2)
+    val host         = parts(0)
+    val explicitPort =
+      if parts.length > 1 then
+        Some(parts(1).toInt)
+      else
+        None
+    val defaultPortFor =
+      if config.useSSL then
+        443
+      else
+        8080
+    TrinoXPConfig(
+      host = host,
+      port = explicitPort.getOrElse(defaultPortFor),
+      user = config.user.getOrElse("wvlet"),
+      catalog = Some(config.catalog),
+      schema = Some(config.schema),
+      useHttps = config.useSSL,
+      source = "wvlet-runner"
+    )
 
   private[connector] override lazy val newConnection: DBConnection =
     val jdbcUrl =

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TrinoConnectorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TrinoConnectorTest.scala
@@ -95,6 +95,20 @@ class TrinoConnectorTest extends WvletDITest:
       val functions = trino.listFunctions("memory")
       debug(functions.mkString("\n"))
     }
+
+    // Sanity for PR-A: the new `asSqlConnector` accessor talks to the same in-process server
+    // via the HTTP client (uni's `HttpSyncClient`) — no `trino-jdbc` on this path. PR-B will
+    // switch `QueryExecutor` over to this; for now both code paths coexist.
+    test("asSqlConnector executes against the same server via HTTP") {
+      val trino                                            = dep[TrinoConnector]
+      given wvlet.lang.compiler.query.QueryProgressMonitor =
+        wvlet.lang.compiler.query.QueryProgressMonitor.noOp
+      val result = trino.asSqlConnector.execute("select 1 as one, 'http' as src")
+      result.columnCount shouldBe 2
+      result.rowCount shouldBe 1
+      result.columns.map(_.name.name) shouldBe List("one", "src")
+      result.rows.head.values shouldBe List(Some("1"), Some("http"))
+    }
   }
 
 end TrinoConnectorTest


### PR DESCRIPTION
## Summary

First step of a staged migration toward dropping `trino-jdbc` from `wvlet-runner` (the explicit follow-up from #1717). Adds `asSqlConnector: SqlConnector` on the JVM `TrinoConnector` that talks Trino's REST API via the cross-platform `TrinoSqlConnector` from `wvlet-lang` — no JDBC driver on this path.

Legacy JDBC paths (`runQuery`, `executeUpdate`, `withStatement`) stay in place. `QueryExecutor` and existing tests continue through the JDBC driver, so this PR is regression-free.

## Staging plan

| PR | Scope |
|----|-------|
| **A (this)** | Add HTTP-backed `asSqlConnector` accessor next to the JDBC paths |
| B | Switch `QueryExecutor`'s Trino path to `asSqlConnector` |
| C | Migrate Trino tests off `trino-jdbc` (`TestTrinoServer`, etc.) |
| D | Drop `trino-jdbc` + JDBC half of `TrinoConnector` from build.sbt |

## Why a separate accessor instead of `extends SqlConnector`

`DBConnector` declares `execute(sql): Boolean` (JDBC's `Statement.execute()` shape) and `SqlConnector` declares `execute(sql): QueryResult` — same signature, different return type. A single class can't implement both, so the new shape is exposed as a view (`asSqlConnector`).

## Verification

- `runner/testOnly *TrinoConnectorTest` — 6/6 green, including a new \"asSqlConnector executes against the same server via HTTP\" case that exercises the new path against the in-process `TestTrinoServer`
- No source changes outside `wvlet-runner` — `wvlet-lang` already provides `TrinoSqlConnector`

## Test plan

- [x] `runner/Test/compile`
- [x] `runner/testOnly *TrinoConnectorTest` — 6/6
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)