### PR TITLE
feature: Resolve table and model references in the new Typer

### DIFF
--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperParityCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperParityCheck.scala
@@ -40,9 +40,11 @@ class TyperParityCheck extends UniTest:
 
   test("new typer must not regress SQL parity over spec/basic") {
     val specDir = File("spec/basic")
-    val wvFiles = Option(specDir.listFiles())
+    // ulid.wv and val.wv generate compile-time ULIDs, so their SQL can never match across runs
+    val nonDeterministicSpecs = Set("ulid.wv", "val.wv")
+    val wvFiles               = Option(specDir.listFiles())
       .getOrElse(Array.empty[File])
-      .filter(f => f.isFile && f.getName.endsWith(".wv"))
+      .filter(f => f.isFile && f.getName.endsWith(".wv") && !nonDeterministicSpecs(f.getName))
       .sortBy(_.getName)
 
     var same       = 0
@@ -80,12 +82,11 @@ class TyperParityCheck extends UniTest:
     crashFiles.result().foreach(f => debug(s"[CRASH] ${f}"))
 
     // Current parity level (2026-07-02). Tighten as more TypeResolver behavior is ported:
-    // remaining diffs are grouping-key indexes (_1), aggregation-function inlining, native
-    // expressions (ulid), and file-path scans; crashes are unresolved TableRef for table values
-    if same < 44 then
-      fail(s"Typer SQL parity regressed: same=${same} (expected >= 44)")
-    if newFailed > 3 then
-      fail(s"Typer compilation crashes increased: newFailed=${newFailed} (expected <= 3)")
+    // remaining diffs are grouping-key indexes (_1) and aggregation-function inlining
+    if same < 48 then
+      fail(s"Typer SQL parity regressed: same=${same} (expected >= 48)")
+    if newFailed > 0 then
+      fail(s"Typer compilation crashes increased: newFailed=${newFailed} (expected 0)")
   }
 
 end TyperParityCheck

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer
+
+import wvlet.lang.catalog.Catalog.TableName
+import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.ContextLogSupport
+import wvlet.lang.compiler.Name
+import wvlet.lang.compiler.RelationAliasSymbolInfo
+import wvlet.lang.compiler.Symbol
+import wvlet.lang.compiler.ContextUtil.*
+import wvlet.lang.model.DataType
+import wvlet.lang.model.DataType.SchemaType
+import wvlet.lang.model.RelationType
+import wvlet.lang.model.expr.*
+import wvlet.lang.model.plan.*
+
+/**
+  * Resolution of table, model, and data-file references into concrete scan nodes, shared between
+  * the current TypeResolver and the new Typer. Compilation of `.wv`/`.sql` file imports stays in
+  * the owning phase because it requires re-running that phase on the referenced unit.
+  */
+object RelationRefResolver extends ContextLogSupport:
+
+  private def lookupType(name: Name, context: Context): Option[Symbol] = context.findSymbolByName(
+    name
+  )
+
+  private def lookup(qName: NameExpr, context: Context): Option[Symbol] =
+    qName match
+      case i: Identifier =>
+        lookupType(i.toTermName, context)
+      case d: DotRef =>
+        // TODO Load table schema from the given qualified name
+        None
+      case _ =>
+        None
+
+  /**
+    * Resolve a TableRef into a ModelScan, Values (table value constant), aliased relation, or
+    * TableScan using the symbols in scope and the catalog
+    */
+  def resolveTableRef(ref: TableRef)(using context: Context): Relation =
+    lookup(ref.name, context) match
+      case Some(sym) =>
+        sym.tree match
+          case m: ModelDef =>
+            val r = m.child.relationType
+            ModelScan(TableName(ref.name.fullName), Nil, r, ref.span)
+          case v: ValDef =>
+            // Check if this is a table value constant by looking at the dataType
+            v.dataType match
+              case schemaType: DataType.SchemaType =>
+                // Handle table value constants: val t1(id, val) = [[...]]
+                // The expression is an ArrayConstructor containing rows (each row is also an
+                // ArrayConstructor)
+                v.expr match
+                  case arr: ArrayConstructor =>
+                    // arr.values contains the rows - use them directly
+                    Values(arr.values, schemaType, arr.span)
+                  case other =>
+                    ref
+              case _ =>
+                // Regular val definition, not a table value constant
+                ref
+          case _ =>
+            sym.symbolInfo match
+              case relAlias: RelationAliasSymbolInfo =>
+                // Replace alias to the referenced query
+                sym.tree.asInstanceOf[Relation]
+              case _ =>
+                ref
+      case None =>
+        // Lookup known types
+        val tblType = Name.typeName(ref.name.leafName)
+        lookupType(tblType, context).map(_.symbolInfo.dataType) match
+          case Some(tpe: SchemaType) =>
+            context.logTrace(s"Found a table type for ${tblType}: ${tpe}")
+            val tableName = TableName.parse(tblType.toTermName.name)
+            TableScan(tableName, tpe, tpe.fields, ref.span)
+          case _ =>
+            val tableName = TableName.parse(ref.name.fullName)
+            context
+              .catalog
+              .findTable(tableName.schema.getOrElse(context.defaultSchema), tableName.name) match
+              case Some(tbl) =>
+                TableScan(tableName, tbl.schemaType, tbl.schemaType.fields, ref.span)
+              case None =>
+                context
+                  .workEnv
+                  .errorLogger
+                  .debug(
+                    s"Unresolved table ref: ${ref.name.fullName}: ${context.scope.getAllEntries}"
+                  )
+                ref
+    end match
+  end resolveTableRef
+
+  /**
+    * Resolve a table function call (e.g. a parameterized model reference) into a ModelScan
+    */
+  def resolveTableFunctionCall(ref: TableFunctionCall)(using context: Context): Relation =
+    lookup(ref.name, context) match
+      case Some(sym) =>
+        val si = sym.symbolInfo
+        si.tpe match
+          case r: RelationType =>
+            context.logTrace(s"Resolved model ref: ${ref.name.fullName} as ${r}")
+            ModelScan(TableName(sym.name.name), ref.args, r, ref.span)
+          case _ =>
+            ref
+      case None =>
+        context.logTrace(s"Unresolved model ref: ${ref.name.fullName}")
+        ref
+
+  /**
+    * Attach the model schema to an unresolved ModelScan
+    */
+  def resolveModelScan(m: ModelScan)(using context: Context): Relation =
+    context.findTermSymbolByName(m.name.fullName) match
+      case Some(sym) if sym.isModelDef =>
+        sym.tree match
+          case md: ModelDef =>
+            val newModelScan = m.copy(schema = md.relationType)
+            newModelScan.symbol = md.child.symbol
+            newModelScan
+          case _ =>
+            m
+      case _ =>
+        m
+
+  /**
+    * Returns true if the given path points to a data file that can be resolved into a FileScan
+    */
+  def isDataFilePath(path: String): Boolean =
+    path.endsWith(".json") || path.endsWith(".json.gz") || path.endsWith(".parquet") ||
+      path.endsWith(".csv")
+
+  /**
+    * Resolve a data-file reference (json/parquet/csv) into a FileScan by analyzing the file schema.
+    * References to `.wv`/`.sql` files are not handled here.
+    */
+  def resolveDataFileRef(f: FileRef)(using context: Context): Option[Relation] =
+    if f.filePath.endsWith(".json") || f.filePath.endsWith(".json.gz") then
+      val file             = context.getDataFile(f.filePath)
+      val jsonRelationType = JSONAnalyzer.analyzeJSONFile(file)
+      val cols             = jsonRelationType.fields
+      Some(FileScan(SingleQuoteString(file, f.span), jsonRelationType, cols, f.span))
+    else if f.filePath.endsWith(".parquet") || f.filePath.endsWith(".csv") then
+      val file         = context.dataFilePath(f.filePath)
+      val relationType = DuckDBAnalyzer.guessSchema(file)
+      val cols         = relationType.fields
+      Some(FileScan(SingleQuoteString(file, f.span), relationType, cols, f.span))
+    else
+      None
+
+end RelationRefResolver

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -78,7 +78,11 @@ object RelationRefResolver extends ContextLogSupport:
             sym.symbolInfo match
               case relAlias: RelationAliasSymbolInfo =>
                 // Replace alias to the referenced query
