### PR TITLE
feature: PR-D toward dropping trino-jdbc — Remove JDBC code paths + dep

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -414,7 +414,9 @@ lazy val runner = project
         "com.github.ben-manes.caffeine" % "caffeine"       % "3.2.4",
         "org.apache.arrow"              % "arrow-vector"   % "19.0.0",
         "org.duckdb"                    % "duckdb_jdbc"    % DUCKDB_JDBC_VERSION,
-        "io.trino"                      % "trino-jdbc"     % TRINO_VERSION,
+        // trino-jdbc removed in PR-D: TrinoConnector now talks the Trino REST protocol via uni's
+        // HttpSyncClient (see wvlet-lang's TrinoSqlConnector). trino-testing stays in test scope
+        // for the in-process TestingTrinoServer — that artifact doesn't pull in trino-jdbc.
         "net.snowflake"                 % "snowflake-jdbc" % SNOWFLAKE_JDBC_VERSION,
         // exclude() and jar() are necessary to avoid https://github.com/sbt/sbt/issues/7407
         // tpc-h connector neesd to download GB's of jar, so excluding it

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -348,14 +348,41 @@ class QueryExecutor(
       }
       rowCount
 
+    // Cross-platform variant for backends that don't expose a JDBC ResultSet (Trino HTTP).
+    // Stream the materialized QueryResult through the same JSON writer the JDBC path produces.
+    def writeJSONLFromXP(r: XPQueryResult, out: File): Long =
+      val rowCodec = summon[Weaver[ListMap[String, Any]]]
+      val names    = r.columns.map(_.name.name)
+      Using.resource(BufferedWriter(OutputStreamWriter(GZIPOutputStream(FileOutputStream(out))))) {
+        w =>
+          r.rows
+            .foreach { row =>
+              val pairs = names
+                .iterator
+                .zip(row.values.iterator)
+                .map { case (n, v) =>
+                  n -> v.orNull.asInstanceOf[Any]
+                }
+              w.write(rowCodec.toJson(ListMap.from(pairs)))
+              w.newLine()
+            }
+      }
+      r.rowCount.toLong
+
     // 1) Execute on Trino (or current engine) and dump to JSONL
     val baseSQL = GenSQL.generateSQLFromRelation(save.child, addHeader = false)
     given monitor: QueryProgressMonitor = context.queryProgressMonitor
-    getDBConnector(defaultProfile).runQuery(baseSQL.sql) { rs =>
-      val n = writeJSONL(rs, jsonlFile)
-      workEnv.info(s"Exported ${n} rows to compressed JSONL at ${jsonlFile.getPath}")
-      n
-    }
+    val sourceConn                      = getDBConnector(defaultProfile)
+    val n                               =
+      sourceConn match
+        case trino: TrinoConnector =>
+          // Trino flows through the HTTP path (PR-D): no JDBC ResultSet, materialize via SqlConnector.
+          writeJSONLFromXP(trino.asSqlConnector.execute(baseSQL.sql), jsonlFile)
+        case _ =>
+          sourceConn.runQuery(baseSQL.sql) { rs =>
+            writeJSONL(rs, jsonlFile)
+          }
+    workEnv.info(s"Exported ${n} rows to compressed JSONL at ${jsonlFile.getPath}")
 
     // 2) Directly COPY from read_json_auto() to Parquet via DuckDB
     val duck                  = dbConnectorProvider.getConnector(DBType.DuckDB, None)

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/DBConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/DBConnector.scala
@@ -15,7 +15,6 @@ package wvlet.lang.runner.connector
 
 import wvlet.uni.control.Control.withResource
 import DBConnector.*
-import io.trino.jdbc.QueryStats
 import wvlet.lang.catalog.Catalog
 import wvlet.lang.catalog.SQLFunction
 import wvlet.lang.catalog.Catalog.TableColumn

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
@@ -60,7 +60,11 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
 
   lazy val asSqlConnector: SqlConnector = TrinoSqlConnector(toCrossPlatformConfig)
 
