### PR TITLE
fix: Support save to (COPY) statements in the JVM DuckDB facade

### DIFF
--- a/wvlet-lang/.jvm/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
+++ b/wvlet-lang/.jvm/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
@@ -14,6 +14,7 @@ import wvlet.lang.model.RelationType
 
 import java.io.File
 import java.sql.DriverManager
+import java.sql.ResultSet
 
 trait DuckDBCompat:
   def isAvailable: Boolean = true
@@ -46,34 +47,52 @@ trait DuckDBCompat:
     * Run `sql` against a fresh in-memory DuckDB and return all rows materialized as strings. Values
     * come back via `rs.getString(col)` — same string-coercion the JS/Native backends get from
     * `duckdb_value_varchar`, so cross-platform output is consistent.
+    *
+    * Statements without a ResultSet (e.g. `COPY ... TO`) are reported as a single `Count` row,
+    * matching the result shape DuckDB's C API gives the JS/Native backends.
     */
   def execute(sql: String): QueryResult = withConnection { conn =>
-    withResource(conn.createStatement().executeQuery(sql)) { rs =>
-      val metadata = rs.getMetaData
-      val colCount = metadata.getColumnCount
-      val columns  = (1 to colCount)
-        .map { i =>
-          val name     = metadata.getColumnName(i)
-          val dataType = metadata.getColumnTypeName(i).toLowerCase
-          NamedType(Name.termName(name), DataType.parse(dataType))
-        }
-        .toList
-
-      val rows = List.newBuilder[QueryResultRow]
-      while rs.next() do
-        val values = (1 to colCount)
-          .map { i =>
-            val v = rs.getString(i)
-            if rs.wasNull() then
-              None
-            else
-              Option(v)
-          }
-          .toList
-        rows += QueryResultRow(values)
-      QueryResult(columns, rows.result())
+    withResource(conn.createStatement()) { stmt =>
+      // JDBC's executeQuery() rejects statements that produce no ResultSet, so dispatch on
+      // execute() and fall back to the update count for COPY/DDL statements.
+      if stmt.execute(sql) then
+        withResource(stmt.getResultSet)(readResult)
+      else
+        val count = stmt.getUpdateCount
+        if count < 0 then
+          QueryResult(Nil, Nil)
+        else
+          QueryResult(
+            List(NamedType(Name.termName("Count"), DataType.LongType)),
+            List(QueryResultRow(List(Some(count.toString))))
+          )
     }
   }
+
+  private def readResult(rs: ResultSet): QueryResult =
+    val metadata = rs.getMetaData
+    val colCount = metadata.getColumnCount
+    val columns  = (1 to colCount)
+      .map { i =>
+        val name     = metadata.getColumnName(i)
+        val dataType = metadata.getColumnTypeName(i).toLowerCase
+        NamedType(Name.termName(name), DataType.parse(dataType))
+      }
+      .toList
+
+    val rows = List.newBuilder[QueryResultRow]
+    while rs.next() do
+      val values = (1 to colCount)
+        .map { i =>
+          val v = rs.getString(i)
+          if rs.wasNull() then
+            None
+          else
+            Option(v)
+        }
+        .toList
+      rows += QueryResultRow(values)
+    QueryResult(columns, rows.result())
 
   private def withConnection[U](f: DuckDBConnection => U): U =
     Class.forName("org.duckdb.DuckDBDriver")

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBExecuteTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBExecuteTest.scala
@@ -55,6 +55,19 @@ class DuckDBExecuteTest extends UniTest:
     r.rows.head.values shouldBe List(None, Some("present"))
   }
 
+  test("execute reports copy ... to statements as a Count row") {
+    skipIfUnavailable()
+    // COPY produces no regular ResultSet; every platform must surface DuckDB's `Count`
+    // result (JDBC update count on JVM, C-API result on JS/Native) with the same shape.
+    val r = DuckDB.execute(
+      "copy (select * from (values (1), (2), (3)) t(id)) to 'target/duckdb-execute-copy-test.parquet'"
+    )
+    r.columnCount shouldBe 1
+    r.columns.head.name.name shouldBe "Count"
+    r.rowCount shouldBe 1
+    r.rows.head.values.head shouldBe Some("3")
+  }
+
   test("execute compiles a query against a parquet fixture") {
     skipIfUnavailable()
     val r = DuckDB.execute(


### PR DESCRIPTION
## Summary

`wv run` with a `save to 'file.parquet'` (or `.csv`) query failed **only on JVM** with:

```
executeQuery() can only be used with queries that return a ResultSet
```

`save to` compiles to `copy (<query>) to '<path>'`, and the JVM `DuckDBCompat.execute` ran every statement through JDBC `Statement.executeQuery()`, which rejects statements that produce no ResultSet. The JS (koffi FFI) and Native (C API) backends go through `duckdb_query`, which handles COPY fine and returns DuckDB's `Count` row.

Found while validating the cross-platform DuckDB backend: CSV/Parquet reads and `save to` round-trips worked on Node and Native, but `save to` failed on JVM.

## Changes

- `DuckDBCompat.scala` (JVM): dispatch on `stmt.execute(sql)`; when no ResultSet is produced, surface the update count as a single `Count` row (LongType), matching the result shape the C API gives JS/Native. ResultSet reading is unchanged, just extracted to `readResult`.
- `DuckDBExecuteTest.scala` (shared): new cross-platform test asserting `copy ... to` returns a `Count` row with the copied row count, so all three platforms are held to the same contract.

## Testing

- `langJVM/testOnly *DuckDBExecuteTest` — 6/6 passed
- `langJS/testOnly *DuckDBExecuteTest` — 6/6 passed (Node + libduckdb 1.5.4 via `WVLET_LIBDUCKDB`)
- `langNative/testOnly *DuckDBExecuteTest` — 6/6 passed (linked against libduckdb 1.5.4)
- End-to-end: `cliCoreJVM/run run -f q_save.wv` now writes the Parquet/CSV file and prints the same `Count` box as Node/Native; Parquet written on JVM reads back correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)