-                sym.tree.asInstanceOf[Relation]
+                sym.tree match
+                  case r: Relation =>
+                    r
+                  case _ =>
+                    ref
               case _ =>
                 ref
       case None =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TypeResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TypeResolver.scala
@@ -229,16 +229,8 @@ object TypeResolver extends Phase("type-resolver") with ContextLogSupport:
                 throw StatusCode
                   .SYNTAX_ERROR
                   .newException(s"${unit.sourceFile} is not a single query file")
-      case f: FileRef if f.filePath.endsWith(".json") || f.filePath.endsWith(".json.gz") =>
-        val file             = context.getDataFile(f.filePath)
-        val jsonRelationType = JSONAnalyzer.analyzeJSONFile(file)
-        val cols             = jsonRelationType.fields
-        FileScan(SingleQuoteString(file, f.span), jsonRelationType, cols, f.span)
-      case f: FileRef if f.filePath.endsWith(".parquet") || f.filePath.endsWith(".csv") =>
-        val file         = context.dataFilePath(f.filePath)
-        val relationType = DuckDBAnalyzer.guessSchema(file)
-        val cols         = relationType.fields
-        FileScan(SingleQuoteString(file, f.span), relationType, cols, f.span)
+      case f: FileRef if RelationRefResolver.isDataFilePath(f.filePath) =>
+        RelationRefResolver.resolveDataFileRef(f)(using context).getOrElse(f)
 
     end apply
 