-  private given QueryProgressMonitor = QueryProgressMonitor.noOp
+  // Metadata methods (listSchemas, listTables, getTableDef, …) don't take a caller-supplied
+  // QueryProgressMonitor because the base `DBConnector` doesn't either — so we feed the
+  // cross-platform connector a no-op monitor by default. Overrides that DO take a monitor
+  // (`executeUpdate`, `execute`) shadow this default at the method level.
+  private given defaultMonitor: QueryProgressMonitor = QueryProgressMonitor.noOp
 
   private def toCrossPlatformConfig: TrinoXPConfig =
     val parts        = config.hostAndPort.split(":", 2)
@@ -87,9 +91,18 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
 
   /**
     * Run a SQL string over the HTTP path and return the materialized [[QueryResult]]. Centralises
-    * the `asSqlConnector.execute` call so the overrides below stay one-liners.
+    * the `asSqlConnector.execute` call so the overrides below stay one-liners. Takes the progress
+    * monitor implicitly so callers that already have one (e.g. `execute` / `executeUpdate`) can
+    * thread it through, while metadata callers fall back to the class-level `noOp` default.
+    *
+    * Note: `SqlConnector.execute` materializes the full result set today — same tradeoff PR-B
+    * shipped for `QueryExecutor`'s Trino path. Large exports that previously streamed through the
+    * JDBC `ResultSet` now build the whole `QueryResult` in memory. Adding chunked iteration to
+    * `QueryHandle` is the right fix; tracked as a follow-up.
     */
-  private def http(sql: String): QueryResult = asSqlConnector.execute(sql)
+  private def http(sql: String)(using QueryProgressMonitor): QueryResult = asSqlConnector.execute(
+    sql
+  )
 
   /** SQL-safe literal escaping for the values we interpolate into information_schema queries. */
   private def lit(s: String): String = s"'${s.replace("'", "''")}'"
@@ -121,11 +134,18 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
 
   override def executeUpdate(sql: String)(using QueryProgressMonitor): Int =
     http(sql)
+    // Trino's HTTP API doesn't surface an "affected rows" count for DDL/DML the way JDBC
+    // `Statement.executeUpdate` does (the `updateCount` in stats is best-effort and not always
+    // populated). Return 0 to match the historical wvlet usage — every existing caller treats
+    // this as a fire-and-forget operation.
     0
 
-  override def execute(sql: String)(using QueryProgressMonitor): Boolean =
-    val r = http(sql)
-    r.columnCount > 0
+  override def execute(sql: String)(using monitor: QueryProgressMonitor): Boolean =
+    // Match the base class's monitor lifecycle so REPL/UI progress UI stays in sync —
+    // base impl calls `newQuery` before, `close` after.
+    monitor.newQuery(sql)
+    try http(sql).columnCount > 0
+    finally monitor.close()
 
   override def createSchema(catalog: String, schema: String): TableSchema =
     http(s"create schema if not exists ${catalog}.${schema}")

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
@@ -13,31 +13,24 @@
  */
 package wvlet.lang.runner.connector.trino
 
-import io.trino.jdbc.QueryStats as TrinoJdbcStats
-import io.trino.jdbc.TrinoConnection
-import io.trino.jdbc.TrinoDriver
-import io.trino.jdbc.TrinoStatement
+import wvlet.lang.catalog.Catalog
+import wvlet.lang.catalog.Catalog.TableColumn
+import wvlet.lang.catalog.Catalog.TableName
+import wvlet.lang.catalog.Catalog.TableSchema
 import wvlet.lang.catalog.SQLFunction
-import wvlet.uni.control.Control
-import wvlet.uni.util.Count
-import wvlet.uni.util.ElapsedTime
 import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.Name
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.compiler.analyzer.trino.TrinoConfig as TrinoXPConfig
 import wvlet.lang.compiler.analyzer.trino.TrinoSqlConnector
