### PR TITLE
internal: Decouple GenSQL model expansion from TypeResolver

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -17,8 +17,8 @@ import wvlet.lang.BuildInfo
 import wvlet.lang.api.SourceLocation
 import wvlet.lang.api.StatusCode
 import wvlet.lang.catalog.Catalog.TableName
-import wvlet.lang.compiler.analyzer.TypeResolver
 import wvlet.lang.compiler.planner.ExecutionPlanner
+import wvlet.lang.compiler.typer.Typer
 import wvlet.lang.compiler.transform.ExpressionEvaluator
 import wvlet.lang.compiler.transform.PreprocessLocalExpr
 import wvlet.lang.compiler.CompilationUnit
@@ -320,7 +320,7 @@ object GenSQL extends Phase("generate-sql"):
           case Some(sym) =>
             val rel = expandModelScan(m, sym)
             // Finally resolve types again
-            TypeResolver.resolve(rel, ctx)
+            Typer.resolveRelation(rel)
           case None =>
             warn(s"unknown model: ${m.name}")
             m

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -21,6 +21,7 @@ import wvlet.lang.compiler.Phase
 import wvlet.lang.compiler.analyzer.AggregationResolver
 import wvlet.lang.compiler.analyzer.FunctionInliner
 import wvlet.lang.compiler.analyzer.RelationRefResolver
+import wvlet.lang.model.expr.ContextInputRef
 import wvlet.lang.model.expr.DotRef
 import wvlet.lang.model.expr.FunctionApply
 import wvlet.lang.model.expr.Identifier
@@ -214,115 +215,7 @@ object Typer extends Phase("typer") with LogSupport:
         typedModelDef
       // Handle Relation - propagate input type through relational operators
       case r: Relation =>
-        // Resolve table/model/file references into concrete scan nodes before typing so that
-        // relation types can propagate bottom-up
-        val refResolved = r
-          .transformUp {
-            case ref: TableRef if !ref.relationType.isResolved =>
-              RelationRefResolver.resolveTableRef(ref)
-            case ref: TableFunctionCall if !ref.relationType.isResolved =>
-              RelationRefResolver.resolveTableFunctionCall(ref)
-            case m: ModelScan if !m.resolved =>
-              RelationRefResolver.resolveModelScan(m)
-            case f: FileRef if f.filePath.endsWith(".wv") || f.filePath.endsWith(".sql") =>
-              resolveQueryFileRef(f)
-            case f: FileRef if RelationRefResolver.isDataFilePath(f.filePath) =>
-              RelationRefResolver.resolveDataFileRef(f).getOrElse(f)
-          }
-          .asInstanceOf[Relation]
-        // Inline partial query applications first (plan-level rewrite with cycle detection)
-        val pqInlined = refResolved
-          .transformUp { case p: PartialQueryApply =>
-            FunctionInliner.resolvePartialQuery(p)
-          }
-          .asInstanceOf[Relation]
-        // Type the relation so that function qualifiers get concrete types
-        typeRelation(pqInlined)
-        // Inline function calls and aggregation expressions. Chained method calls (e.g.
-        // x.to_double.round(1)) resolve one link per round, so iterate to a fixpoint
-        var current  = pqInlined
-        var continue = true
-        var rounds   = 0
-        while continue && rounds < maxFunctionResolutionRounds do
-          rounds += 1
-          // Type identifiers, parentheses, and method references from each relation's input
-          // type, so an enclosing call can resolve its qualifier type without inlining the
-          // reference (which would drop call arguments). Typing mutates the tpe field in place
-          // and every case returns the same node instance, so the tree structure is unchanged;
-          // the result is reassigned for safety should a case ever start rebuilding nodes
-          current = current
-            .transformUp { case rel: Relation =>
-              val inputType = rel.inputRelationType
-              rel
-                .childExpressions
-                .foreach { root =>
-                  root.transformUpExpression {
-                    case i: Identifier =>
-                      if !hasResolvedType(i) then
-                        inputType
-                          .find(_.name == i.fullName)
-                          .foreach { attr =>
-                            i.tpe = attr.dataType
-                          }
-                      i
-                    case p: ParenthesizedExpression =>
-                      // Propagate the child type through parentheses
-                      if !hasResolvedType(p) then
-                        if p.child.dataType.isResolved then
-                          p.tpe = p.child.dataType
-                        else if p.child.isTyped then
-                          p.tpe = p.child.tpe
-                      p
-                    case d: DotRef =>
-                      if !hasResolvedType(d) then
-                        FunctionInliner
-                          .findFunctionDef(d)
-                          .foreach { m =>
-                            if m.ft.returnType.isResolved then
-                              d.tpe = m.ft.returnType
-                          }
-                      d
-                  }
-                }
-              rel
-            }
-            .asInstanceOf[Relation]
-          // Inline function applications, then bare member references. Only no-arg methods are
-          // inlined from a bare DotRef: a DotRef with declared arguments is the base of an
-          // enclosing FunctionApply that must bind them first (possibly in a later round)
-          val fnInlined = current
-            .transformUpExpressions { case f: FunctionApply =>
-              FunctionInliner.resolveFunctionApply(f)
-            }
-            .transformUpExpressions { case d: DotRef =>
-              FunctionInliner.findFunctionDef(d) match
-                case Some(m) if m.ft.args.isEmpty =>
-                  FunctionInliner.inlineFunctionBody(d, m, Nil)
-                case _ =>
-                  d
-            }
-            .transformUpExpressions {
-              case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
-                // Replace references to native (compile-time evaluated) functions
-                FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
-            }
-            .asInstanceOf[Relation]
-          // Inline aggregation functions applied via dot syntax (e.g. expr.sum) and expand
-          // grouping-key indexes (_1, _2, ...) in select clauses
-          val aggResolved = AggregationResolver
-            .resolveNoGroupByAggregations(fnInlined)
-            .transformUp { case p: AggSelect =>
-              AggregationResolver.resolveGroupingKeyIndexes(p)
-            }
-            .asInstanceOf[Relation]
-          if aggResolved eq current then
-            continue = false
-          else
-            // Re-type so the inlined bodies get tpe assigned for the next round
-            typeRelation(aggResolved)
-            current = aggResolved
-        end while
-        current
+        resolveRelation(r)
       // Handle ValDef - resolve native function references in the bound expression so it can be
       // evaluated once at execution time (e.g. val id = ulid_string)
       case v: ValDef =>
