### PR TITLE
feature: Run all basic and TPC-H specs with the new Typer

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
@@ -162,10 +162,10 @@ object FunctionInliner extends ContextLogSupport:
   def findNativeFunction(context: Context, name: String): Option[NativeExpression] = context
     .findTermSymbolByName(name)
     .map(_.symbolInfo)
-    .collect {
-      case m: MethodSymbolInfo if m.body.isDefined =>
-        m.body.get
+    .collect { case m: MethodSymbolInfo =>
+      m.body
     }
+    .flatten
     .collect { case n: NativeExpression =>
       n
     }

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
@@ -156,6 +156,21 @@ object FunctionInliner extends ContextLogSupport:
   end findFunctionDef
 
   /**
+    * Find a native (compile-time evaluated) function body for the given unresolved identifier name,
+    * e.g. ulid_string
+    */
+  def findNativeFunction(context: Context, name: String): Option[NativeExpression] = context
+    .findTermSymbolByName(name)
+    .map(_.symbolInfo)
+    .collect {
+      case m: MethodSymbolInfo if m.body.isDefined =>
+        m.body.get
+    }
+    .collect { case n: NativeExpression =>
+      n
+    }
+
+  /**
     * Inline the body of the function definition, substituting `this` and function arguments.
     * `activeFunctions` tracks the function symbols currently being inlined (innermost first) so
     * that recursive references are reported as user errors instead of looping forever.

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TypeResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TypeResolver.scala
@@ -490,25 +490,11 @@ object TypeResolver extends Phase("type-resolver") with ContextLogSupport:
   end resolveFunctionBodyInTypeDef
 
   private object resolveNativeExpressions extends RewriteRule:
-
-    private def findNativeFunction(context: Context, name: String): Option[NativeExpression] =
-      context
-        .findTermSymbolByName(name)
-        .map(_.symbolInfo)
-        .collect {
-          case m: MethodSymbolInfo if m.body.isDefined =>
-            m.body.get
-        }
-        .collect { case n: NativeExpression =>
-          n
-        }
-
     def apply(context: Context): PlanRewriter = { case q: TopLevelStatement =>
       q.transformUpExpressions {
         case id: Identifier if id.unresolved && id.nonEmpty =>
           // Replace the id with the referenced native expression
-          val expr = findNativeFunction(context, id.fullName).getOrElse(id)
-          expr
+          FunctionInliner.findNativeFunction(context, id.fullName).getOrElse(id)
       }
     }
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -332,13 +332,16 @@ object Typer extends Phase("typer") with LogSupport:
             case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
               FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
           }
-        if newExpr eq v.expr then
-          v
-        else
-          val copied = v.copy(expr = newExpr)
-          // A case-class copy does not carry over the mutable symbol/comment fields
-          copied.copyMetadataFrom(v)
-          copied
+        val typedValDef =
+          if newExpr eq v.expr then
+            v
+          else
+            val copied = v.copy(expr = newExpr)
+            // A case-class copy does not carry over the mutable symbol/comment fields
+            copied.copyMetadataFrom(v)
+            copied
+        TyperRules.typeStatement(typedValDef)
+        typedValDef
       // Default: bottom-up typing for other nodes
       case other =>
         val withTypedChildren = other.mapChildren(typePlan)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.lang.compiler.typer
 
+import wvlet.lang.api.StatusCode
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Context
 import wvlet.lang.compiler.Name
@@ -167,6 +168,8 @@ object Typer extends Phase("typer") with LogSupport:
             typedStmt
           }
         val typedPackage = p.copy(statements = typedStatements)
+        // A case-class copy does not carry over the mutable symbol/comment fields
+        typedPackage.copyMetadataFrom(p)
         TyperRules.typeStatement(typedPackage)
         typedPackage
       // Handle TypeDef - enters type scope for methods
@@ -181,6 +184,8 @@ object Typer extends Phase("typer") with LogSupport:
             typeTypeElem(elem)(using bodyCtx)
           }
         val typedTypeDef = t.copy(elems = typedElems)
+        // A case-class copy does not carry over the mutable symbol/comment fields
+        typedTypeDef.copyMetadataFrom(t)
         TyperRules.typeStatement(typedTypeDef)
         typedTypeDef
       // Handle ModelDef - enters model scope with parameters
@@ -198,7 +203,10 @@ object Typer extends Phase("typer") with LogSupport:
         val typedModelDef =
           typedChild match
             case q: Query =>
-              m.copy(child = q)
+              val copied = m.copy(child = q)
+              // A case-class copy does not carry over the mutable symbol/comment fields
+              copied.copyMetadataFrom(m)
+              copied
             case _ =>
               // Should not happen for well-formed ModelDef
               m
@@ -216,6 +224,8 @@ object Typer extends Phase("typer") with LogSupport:
               RelationRefResolver.resolveTableFunctionCall(ref)
             case m: ModelScan if !m.resolved =>
               RelationRefResolver.resolveModelScan(m)
+            case f: FileRef if f.filePath.endsWith(".wv") || f.filePath.endsWith(".sql") =>
+              resolveQueryFileRef(f)
             case f: FileRef if RelationRefResolver.isDataFilePath(f.filePath) =>
               RelationRefResolver.resolveDataFileRef(f).getOrElse(f)
           }
@@ -291,6 +301,11 @@ object Typer extends Phase("typer") with LogSupport:
                 case _ =>
                   d
             }
+            .transformUpExpressions {
+              case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
+                // Replace references to native (compile-time evaluated) functions
+                FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
+            }
             .asInstanceOf[Relation]
           // Inline aggregation functions applied via dot syntax (e.g. expr.sum) and expand
           // grouping-key indexes (_1, _2, ...) in select clauses
@@ -308,10 +323,50 @@ object Typer extends Phase("typer") with LogSupport:
             current = aggResolved
         end while
         current
+      // Handle ValDef - resolve native function references in the bound expression so it can be
+      // evaluated once at execution time (e.g. val id = ulid_string)
+      case v: ValDef =>
+        val newExpr = v
+          .expr
+          .transformUpExpression {
+            case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
+              FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
+          }
+        if newExpr eq v.expr then
+          v
+        else
+          val copied = v.copy(expr = newExpr)
+          // A case-class copy does not carry over the mutable symbol/comment fields
+          copied.copyMetadataFrom(v)
+          copied
       // Default: bottom-up typing for other nodes
       case other =>
         val withTypedChildren = other.mapChildren(typePlan)
         typeNode(withTypedChildren)
+
+  /**
+    * Import a query from another .wv or .sql file by compiling the referenced unit with this phase
+    * and replacing the reference with its resolved single query
+    */
+  private def resolveQueryFileRef(r: FileRef)(using ctx: Context): Relation =
+    ctx.findCompilationUnit(r.filePath) match
+      case None =>
+        throw StatusCode.FILE_NOT_FOUND.newException(s"${r.path} is not found")
+      case Some(unit) =>
+        // compile the query
+        val compiledUnit =
+          if unit.isFinished(Typer) then
+            unit
+          else
+            run(unit, ctx.withCompilationUnit(unit))
+        // Replace with the resolved plan
+        compiledUnit.resolvedPlan match
+          case PackageDef(_, List(rel: Relation), _, _) =>
+            BracedRelation(rel, r.span)
+          case other =>
+            throw StatusCode
+              .SYNTAX_ERROR
+              .newException(s"${unit.sourceFile} is not a single query file")
 
   /**
     * Update context based on a typed statement (e.g., adding imports)

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/RunnerSpec.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/RunnerSpec.scala
@@ -30,7 +30,8 @@ trait RunnerSpec(
     ignoredSpec: Map[String, String] = Map.empty,
     parseOnly: Boolean = false,
     prepareTPCH: Boolean = false,
-    prepareTPCDS: Boolean = false
+    prepareTPCDS: Boolean = false,
+    useNewTyper: Boolean = false
 ) extends UniTest:
   private val workEnv = WorkEnv(path = specPath, logLevel = logger.getLogLevel)
   private val profile = Profile
@@ -48,6 +49,8 @@ trait RunnerSpec(
     val options = CompilerOptions(sourceFolders = List(specPath), workEnv = workEnv)
     if parseOnly then
       Compiler.parseOnly(options)
+    else if useNewTyper then
+      Compiler.withNewTyper(options)
     else
       Compiler(options) // Uses default allPhases
 
@@ -100,6 +103,17 @@ class RunnerSpecBasic
     )
 
 class RunnerSpecTPCH extends RunnerSpec("spec/tpch", prepareTPCH = true)
+
+// Execution parity gates for the new Typer (issue #1764): the same specs must run and pass with
+// the new typer before it can become the default
+class RunnerSpecBasicNewTyper
+    extends RunnerSpec(
+      "spec/basic",
+      ignoredSpec = Map("table-value-constant.wv" -> "Need to support table value constant"),
+      useNewTyper = true
+    )
+
+class RunnerSpecTPCHNewTyper extends RunnerSpec("spec/tpch", prepareTPCH = true, useNewTyper = true)
 
 // Negative tests, expecting some errors
 class RunnerSpecNeg extends RunnerSpec("spec/neg"):

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
@@ -103,11 +103,10 @@ class TyperExecutionParityCheck extends UniTest:
     diffFiles.result().foreach(f => debug(s"[DIFF] ${f}"))
     crashFiles.result().foreach(f => debug(s"[CRASH] ${f}"))
 
-    // Current parity level (2026-07-02): 101/102 measurable specs produce identical SQL (with a
-    // one-spec allowance for shared-symbol-state flakiness across compiler runs in one JVM).
-    // The only remaining diff is .wv file imports (read-wv). Tighten when that is ported
-    if same < 100 then
-      fail(s"Typer SQL parity regressed: same=${same} (expected >= 100)")
+    // Full parity (2026-07-02): every measurable spec produces identical SQL (with a one-spec
+    // allowance for shared-symbol-state flakiness across compiler runs in one JVM)
+    if same < 101 then
+      fail(s"Typer SQL parity regressed: same=${same} (expected >= 101)")
     if newFailed > 0 then
       fail(s"Typer compilation crashes increased: newFailed=${newFailed} (expected 0)")
   }


### PR DESCRIPTION
## Summary

Fourth step of the Typer migration track of #1764 (part of #392), following #1766–#1768. This PR reaches **full SQL parity (102/102)** and, more importantly, **full end-to-end execution** of the spec corpus with the new Typer — the readiness gate for flipping the `useNewTyper` default.

## Changes

### `.wv`/`.sql` file imports in Typer
The last parity diff (`read-wv.wv`): the Typer now compiles the referenced unit with itself and replaces the `FileRef` with the resolved single query, mirroring TypeResolver's `resolveLocalFileScan`.

### Symbol/comment loss in typed copies (the model crash)
Running specs end-to-end (not just diffing SQL) exposed a latent Typer defect: `ModelDef`/`TypeDef`/`PackageDef` typing used plain case-class `copy`, which does **not** carry over the mutable `symbol`/`comment` fields. Model symbols degraded to `NoSymbol`, definition trees stayed untyped, GenSQL model expansion left unexpandable `ModelScan`s behind, and the SQL printer's catch-all recursed into a `StackOverflowError`. Typed copies now use `copyMetadataFrom` (this also restores model doc comments for `show models`).

### Native expressions
`resolveNativeExpressions` (e.g. `ulid_string`) ported via a shared `FunctionInliner.findNativeFunction`, including `ValDef` bodies so `val id = ulid_string` is evaluated exactly once at execution time (both uses of the val see the same value).

### Execution gates
New `RunnerSpecBasicNewTyper` and `RunnerSpecTPCHNewTyper` run the same spec corpus end-to-end with `Compiler.withNewTyper`:
- **spec/basic: 127 tests — all pass** (126 passed + 1 pre-existing ignore)
- **spec/tpch: 25 tests — all pass**

## Parity progression over `spec/basic`

| metric | #1768 | this PR |
|---|---|---|
| SQL parity (with DuckDB catalog) | 101/102 | **102/102** |
| end-to-end execution with new typer | — | **127/127 basic, 25/25 TPC-H** |

## Remaining before retiring TypeResolver (B4)

- Flip the `useNewTyper` default (one-line change; proposed as the next PR after this soaks)
- `GenSQL.expandRelation` still calls `TypeResolver.resolve` for post-expansion resolution in both pipelines — decoupling that is the final retirement step, not a flip blocker

## Testing

- `runner/test` (incl. both new-typer execution suites): 547 total, 0 failed
- `langJVM/test`: 1449 tests, 1445 passed, 4 pending
- `projectJS/Test/compile`, `projectNative/Test/compile`, `langJS/Test/fastLinkJS` pass
- `scalafmtAll` applied

Part of #1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review updates

- The explicit `ValDef` case now calls `TyperRules.typeStatement` (assigns `v.dataType` to `tpe`), consistent with the other statement cases
- `findNativeFunction` extracts the method body via `collect`+`flatten` instead of `Option.get`
