### PR TITLE
feature: PR-C toward dropping trino-jdbc — Migrate Trino tests + listFunctions off JDBC

### DIFF
--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
@@ -156,8 +156,8 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
       .rows
       .iterator
       .map { r =>
-        val row           = r.values
-        val returnType    = col(row, "Return Type").map(DataType.parse).getOrElse(DataType.AnyType)
+        val row        = r.values
+        val returnType = col(row, "Return Type").map(DataType.parse).getOrElse(DataType.AnyType)
         // Zero-arg functions (e.g. `now()`, `pi()`) report an empty `Argument Types` cell.
         // `"".split(", ")` returns `Array("")` in Scala — guard before parsing.
         val argumentTypes = col(row, "Argument Types")
@@ -177,5 +177,7 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
         )
       }
       .toList
+
+  end listFunctions
 
 end TrinoConnector

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
@@ -141,25 +141,38 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
       finally
         stmt.clearProgressMonitor()
 
+  /**
+    * Trino's `show functions` over HTTP. Result columns are addressed by name rather than position
+    * because Trino reorders them between versions (e.g. 481 added a `Variadic` column); a
+    * positional lookup would silently break under those upgrades.
+    */
   override def listFunctions(catalog: String): List[SQLFunction] =
-    val functionList = List.newBuilder[SQLFunction]
-    runQuery("show functions") { rs =>
-      while rs.next() do
-        val returnType    = DataType.parse(rs.getString("Return Type"))
-        val argumentTypes = rs.getString("Argument Types").split(", ").map(DataType.parse).toList
-        val prop          = Map.newBuilder[String, Any]
-        Option(rs.getString("description")).foreach(x => prop += "description" -> x)
-        functionList +=
-          SQLFunction(
-            name = rs.getString("Function"),
-            functionType = SQLFunction
-              .FunctionType
-              .valueOf(rs.getString("Function Type").toUpperCase),
-            returnType = returnType,
-            args = argumentTypes,
-            properties = prop.result()
-          )
-    }
-    functionList.result()
+    given QueryProgressMonitor = QueryProgressMonitor.noOp
+    val result                 = asSqlConnector.execute("show functions")
+    val colIndex               = result.columns.map(_.name.name.toLowerCase).zipWithIndex.toMap
+    def col(row: Seq[Option[String]], name: String): Option[String] =
+      colIndex.get(name.toLowerCase).flatMap(row.lift).flatten
+    result
+      .rows
+      .iterator
+      .map { r =>
+        val row           = r.values
+        val returnType    = col(row, "Return Type").map(DataType.parse).getOrElse(DataType.AnyType)
+        val argumentTypes = col(row, "Argument Types")
+          .map(_.split(", ").iterator.map(DataType.parse).toList)
+          .getOrElse(Nil)
+        val prop = Map.newBuilder[String, Any]
+        col(row, "description").foreach(x => prop += "description" -> x)
+        SQLFunction(
+          name = col(row, "Function").getOrElse(""),
+          functionType = SQLFunction
+            .FunctionType
+            .valueOf(col(row, "Function Type").getOrElse("scalar").toUpperCase),
+          returnType = returnType,
+          args = argumentTypes,
+          properties = prop.result()
+        )
+      }
+      .toList
 
 end TrinoConnector

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
@@ -158,7 +158,10 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
       .map { r =>
         val row           = r.values
         val returnType    = col(row, "Return Type").map(DataType.parse).getOrElse(DataType.AnyType)
+        // Zero-arg functions (e.g. `now()`, `pi()`) report an empty `Argument Types` cell.
+        // `"".split(", ")` returns `Array("")` in Scala — guard before parsing.
         val argumentTypes = col(row, "Argument Types")
+          .filter(_.nonEmpty)
           .map(_.split(", ").iterator.map(DataType.parse).toList)
           .getOrElse(Nil)
         val prop = Map.newBuilder[String, Any]

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TableFunctionTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TableFunctionTest.scala
@@ -1,6 +1,6 @@
 package wvlet.lang.runner.connector.trino
 
-import wvlet.lang.runner.codec.JDBCCodec.ResultSetCodec
+import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.test.WvletDITest
 
 class TableFunctionTest extends WvletDITest:
@@ -21,21 +21,19 @@ class TableFunctionTest extends WvletDITest:
       }
   }
 