@@ -346,6 +239,146 @@ object Typer extends Phase("typer") with LogSupport:
       case other =>
         val withTypedChildren = other.mapChildren(typePlan)
         typeNode(withTypedChildren)
+
+  private def hasUnresolvedUnderscore(r: Relation): Boolean =
+    var found = false
+    r.childExpressions
+      .foreach { e =>
+        e.traverseExpressions {
+          case c: ContextInputRef if !c.dataType.isResolved =>
+            found = true
+        }
+      }
+    found
+
+  /**
+    * Resolve a relation tree: table/model/file references, partial-query and function inlining,
+    * aggregation expressions, and in-place typing. Also used by GenSQL to re-resolve model bodies
+    * after model expansion
+    */
+  def resolveRelation(r: Relation)(using ctx: Context): Relation =
+    // Resolve table/model/file references into concrete scan nodes before typing so that
+    // relation types can propagate bottom-up
+    val refResolved = r
+      .transformUp {
+        case ref: TableRef if !ref.relationType.isResolved =>
+          RelationRefResolver.resolveTableRef(ref)
+        case ref: TableFunctionCall if !ref.relationType.isResolved =>
+          RelationRefResolver.resolveTableFunctionCall(ref)
+        case m: ModelScan if !m.resolved =>
+          RelationRefResolver.resolveModelScan(m)
+        case f: FileRef if f.filePath.endsWith(".wv") || f.filePath.endsWith(".sql") =>
+          resolveQueryFileRef(f)
+        case f: FileRef if RelationRefResolver.isDataFilePath(f.filePath) =>
+          RelationRefResolver.resolveDataFileRef(f).getOrElse(f)
+      }
+      .asInstanceOf[Relation]
+    // Inline partial query applications first (plan-level rewrite with cycle detection)
+    val pqInlined = refResolved
+      .transformUp { case p: PartialQueryApply =>
+        FunctionInliner.resolvePartialQuery(p)
+      }
+      .transformUp {
+        // Resolve underscore (_) references from the input relation of the enclosing operator
+        case u: UnaryRelation if hasUnresolvedUnderscore(u) =>
+          val contextType = u.inputRelation.relationType
+          u.transformChildExpressions { case expr: Expression =>
+            expr.transformExpression {
+              case ref: ContextInputRef if !ref.dataType.isResolved =>
+                ContextInputRef(dataType = contextType, ref.span)
+            }
+          }
+      }
+      .asInstanceOf[Relation]
+    // Type the relation so that function qualifiers get concrete types
+    typeRelation(pqInlined)
+    // Inline function calls and aggregation expressions. Chained method calls (e.g.
+    // x.to_double.round(1)) resolve one link per round, so iterate to a fixpoint
+    var current  = pqInlined
+    var continue = true
+    var rounds   = 0
+    while continue && rounds < maxFunctionResolutionRounds do
+      rounds += 1
+      // Type identifiers, parentheses, and method references from each relation's input
+      // type, so an enclosing call can resolve its qualifier type without inlining the
+      // reference (which would drop call arguments). Typing mutates the tpe field in place
+      // and every case returns the same node instance, so the tree structure is unchanged;
+      // the result is reassigned for safety should a case ever start rebuilding nodes
+      current = current
+        .transformUp { case rel: Relation =>
+          val inputType = rel.inputRelationType
+          rel
+            .childExpressions
+            .foreach { root =>
+              root.transformUpExpression {
+                case i: Identifier =>
+                  if !hasResolvedType(i) then
+                    inputType
+                      .find(_.name == i.fullName)
+                      .foreach { attr =>
+                        i.tpe = attr.dataType
+                      }
+                  i
+                case p: ParenthesizedExpression =>
+                  // Propagate the child type through parentheses
+                  if !hasResolvedType(p) then
+                    if p.child.dataType.isResolved then
+                      p.tpe = p.child.dataType
+                    else if p.child.isTyped then
+                      p.tpe = p.child.tpe
+                  p
+                case d: DotRef =>
+                  if !hasResolvedType(d) then
+                    FunctionInliner
+                      .findFunctionDef(d)
+                      .foreach { m =>
+                        if m.ft.returnType.isResolved then
+                          d.tpe = m.ft.returnType
+                      }
+                  d
+              }
+            }
+          rel
+        }
+        .asInstanceOf[Relation]
+      // Inline function applications, then bare member references. Only no-arg methods are
+      // inlined from a bare DotRef: a DotRef with declared arguments is the base of an
+      // enclosing FunctionApply that must bind them first (possibly in a later round)
+      val fnInlined = current
+        .transformUpExpressions { case f: FunctionApply =>
+          FunctionInliner.resolveFunctionApply(f)
+        }
+        .transformUpExpressions { case d: DotRef =>
+          FunctionInliner.findFunctionDef(d) match
+            case Some(m) if m.ft.args.isEmpty =>
+              FunctionInliner.inlineFunctionBody(d, m, Nil)
+            case _ =>
+              d
+        }
+        .transformUpExpressions {
+          case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
+            // Replace references to native (compile-time evaluated) functions
+            FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
+        }
+        .asInstanceOf[Relation]
+      // Inline aggregation functions applied via dot syntax (e.g. expr.sum) and expand
+      // grouping-key indexes (_1, _2, ...) in select clauses
+      val aggResolved = AggregationResolver
+        .resolveNoGroupByAggregations(fnInlined)
+        .transformUp { case p: AggSelect =>
+          AggregationResolver.resolveGroupingKeyIndexes(p)
+        }
+        .asInstanceOf[Relation]
+      if aggResolved eq current then
+        continue = false
+      else
+        // Re-type so the inlined bodies get tpe assigned for the next round
+        typeRelation(aggResolved)
+        current = aggResolved
+    end while
+    current
+
+  end resolveRelation
 
   /**
     * Import a query from another .wv or .sql file by compiling the referenced unit with this phase


### PR DESCRIPTION
## Summary

Final structural step of the Typer migration track of #1764 (part of #392), following the default flip in #1770. `GenSQL.expandRelation` re-resolved each expanded model body via `TypeResolver.resolve` — the last production dependency on the legacy resolver. It now uses the (default) Typer's resolution instead.

## Changes

- `Typer.resolveRelation` — the Typer's relation resolution (reference resolution, partial-query/function inlining, aggregation expressions, in-place typing) extracted into a public entry point, used both by `typePlan` and by GenSQL post-model-expansion
- Adds an underscore (`_`/`ContextInputRef`) resolution pass to it, mirroring TypeResolver's `resolveUnderscore` — this behavior was previously supplied only by TypeResolver's rule set during GenSQL's post-expansion resolve
- `GenSQL` no longer imports `TypeResolver`

After this change, `TypeResolver` has no production callers outside the legacy pipeline (`Compiler.withLegacyTypeResolver`). Deleting it — together with the fallback factory, the `useNewTyper` plumbing, and the legacy runner suites — is a mechanical follow-up once the new Typer has soaked in a release.

## Testing

- `runner/test`: 547 tests, 0 failed — includes the legacy-resolver suites (legacy compile + Typer post-expansion resolution work together since all resolution components are shared) and both parity gates (102/102)
- `langJVM/test`: 1449 tests, 1445 passed, 4 pending
- `projectJS/Test/compile`, `projectNative/Test/compile`, `langJS/Test/fastLinkJS` pass
- `scalafmtAll` applied

Part of #1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)