### PR TITLE
internal: Bridge the legacy dataType field to the Typer's tpe assignments

### DIFF
--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
@@ -103,6 +103,9 @@ class TyperCoverageCheck extends UniTest:
     var needsCatalog  = 0
     wvFiles.foreach { f =>
       try
+        // A fresh Compiler per file is deliberate: spec files share one global namespace, so
+        // reusing a compiler would make symbol resolution depend on the compilation order of
+        // unrelated files
         val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(specDir.getPath)))
         val unit     = CompilationUnit.fromFile(f.getPath)
         compiler.compileSingleUnit(unit)
@@ -135,9 +138,9 @@ class TyperCoverageCheck extends UniTest:
     info(s"top unresolved relations: ${top(c.unresolvedRelations, 10)}")
     info(s"top untyped expressions:  ${top(c.untypedExprs, 10)}")
 
-    // Ratchet (2026-07-03 baseline). Raise these as coverage improves toward 1.0
-    val minRelationCoverage = 0.58
-    val minExprCoverage     = 0.70
+    // Ratchet (2026-07-03: 71.8% / 74.6%). Raise these as coverage improves toward 1.0
+    val minRelationCoverage = 0.70
+    val minExprCoverage     = 0.73
     if c.relationCoverage < minRelationCoverage then
       fail(
         f"Relation type coverage regressed: ${c.relationCoverage *

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -67,8 +67,10 @@ object RelationRefResolver extends ContextLogSupport:
                 // ArrayConstructor)
                 v.expr match
                   case arr: ArrayConstructor =>
-                    // arr.values contains the rows - use them directly
-                    Values(arr.values, schemaType, arr.span)
+                    // arr.values contains the rows - use them directly. The declared schema
+                    // (val t1(id, name) = ...) carries no column types, so refine them from
+                    // the first row's values
+                    Values(arr.values, refineSchemaFromRows(schemaType, arr.values), arr.span)
                   case other =>
                     ref
               case _ =>
@@ -110,6 +112,29 @@ object RelationRefResolver extends ContextLogSupport:
                 ref
     end match
   end resolveTableRef
+
+  /**
+    * Fill in unresolved column types of a table-value-constant schema from the literal values of
+    * the first row
+    */
+  private def refineSchemaFromRows(schema: SchemaType, rows: List[Expression]): SchemaType =
+    if schema.isResolved then
+      schema
+    else
+      rows.headOption match
+        case Some(row: ArrayConstructor) if row.values.length == schema.columnTypes.length =>
+          val refined = schema
+            .columnTypes
+            .zip(row.values)
+            .map { (col, v) =>
+              if col.dataType.isResolved then
+                col
+              else
+                DataType.NamedType(col.name, v.dataType)
+            }
+          schema.copy(columnTypes = refined)
+        case _ =>
+          schema
 
   /**
     * Resolve a table function call (e.g. a parameterized model reference) into a ModelScan

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/transform/RewriteExpr.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/transform/RewriteExpr.scala
@@ -30,7 +30,7 @@ object RewriteExpr extends Phase("rewrite-expr"):
     override def apply(context: Context) =
       case a @ ArithmeticBinaryExpr(BinaryExprType.Add, left, right, _)
           if left.dataType == DataType.StringType =>
-        FunctionApply(
+        val f = FunctionApply(
           base = NameExpr.fromString("concat"),
           args = List(
             FunctionArg(None, left, false, Nil, left.span),
@@ -40,6 +40,9 @@ object RewriteExpr extends Phase("rewrite-expr"):
           filter = None,
           span = a.span
         )
+        // This rule runs after the Typer, so stamp the known result type on the new node
+        f.tpe = DataType.StringType
+        f
 
   object RewriteStringInterpolation extends ExpressionRewriteRule:
     override def apply(context: Context) =
@@ -57,7 +60,7 @@ object RewriteExpr extends Phase("rewrite-expr"):
                 else
                   e
 
-          FunctionApply(
+          val f = FunctionApply(
             base = NameExpr.fromString("concat"),
             args = List(
               FunctionArg(None, quote(left), false, Nil, left.span),
@@ -67,7 +70,12 @@ object RewriteExpr extends Phase("rewrite-expr"):
             filter = None,
             span = s.span
           )
+          // This rule runs after the Typer, so stamp the known result type on the new node
+          f.tpe = DataType.StringType
+          f
         }
+
+  end RewriteStringInterpolation
 
   /**
     * DuckDB doesn't support two-argument if expressions, so we need to populate the third argument

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -280,19 +280,28 @@ object Typer extends Phase("typer") with LogSupport:
         // references in a single bottom-up pass. Only no-arg methods are inlined from a bare
         // DotRef: a DotRef with declared arguments is the base of an enclosing FunctionApply
         // that must bind them first (possibly in a later round)
+        val inlineRule: PartialFunction[Expression, Expression] =
+          case f: FunctionApply =>
+            FunctionInliner.resolveFunctionApply(f)
+          case d: DotRef =>
+            FunctionInliner.findFunctionDef(d) match
+              case Some(m) if m.ft.args.isEmpty =>
+                FunctionInliner.inlineFunctionBody(d, m, Nil)
+              case _ =>
+                d
+          case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
+            // Replace references to native (compile-time evaluated) functions
+            FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
         val fnInlined = current
-          .transformUpExpressions {
-            case f: FunctionApply =>
-              FunctionInliner.resolveFunctionApply(f)
-            case d: DotRef =>
-              FunctionInliner.findFunctionDef(d) match
-                case Some(m) if m.ft.args.isEmpty =>
-                  FunctionInliner.inlineFunctionBody(d, m, Nil)
-                case _ =>
-                  d
-            case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
-              // Replace references to native (compile-time evaluated) functions
-              FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
+          .transformUp {
+            // Test expressions form an assertion DSL evaluated by the test runner, so keep
+            // them as written (the aggregation resolver skips ShouldExpr for the same reason)
+            case t: TestRelation =>
+              t
+            case r: Relation =>
+              r.transformChildExpressions { case e: Expression =>
+                e.transformUpExpression(inlineRule)
+              }
           }
           .asInstanceOf[Relation]
         // Inline aggregation functions applied via dot syntax (e.g. expr.sum) and expand

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -40,7 +40,8 @@ object TyperRules:
     */
   def exprRules(using ctx: Context): PartialFunction[Expression, Expression] =
     literalRules orElse identifierRules orElse binaryOpRules orElse castRules orElse
-      caseExprRules orElse parenRules orElse dotRefRules orElse functionApplyRules
+      caseExprRules orElse interpolatedStringRules orElse parenRules orElse dotRefRules orElse
+      functionApplyRules
 
   /**
     * All typing rules for relations. Sets tpe field from relationType.
@@ -325,6 +326,16 @@ object TyperRules:
         caseExpr.tpe = commonType
 
       caseExpr
+  }
+
+  /**
+    * Rule for typing string interpolations. An s"..." interpolation always yields a string, while
+    * sql"..." fragments have no statically known type
+    */
+  def interpolatedStringRules(using ctx: Context): PartialFunction[Expression, Expression] = {
+    case s: InterpolatedString if s.prefix.fullName == "s" =>
+      s.tpe = StringType
+      s
   }
 
   /**

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/Expression.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/Expression.scala
@@ -34,7 +34,18 @@ trait Expression extends SyntaxTreeNode with LogSupport:
     */
   def attributeName: String = "?"
   def dataTypeName: String  = dataType.typeDescription
-  def dataType: DataType    = DataType.UnknownType
+
+  /**
+    * The data type of this expression. Expressions that do not compute their type structurally
+    * report the type assigned to the tpe field by the Typer, bridging the legacy dataType field and
+    * the in-place typing of the new Typer (issue #392)
+    */
+  def dataType: DataType =
+    tpe match
+      case dt: DataType if dt.isResolved =>
+        dt
+      case _ =>
+        DataType.UnknownType
 
   def isIdentifier: Boolean =
     this match


### PR DESCRIPTION
## Summary

Part of #392 (items 2 and 3 of the [status evaluation](https://github.com/wvlet/wvlet/issues/392#issuecomment-4876651474)): first concrete step of the `dataType`/`tpe` unification (#71), plus typing-coverage gains it unlocks.

The tree carried two parallel type fields: the legacy `dataType` (still read by every `relationType` computation) and the `tpe` field the new Typer assigns in place. The base `Expression.dataType` now reports a resolved `tpe`, so Typer-assigned types finally propagate into relation schemas — `SingleColumn`/`SortItem`/`FunctionArg` all delegate `dataType` structurally and cascade automatically.

Gaps this exposed, also fixed:

- **s"..." interpolations** are typed as string, and the post-Typer `RewriteExpr` rules stamp the string type on the `concat` calls they fabricate (they run after typing, so nothing else would).
- **Table value constants** (`val t(id, name) = [[...]]`): the declared schema carries no column types; they are now refined from the first row's values.
- **Test expressions are excluded from function inlining**: they form an assertion DSL evaluated by the test runner. With `_` now properly typed after `group by`, the inliner would otherwise rewrite `_.size` into `sql"length(${_})"` and break the evaluator (caught by `spec/trino/group-by-reserved-keywords.wv`). This matches the existing `ShouldExpr` exclusion in the aggregation resolver.

Also documents why `TyperCoverageCheck` builds a fresh `Compiler` per spec file (Gemini's review note on #1779): spec files share one global namespace, so reuse would make resolution order-dependent.

## Results

| metric | before | after |
|---|---|---|
| relations resolved | 59.2% | **71.8%** |
| expressions typed | 70.6% | **74.6%** |
| corpus compile (median) | 98.6 ms | 97.4 ms |

Ratchet raised to 70% / 73%.

Verified: `runner/test` 394 passed, `langJVM/test` 1443 passed, JS/Native compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)