-import wvlet.lang.compiler.connector.QueryHandle
-import wvlet.lang.compiler.connector.QueryState
-import wvlet.lang.compiler.connector.QueryStats
+import wvlet.lang.compiler.connector.QueryResult
 import wvlet.lang.compiler.connector.SqlConnector
 import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.model.DataType
 import wvlet.lang.runner.connector.*
 import wvlet.uni.log.LogSupport
 
-import java.sql.Connection
 import java.sql.Statement
-import java.util.Properties
-import java.util.function.Consumer
 
 case class TrinoConfig(
     catalog: String,
@@ -48,31 +41,27 @@ case class TrinoConfig(
     password: Option[String] = None
 )
 
+/**
+  * JVM `DBConnector` for Trino that no longer uses `trino-jdbc`. All SQL flows through the
+  * cross-platform [[TrinoSqlConnector]] (uni's `HttpSyncClient`). The `DBConnector` superclass is
+  * still extended because callers (in particular `DBConnectorProvider` and `ConnectorCatalog`)
+  * dispatch on that type today, but every JDBC-shaped method (`runQuery`, `executeUpdate`,
+  * `withStatement`, `newConnection`) either delegates to HTTP or throws — none of them touch
+  * `java.sql.*` machinery anymore. The base class's JDBC `getCatalog` plumbing is bypassed by
+  * overriding the information-schema metadata methods (`listSchemas`, `listTables`, `getTableDef`,
+  * `getCatalogNames`) with HTTP equivalents.
+  *
+  * `password` on [[TrinoConfig]] is preserved so the case class binary doesn't break clients
+  * mid-migration, but the HTTP path uses `X-Trino-User` only today; Basic / JWT auth lands later.
+  */
 class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
     extends DBConnector(DBType.Trino, workEnv)
     with LogSupport:
-  private lazy val driver = new TrinoDriver()
 
-  /**
-    * HTTP-backed [[SqlConnector]] view of this Trino instance, exposed as a separate accessor
-    * because [[DBConnector]] and [[SqlConnector]] both declare `execute(sql)` with different return
-    * types (Boolean vs QueryResult) and can't coexist on one class. Built lazily so the JDBC code
-    * path (still the default for `QueryExecutor`'s `runQuery` / `executeUpdate`) doesn't pay any
-    * HTTP setup cost when the caller never asks for it.
-    *
-    * Re-uses the cross-platform `TrinoSqlConnector` from `wvlet-lang` so the runner doesn't
-    * reimplement the protocol. Once `QueryExecutor` migrates to this path (PR-B), we can drop the
-    * JDBC half of `TrinoConnector` and stop dragging in `trino-jdbc`.
-    */
   lazy val asSqlConnector: SqlConnector = TrinoSqlConnector(toCrossPlatformConfig)
 
-  /**
-    * Bridge the runner's JDBC-shaped [[TrinoConfig]] to the cross-platform variant in `wvlet-lang`.
-    * `hostAndPort` collapses host + port into a single string for the JDBC URL; the cross-platform
-    * shape wants them separate, with the port autoderived from the scheme when missing. `password`
-    * is currently dropped on the HTTP path — auth on the cross-platform connector is `X-Trino-User`
-    * only until the auth story (Basic/JWT) lands.
-    */
+  private given QueryProgressMonitor = QueryProgressMonitor.noOp
+
   private def toCrossPlatformConfig: TrinoXPConfig =
     val parts        = config.hostAndPort.split(":", 2)
     val host         = parts(0)
@@ -96,50 +85,135 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
       source = "wvlet-runner"
     )
 
-  private[connector] override lazy val newConnection: DBConnection =
-    val jdbcUrl =
-      s"jdbc:trino://${config.hostAndPort}/${config.catalog}/${config.schema}${
-          if config.useSSL then
-            "?SSL=true"
-          else
-            ""
-        }"
-    trace(s"Connecting to Trino: ${jdbcUrl}")
-    val properties = new Properties()
-    config.user.foreach(x => properties.put("user", x))
-    config.password.foreach(x => properties.put("password", x))
-    DBConnection(driver.connect(jdbcUrl, properties).asInstanceOf[TrinoConnection])
+  /**
+    * Run a SQL string over the HTTP path and return the materialized [[QueryResult]]. Centralises
+    * the `asSqlConnector.execute` call so the overrides below stay one-liners.
+    */
+  private def http(sql: String): QueryResult = asSqlConnector.execute(sql)
 
