### PR TITLE
internal: Collapse the Typer's per-relation passes for faster compilation

### DIFF
--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperBench.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperBench.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.typer
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, WorkEnv}
+
+import java.io.File
+
+/**
+  * A lightweight timing probe for compiler performance work (issue #392): compiles the spec/basic
+  * corpus repeatedly after warmup and logs the median wall time. No assertion — the numbers are for
+  * comparing before/after within a single machine and JVM session.
+  */
+class TyperBench extends UniTest:
+
+  test("time spec/basic corpus compilation") {
+    val specDir = File("spec/basic")
+    val wvFiles = Option(specDir.listFiles())
+      .getOrElse(Array.empty[File])
+      .filter(f => f.isFile && f.getName.endsWith(".wv"))
+      .sortBy(_.getName)
+
+    def compileAll(): Unit = wvFiles.foreach { f =>
+      try
+        val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(specDir.getPath)))
+        val unit     = CompilationUnit.fromFile(f.getPath)
+        compiler.compileSingleUnit(unit)
+      catch
+        case _: Throwable =>
+          ()
+    }
+
+    // Warm up the JIT before measuring
+    (1 to 5).foreach(_ => compileAll())
+    val times = (1 to 10).map { _ =>
+      val t0 = System.nanoTime()
+      compileAll()
+      (System.nanoTime() - t0) / 1000000.0
+    }
+    info(
+      f"corpus compile: median=${times.sorted.apply(times.size / 2)}%.1f ms min=${times
+          .min}%.1f ms max=${times.max}%.1f ms"
+    )
+  }
+
+end TyperBench

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.typer
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, WorkEnv}
+import wvlet.lang.model.DataType
+import wvlet.lang.model.plan.{LogicalPlan, Relation}
+import wvlet.lang.model.expr.Expression
+
+import java.io.File
+import scala.collection.mutable
+
+/**
+  * Coverage gate for the Typer (issue #392): compile every spec under spec/basic and measure how
+  * many plan nodes and expressions end up with a resolved type.
+  *
+  * The bounds below pin the current typing coverage. Improvements are accepted automatically;
+  * regressions fail this test. Ratchet the bounds upward as typing coverage improves toward 100%.
+  */
+class TyperCoverageCheck extends UniTest:
+
+  private case class Coverage(
+      relationTotal: Int,
+      relationResolved: Int,
+      exprTotal: Int,
+      exprTyped: Int,
+      exprTpeSet: Int,
+      unresolvedRelations: Map[String, Int],
+      untypedExprs: Map[String, Int]
+  ):
+    def relationCoverage: Double = relationResolved.toDouble / relationTotal.max(1)
+    def exprCoverage: Double     = exprTyped.toDouble / exprTotal.max(1)
+
+  private def isTypedExpr(e: Expression): Boolean =
+    e.dataType.isResolved || (
+      e.tpe match
+        case dt: DataType =>
+          dt.isResolved
+        case _ =>
+          false
+    )
+
+  private def measure(plans: Seq[LogicalPlan]): Coverage =
+    var relationTotal    = 0
+    var relationResolved = 0
+    var exprTotal        = 0
+    var exprTyped        = 0
+    var exprTpeSet       = 0
+    val unresolvedRel    = mutable.Map.empty[String, Int].withDefaultValue(0)
+    val untypedExpr      = mutable.Map.empty[String, Int].withDefaultValue(0)
+
+    plans.foreach { plan =>
+      plan.traverse { case r: Relation =>
+        relationTotal += 1
+        if r.relationType.isResolved then
+          relationResolved += 1
+        else
+          unresolvedRel(r.nodeName) += 1
+      }
+      plan.traverseExpressions { case e: Expression =>
+        exprTotal += 1
+        if e.isTyped then
+          exprTpeSet += 1
+        if isTypedExpr(e) then
+          exprTyped += 1
+        else
+          untypedExpr(e.nodeName) += 1
+      }
+    }
+    Coverage(
+      relationTotal,
+      relationResolved,
+      exprTotal,
+      exprTyped,
+      exprTpeSet,
+      unresolvedRel.toMap,
+      untypedExpr.toMap
+    )
+
+  end measure
+
+  test("typing coverage over spec/basic must not regress") {
+    val specDir = File("spec/basic")
+    val wvFiles = Option(specDir.listFiles())
+      .getOrElse(Array.empty[File])
+      .filter(f => f.isFile && f.getName.endsWith(".wv"))
+      .sortBy(_.getName)
+
+    val resolvedPlans = List.newBuilder[LogicalPlan]
+    var compiled      = 0
+    var needsCatalog  = 0
+    wvFiles.foreach { f =>
+      try
+        val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(specDir.getPath)))
+        val unit     = CompilationUnit.fromFile(f.getPath)
+        compiler.compileSingleUnit(unit)
+        resolvedPlans += unit.resolvedPlan
+        compiled += 1
+      catch
+        case e: Throwable =>
+          // Specs requiring a catalog (DB connection) cannot be compiled standalone; they are
+          // covered by the runner-side spec tests
+          needsCatalog += 1
+    }
+
+    val c = measure(resolvedPlans.result())
+    info(f"compiled ${compiled}/${wvFiles.length} specs (${needsCatalog} need a catalog)")
+    info(
+      f"relations resolved: ${c.relationResolved}/${c.relationTotal} (${c.relationCoverage *
+          100}%.1f%%)"
+    )
+    info(f"expressions typed:  ${c.exprTyped}/${c.exprTotal} (${c.exprCoverage * 100}%.1f%%)")
+    info(f"expressions with tpe set: ${c.exprTpeSet}/${c.exprTotal}")
+
+    def top(m: Map[String, Int], n: Int): String = m
+      .toSeq
+      .sortBy(-_._2)
+      .take(n)
+      .map { case (k, v) =>
+        s"${k}=${v}"
+      }
+      .mkString(", ")
+    info(s"top unresolved relations: ${top(c.unresolvedRelations, 10)}")
+    info(s"top untyped expressions:  ${top(c.untypedExprs, 10)}")
+
+    // Ratchet (2026-07-03 baseline). Raise these as coverage improves toward 1.0
+    val minRelationCoverage = 0.58
+    val minExprCoverage     = 0.70
+    if c.relationCoverage < minRelationCoverage then
+      fail(
+        f"Relation type coverage regressed: ${c.relationCoverage *
+            100}%.1f%% (expected >= ${minRelationCoverage * 100}%.0f%%)"
+      )
+    if c.exprCoverage < minExprCoverage then
+      fail(
+        f"Expression type coverage regressed: ${c.exprCoverage *
+            100}%.1f%% (expected >= ${minExprCoverage * 100}%.0f%%)"
+      )
+  }
+
+end TyperCoverageCheck

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/AggregationResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/AggregationResolver.scala
@@ -63,13 +63,27 @@ object AggregationResolver extends ContextLogSupport:
       other.transformChildExpressions(resolveAggregationExpr(aggFunctions))
 
   /**
-    * Inline aggregation functions (e.g. {{{expr.sum}}}) applied without an explicit GroupBy node in
-    * selection expressions
+    * Resolve aggregation expressions in a single traversal: inline aggregation functions applied
+    * without an explicit GroupBy node (e.g. {{{expr.sum}}}) in selection expressions, and expand
+    * grouping-key indexes (_1, _2, ...) in select clauses
     */