+  private given QueryProgressMonitor = QueryProgressMonitor.noOp
+
   test("Run table functions") {
     test("hello table function") {
-      val trino = dep[TrinoConnector]
-      trino.runQuery("select * from TABLE(wvlet.hello('wvlet'))") { rs =>
-        rs.next() shouldBe true
-        val name = rs.getString(1)
-        debug(name)
-        name shouldBe "Hello wvlet!"
-        rs.next() shouldBe false
-      }
+      val trino = dep[TrinoConnector].asSqlConnector
+      val r     = trino.execute("select * from TABLE(wvlet.hello('wvlet'))")
+      r.rowCount shouldBe 1
+      r.rows.head.values.head shouldBe Some("Hello wvlet!")
     }
 
     test("hello duckdb table function") {
-      val trino = dep[TrinoConnector]
-      trino.runQuery(s"""
+      val trino = dep[TrinoConnector].asSqlConnector
+      val r     = trino.execute(s"""
            |-- Projection in Trino
            |select c_custkey, c_nationkey, c_phone
            |-- Read a parquet file with DuckDB
@@ -46,11 +44,10 @@ class TableFunctionTest extends WvletDITest:
            |     where c_custkey = 1'
            |  )
            |)
-           |""".stripMargin) { rs =>
-        val json = ResultSetCodec(rs).toJson
-        debug(json)
-        json shouldBe """[{"c_custkey":1,"c_nationkey":15,"c_phone":"25-989-741-2988"}]"""
-      }
+           |""".stripMargin)
+      r.rowCount shouldBe 1
+      r.columns.map(_.name.name) shouldBe List("c_custkey", "c_nationkey", "c_phone")
+      r.rows.head.values shouldBe List(Some("1"), Some("15"), Some("25-989-741-2988"))
     }
   }
 

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TrinoConnectorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TrinoConnectorTest.scala
@@ -13,11 +13,9 @@
  */
 package wvlet.lang.runner.connector.trino
 
-import wvlet.lang.runner.codec.JDBCCodec
-import wvlet.lang.runner.codec.JDBCCodec.ResultSetCodec
+import wvlet.lang.compiler.connector.QueryResult
+import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.test.WvletDITest
-import wvlet.uni.control.Control
-import wvlet.uni.control.Control.withResource
 
 import java.io.File
 
@@ -37,73 +35,78 @@ class TrinoConnectorTest extends WvletDITest:
       }
   }
 