@@ -299,17 +291,7 @@ object TypeResolver extends Phase("type-resolver") with ContextLogSupport:
   private object resolveModelScan extends RewriteRule:
     override def apply(context: Context): PlanRewriter =
       case m: ModelScan if !m.resolved =>
-        context.findTermSymbolByName(m.name.fullName) match
-          case Some(sym) if sym.isModelDef =>
-            sym.tree match
-              case md: ModelDef =>
-                val newModelScan = m.copy(schema = md.relationType)
-                newModelScan.symbol = md.child.symbol
-                newModelScan
-              case _ =>
-                m
-          case _ =>
-            m
+        RelationRefResolver.resolveModelScan(m)(using context)
 
   end resolveModelScan
 
@@ -317,96 +299,11 @@ object TypeResolver extends Phase("type-resolver") with ContextLogSupport:
     * Resolve TableRefs with concrete TableScans using the table schema in the catalog.
     */
   private object resolveTableRef extends RewriteRule:
-    private def lookup(qName: NameExpr, context: Context): Option[Symbol] =
-      def getTableName(d: DotRef): Option[TableName] = Try(TableName(d.fullName)).toOption
-
-      qName match
-        case i: Identifier =>
-          lookupType(i.toTermName, context)
-        case d: DotRef =>
-          // TODO Load table schema from the given qualified name
-//          getTableName(d).flatMap { tbl =>
-//            context.catalog.getTable(tbl)
-//          }
-          None
-        case _ =>
-          None
-
     override def apply(context: Context): PlanRewriter =
       case ref: TableRef if !ref.relationType.isResolved =>
-        lookup(ref.name, context) match
-          case Some(sym) =>
-            sym.tree match
-              case m: ModelDef =>
-                val r = m.child.relationType
-                ModelScan(TableName(ref.name.fullName), Nil, r, ref.span)
-              case v: ValDef =>
-                // Check if this is a table value constant by looking at the dataType
-                v.dataType match
-                  case schemaType: DataType.SchemaType =>
-                    // Handle table value constants: val t1(id, val) = [[...]]
-                    // The expression is an ArrayConstructor containing rows (each row is also an ArrayConstructor)
-                    v.expr match
-                      case arr: ArrayConstructor =>
-                        // arr.values contains the rows - use them directly
-                        val values = Values(arr.values, schemaType, arr.span)
-                        values
-                      case other =>
-                        ref
-                  case _ =>
-                    // Regular val definition, not a table value constant
-                    ref
-              case _ =>
-                val si = sym.symbolInfo
-                si match
-                  case relAlias: RelationAliasSymbolInfo =>
-                    // Replace alias to the referenced query
-                    sym.tree.asInstanceOf[Relation]
-                  case _ =>
-                    ref
-          case None =>
-            // Lookup known types
-            val tblType = Name.typeName(ref.name.leafName)
-            lookupType(tblType, context).map(_.symbolInfo.dataType) match
-              case Some(tpe: SchemaType) =>
-                context.logTrace(s"Found a table type for ${tblType}: ${tpe}")
-                val tableName = TableName.parse(tblType.toTermName.name)
-                TableScan(tableName, tpe, tpe.fields, ref.span)
-              case _ =>
-                val tableName = TableName.parse(ref.name.fullName)
-                context
-                  .catalog
-                  .findTable(
-                    tableName.schema.getOrElse(context.defaultSchema),
-                    tableName.name
-                  ) match
-                  case Some(tbl) =>
-                    TableScan(tableName, tbl.schemaType, tbl.schemaType.fields, ref.span)
-                  case None =>
-                    context
-                      .workEnv
-                      .errorLogger
-                      .debug(
-                        s"Unresolved table ref: ${ref.name.fullName}: ${context
-                            .scope
-                            .getAllEntries}"
-                      )
-                    ref
+        RelationRefResolver.resolveTableRef(ref)(using context)
       case ref: TableFunctionCall if !ref.relationType.isResolved =>
