### PR TITLE
feature: Make the new Typer the default type resolution phase

### DIFF
--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperParityCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperParityCheck.scala
@@ -55,7 +55,7 @@ class TyperParityCheck extends UniTest:
     val crashFiles = List.newBuilder[String]
 
     wvFiles.foreach { f =>
-      val oldCompiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+      val oldCompiler = Compiler.withLegacyTypeResolver(CompilerOptions(workEnv = WorkEnv(".")))
       val newCompiler = Compiler.withNewTyper(CompilerOptions(workEnv = WorkEnv(".")))
       val oldSQL      = generateSQL(oldCompiler, f.getPath)
       val newSQL      = generateSQL(newCompiler, f.getPath)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
@@ -63,9 +63,18 @@ object Compiler extends LogSupport:
   )
 
   /**
+    * Create a compiler with the legacy TypeResolver, kept as a fallback while the new Typer is
+    * being battle-tested (issue #1764). This will be removed together with TypeResolver
+    */
+  def withLegacyTypeResolver(options: CompilerOptions): Compiler = Compiler(
+    options,
+    allPhasesWithTyper(useNewTyper = false)
+  )
+
+  /**
     * Phases for text-based analysis of the source code
     */
-  def analysisPhases: List[Phase] = analysisPhasesWithTyper(useNewTyper = false)
+  def analysisPhases: List[Phase] = analysisPhasesWithTyper(useNewTyper = true)
 
   def analysisPhasesWithTyper(useNewTyper: Boolean): List[Phase] = List(
     ParserPhase, // Parse *.wv files and create untyped plans
@@ -98,7 +107,7 @@ object Compiler extends LogSupport:
     */
   def codeGenPhases: List[Phase] = List(ExecutionPlanner, ExecutionPlanRewriter)
 
-  def allPhases: List[List[Phase]] = allPhasesWithTyper(useNewTyper = false)
+  def allPhases: List[List[Phase]] = allPhasesWithTyper(useNewTyper = true)
 
   def allPhasesWithTyper(useNewTyper: Boolean): List[List[Phase]] = List(
     analysisPhasesWithTyper(useNewTyper),

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/RunnerSpec.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/RunnerSpec.scala
@@ -31,7 +31,7 @@ trait RunnerSpec(
     parseOnly: Boolean = false,
     prepareTPCH: Boolean = false,
     prepareTPCDS: Boolean = false,
-    useNewTyper: Boolean = false
+    useLegacyTypeResolver: Boolean = false
 ) extends UniTest:
   private val workEnv = WorkEnv(path = specPath, logLevel = logger.getLogLevel)
   private val profile = Profile
@@ -49,10 +49,10 @@ trait RunnerSpec(
     val options = CompilerOptions(sourceFolders = List(specPath), workEnv = workEnv)
     if parseOnly then
       Compiler.parseOnly(options)
-    else if useNewTyper then
-      Compiler.withNewTyper(options)
+    else if useLegacyTypeResolver then
+      Compiler.withLegacyTypeResolver(options)
     else
-      Compiler(options) // Uses default allPhases
+      Compiler(options) // Uses default allPhases (the new Typer)
 
   compiler.setDefaultCatalog(queryExecutor.getDBConnector(profile).getCatalog("memory", "main"))
 
@@ -104,16 +104,16 @@ class RunnerSpecBasic
 
 class RunnerSpecTPCH extends RunnerSpec("spec/tpch", prepareTPCH = true)
 
-// Execution parity gates for the new Typer (issue #1764): the same specs must run and pass with
-// the new typer before it can become the default
-class RunnerSpecBasicNewTyper
+// The legacy TypeResolver remains covered by these suites until it is removed (issue #1764)
+class RunnerSpecBasicLegacyTypeResolver
     extends RunnerSpec(
       "spec/basic",
       ignoredSpec = Map("table-value-constant.wv" -> "Need to support table value constant"),
-      useNewTyper = true
+      useLegacyTypeResolver = true
     )
 
-class RunnerSpecTPCHNewTyper extends RunnerSpec("spec/tpch", prepareTPCH = true, useNewTyper = true)
+class RunnerSpecTPCHLegacyTypeResolver
+    extends RunnerSpec("spec/tpch", prepareTPCH = true, useLegacyTypeResolver = true)
 
 // Negative tests, expecting some errors
 class RunnerSpecNeg extends RunnerSpec("spec/neg"):

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/TyperExecutionParityCheck.scala
@@ -50,7 +50,7 @@ class TyperExecutionParityCheck extends UniTest:
       if useNewTyper then
         Compiler.withNewTyper(options)
       else
-        Compiler(options)
+        Compiler.withLegacyTypeResolver(options)
     compiler.setDefaultCatalog(catalog)
     compiler
 


### PR DESCRIPTION
## Summary

Completes the migration tracked in #1764 (part of #392): the new `Typer` — which reached full SQL parity (102/102) and full end-to-end spec execution with the legacy `TypeResolver` across #1766–#1769 — becomes the **default** type resolution phase.

## Changes

- `Compiler.analysisPhases` / `allPhases` now use the new `Typer` (`useNewTyper = true`)
- `Compiler.withLegacyTypeResolver` provides the previous pipeline as an explicit fallback while the new Typer is battle-tested; it will be removed together with TypeResolver
- The legacy pipeline stays covered until removal by `RunnerSpecBasicLegacyTypeResolver` and `RunnerSpecTPCHLegacyTypeResolver` (renamed from the `NewTyper` variants, whose role the default suites now play)
- Both parity gates (`TyperParityCheck`, `TyperExecutionParityCheck`) now compare the legacy resolver against the default pipeline

## Validation

With the default flipped, **every** spec suite runs through the new Typer — including corpora never gated during the migration (neg, cdp_behavior, sql/basic, sql/tpc-h, benchmark, Trino tests):

- `runner/test`: **547 tests, 0 failed**
- `langJVM/test`: **1449 tests, 1445 passed, 4 pending**
- `projectJS/Test/compile`, `projectNative/Test/compile`, `langJS/Test/fastLinkJS` pass
- `scalafmtAll` applied

## Remaining cleanup (follow-up, not a flip blocker)

`GenSQL.expandRelation` still calls `TypeResolver.resolve` for post-expansion resolution (in both pipelines, as it always has). Decoupling that is the final step before deleting `TypeResolver` and the `useNewTyper` plumbing.

Closes the migration track of #1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)