### PR TITLE
feature: Resolve aggregation expressions and grouping keys in the new Typer

### DIFF
--- a/spec/basic/table_val_asof_join.wv
+++ b/spec/basic/table_val_asof_join.wv
@@ -1,5 +1,5 @@
 -- Test table val references in asof join conditions (from issue #1380)
-val quotes(timestamp, symbol, bid_price, ask_price) = [
+val asof_quotes(timestamp, symbol, bid_price, ask_price) = [
   ["2024-01-15 09:30:00", "AAPL", 150.00, 150.10],
   ["2024-01-15 09:31:00", "AAPL", 150.50, 150.60],
   ["2024-01-15 09:32:00", "AAPL", 151.00, 151.10],
@@ -9,7 +9,7 @@ val quotes(timestamp, symbol, bid_price, ask_price) = [
   ["2024-01-15 09:34:00", "GOOGL", 2803.00, 2804.00]
 ]
 
-val trades(trade_time, symbol, quantity, executed_price) = [
+val asof_trades(trade_time, symbol, quantity, executed_price) = [
   ["2024-01-15 09:30:45", "AAPL", 100, 150.05],
   ["2024-01-15 09:31:30", "AAPL", 200, 150.55],
   ["2024-01-15 09:33:15", "AAPL", 150, 150.85],
@@ -18,11 +18,11 @@ val trades(trade_time, symbol, quantity, executed_price) = [
   ["2024-01-15 09:35:00", "GOOGL", 100, 2803.50]
 ]
 
-from trades
-asof join quotes
-  on trades.symbol = quotes.symbol
-  and trades.trade_time >= quotes.timestamp
+from asof_trades
+asof join asof_quotes
+  on asof_trades.symbol = asof_quotes.symbol
+  and asof_trades.trade_time >= asof_quotes.timestamp
 add
   executed_price - bid_price as price_vs_bid,
   executed_price - ask_price as price_vs_ask
-order by trades.symbol, trade_time
+order by asof_trades.symbol, trade_time

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperParityCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperParityCheck.scala
@@ -81,10 +81,10 @@ class TyperParityCheck extends UniTest:
     diffFiles.result().foreach(f => debug(s"[DIFF] ${f}"))
     crashFiles.result().foreach(f => debug(s"[CRASH] ${f}"))
 
-    // Current parity level (2026-07-02). Tighten as more TypeResolver behavior is ported:
-    // remaining diffs are grouping-key indexes (_1) and aggregation-function inlining
-    if same < 48 then
-      fail(s"Typer SQL parity regressed: same=${same} (expected >= 48)")
+    // Current parity level (2026-07-02): all standalone-compilable specs produce identical SQL
+    // (with a one-spec allowance for shared-symbol-state flakiness across compiler runs)
+    if same < 51 then
+      fail(s"Typer SQL parity regressed: same=${same} (expected >= 51)")
     if newFailed > 0 then
       fail(s"Typer compilation crashes increased: newFailed=${newFailed} (expected 0)")
   }

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/AggregationResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/AggregationResolver.scala
@@ -55,7 +55,9 @@ object AggregationResolver extends ContextLogSupport:
         .find(_.name == nme)
         .map(_.symbolInfo)
         .collect { case m: MethodSymbolInfo =>
-          FunctionInliner.inlineFunctionBody(d, m, Nil)
+          // Inline with the transformed DotRef so aggregations already resolved in the
+          // qualifier's child expressions are preserved
+          FunctionInliner.inlineFunctionBody(dd, m, Nil)
         }
         .getOrElse(dd)
     case other =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/AggregationResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/AggregationResolver.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.ContextLogSupport
+import wvlet.lang.compiler.MethodSymbolInfo
+import wvlet.lang.compiler.Name
+import wvlet.lang.compiler.Symbol
+import wvlet.lang.compiler.TypeSymbolInfo
+import wvlet.lang.compiler.ContextUtil.*
+import wvlet.lang.model.expr.*
+import wvlet.lang.model.plan.*
+
+/**
+  * Resolution of aggregation expressions and grouping-key indexes, shared between the current
+  * TypeResolver and the new Typer.
+  */
+object AggregationResolver extends ContextLogSupport:
+
+  /**
+    * Aggregation functions (members of the array type) that can be applied to a column or
+    * expression via dot syntax, e.g. {{{(l_extendedprice * l_discount).sum}}}
+    */
+  private def aggregationFunctions(ctx: Context): List[Symbol] = ctx
+    .findSymbolByName(Name.typeName("array"))
+    .map(_.symbolInfo)
+    .collect { case t: TypeSymbolInfo =>
+      t.members
+    }
+    .getOrElse(Nil)
+
+  private def resolveAggregationExpr(aggFunctions: List[Symbol])(using
+      ctx: Context
+  ): PartialFunction[Expression, Expression] =
+    case e: ShouldExpr =>
+      // do not resolve aggregation expr in test expressions
+      e
+    case d: DotRef =>
+      val dd  = d.transformChildExpressions(resolveAggregationExpr(aggFunctions))
+      val nme = dd.name.toTermName
+      aggFunctions
+        .find(_.name == nme)
+        .map(_.symbolInfo)
+        .collect { case m: MethodSymbolInfo =>
+          FunctionInliner.inlineFunctionBody(d, m, Nil)
+        }
+        .getOrElse(dd)
+    case other =>
+      other.transformChildExpressions(resolveAggregationExpr(aggFunctions))
+
+  /**
+    * Inline aggregation functions (e.g. {{{expr.sum}}}) applied without an explicit GroupBy node in
+    * selection expressions
+    */
+  def resolveNoGroupByAggregations(q: Relation)(using ctx: Context): Relation =
+    val aggFunctions = aggregationFunctions(ctx)
+    q.transformUp { case s: GeneralSelection =>
+        s.transformChildExpressions(resolveAggregationExpr(aggFunctions))
+      }
+      .asInstanceOf[Relation]
+
+  // Find the first Aggregate node
+  private def findAggregate(r: Relation): Option[GroupBy] =
+    r match
+      case a: GroupBy =>
+        Some(a)
+      case f: FilteringRelation =>
+        findAggregate(f.child)
+      case p: Project =>
+        findAggregate(p.child)
+      case _ =>
+        None
+
+  /**
+    * Replace grouping key indexes (_1, _2, ...) in select clauses with the referenced grouping keys
+    */
+  def resolveGroupingKeyIndexes(p: AggSelect)(using ctx: Context): Relation =
+    if !p.selectItems.exists(_.nameExpr.isGroupingKeyIndex) then
+      p
+    else
+      findAggregate(p.child) match
+        case Some(agg) =>
+          val resolved = p.transformChildExpressions {
+            case attr: SingleColumn if attr.nameExpr.isGroupingKeyIndex =>
+              val index = attr.nameExpr.fullName.stripPrefix("_").toInt - 1
+              if index >= agg.groupingKeys.length then
+                throw StatusCode
+                  .SYNTAX_ERROR
+                  .newException(
+                    s"Invalid grouping key index: ${attr.nameExpr}",
+                    ctx.sourceLocationAt(attr.span)
+                  )
+
+              val referencedGroupingKey = agg.groupingKeys(index)
+              SingleColumn(referencedGroupingKey.name, expr = referencedGroupingKey, attr.span)
+          }
+          resolved.asInstanceOf[Relation]
+        case None =>
+          p
+
+end AggregationResolver

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
@@ -83,10 +83,18 @@ object FunctionInliner extends ContextLogSupport:
           if qual.dataType.isResolved then
             qual.dataType
           else
-            DataType.AnyType
+            // The new Typer assigns types to the tpe field instead of rewriting nodes with
+            // resolved dataTypes, so fall back to tpe before giving up
+            qual.tpe match
+              case dt: DataType if dt.isResolved =>
+                dt
+              case _ =>
+                DataType.AnyType
 
-        val m: Option[MethodSymbolInfo] = lookupType(qualType.typeName, context)
-          .map { sym =>
+        def memberOf(baseType: DataType): Option[MethodSymbolInfo] = lookupType(
+          baseType.typeName,
+          context
+        ).map { sym =>
             // TODO: Resolve member with different arg types
             sym.symbolInfo.findMember(methodName).symbolInfo
           }
@@ -108,7 +116,7 @@ object FunctionInliner extends ContextLogSupport:
               case Some(ownerType: TypeSymbolInfo) =>
                 val typeMap: Map[TypeName, DataType] = ownerType
                   .typeParams
-                  .zipAll(qualType.typeParams, UnknownType, UnknownType)
+                  .zipAll(baseType.typeParams, UnknownType, UnknownType)
                   .collect { case (t1: TypeParameter, t2) =>
                     t1.typeName -> t2
                   }
@@ -123,9 +131,19 @@ object FunctionInliner extends ContextLogSupport:
                 mi
           }
           .map { m =>
-            context.logTrace(s"Resolved method ${qualType}.${methodName} => ${m}")
+            context.logTrace(s"Resolved method ${baseType}.${methodName} => ${m}")
             m
           }
+
+        // Retry with the any type when the method is not a member of the qualifier's type: with
+        // an unresolved qualifier this lookup has always consulted the any type, so typing the
+        // qualifier (as the new Typer does) must not narrow what could be resolved before
+        val m: Option[MethodSymbolInfo] = memberOf(qualType).orElse {
+          if qualType != DataType.AnyType then
+            memberOf(DataType.AnyType)
+          else
+            None
+        }
 
         if m.isEmpty then
           context.logTrace(s"Failed to find function `${methodName}` for ${qual}:${qual.dataType}")

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TypeResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TypeResolver.scala
@@ -338,38 +338,9 @@ object TypeResolver extends Phase("type-resolver") with ContextLogSupport:
     * Resolve grouping key indexes _1, _2, .... in select clauses
     */
   private object resolveGroupingKeyIndexes extends RewriteRule:
-    // Find the first Aggregate node
-    private def findAggregate(r: Relation): Option[GroupBy] =
-      r match
-        case a: GroupBy =>
-          Some(a)
-        case f: FilteringRelation =>
-          findAggregate(f.child)
-        case p: Project =>
-          findAggregate(p.child)
-        case _ =>
-          None
-
     override def apply(context: Context): PlanRewriter = {
       case p: AggSelect if p.selectItems.exists(_.nameExpr.isGroupingKeyIndex) =>
-        findAggregate(p.child) match
-          case Some(agg) =>
-            p.transformChildExpressions {
-              case attr: SingleColumn if attr.nameExpr.isGroupingKeyIndex =>
-                val index = attr.nameExpr.fullName.stripPrefix("_").toInt - 1
-                if index >= agg.groupingKeys.length then
-                  throw StatusCode
-                    .SYNTAX_ERROR
-                    .newException(
-                      s"Invalid grouping key index: ${attr.nameExpr}",
-                      context.sourceLocationAt(attr.span)
-                    )
-
-                val referencedGroupingKey = agg.groupingKeys(index)
-                SingleColumn(referencedGroupingKey.name, expr = referencedGroupingKey, attr.span)
-            }
-          case None =>
-            p
+        AggregationResolver.resolveGroupingKeyIndexes(p)(using context)
     }
 
   end resolveGroupingKeyIndexes
@@ -549,44 +520,8 @@ object TypeResolver extends Phase("type-resolver") with ContextLogSupport:
     * is applied like {{{(l_extendedprice * l_discount).sum}}}.
     */
   private object resolveNoGroupByAggregations extends RewriteRule:
-
-    private var aggregationFunctions: List[Symbol] = Nil
-
-    private def init(ctx: Context): Unit =
-      // TODO Support adding more methods to the array type
-      if aggregationFunctions.isEmpty then
-        aggregationFunctions = lookupType(Name.typeName("array"), ctx)
-          .map(_.symbolInfo)
-          .collect { case t: TypeSymbolInfo =>
-            t.members
-          }
-          .getOrElse(Nil)
-
-    private def resolveAggregationExpr(using
-        ctx: Context
-    ): PartialFunction[Expression, Expression] =
-      case e: ShouldExpr =>
-        // do not resolve aggregation expr in test expressions
-        e
-      case d: DotRef =>
-        val dd  = d.transformChildExpressions(resolveAggregationExpr)
-        val nme = dd.name.toTermName
-        aggregationFunctions
-          .find(_.name == nme)
-          .map(_.symbolInfo)
-          .collect { case m: MethodSymbolInfo =>
-            FunctionInliner.inlineFunctionBody(d, m, Nil)
-          }
-          .getOrElse(dd)
-      case other =>
-        other.transformChildExpressions(resolveAggregationExpr)
-    end resolveAggregationExpr
-
     override def apply(context: Context): PlanRewriter = { case q: Query =>
-      init(context)
-      q.transformUp { case s: GeneralSelection =>
-        s.transformChildExpressions(resolveAggregationExpr(using context))
-      }
+      AggregationResolver.resolveNoGroupByAggregations(q)(using context)
     }
 
   end resolveNoGroupByAggregations

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -17,10 +17,13 @@ import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Context
 import wvlet.lang.compiler.Name
 import wvlet.lang.compiler.Phase
+import wvlet.lang.compiler.analyzer.AggregationResolver
 import wvlet.lang.compiler.analyzer.FunctionInliner
 import wvlet.lang.compiler.analyzer.RelationRefResolver
 import wvlet.lang.model.expr.DotRef
 import wvlet.lang.model.expr.FunctionApply
+import wvlet.lang.model.expr.Identifier
+import wvlet.lang.model.expr.ParenthesizedExpression
 import wvlet.lang.model.DataType
 import wvlet.lang.model.DataType.NamedType
 import wvlet.lang.model.DataType.SchemaType
@@ -42,6 +45,25 @@ import wvlet.uni.log.LogSupport
   *   2. Type: Bottom-up traversal with context-aware scope management
   */
 object Typer extends Phase("typer") with LogSupport:
+
+  /**
+    * The maximum number of function-resolution rounds per relation. Each round resolves at least
+    * one link of a chained method call, so chains longer than this are exceedingly unlikely
+    */
+  private inline val maxFunctionResolutionRounds = 10
+
+  /**
+    * Returns true if the expression already carries a resolved data type in either the dataType or
+    * tpe field. An ErrorType in tpe does not count, so a later pass may still resolve it
+    */
+  private def hasResolvedType(e: Expression): Boolean =
+    e.dataType.isResolved || (
+      e.tpe match
+        case dt: DataType if dt.isResolved =>
+          true
+        case _ =>
+          false
+    )
 
   override def run(unit: CompilationUnit, context: Context): CompilationUnit =
     trace(s"Running new typer on ${unit.sourceFile.fileName}")
@@ -137,6 +159,11 @@ object Typer extends Phase("typer") with LogSupport:
               case t: TypeDef =>
                 t.symbol.tree = t
               case _ =>
+            // Re-point relation alias symbols (select as ...) to the rewritten child relation so
+            // later references expand to the resolved query
+            typedStmt.traverse { case s: SelectAsAlias =>
+              s.symbol.tree = s.child
+            }
             typedStmt
           }
         val typedPackage = p.copy(statements = typedStatements)
@@ -201,25 +228,82 @@ object Typer extends Phase("typer") with LogSupport:
           .asInstanceOf[Relation]
         // Type the relation so that function qualifiers get concrete types
         typeRelation(pqInlined)
-        // Inline function applications, then no-arg member references (e.g. obj.method). These are
-        // separate passes: mixing them in one traversal would inline a member call's base DotRef
-        // before its enclosing FunctionApply and drop the arguments
-        val fnInlined = pqInlined
-          .transformUpExpressions { case f: FunctionApply =>
-            FunctionInliner.resolveFunctionApply(f)
+        // Inline function calls and aggregation expressions. Chained method calls (e.g.
+        // x.to_double.round(1)) resolve one link per round, so iterate to a fixpoint
+        var current  = pqInlined
+        var continue = true
+        var rounds   = 0
+        while continue && rounds < maxFunctionResolutionRounds do
+          rounds += 1
+          // Type identifiers, parentheses, and method references in place from each relation's
+          // input type, so an enclosing call can resolve its qualifier type without inlining the
+          // reference (which would drop call arguments)
+          current.transformUp { case rel: Relation =>
+            val inputType = rel.inputRelationType
+            rel
+              .childExpressions
+              .foreach { root =>
+                root.transformUpExpression {
+                  case i: Identifier =>
+                    if !hasResolvedType(i) then
+                      inputType
+                        .find(_.name == i.fullName)
+                        .foreach { attr =>
+                          i.tpe = attr.dataType
+                        }
+                    i
+                  case p: ParenthesizedExpression =>
+                    // Propagate the child type through parentheses
+                    if !hasResolvedType(p) then
+                      if p.child.dataType.isResolved then
+                        p.tpe = p.child.dataType
+                      else if p.child.isTyped then
+                        p.tpe = p.child.tpe
+                    p
+                  case d: DotRef =>
+                    if !hasResolvedType(d) then
+                      FunctionInliner
+                        .findFunctionDef(d)
+                        .foreach { m =>
+                          if m.ft.returnType.isResolved then
+                            d.tpe = m.ft.returnType
+                        }
+                    d
+                }
+              }
+            rel
           }
-          .transformUpExpressions { case d: DotRef =>
-            FunctionInliner.findFunctionDef(d) match
-              case Some(m) =>
-                FunctionInliner.inlineFunctionBody(d, m, Nil)
-              case None =>
-                d
-          }
-          .asInstanceOf[Relation]
-        // Re-type so the inlined bodies get tpe assigned
-        if !(fnInlined eq pqInlined) then
-          typeRelation(fnInlined)
-        fnInlined
+          // Inline function applications, then bare member references. Only no-arg methods are
+          // inlined from a bare DotRef: a DotRef with declared arguments is the base of an
+          // enclosing FunctionApply that must bind them first (possibly in a later round)
+          val fnInlined = current
+            .transformUpExpressions { case f: FunctionApply =>
+              FunctionInliner.resolveFunctionApply(f)
+            }
+            .transformUpExpressions { case d: DotRef =>
+              FunctionInliner.findFunctionDef(d) match
+                case Some(m) if m.ft.args.isEmpty =>
+                  FunctionInliner.inlineFunctionBody(d, m, Nil)
+                case _ =>
+                  d
+            }
+            .asInstanceOf[Relation]
+          // Inline aggregation functions applied via dot syntax (e.g. expr.sum) and expand
+          // grouping-key indexes (_1, _2, ...) in select clauses
+          val aggResolved = AggregationResolver
+            .resolveNoGroupByAggregations(fnInlined)
+            .transformUp { case p: AggSelect =>
+              AggregationResolver.resolveGroupingKeyIndexes(p)
+            }
+            .asInstanceOf[Relation]
+          if aggResolved eq current then
+            continue = false
+          else
+            // Re-type so the inlined bodies get tpe assigned for the next round
+            typeRelation(aggResolved)
+            current = aggResolved
+        end while
+        current
       // Default: bottom-up typing for other nodes
       case other =>
         val withTypedChildren = other.mapChildren(typePlan)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -235,44 +235,48 @@ object Typer extends Phase("typer") with LogSupport:
         var rounds   = 0
         while continue && rounds < maxFunctionResolutionRounds do
           rounds += 1
-          // Type identifiers, parentheses, and method references in place from each relation's
-          // input type, so an enclosing call can resolve its qualifier type without inlining the
-          // reference (which would drop call arguments)
-          current.transformUp { case rel: Relation =>
-            val inputType = rel.inputRelationType
-            rel
-              .childExpressions
-              .foreach { root =>
-                root.transformUpExpression {
-                  case i: Identifier =>
-                    if !hasResolvedType(i) then
-                      inputType
-                        .find(_.name == i.fullName)
-                        .foreach { attr =>
-                          i.tpe = attr.dataType
-                        }
-                    i
-                  case p: ParenthesizedExpression =>
-                    // Propagate the child type through parentheses
-                    if !hasResolvedType(p) then
-                      if p.child.dataType.isResolved then
-                        p.tpe = p.child.dataType
-                      else if p.child.isTyped then
-                        p.tpe = p.child.tpe
-                    p
-                  case d: DotRef =>
-                    if !hasResolvedType(d) then
-                      FunctionInliner
-                        .findFunctionDef(d)
-                        .foreach { m =>
-                          if m.ft.returnType.isResolved then
-                            d.tpe = m.ft.returnType
-                        }
-                    d
+          // Type identifiers, parentheses, and method references from each relation's input
+          // type, so an enclosing call can resolve its qualifier type without inlining the
+          // reference (which would drop call arguments). Typing mutates the tpe field in place
+          // and every case returns the same node instance, so the tree structure is unchanged;
+          // the result is reassigned for safety should a case ever start rebuilding nodes
+          current = current
+            .transformUp { case rel: Relation =>
+              val inputType = rel.inputRelationType
+              rel
+                .childExpressions
+                .foreach { root =>
+                  root.transformUpExpression {
+                    case i: Identifier =>
+                      if !hasResolvedType(i) then
+                        inputType
+                          .find(_.name == i.fullName)
+                          .foreach { attr =>
+                            i.tpe = attr.dataType
+                          }
+                      i
+                    case p: ParenthesizedExpression =>
+                      // Propagate the child type through parentheses
+                      if !hasResolvedType(p) then
+                        if p.child.dataType.isResolved then
+                          p.tpe = p.child.dataType
+                        else if p.child.isTyped then
+                          p.tpe = p.child.tpe
+                      p
+                    case d: DotRef =>
+                      if !hasResolvedType(d) then
+                        FunctionInliner
+                          .findFunctionDef(d)
+                          .foreach { m =>
+                            if m.ft.returnType.isResolved then
+                              d.tpe = m.ft.returnType
+                          }
+                      d
+                  }
                 }
-              }
-            rel
-          }
+              rel
+            }
+            .asInstanceOf[Relation]
           // Inline function applications, then bare member references. Only no-arg methods are
           // inlined from a bare DotRef: a DotRef with declared arguments is the base of an
           // enclosing FunctionApply that must bind them first (possibly in a later round)

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
@@ -103,11 +103,12 @@ class TyperExecutionParityCheck extends UniTest:
     diffFiles.result().foreach(f => debug(s"[DIFF] ${f}"))
     crashFiles.result().foreach(f => debug(s"[CRASH] ${f}"))
 
-    // Current parity level (2026-07-02): ~84/102 measurable specs produce identical SQL (with a
+    // Current parity level (2026-07-02): ~98/102 measurable specs produce identical SQL (with a
     // one-spec allowance for shared-symbol-state flakiness across compiler runs in one JVM).
-    // Tighten as more TypeResolver behavior is ported
-    if same < 83 then
-      fail(s"Typer SQL parity regressed: same=${same} (expected >= 83)")
+    // Remaining diffs: chained aggregation methods (method_chain*, agg_col_type) and .wv file
+    // imports (read-wv). Tighten as more TypeResolver behavior is ported
+    if same < 96 then
+      fail(s"Typer SQL parity regressed: same=${same} (expected >= 96)")
     if newFailed > 0 then
       fail(s"Typer compilation crashes increased: newFailed=${newFailed} (expected 0)")
   }

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
@@ -103,12 +103,11 @@ class TyperExecutionParityCheck extends UniTest:
     diffFiles.result().foreach(f => debug(s"[DIFF] ${f}"))
     crashFiles.result().foreach(f => debug(s"[CRASH] ${f}"))
 
-    // Current parity level (2026-07-02): ~98/102 measurable specs produce identical SQL (with a
+    // Current parity level (2026-07-02): 101/102 measurable specs produce identical SQL (with a
     // one-spec allowance for shared-symbol-state flakiness across compiler runs in one JVM).
-    // Remaining diffs: chained aggregation methods (method_chain*, agg_col_type) and .wv file
-    // imports (read-wv). Tighten as more TypeResolver behavior is ported
-    if same < 96 then
-      fail(s"Typer SQL parity regressed: same=${same} (expected >= 96)")
+    // The only remaining diff is .wv file imports (read-wv). Tighten when that is ported
+    if same < 100 then
+      fail(s"Typer SQL parity regressed: same=${same} (expected >= 100)")
     if newFailed > 0 then
       fail(s"Typer compilation crashes increased: newFailed=${newFailed} (expected 0)")
   }


### PR DESCRIPTION
## Summary

Third step of the Typer migration track of #1764 (part of #392), following #1766 (shared inliner) and #1767 (table/model references). Ports aggregation-expression resolution and grouping-key index expansion to the new `Typer`, and introduces bounded fixpoint resolution for chained method calls.

## Changes

### Shared aggregation resolution
`resolveNoGroupByAggregations` (dot-syntax aggregation inlining, e.g. `expr.sum`) and `resolveGroupingKeyIndexes` (`_1`, `_2` expansion in select clauses) extracted into `analyzer.AggregationResolver`; TypeResolver delegates unchanged. Bonus: removes a cross-compiler mutable cache of aggregation function symbols in the old rule.

### Fixpoint function resolution in Typer
Chained method calls (`x.to_double.round(1)`) need one resolution per link, which the old pipeline got implicitly from its two-round rewrite. The Typer now iterates (bounded at 10 rounds), each round doing:
1. **In-place typing** of identifiers, parentheses, and method references from each relation's own `inputRelationType` (mirroring `TypeResolver.resolveExpression`) — this is what makes agg columns type as `array(elem)` so `sum: A` binds correctly
2. `FunctionApply` inlining, then **no-arg** member references — a bare `DotRef` of a method *with* declared arguments is never inlined, since it is the base of an enclosing `FunctionApply` that must bind them (possibly next round)
3. Aggregation inlining + grouping-key index expansion

### `findFunctionDef` robustness (shared)
- Falls back to the `tpe` field when `dataType` is unresolved (the new Typer types in place rather than rewriting nodes)
- Retries member lookup on the `any` type: an unresolved qualifier has always consulted `any`-type members, so typing the qualifier must not narrow what could be resolved before

### Other
- `SelectAsAlias` symbols re-pointed to the rewritten child so later references expand to the resolved query
- `table_val_asof_join.wv` vals renamed — they collided with `table_val_join.wv` (specs share one namespace), making resolution order-dependent in both pipelines

## Parity progression over `spec/basic`

| metric | #1767 | this PR |
|---|---|---|
| standalone-compilable identical SQL | 49/52 | **52/52** |
| with DuckDB catalog | 84/102 | **101/102** |
| new-typer crashes | 0 | 0 |

## Review updates

- Gemini's catch on `AggregationResolver` (pass the transformed `dd` to `inlineFunctionBody` — a latent issue carried over from TypeResolver) resolved the remaining chained-aggregation diffs (`method_chain.wv`, `method_chain_agg.wv`, `agg_col_type.wv`): parity went from 98/102 to **101/102**, with only `.wv` file imports (`read-wv.wv`) left. Gates tightened accordingly (runner ≥100).
- The in-place typing pass result is defensively reassigned and its mutate-in-place invariant documented.

## Testing

- `langJVM/test`: 1449 tests, 1445 passed, 4 pending (lang parity gate: 52/52)
- `runner/test` (incl. RunnerSpecBasic, RunnerSpecNeg, TPC-H, execution parity gate ≥100): 396 total, 0 failed
- `projectJS/Test/compile`, `projectNative/Test/compile`, `langJS/Test/fastLinkJS` pass
- `scalafmtAll` applied

Part of #1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