-        lookup(ref.name, context) match
-          case Some(sym) =>
-            val si = sym.symbolInfo
-            si.tpe match
-              case r: RelationType =>
-                context.logTrace(s"Resolved model ref: ${ref.name.fullName} as ${r}")
-                ModelScan(TableName(sym.name.name), ref.args, r, ref.span)
-              case _ =>
-                ref
-          case None =>
-            context.logTrace(s"Unresolved model ref: ${ref.name.fullName}")
-            ref
-
-    end apply
+        RelationRefResolver.resolveTableFunctionCall(ref)(using context)
 
   end resolveTableRef
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -18,6 +18,7 @@ import wvlet.lang.compiler.Context
 import wvlet.lang.compiler.Name
 import wvlet.lang.compiler.Phase
 import wvlet.lang.compiler.analyzer.FunctionInliner
+import wvlet.lang.compiler.analyzer.RelationRefResolver
 import wvlet.lang.model.expr.DotRef
 import wvlet.lang.model.expr.FunctionApply
 import wvlet.lang.model.DataType
@@ -129,6 +130,13 @@ object Typer extends Phase("typer") with LogSupport:
             val typedStmt = typePlan(stmt)(using currentCtx)
             // Update context for imports
             currentCtx = updateContextForStatement(typedStmt, currentCtx)
+            // Point the symbol to the typed tree so later references (e.g. ModelScan) see it
+            typedStmt match
+              case m: ModelDef =>
+                m.symbol.tree = m
+              case t: TypeDef =>
+                t.symbol.tree = t
+              case _ =>
             typedStmt
           }
         val typedPackage = p.copy(statements = typedStatements)
@@ -171,8 +179,22 @@ object Typer extends Phase("typer") with LogSupport:
         typedModelDef
       // Handle Relation - propagate input type through relational operators
       case r: Relation =>
+        // Resolve table/model/file references into concrete scan nodes before typing so that
+        // relation types can propagate bottom-up
+        val refResolved = r
+          .transformUp {
+            case ref: TableRef if !ref.relationType.isResolved =>
+              RelationRefResolver.resolveTableRef(ref)
+            case ref: TableFunctionCall if !ref.relationType.isResolved =>
+              RelationRefResolver.resolveTableFunctionCall(ref)
+            case m: ModelScan if !m.resolved =>
+              RelationRefResolver.resolveModelScan(m)
+            case f: FileRef if RelationRefResolver.isDataFilePath(f.filePath) =>
+              RelationRefResolver.resolveDataFileRef(f).getOrElse(f)
+          }
+          .asInstanceOf[Relation]
         // Inline partial query applications first (plan-level rewrite with cycle detection)
-        val pqInlined = r
+        val pqInlined = refResolved
           .transformUp { case p: PartialQueryApply =>
             FunctionInliner.resolvePartialQuery(p)
           }

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/TreeNode.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/TreeNode.scala
@@ -111,8 +111,10 @@ trait SyntaxTreeNode extends TreeNode with Product with LogSupport:
       val newObj = getSingletonObject.getOrElse(newInstance(args*))
       newObj match
         case t: SyntaxTreeNode =>
