### PR TITLE
feature: Cross-platform DuckDBSqlConnector

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSqlConnector.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSqlConnector.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer.duckdb
+
+import wvlet.lang.compiler.connector.QueryHandle
+import wvlet.lang.compiler.connector.QueryResult
+import wvlet.lang.compiler.connector.QueryState
+import wvlet.lang.compiler.connector.QueryStats
+import wvlet.lang.compiler.connector.SqlConnector
+import wvlet.lang.compiler.query.QueryProgressMonitor
+
+/**
+  * Cross-platform `SqlConnector` impl for DuckDB. Wraps the synchronous [[DuckDB.execute]] so the
+  * SqlConnector trait has a DuckDB impl alongside
+  * [[wvlet.lang.compiler.analyzer.trino.TrinoSqlConnector]].
+  *
+  * DuckDB runs in-process and synchronously — there's no async submission, no server-side query id,
+  * and no cancel mid-flight. `submit` therefore runs the query inline and returns an already-
+  * finished [[QueryHandle]]; `state` is always `Finished`, `cancel` is a no-op. Callers that want
+  * streaming progress should pass a [[QueryProgressMonitor]] — the underlying chunk-reader backends
+  * (JDBC on JVM, libduckdb on Native, koffi on JS) don't surface per-batch stats today, but the
+  * monitor is reserved for the same role when they do.
+  *
+  * Each `submit` invokes `DuckDB.execute(sql)`, which on JVM opens a fresh in-memory `jdbc:duckdb:`
+  * connection per call; in-memory tables don't persist across calls. The runner's JVM
+  * `DuckDBConnector` keeps using its long-lived JDBC connection for that reason; this
+  * cross-platform `SqlConnector` is the right tool for one-shot CLI queries against ephemeral
+  * DuckDB instances.
+  */
+class DuckDBSqlConnector extends SqlConnector:
+
+  override def submit(sql: String)(using QueryProgressMonitor): QueryHandle =
+    val result = DuckDB.execute(sql)
+    DuckDBSqlConnector.completedHandle(result)
+
+  override def close(): Unit = ()
+
+end DuckDBSqlConnector
+
+object DuckDBSqlConnector:
+
+  /**
+    * Build a [[QueryHandle]] that wraps an already-materialized [[QueryResult]]. Used for backends
+    * (DuckDB today) whose `submit` is synchronous so callers still see the trait's submit/await/
+    * cancel surface.
+    */
+  private[duckdb] def completedHandle(result: QueryResult): QueryHandle =
+    new QueryHandle:
+      override def queryId: Option[String] = None
+      override def state: QueryState       = QueryState.Finished
+      override def stats: QueryStats       = QueryStats(QueryState.Finished)
+      override def await(): QueryResult    = result
+      override def cancel(): Unit          = ()
+      override def close(): Unit           = ()
+
+end DuckDBSqlConnector

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSqlConnectorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSqlConnectorTest.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer.duckdb
+
+import wvlet.lang.compiler.connector.QueryState
+import wvlet.lang.compiler.query.QueryProgressMonitor
+import wvlet.uni.test.UniTest
+
+/**
+  * Exercise [[DuckDBSqlConnector]] over the `SqlConnector` trait surface — `submit` → `await`,
+  * `state`, `cancel`, the default `execute` path. Runs on every platform that supports
+  * `DuckDB.execute` (auto-skips when libduckdb isn't loadable).
+  */
+class DuckDBSqlConnectorTest extends UniTest:
+
+  private given QueryProgressMonitor = QueryProgressMonitor.noOp
+
+  private def skipIfUnavailable(): Unit =
+    if !DuckDB.canExecute then
+      ignore("DuckDB.execute not available on this platform (libduckdb missing?)")
+
+  test("submit returns an already-Finished handle with the query result") {
+    skipIfUnavailable()
+    val conn = DuckDBSqlConnector()
+    try
+      val h = conn.submit("select 1 as one, 'duck' as src")
+      try
+        h.state shouldBe QueryState.Finished
+        h.queryId shouldBe None
+        val r = h.await()
+        r.columnCount shouldBe 2
+        r.rowCount shouldBe 1
+        r.columns.map(_.name.name) shouldBe List("one", "src")
+        r.rows.head.values shouldBe List(Some("1"), Some("duck"))
+      finally
+        h.close()
+    finally
+      conn.close()
+  }
+
+  test("await is idempotent — second call returns the same QueryResult instance") {
+    skipIfUnavailable()
+    val conn = DuckDBSqlConnector()
+    try
+      val h     = conn.submit("select 42 as answer")
+      val first = h.await()
+      h.await() shouldBe first
+    finally
+      conn.close()
+  }
+
+  test("execute (default trait method) returns the materialized result directly") {
+    skipIfUnavailable()
+    val r = DuckDBSqlConnector().execute("select 'hi' as greeting")
+    r.rowCount shouldBe 1
+    r.rows.head.values.head shouldBe Some("hi")
+  }
+
+  test("cancel on a synchronous DuckDB query is a safe no-op") {
+    skipIfUnavailable()
+    val conn = DuckDBSqlConnector()
+    try
+      val h = conn.submit("select 1")
+      // Already Finished by the time submit returns; cancel must not throw.
+      h.cancel()
+      h.state shouldBe QueryState.Finished
+    finally
+      conn.close()
+  }
+
+end DuckDBSqlConnectorTest


### PR DESCRIPTION
## Summary

Gives the cross-platform `SqlConnector` trait (introduced in #1717) a DuckDB implementation alongside `TrinoSqlConnector`. Wraps the synchronous `DuckDB.execute` and returns an already-`Finished` `QueryHandle` — DuckDB runs in-process synchronously, so there's no async submission, no server-side query id, and no cancel mid-flight.

## Semantics

- `submit(sql)` runs the query inline and returns a `QueryHandle` whose `state` is already `Finished`.
- `await()` returns the cached `QueryResult` (idempotent across repeated calls).
- `cancel()` is a no-op (the query has already finished by the time the caller has the handle).
- Each `submit` opens a fresh `jdbc:duckdb:` connection on JVM (or fresh libduckdb instance on Native/JS); in-memory tables don't persist across calls. Right semantics for the cross-platform CLI (`wvlet run -t duckdb`).

The runner's JVM `DuckDBConnector` keeps its long-lived JDBC connection for session-state preservation — wiring it through a stateful `asSqlConnector` accessor is a follow-up PR (the DuckDB equivalent of #1718).

## Verification

- `langJVM/testOnly *DuckDBSqlConnectorTest` — 4/4 green
- `langJS/testOnly *DuckDBSqlConnectorTest` — 4/4 green
- `langNative/testOnly *DuckDBSqlConnectorTest` — 4/4 green

## Test plan

- [x] Compile on JVM/JS/Native
- [x] Tests pass on all three platforms
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)