-  def resolveNoGroupByAggregations(q: Relation)(using ctx: Context): Relation =
+  def resolveAggregations(q: Relation)(using ctx: Context): Relation =
     val aggFunctions = aggregationFunctions(ctx)
-    q.transformUp { case s: GeneralSelection =>
-        s.transformChildExpressions(resolveAggregationExpr(aggFunctions))
+    q.transformUp { case r: Relation =>
+        // A node can be both a GeneralSelection and an AggSelect (e.g. Agg), so apply both
+        // rewrites in sequence
+        val withAgg =
+          r match
+            case s: GeneralSelection =>
+              s.transformChildExpressions(resolveAggregationExpr(aggFunctions))
+                .asInstanceOf[Relation]
+            case _ =>
+              r
+        withAgg match
+          case p: AggSelect =>
+            resolveGroupingKeyIndexes(p)
+          case _ =>
+            withAgg
       }
       .asInstanceOf[Relation]
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -25,7 +25,11 @@ import wvlet.lang.model.expr.ContextInputRef
 import wvlet.lang.model.expr.DotRef
 import wvlet.lang.model.expr.FunctionApply
 import wvlet.lang.model.expr.Identifier
-import wvlet.lang.model.expr.ParenthesizedExpression
+import wvlet.lang.model.expr.InRelation
+import wvlet.lang.model.expr.NotInRelation
+import wvlet.lang.model.expr.SubQueryExpression
+import wvlet.lang.model.expr.TupleInRelation
+import wvlet.lang.model.expr.TupleNotInRelation
 import wvlet.lang.model.DataType
 import wvlet.lang.model.DataType.NamedType
 import wvlet.lang.model.DataType.SchemaType
@@ -256,128 +260,112 @@ object Typer extends Phase("typer") with LogSupport:
     * after model expansion
     */
   def resolveRelation(r: Relation)(using ctx: Context): Relation =
-    // Resolve table/model/file references into concrete scan nodes before typing so that
-    // relation types can propagate bottom-up
-    val refResolved = r
-      .transformUp {
-        case ref: TableRef if !ref.relationType.isResolved =>
-          RelationRefResolver.resolveTableRef(ref)
-        case ref: TableFunctionCall if !ref.relationType.isResolved =>
-          RelationRefResolver.resolveTableFunctionCall(ref)
-        case m: ModelScan if !m.resolved =>
-          RelationRefResolver.resolveModelScan(m)
-        case f: FileRef if f.filePath.endsWith(".wv") || f.filePath.endsWith(".sql") =>
-          resolveQueryFileRef(f)
-        case f: FileRef if RelationRefResolver.isDataFilePath(f.filePath) =>
-          RelationRefResolver.resolveDataFileRef(f).getOrElse(f)
-      }
-      .asInstanceOf[Relation]
-    // Inline partial query applications first (plan-level rewrite with cycle detection)
-    val pqInlined = refResolved
-      .transformUp { case p: PartialQueryApply =>
-        FunctionInliner.resolvePartialQuery(p)
-      }
-      .transformUp {
-        // Resolve underscore (_) references from the input relation of the enclosing operator
-        case u: UnaryRelation if hasUnresolvedUnderscore(u) =>
-          val contextType = u.inputRelation.relationType
-          u.transformChildExpressions { case expr: Expression =>
-            expr.transformExpression {
-              case ref: ContextInputRef if !ref.dataType.isResolved =>
-                ContextInputRef(dataType = contextType, ref.span)
-            }
-          }
-      }
-      .asInstanceOf[Relation]
-    // Type the relation so that function qualifiers get concrete types
-    typeRelation(pqInlined)
-    // Inline function calls and aggregation expressions. Chained method calls (e.g.
-    // x.to_double.round(1)) resolve one link per round, so iterate to a fixpoint
-    var current  = pqInlined
-    var continue = true
-    var rounds   = 0
-    while continue && rounds < maxFunctionResolutionRounds do
-      rounds += 1
-      // Type identifiers, parentheses, and method references from each relation's input
-      // type, so an enclosing call can resolve its qualifier type without inlining the
-      // reference (which would drop call arguments). Typing mutates the tpe field in place
-      // and every case returns the same node instance, so the tree structure is unchanged;
-      // the result is reassigned for safety should a case ever start rebuilding nodes
-      current = current
-        .transformUp { case rel: Relation =>
-          val inputType = rel.inputRelationType
-          rel
-            .childExpressions
-            .foreach { root =>
-              root.transformUpExpression {
-                case i: Identifier =>
-                  if !hasResolvedType(i) then
-                    inputType
-                      .find(_.name == i.fullName)
-                      .foreach { attr =>
-                        i.tpe = attr.dataType
-                      }
-                  i
-                case p: ParenthesizedExpression =>
-                  // Propagate the child type through parentheses
-                  if !hasResolvedType(p) then
-                    if p.child.dataType.isResolved then
-                      p.tpe = p.child.dataType
-                    else if p.child.isTyped then
-                      p.tpe = p.child.tpe
-                  p
-                case d: DotRef =>
-                  if !hasResolvedType(d) then
-                    FunctionInliner
-                      .findFunctionDef(d)
-                      .foreach { m =>
-                        if m.ft.returnType.isResolved then
-                          d.tpe = m.ft.returnType
-                      }
+    // Resolve all structural references (tables, models, files, partial queries, underscores)
+    // in a single bottom-up pass
+    val prepared = r.transformUp(structuralResolutionRule).asInstanceOf[Relation]
+    // Type the relation in place so that function qualifiers get concrete types. The typing
+    // rules cover identifiers (from the input relation type), parenthesized expressions, and
+    // method references (typed by their declared return type without inlining)
+    typeRelation(prepared)
+    // Inline function calls and aggregation expressions only when candidates are present.
+    // Chained method calls (e.g. x.to_double.round(1)) resolve one link per round, so iterate
+    // to a fixpoint
+    var current = prepared
+    if needsFunctionResolution(current) then
+      var continue = true
+      var rounds   = 0
+      while continue && rounds < maxFunctionResolutionRounds do
+        rounds += 1
+        // Inline function applications, bare member references, and native function
+        // references in a single bottom-up pass. Only no-arg methods are inlined from a bare
+        // DotRef: a DotRef with declared arguments is the base of an enclosing FunctionApply
+        // that must bind them first (possibly in a later round)
+        val fnInlined = current
+          .transformUpExpressions {
+            case f: FunctionApply =>
+              FunctionInliner.resolveFunctionApply(f)
+            case d: DotRef =>
+              FunctionInliner.findFunctionDef(d) match
+                case Some(m) if m.ft.args.isEmpty =>
+                  FunctionInliner.inlineFunctionBody(d, m, Nil)
+                case _ =>
                   d
-              }
-            }
-          rel
-        }
-        .asInstanceOf[Relation]
-      // Inline function applications, then bare member references. Only no-arg methods are
-      // inlined from a bare DotRef: a DotRef with declared arguments is the base of an
-      // enclosing FunctionApply that must bind them first (possibly in a later round)
-      val fnInlined = current
-        .transformUpExpressions { case f: FunctionApply =>
-          FunctionInliner.resolveFunctionApply(f)
-        }
-        .transformUpExpressions { case d: DotRef =>
-          FunctionInliner.findFunctionDef(d) match
-            case Some(m) if m.ft.args.isEmpty =>
-              FunctionInliner.inlineFunctionBody(d, m, Nil)
-            case _ =>
-              d
-        }
-        .transformUpExpressions {
-          case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
-            // Replace references to native (compile-time evaluated) functions
-            FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
-        }
-        .asInstanceOf[Relation]
-      // Inline aggregation functions applied via dot syntax (e.g. expr.sum) and expand
-      // grouping-key indexes (_1, _2, ...) in select clauses
-      val aggResolved = AggregationResolver
-        .resolveNoGroupByAggregations(fnInlined)
-        .transformUp { case p: AggSelect =>
-          AggregationResolver.resolveGroupingKeyIndexes(p)
-        }
-        .asInstanceOf[Relation]
-      if aggResolved eq current then
-        continue = false
-      else
-        // Re-type so the inlined bodies get tpe assigned for the next round
-        typeRelation(aggResolved)
-        current = aggResolved
-    end while
+            case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
+              // Replace references to native (compile-time evaluated) functions
+              FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
+          }
+          .asInstanceOf[Relation]
+        // Inline aggregation functions applied via dot syntax (e.g. expr.sum) and expand
+        // grouping-key indexes (_1, _2, ...) in select clauses
+        val aggResolved = AggregationResolver.resolveAggregations(fnInlined)
+        if aggResolved eq current then
+          continue = false
+        else
+          // Re-type so the inlined bodies get tpe assigned for the next round
+          typeRelation(aggResolved)
+          current = aggResolved
+      end while
+    end if
     current
 
   end resolveRelation
+
+  /**
+    * A single bottom-up rewrite that resolves table/model/file references into concrete scan nodes,
+    * inlines partial query applications (with cycle detection), and resolves underscore (_)
+    * references from the input relation of the enclosing operator
+    */
+  private def structuralResolutionRule(using
+      ctx: Context
+  ): PartialFunction[LogicalPlan, LogicalPlan] =
+    case ref: TableRef if !ref.relationType.isResolved =>
+      RelationRefResolver.resolveTableRef(ref)
+    case ref: TableFunctionCall if !ref.relationType.isResolved =>
+      RelationRefResolver.resolveTableFunctionCall(ref)
+    case m: ModelScan if !m.resolved =>
+      RelationRefResolver.resolveModelScan(m)
+    case f: FileRef if f.filePath.endsWith(".wv") || f.filePath.endsWith(".sql") =>
+      resolveQueryFileRef(f)
+    case f: FileRef if RelationRefResolver.isDataFilePath(f.filePath) =>
+      RelationRefResolver.resolveDataFileRef(f).getOrElse(f)
+    case p: PartialQueryApply =>
+      // The inlined body is spliced above the already-resolved child and is not revisited by
+      // the enclosing bottom-up traversal, so resolve the body recursively
+      val inlined = FunctionInliner.resolvePartialQuery(p)
+      if inlined eq p then
+        p
+      else
+        inlined.transformUp(structuralResolutionRule)
+    case u: UnaryRelation if hasUnresolvedUnderscore(u) =>
+      val contextType = u.inputRelation.relationType
+      u.transformChildExpressions { case expr: Expression =>
+        expr.transformExpression {
+          case ref: ContextInputRef if !ref.dataType.isResolved =>
+            ContextInputRef(dataType = contextType, ref.span)
+        }
+      }
+
+  /**
+    * Returns true if the relation tree may contain function applications, method or native function
+    * references, aggregation shorthands, or grouping-key indexes that require the inlining
+    * fixpoint. This scan keeps simple queries to a single typing pass
+    */
+  private def needsFunctionResolution(r: Relation): Boolean =
+    var needs = false
+    r.traverseExpressions {
+      case _: FunctionApply =>
+        needs = true
+      case _: DotRef =>
+        needs = true
+      case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
+        needs = true
+    }
+    if !needs then
+      r.traverse { case p: AggSelect =>
+        if p.selectItems.exists(_.nameExpr.isGroupingKeyIndex) then
+          needs = true
+      }
+    needs
 
   /**
     * Import a query from another .wv or .sql file by compiling the referenced unit with this phase
@@ -475,6 +463,22 @@ object Typer extends Phase("typer") with LogSupport:
     * mutable tpe fields without creating new tree instances.
     */
   private def typeExpression(expr: Expression)(using ctx: Context): Expression =
+    // Type relations nested inside this expression (e.g. subquery expressions) so their
+    // inner expressions resolve against their own input relations
+    expr match
+      case s: SubQueryExpression =>
+        typeRelation(s.query)
+      case i: InRelation =>
+        typeRelation(i.in)
+      case i: NotInRelation =>
+        typeRelation(i.in)
+      case i: TupleInRelation =>
+        typeRelation(i.in)
+      case i: TupleNotInRelation =>
+        typeRelation(i.in)
+      case _ =>
+        ()
+
     // Bottom-up: type children first - in place
     expr.children.foreach(typeExpression)
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -13,7 +13,9 @@
  */
 package wvlet.lang.compiler.typer
 
+import wvlet.lang.api.WvletLangException
 import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.analyzer.FunctionInliner
 import wvlet.lang.model.plan.*
 import wvlet.lang.model.expr.*
 import wvlet.lang.model.Type
@@ -38,7 +40,7 @@ object TyperRules:
     */
   def exprRules(using ctx: Context): PartialFunction[Expression, Expression] =
     literalRules orElse identifierRules orElse binaryOpRules orElse castRules orElse
-      caseExprRules orElse dotRefRules orElse functionApplyRules
+      caseExprRules orElse parenRules orElse dotRefRules orElse functionApplyRules
 
   /**
     * All typing rules for relations. Sets tpe field from relationType.
@@ -93,9 +95,16 @@ object TyperRules:
               id.tpe = field.dataType
               id
             case None =>
-              // Unresolved identifier
-              id.tpe = ErrorType(s"Unresolved identifier: ${id.unquotedValue}")
-              id
+              // Consult RelationType.find as well, which also resolves virtual columns
+              // (e.g. aggregated array columns of a GroupBy input)
+              ctx.inputType.find(_.name == id.fullName) match
+                case Some(attr) =>
+                  id.tpe = attr.dataType
+                  id
+                case None =>
+                  // Unresolved identifier
+                  id.tpe = ErrorType(s"Unresolved identifier: ${id.unquotedValue}")
+                  id
   }
 
   /**
@@ -319,12 +328,36 @@ object TyperRules:
   }
 
   /**
-    * Rules for typing DotRef expressions (field access)
+    * Rule for propagating the child type through parenthesized expressions
+    */
+  def parenRules(using ctx: Context): PartialFunction[Expression, Expression] = {
+    case p: ParenthesizedExpression =>
+      if p.child.dataType.isResolved then
+        p.tpe = p.child.dataType
+      else if p.child.isTyped then
+        p.tpe = p.child.tpe
+      p
+  }
+
+  /**
+    * Rules for typing DotRef expressions: field access on a schema-typed qualifier, or a method
+    * reference (e.g. {{{x.to_double}}}) typed by the method's declared return type. Typing a method
+    * reference lets an enclosing call resolve its qualifier type without inlining the reference
     */
   def dotRefRules(using ctx: Context): PartialFunction[Expression, Expression] = {
     case dotRef: DotRef =>
       val qualifierType = dotRef.qualifier.tpe
       val fieldName     = dotRef.name.leafName
+
+      // Typing is best-effort: an ambiguous method reference (e.g. same-named defs in multiple
+      // types with a still-unresolved qualifier) is not a type, not a user error. The inlining
+      // path reports real ambiguity with a proper source location
+      def methodReturnType: Option[DataType] =
+        try
+          FunctionInliner.findFunctionDef(dotRef).map(_.ft.returnType).filter(_.isResolved)
+        catch
+          case _: WvletLangException =>
+            None
 
       qualifierType match
         case schema: SchemaType =>
@@ -333,19 +366,26 @@ object TyperRules:
             case Some(field) =>
               dotRef.tpe = field.dataType
             case None =>
-              dotRef.tpe = ErrorType(s"Field $fieldName not found in schema")
+              dotRef.tpe = methodReturnType.getOrElse(
+                ErrorType(s"Field $fieldName not found in schema")
+              )
 
         case NoType =>
-          // Qualifier not typed yet, keep as NoType
-          dotRef.tpe = NoType
+          // Qualifier not typed yet; a method reference may still resolve from the legacy
+          // dataType of the qualifier
+          methodReturnType.foreach { t =>
+            dotRef.tpe = t
+          }
 
         case _: ErrorType =>
-          // Propagate error from qualifier
-          dotRef.tpe = qualifierType
+          // Propagate error from qualifier unless this is a method reference
+          dotRef.tpe = methodReturnType.getOrElse(qualifierType)
 
         case _ =>
-          // If qualifier has been typed and is not a SchemaType, it's a type error
-          dotRef.tpe = ErrorType(s"Type ${qualifierType} does not support field access via '.'")
+          // A non-schema qualifier supports method references (e.g. primitive methods)
+          dotRef.tpe = methodReturnType.getOrElse(
+            ErrorType(s"Type ${qualifierType} does not support field access via '.'")
+          )
 
       dotRef
   }


### PR DESCRIPTION
## Summary

Part of #392 (item 1 of the [status evaluation](https://github.com/wvlet/wvlet/issues/392#issuecomment-4876651474): erase the Typer's traversal-count regression).

`Typer.resolveRelation` previously ran ~10 full-tree traversals per relation (3 structural passes, a typing pass, then a fixpoint loop doing 6 passes per round, with a mandatory no-change round for every relation). This PR restructures it to 2–4:

- **One structural pass** resolves table/model/file refs, inlines partial queries (recursing into the inlined body, which the enclosing bottom-up traversal cannot revisit), and resolves `_` references.
- **The typing rules now cover what the loop's pre-pass re-derived every round**: identifier resolution also consults `RelationType.find` (virtual aggregated columns of a GroupBy input, e.g. `title: array(string)`), parenthesized expressions propagate their child type, and `DotRef` method references are typed by their declared return type (best-effort — ambiguity during typing is not a user error; the inlining path still reports it).
- **The fixpoint runs only when candidates exist** (function applies, method refs, unresolved identifiers, grouping-key indexes), and each round is 2 traversals: the three inlining passes fused into one `transformUpExpressions`, and aggregation + grouping-key resolution fused into one `transformUp`.

### Latent bug fixed

The restructure exposed that expressions inside subquery relations (correlated scalar subqueries, `in (subquery)`) were typed only by the old per-round pre-pass. `typeExpression` now types nested relations directly. Without this, catalog-backed runs left method chains like `c_phone.substring(1,2).in(...)` uninlined in TPC-H q16/q20/q22 — the standalone SQL-parity corpus had masked this because those specs never execute standalone.

### Results

| metric | before | after |
|---|---|---|
| spec/basic corpus compile (median, warm JIT) | 117.1 ms | 98.6 ms (**−15%**) |
| relations resolved | 59.2% | 59.2% |
| expressions typed | 70.6% | 70.6% |
| expressions with `tpe` set | 2303/4068 | 2386/4068 |

Verified: `runner/test` 394 passed (all specs incl. TPC-H), `langJVM/test` 1440 passed, JS/Native compile clean, `TyperCoverageCheck` ratchet green.

Also adds `TyperBench`, a log-only timing probe for subsequent #392 perf work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)