-          if this.symbol.tree != null then
-            // Update the tree reference with the rewritten tree
+          // Update the definition link only when this node IS the symbol's defining tree.
+          // Copying a node that merely references the symbol (e.g. an identifier carrying the
+          // symbol of its definition) must not re-point the definition to the reference
+          if this.symbol.tree eq this then
             this.symbol.tree = t
           // Copy metadata to preserve symbol and comments
           t.copyMetadataFrom(this)

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.catalog.Profile
+import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, WorkEnv}
+import wvlet.lang.compiler.codegen.GenSQL
+import wvlet.lang.runner.connector.DBConnectorProvider
+
+import java.io.File
+
+/**
+  * Execution-side parity gate for the new Typer (issue #1764): compile every spec under spec/basic
+  * with both the default TypeResolver and the new Typer using a DuckDB catalog (covering specs that
+  * cannot compile standalone in wvlet-lang tests), and compare the generated SQL.
+  *
+  * The bounds below pin the current parity level: improvements pass automatically; regressions fail
+  * the build. Tighten as the gap burns down.
+  */
+class TyperExecutionParityCheck extends UniTest:
+
+  private val specPath            = "spec/basic"
+  private val workEnv             = WorkEnv(path = specPath, logLevel = logger.getLogLevel)
+  private val profile             = Profile.defaultDuckDBProfile
+  private val dbConnectorProvider = DBConnectorProvider(workEnv)
+  private val queryExecutor       = QueryExecutor(dbConnectorProvider, profile, workEnv)
+
+  override def afterAll: Unit =
+    queryExecutor.close()
+    dbConnectorProvider.close()
+
+  private def newCompiler(useNewTyper: Boolean): Compiler =
+    val options  = CompilerOptions(sourceFolders = List(specPath), workEnv = workEnv)
+    val compiler =
+      if useNewTyper then
+        Compiler.withNewTyper(options)
+      else
+        Compiler(options)
+    compiler.setDefaultCatalog(queryExecutor.getDBConnector(profile).getCatalog("memory", "main"))
+    compiler
+
+  private def generateSQL(compiler: Compiler, path: String): Either[String, String] =
+    try
+      val unit   = CompilationUnit.fromFile(path)
+      val result = compiler.compileSingleUnit(unit)
+      Right(GenSQL.generateSQL(unit)(using result.context))
+    catch
+      case e: Throwable =>
+        Left(s"${e.getClass.getSimpleName}: ${e.getMessage}")
+
+  // Specs whose generated SQL contains compile-time-generated values (e.g. ulid_string), which
+  // can never match across two independent compiler runs
+  private val nonDeterministicSpecs = Set("ulid.wv", "val.wv")
+
+  test("new typer must not regress SQL parity over spec/basic with a DuckDB catalog") {
+    val wvFiles = Option(File(specPath).listFiles())
+      .getOrElse(Array.empty[File])
+      .filter(f => f.isFile && f.getName.endsWith(".wv") && !nonDeterministicSpecs(f.getName))
+      .sortBy(_.getName)
+
+    var same       = 0
+    var diff       = 0
+    var newFailed  = 0
+    var oldFailed  = 0
+    val diffFiles  = List.newBuilder[String]
+    val crashFiles = List.newBuilder[String]
+
+    wvFiles.foreach { f =>
+      val oldSQL = generateSQL(newCompiler(useNewTyper = false), f.getPath)
+      val newSQL = generateSQL(newCompiler(useNewTyper = true), f.getPath)
+      (oldSQL, newSQL) match
+        case (Right(o), Right(n)) if o == n =>
+          same += 1
+        case (Right(o), Right(n)) =>
+          diff += 1
+          diffFiles += f.getName
+        case (Right(_), Left(err)) =>
+          newFailed += 1
+          crashFiles += s"${f.getName}: ${err.linesIterator.nextOption().getOrElse("")}"
+        case (Left(_), _) =>
+          oldFailed += 1
+    }
+
+    info(
+      s"typer execution parity: total=${wvFiles
+          .length} same=${same} diff=${diff} newTyperFailed=${newFailed} oldFailed=${oldFailed}"
+    )
+    diffFiles.result().foreach(f => debug(s"[DIFF] ${f}"))
+    crashFiles.result().foreach(f => debug(s"[CRASH] ${f}"))
+
+    // Current parity level (2026-07-02): ~84/102 measurable specs produce identical SQL (with a
+    // one-spec allowance for shared-symbol-state flakiness across compiler runs in one JVM).
+    // Tighten as more TypeResolver behavior is ported
+    if same < 83 then
+      fail(s"Typer SQL parity regressed: same=${same} (expected >= 83)")
+    if newFailed > 0 then
+      fail(s"Typer compilation crashes increased: newFailed=${newFailed} (expected 0)")
+  }
+
+end TyperExecutionParityCheck

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
@@ -36,6 +36,9 @@ class TyperExecutionParityCheck extends UniTest:
   private val profile             = Profile.defaultDuckDBProfile
   private val dbConnectorProvider = DBConnectorProvider(workEnv)
   private val queryExecutor       = QueryExecutor(dbConnectorProvider, profile, workEnv)