-  override def close(): Unit = Control.closeResources(newConnection, driver)
+  /** SQL-safe literal escaping for the values we interpolate into information_schema queries. */
+  private def lit(s: String): String = s"'${s.replace("'", "''")}'"
 
-  override protected def withConnection[U](body: DBConnection => U): U =
-    val conn = newConnection
-    // Do not close the connection for reusing the connection
-    body(conn)
+  override def close(): Unit = ()
 
   def withConfig(newConfig: TrinoConfig): TrinoConnector = new TrinoConnector(newConfig, workEnv)
 
+  // -------- JDBC-shaped abstract members of DBConnector ----------------------------------------
+  //
+  // These exist only because the base class declares them. Every caller has either been moved to
+  // HTTP (`asSqlConnector`) or is exercised through overridden metadata methods. If a future caller
+  // slips through and triggers `newConnection`, the throw below is the loud failure mode we want.
+
+  private[connector] override def newConnection: DBConnection =
+    throw new UnsupportedOperationException(
+      "TrinoConnector no longer uses JDBC. Use `asSqlConnector` or the connector's metadata APIs."
+    )
+
+  override protected def withConnection[U](body: DBConnection => U): U = newConnection.asInstanceOf[
+    Nothing
+  ]
+
   override protected def withStatement[U](body: Statement => U)(using
-      queryProgressMonitor: QueryProgressMonitor = QueryProgressMonitor.noOp
-  ): U = withConnection: conn =>
-    Control.withResource(conn.createStatement().asInstanceOf[TrinoStatement]): stmt =>
-      try
-        stmt.setProgressMonitor(
-          new Consumer[TrinoJdbcStats]:
-            override def accept(stats: TrinoJdbcStats): Unit = queryProgressMonitor.reportProgress(
-              QueryStats(
-                state = QueryState.fromTrino(stats.getState),
-                rowsProcessed = Some(stats.getProcessedRows),
-                bytesProcessed = Some(stats.getProcessedBytes),
-                elapsedMs = Some(stats.getElapsedTimeMillis),
-                splitsCompleted = Some(stats.getCompletedSplits),
-                splitsTotal = Some(stats.getTotalSplits)
-              )
+      queryProgressMonitor: QueryProgressMonitor
+  ): U = newConnection.asInstanceOf[Nothing]
+
+  // -------- DDL / mutation overrides -----------------------------------------------------------
+
+  override def executeUpdate(sql: String)(using QueryProgressMonitor): Int =
+    http(sql)
+    0
+
+  override def execute(sql: String)(using QueryProgressMonitor): Boolean =
+    val r = http(sql)
+    r.columnCount > 0
+
+  override def createSchema(catalog: String, schema: String): TableSchema =
+    http(s"create schema if not exists ${catalog}.${schema}")
+    TableSchema(Some(catalog), schema)
+
+  override def dropTable(catalog: String, schema: String, table: String): Unit = http(
+    s"drop table if exists ${catalog}.${schema}.${table}"
+  )
+
+  override def dropSchema(catalog: String, schema: String): Unit = http(
+    s"drop schema if exists ${catalog}.${schema}"
+  )
+
+  // -------- Metadata overrides (information_schema over HTTP) ----------------------------------
+
+  override def getCatalogNames: List[String] =
+    val r = http("show catalogs")
+    r.rows.flatMap(_.values.headOption.flatten).toList
+
+  override def listSchemas(catalog: String): List[TableSchema] =
+    val r = http(
+      s"select schema_name from information_schema.schemata where catalog_name = ${lit(catalog)}"
+    )
+    r.rows.flatMap(_.values.headOption.flatten).map(name => TableSchema(Some(catalog), name)).toList
+
+  override def listSchemaNames(catalog: String): List[String] = listSchemas(catalog).map(_.name)
+
+  override def getSchema(catalog: String, schema: String): Option[TableSchema] = listSchemas(
+    catalog
+  ).find(_.name == schema)
+
+  override def listTables(catalog: String, schema: String): List[TableName] =
+    val r = http(
+      s"select table_name from information_schema.tables where table_catalog = ${lit(
+          catalog
+        )} and table_schema = ${lit(schema)}"
+    )
+    r.rows
+      .flatMap(_.values.headOption.flatten)
+      .map(name => TableName(Some(catalog), Some(schema), name))
+      .toList
+
+  override def listTableDefs(catalog: String, schema: String): List[Catalog.TableDef] =
+    val r = http(s"""select table_name, column_name, ordinal_position, data_type
+         |from information_schema.columns
+         |where table_catalog = ${lit(catalog)} and table_schema = ${lit(schema)}""".stripMargin)
+    val idx = columnIndex(r)
+    r.rows
+      .groupBy(row => stringAt(row, idx, "table_name").getOrElse(""))
+      .map { case (table, rows) =>
+        val columns = rows
+          .sortBy(row => stringAt(row, idx, "ordinal_position").flatMap(_.toIntOption).getOrElse(0))
+          .map { row =>
+            TableColumn(
+              stringAt(row, idx, "column_name").getOrElse(""),
+              DataType.parse(stringAt(row, idx, "data_type").getOrElse("any").toLowerCase)
             )
-        )
-        body(stmt)
-      finally
-        stmt.clearProgressMonitor()
+          }
+        Catalog.TableDef(TableName(Some(catalog), Some(schema), table), columns = columns)
+      }
+      .toList
+
+  override def getTableDef(
+      catalog: String,
+      schema: String,
+      table: String
+  ): Option[Catalog.TableDef] =
+    val r = http(
+      s"""select column_name, ordinal_position, data_type
+         |from information_schema.columns
+         |where table_catalog = ${lit(catalog)} and table_schema = ${lit(
+          schema
+        )} and table_name = ${lit(table)}""".stripMargin
+    )
+    if r.rowCount == 0 then
+      None
+    else
+      val idx     = columnIndex(r)
+      val columns = r
+        .rows
+        .sortBy(row => stringAt(row, idx, "ordinal_position").flatMap(_.toIntOption).getOrElse(0))
+        .map { row =>
+          TableColumn(
+            stringAt(row, idx, "column_name").getOrElse(""),
+            DataType.parse(stringAt(row, idx, "data_type").getOrElse("any").toLowerCase)
+          )
+        }
+      Some(Catalog.TableDef(TableName(Some(catalog), Some(schema), table), columns = columns))
 
   /**
     * Trino's `show functions` over HTTP. Result columns are addressed by name rather than position
@@ -147,30 +221,28 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
     * positional lookup would silently break under those upgrades.
     */
   override def listFunctions(catalog: String): List[SQLFunction] =