+  // All test SQL flows through `asSqlConnector` so this suite no longer depends on
+  // `trino-jdbc` — only `trino-testing`'s in-process `TestingTrinoServer` (PR-C). PR-D removes
+  // the JDBC half of `TrinoConnector` along with the `trino-jdbc` dep.
+  private given QueryProgressMonitor = QueryProgressMonitor.noOp
+
+  private def render(r: QueryResult): String =
+    val cols = r.columns.map(_.name.name)
+    r.rows
+      .map { row =>
+        cols
+          .iterator
+          .zip(row.values.iterator)
+          .map { case (n, v) =>
+            s""""${n}":${v.map(s => s""""${s}"""").getOrElse("null")}"""
+          }
+          .mkString("{", ",", "}")
+      }
+      .mkString("[", ",", "]")
+
   test("Create an in-memory schema and table") {
-    val trino = dep[TrinoConnector]
-    trino.createSchema("memory", "main")
-    trino.getSchema("memory", "main") shouldBe defined
+    val trino = dep[TrinoConnector].asSqlConnector
+    trino.execute("create schema if not exists memory.main")
+    trino.execute("create table memory.main.a(id bigint)")
 
-    trino.executeUpdate("create table a(id bigint)")
-
-    trino.getTableDef("memory", "main", "a") shouldBe defined
+    test("describe the table") {
+      val r = trino.execute("describe memory.main.a")
+      r.rowCount shouldBe 1
+      r.rows.head.values.head shouldBe Some("id")
+    }
 
     test("drop table") {
-      val trino = dep[TrinoConnector]
-      trino.dropTable("memory", "main", "a")
-      trino.getTableDef("memory", "main", "a") shouldBe empty
+      trino.execute("drop table if exists memory.main.a")
+      val r = trino.execute(
+        "select count(*) as c from information_schema.tables where table_schema = 'main' and table_name = 'a'"
+      )
+      r.rows.head.values.head shouldBe Some("0")
     }
 
     test("drop schema") {
-      val trino = dep[TrinoConnector]
-      trino.dropSchema("memory", "main")
+      trino.execute("drop schema if exists memory.main")
     }
 
     test("Create delta Lake table") {
-      // The schema is created on the (shared) TestTrinoServer once here; nested tests below
-      // derive their own delta-configured connector via dep[TrinoConnector].withConfig(...).
-      val trino      = dep[TrinoConnector]
-      val baseDir    = new File(sys.props("user.dir")).getAbsolutePath
-      val trinoDelta = trino.withConfig(trino.config.copy(catalog = "delta", schema = "delta_db"))
-      trinoDelta.createSchema("delta", "delta_db")
+      val baseDir = new File(sys.props("user.dir")).getAbsolutePath
+      trino.execute("create schema if not exists delta.delta_db")
 
       test("create a local delta lake file") {
-        val trinoDelta = dep[TrinoConnector].withConfig(
-          dep[TrinoConfig].copy(catalog = "delta", schema = "delta_db")
-        )
-        trinoDelta.executeUpdate("create table a as select 1 as id, 'leo' as name")
-        trinoDelta.executeUpdate("insert into a values(2, 'yui')")
-        trinoDelta.runQuery("select * from a"): rs =>
-          val queryResultJson = ResultSetCodec(rs).toJson
-          debug(queryResultJson)
+        trino.execute("create table delta.delta_db.a as select 1 as id, 'leo' as name")
+        trino.execute("insert into delta.delta_db.a values(2, 'yui')")
+        val r = trino.execute("select * from delta.delta_db.a order by id")
+        debug(render(r))
+        r.rowCount shouldBe 2
       }
 
       test("register a local delta lake table") {
-        val trinoDelta = dep[TrinoConnector].withConfig(
-          dep[TrinoConfig].copy(catalog = "delta", schema = "delta_db")
-        )
-        trinoDelta.execute(
+        trino.execute(
           s"call delta.system.register_table(schema_name => 'delta_db', table_name => 'www_access', table_location => 'file://${baseDir}/spec/delta/data/www_access')"
         )
-        trinoDelta.runQuery("select * from www_access limit 5") { rs =>
-          val queryResultJson = ResultSetCodec(rs).toJson
-          debug(queryResultJson)
-        }
+        val r = trino.execute("select * from delta.delta_db.www_access limit 5")
+        debug(render(r))
+        r.rowCount shouldBe 5
       }
     }
 
     test("list functions") {
-      val trino     = dep[TrinoConnector]
-      val functions = trino.listFunctions("memory")
+      val functions = dep[TrinoConnector].listFunctions("memory")
       debug(functions.mkString("\n"))
+      functions.nonEmpty shouldBe true
     }
 
-    // Sanity for PR-A: the new `asSqlConnector` accessor talks to the same in-process server
-    // via the HTTP client (uni's `HttpSyncClient`) — no `trino-jdbc` on this path. PR-B will
-    // switch `QueryExecutor` over to this; for now both code paths coexist.
-    test("asSqlConnector executes against the same server via HTTP") {
-      val trino                                            = dep[TrinoConnector]
-      given wvlet.lang.compiler.query.QueryProgressMonitor =
-        wvlet.lang.compiler.query.QueryProgressMonitor.noOp
-      val result = trino.asSqlConnector.execute("select 1 as one, 'http' as src")
+    test("asSqlConnector executes a trivial select") {
+      val result = trino.execute("select 1 as one, 'http' as src")
       result.columnCount shouldBe 2
       result.rowCount shouldBe 1
       result.columns.map(_.name.name) shouldBe List("one", "src")

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TrinoConnectorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TrinoConnectorTest.scala
@@ -13,7 +13,6 @@
  */
 package wvlet.lang.runner.connector.trino
 
-import wvlet.lang.compiler.connector.QueryResult
 import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.test.WvletDITest
 
@@ -39,20 +38,6 @@ class TrinoConnectorTest extends WvletDITest:
   // `trino-jdbc` — only `trino-testing`'s in-process `TestingTrinoServer` (PR-C). PR-D removes
   // the JDBC half of `TrinoConnector` along with the `trino-jdbc` dep.
   private given QueryProgressMonitor = QueryProgressMonitor.noOp
-
-  private def render(r: QueryResult): String =
-    val cols = r.columns.map(_.name.name)
-    r.rows
-      .map { row =>
-        cols
-          .iterator
-          .zip(row.values.iterator)
-          .map { case (n, v) =>
-            s""""${n}":${v.map(s => s""""${s}"""").getOrElse("null")}"""
-          }
-          .mkString("{", ",", "}")
-      }
-      .mkString("[", ",", "]")
 
   test("Create an in-memory schema and table") {
     val trino = dep[TrinoConnector].asSqlConnector
@@ -85,7 +70,7 @@ class TrinoConnectorTest extends WvletDITest:
         trino.execute("create table delta.delta_db.a as select 1 as id, 'leo' as name")
         trino.execute("insert into delta.delta_db.a values(2, 'yui')")
         val r = trino.execute("select * from delta.delta_db.a order by id")
-        debug(render(r))
+        debug(r.rows.map(_.values))
         r.rowCount shouldBe 2
       }
 
@@ -94,7 +79,7 @@ class TrinoConnectorTest extends WvletDITest:
           s"call delta.system.register_table(schema_name => 'delta_db', table_name => 'www_access', table_location => 'file://${baseDir}/spec/delta/data/www_access')"
         )
         val r = trino.execute("select * from delta.delta_db.www_access limit 5")
-        debug(render(r))
+        debug(r.rows.map(_.values))
         r.rowCount shouldBe 5
       }
     }


### PR DESCRIPTION
## Summary

Third step in the staged migration off `trino-jdbc` (after #1718, #1719).

After this PR, **no production helper or test code outside `TrinoConnector.scala` itself reaches into `io.trino.jdbc.*`**. PR-D can rip out the JDBC half of `TrinoConnector` and the dep with no caller-side fallout.

## Changes

**Production**:
- `TrinoConnector.listFunctions` rewritten on `asSqlConnector` — no more `DBConnector.runQuery` + `JDBCCodec`. Also switched to name-based column lookup so a Trino-side reorder of `show functions` columns (e.g. 481 added a `Variadic` column) doesn't silently break.

**Tests**:
- `TrinoConnectorTest` rewritten on top of `asSqlConnector.execute`:
  - `createSchema` / `dropTable` / `executeUpdate` calls replaced by direct DDL through HTTP
  - `runQuery(rs => ResultSetCodec(rs).toJson)` delta-lake assertions replaced with row-count checks via `execute`
- `TableFunctionTest` same migration. Drops `ResultSetCodec` dependency.

## Staging plan

| PR | Scope | Status |
|----|-------|--------|
| A | HTTP-backed `asSqlConnector` accessor | merged (#1718) |
| B | `QueryExecutor`'s Trino path through `asSqlConnector` | merged (#1719) |
| **C (this)** | `listFunctions` + tests off JDBC | this PR |
| D | Drop `trino-jdbc` + JDBC half of `TrinoConnector` | future |

## Verification

- `runner/testOnly *TrinoConnectorTest *TableFunctionTest *TrinoSpec*` — 19/19 green
- `runner/Test/compile` clean

## Test plan

- [x] Compile clean
- [x] All 19 Trino tests pass on the new path
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)