+  // Resolve the catalog once and share it across all compiler instances to avoid querying the
+  // database connector for every spec file
+  private lazy val catalog = queryExecutor.getDBConnector(profile).getCatalog("memory", "main")
 
   override def afterAll: Unit =
     queryExecutor.close()
@@ -48,7 +51,7 @@ class TyperExecutionParityCheck extends UniTest:
         Compiler.withNewTyper(options)
       else
         Compiler(options)
-    compiler.setDefaultCatalog(queryExecutor.getDBConnector(profile).getCatalog("memory", "main"))
+    compiler.setDefaultCatalog(catalog)
     compiler
 
   private def generateSQL(compiler: Compiler, path: String): Either[String, String] =


### PR DESCRIPTION
## Summary

Second step of the Typer migration track of #1764 (part of #392), following the shared inliner in #1766. Ports table/model/file reference resolution to the new `Typer` via a shared component, fixes a latent tree-linking defect it exposed, and adds the runner-side execution parity gate.

## Changes

### Shared reference resolution
`TypeResolver`'s `resolveTableRef` / `resolveTableFunctionCall` / `resolveModelScan` / data-file `FileScan` resolution is extracted into `analyzer.RelationRefResolver` (pure extraction — TypeResolver delegates unchanged). The new `Typer` applies it **before** typing so relation types propagate bottom-up. `.wv`/`.sql` file imports stay in TypeResolver since they re-run the owning phase.

### `TreeNode.copyInstance` fix (latent defect)
`copyInstance` re-pointed `symbol.tree` to the copy whenever **any** node carrying a symbol was copied. The old pipeline rarely attaches symbols to referencing nodes, so this stayed hidden; the new Typer attaches symbols to referencing identifiers (`id.symbol = sym`), so copying a reference **clobbered the definition link** — e.g. a table-val's `ValDef` became an `UnquotedIdentifier`, which broke GenSQL's table-val guard (`tableRefQualifiers`) and substituted table values into join `on` conditions (`on [[...]].symbol = ...`). The definition link is now updated only when the copied node *is* the defining tree. All 1449 langJVM + 396 runner tests confirm the default pipeline is unaffected.

### Execution parity gate (runner-side)
New `TyperExecutionParityCheck` compiles every `spec/basic` file with both pipelines **with a DuckDB catalog**, covering the 51 specs that cannot compile standalone in wvlet-lang tests. Nondeterministic specs (compile-time `ulid_string`) are excluded from both parity gates.

## Parity progression over `spec/basic`

| metric | #1766 | this PR |
|---|---|---|
| standalone-compilable identical SQL | 44/54 | **49/52** |
| new-typer crashes | 3 | **0** |
| with DuckDB catalog (new gate) | — | **84/103** |

Remaining gaps (follow-up): grouping-key indexes (`_1`), aggregation-function inlining, pivot handling, native expressions, `.wv` file imports, GenSQL decoupling from `TypeResolver.resolve`.

## Testing

- `langJVM/test`: 1449 tests, 1445 passed, 4 pending
- `runner/test` (incl. RunnerSpecBasic, RunnerSpecNeg, TPC-H, new parity gate): 396 total, 0 failed
- `projectJS/Test/compile`, `projectNative/Test/compile`, and `langJS/Test/fastLinkJS` pass
- `scalafmtAll` applied

Part of #1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review updates

- Alias resolution now pattern-matches on `sym.tree` instead of `asInstanceOf[Relation]` (pre-existing `ClassCastException` hazard surfaced by Gemini; `Symbol.tree` never returns null)
- `TyperExecutionParityCheck` resolves the DuckDB catalog once instead of per spec file