-    given QueryProgressMonitor = QueryProgressMonitor.noOp
-    val result                 = asSqlConnector.execute("show functions")
-    val colIndex               = result.columns.map(_.name.name.toLowerCase).zipWithIndex.toMap
-    def col(row: Seq[Option[String]], name: String): Option[String] =
-      colIndex.get(name.toLowerCase).flatMap(row.lift).flatten
+    val result = http("show functions")
+    val idx    = columnIndex(result)
     result
       .rows
       .iterator
-      .map { r =>
-        val row        = r.values
-        val returnType = col(row, "Return Type").map(DataType.parse).getOrElse(DataType.AnyType)
+      .map { row =>
+        val returnType = stringAt(row, idx, "Return Type")
+          .map(DataType.parse)
+          .getOrElse(DataType.AnyType)
         // Zero-arg functions (e.g. `now()`, `pi()`) report an empty `Argument Types` cell.
         // `"".split(", ")` returns `Array("")` in Scala — guard before parsing.
-        val argumentTypes = col(row, "Argument Types")
+        val argumentTypes = stringAt(row, idx, "Argument Types")
           .filter(_.nonEmpty)
           .map(_.split(", ").iterator.map(DataType.parse).toList)
           .getOrElse(Nil)
         val prop = Map.newBuilder[String, Any]
-        col(row, "description").foreach(x => prop += "description" -> x)
+        stringAt(row, idx, "description").foreach(x => prop += "description" -> x)
         SQLFunction(
-          name = col(row, "Function").getOrElse(""),
+          name = stringAt(row, idx, "Function").getOrElse(""),
           functionType = SQLFunction
             .FunctionType
-            .valueOf(col(row, "Function Type").getOrElse("scalar").toUpperCase),
+            .valueOf(stringAt(row, idx, "Function Type").getOrElse("scalar").toUpperCase),
           returnType = returnType,
           args = argumentTypes,
           properties = prop.result()
@@ -178,6 +250,15 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
       }
       .toList
 
-  end listFunctions
+  // -------- helpers ----------------------------------------------------------------------------
+
+  private def columnIndex(r: QueryResult): Map[String, Int] =
+    r.columns.map(_.name.name.toLowerCase).zipWithIndex.toMap
+
+  private def stringAt(
+      row: wvlet.lang.compiler.connector.QueryResultRow,
+      idx: Map[String, Int],
+      name: String
+  ): Option[String] = idx.get(name.toLowerCase).flatMap(row.values.lift).flatten
 
 end TrinoConnector


### PR DESCRIPTION
## Summary

Final step in the staged migration. After #1718 / #1719 / #1720 every caller of `TrinoConnector` was already exercised through the HTTP-backed `asSqlConnector` (uni's `HttpSyncClient`). This PR removes the JDBC code paths and drops the `trino-jdbc` dep entirely.

## Staging plan

| PR | Scope | Status |
|----|-------|--------|
| A | HTTP-backed `asSqlConnector` accessor | merged (#1718) |
| B | `QueryExecutor`'s Trino path through `asSqlConnector` | merged (#1719) |
| C | `listFunctions` + tests off JDBC | merged (#1720) |
| **D (this)** | Drop `trino-jdbc` dep + JDBC code paths in `TrinoConnector` | this PR |

## Changes

**`TrinoConnector` rewritten on `asSqlConnector`**: overrides every JDBC-shaped method on the `DBConnector` base — `executeUpdate`, `execute`, `createSchema`, `dropTable`, `dropSchema`, `getCatalogNames`, `listSchemas`, `listSchemaNames`, `getSchema`, `listTables`, `listTableDefs`, `getTableDef`, `listFunctions` — to talk Trino's REST + `information_schema` directly. `newConnection` / `withConnection` / `withStatement` throw `UnsupportedOperationException` (abstract on the base, but no caller reaches them now).

**`QueryExecutor.executeSaveToLocalFileViaDuckDB`** learns a Trino branch: stream the SQL result through HTTP and write JSONL from the `QueryResult` (no JDBC ResultSet, no `JDBCCodec`). DuckDB stays on the JDBC path.

**`DBConnector.scala`** drops a stray unused `import io.trino.jdbc.QueryStats`.

**`build.sbt`** drops `\"io.trino\" % \"trino-jdbc\" % TRINO_VERSION`. `trino-testing` stays in test scope for the in-process `TestingTrinoServer` — that artifact doesn't pull in `trino-jdbc`.

## Verification

- `runner/testOnly *TrinoConnectorTest *TableFunctionTest *TrinoSpec*` — 19/19 green
- `runner/testOnly *DuckDB* *RunnerSpec*` — 354/354 green (no regression in DuckDB / TPC-H / benchmark specs)
- No `io.trino.jdbc.*` imports remain (only doc-comment mentions)

## Test plan

- [x] Compile clean
- [x] Trino tests green over HTTP
- [x] DuckDB + TPC-H specs unaffected
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)