### PR TITLE
internal: Type test expressions, local relation refs, and rewritten nodes (issue #392)

### DIFF
--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
@@ -142,9 +142,9 @@ class TyperCoverageCheck extends UniTest:
     info(s"top unresolved relations: ${top(c.unresolvedRelations, 10)}")
     info(s"top untyped expressions:  ${top(c.untypedExprs, 10)}")
 
-    // Ratchet (2026-07-03: 71.8% / 74.6%). Raise these as coverage improves toward 1.0
-    val minRelationCoverage = 0.70
-    val minExprCoverage     = 0.73
+    // Ratchet (2026-07-03: 76.4% / 83.5%). Raise these as coverage improves toward 1.0
+    val minRelationCoverage = 0.75
+    val minExprCoverage     = 0.82
     if c.relationCoverage < minRelationCoverage then
       fail(
         f"Relation type coverage regressed: ${c.relationCoverage *

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
@@ -17,7 +17,7 @@ import wvlet.uni.test.UniTest
 import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, WorkEnv}
 import wvlet.lang.model.DataType
 import wvlet.lang.model.plan.{LogicalPlan, Relation}
-import wvlet.lang.model.expr.Expression
+import wvlet.lang.model.expr.{Expression, Identifier}
 
 import java.io.File
 import scala.collection.mutable
@@ -69,14 +69,18 @@ class TyperCoverageCheck extends UniTest:
         else
           unresolvedRel(r.nodeName) += 1
       }
-      plan.traverseExpressions { case e: Expression =>
-        exprTotal += 1
-        if e.isTyped then
-          exprTpeSet += 1
-        if isTypedExpr(e) then
-          exprTyped += 1
-        else
-          untypedExpr(e.nodeName) += 1
+      plan.traverseExpressions {
+        case i: Identifier if i.isEmpty =>
+        // An empty name is a structural placeholder (e.g. an unnamed column slot), not an
+        // expression that could carry a type
+        case e: Expression =>
+          exprTotal += 1
+          if e.isTyped then
+            exprTpeSet += 1
+          if isTypedExpr(e) then
+            exprTyped += 1
+          else
+            untypedExpr(e.nodeName) += 1
       }
     }
     Coverage(

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -115,9 +115,10 @@ object RelationRefResolver extends ContextLogSupport:
 
   /**
     * Fill in unresolved column types of a table-value-constant schema from the literal values of
-    * the first row
+    * the first row. Also used by SymbolLabeler so that references through the val's symbol (e.g.
+    * alias-qualified columns in joins) see the refined column types
     */
-  private def refineSchemaFromRows(schema: SchemaType, rows: List[Expression]): SchemaType =
+  def refineSchemaFromRows(schema: SchemaType, rows: List[Expression]): SchemaType =
     if schema.isResolved then
       schema
     else

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
@@ -36,6 +36,7 @@ import wvlet.lang.model.DataType.SchemaType
 import wvlet.lang.model.Type.FunctionType
 import wvlet.lang.model.Type.ImportType
 import wvlet.lang.model.Type.PackageType
+import wvlet.lang.model.expr.ArrayConstructor
 import wvlet.lang.model.expr.DotRef
 import wvlet.lang.model.expr.Identifier
 import wvlet.lang.model.expr.NameExpr
@@ -96,7 +97,15 @@ object SymbolLabeler extends Phase("symbol-labeler"):
           ctx
         case v: ValDef =>
           val sym = Symbol(ctx.global.newSymbolId, v.span)
-          sym.symbolInfo = ValSymbolInfo(ctx.owner, sym, v.name, v.dataType, v.expr)
+          // For table value constants (val t(id, name) = [[...]]), the declared schema has no
+          // column types, so refine them from the first row's values
+          val declaredType =
+            (v.dataType, v.expr) match
+              case (s: SchemaType, arr: ArrayConstructor) if !s.isResolved =>
+                RelationRefResolver.refineSchemaFromRows(s, arr.values)
+              case _ =>
+                v.dataType
+          sym.symbolInfo = ValSymbolInfo(ctx.owner, sym, v.name, declaredType, v.expr)
           v.symbol = sym
           sym.tree = v
           ctx.compilationUnit.enter(sym)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -260,13 +260,11 @@ object Typer extends Phase("typer") with LogSupport:
     * after model expansion
     */
   def resolveRelation(r: Relation)(using ctx: Context): Relation =
-    // Resolve all structural references (tables, models, files, partial queries, underscores)
-    // in a single bottom-up pass
-    val prepared = r.transformUp(structuralResolutionRule).asInstanceOf[Relation]
-    // Type the relation in place so that function qualifiers get concrete types. The typing
-    // rules cover identifiers (from the input relation type), parenthesized expressions, and
-    // method references (typed by their declared return type without inlining)
-    typeRelation(prepared)
+    // Resolve structural references (tables, models, files, partial queries, underscores) and
+    // type each node's expressions in a single bottom-up pass. Interleaving resolution and
+    // typing matters: several relation nodes memoize their relationType on first access, so a
+    // parent must not read a child's relation type before the child's expressions are typed
+    val prepared = prepareRelation(r)
     // Inline function calls and aggregation expressions only when candidates are present.
     // Chained method calls (e.g. x.to_double.round(1)) resolve one link per round, so iterate
     // to a fixpoint
@@ -320,6 +318,41 @@ object Typer extends Phase("typer") with LogSupport:
   end resolveRelation
 
   /**
+    * A single bottom-up pass that resolves structural references and types each relation node's own
+    * expressions. Children are processed before their parents (including plans nested inside
+    * expressions), so a node's input relation type is fully typed by the time it is read
+    */
+  private def prepareRelation(r: Relation)(using ctx: Context): Relation = r
+    .transformUp { case plan: LogicalPlan =>
+      val resolved = structuralResolutionRule.applyOrElse(plan, identity[LogicalPlan])
+      resolved match
+        case rel: Relation =>
+          typeRelationNode(rel)
+          rel
+        case other =>
+          other
+    }
+    .asInstanceOf[Relation]
+
+  /**
+    * Type the direct child expressions of a single relation node (the node's children are expected
+    * to be typed already) and assign its own tpe
+    */
+  private def typeRelationNode(rel: Relation)(using ctx: Context): Unit =
+    val exprCtx = ctx.withInputType(rel.inputRelationType)
+    rel match
+      case t: TestRelation =>
+        // Test expressions are an assertion DSL over the tested query's result
+        typeTestExpression(t.testExpr)(using exprCtx)
+      case _ =>
+        rel
+          .childExpressions
+          .foreach { expr =>
+            typeExpression(expr)(using exprCtx)
+          }
+    rel.tpe = rel.relationType
+
+  /**
     * A single bottom-up rewrite that resolves table/model/file references into concrete scan nodes,
     * inlines partial query applications (with cycle detection), and resolves underscore (_)
     * references from the input relation of the enclosing operator
@@ -339,12 +372,13 @@ object Typer extends Phase("typer") with LogSupport:
       RelationRefResolver.resolveDataFileRef(f).getOrElse(f)
     case p: PartialQueryApply =>
       // The inlined body is spliced above the already-resolved child and is not revisited by
-      // the enclosing bottom-up traversal, so resolve the body recursively
+      // the enclosing bottom-up traversal, so resolve and type the body recursively
       val inlined = FunctionInliner.resolvePartialQuery(p)
-      if inlined eq p then
-        p
-      else
-        inlined.transformUp(structuralResolutionRule)
+      inlined match
+        case rel: Relation if !(inlined eq p) =>
+          prepareRelation(rel)
+        case _ =>
+          p
     case u: UnaryRelation if hasUnresolvedUnderscore(u) =>
       val contextType = u.inputRelation.relationType
       u.transformChildExpressions { case expr: Expression =>
@@ -353,6 +387,8 @@ object Typer extends Phase("typer") with LogSupport:
             ContextInputRef(dataType = contextType, ref.span)
         }
       }
+
+  end structuralResolutionRule
 
   /**
     * Returns true if the relation tree may contain function applications, method or native function
@@ -459,13 +495,48 @@ object Typer extends Phase("typer") with LogSupport:
 
     // Type direct child expressions with the input type context - in place
     val exprCtx = ctx.withInputType(inputType)
-    r.childExpressions
-      .foreach { expr =>
-        typeExpression(expr)(using exprCtx)
-      }
+    r match
+      case t: TestRelation =>
+        // Test expressions are an assertion DSL over the tested query's result
+        typeTestExpression(t.testExpr)(using exprCtx)
+      case _ =>
+        r.childExpressions
+          .foreach { expr =>
+            typeExpression(expr)(using exprCtx)
+          }
 
     // Set tpe from relationType
     r.tpe = r.relationType
+
+  /**
+    * Type a test expression. Tests inspect the result of the tested query through pseudo members of
+    * the underscore (_.size, _.columns, _.rows, _.output, _.json) that are evaluated by the test
+    * runner, so they are typed here rather than through the regular member lookup
+    */
+  private def typeTestExpression(e: Expression)(using ctx: Context): Unit =
+    e.children.foreach(typeTestExpression)
+    e match
+      case d @ DotRef(q: Identifier, name, _, _) if q.fullName == "_" =>
+        name.leafName match
+          case "size" =>
+            d.tpe = DataType.LongType
+          case "columns" =>
+            d.tpe = DataType.ArrayType(DataType.StringType)
+          case "rows" =>
+            d.tpe = DataType.ArrayType(DataType.ArrayType(DataType.AnyType))
+          case "output" | "json" =>
+            d.tpe = DataType.StringType
+          case _ =>
+            TyperRules.exprRules.applyOrElse(d, identity[Expression])
+      case i: Identifier if i.fullName == "_" && !hasResolvedType(i) =>
+        // The underscore denotes the full result of the tested query
+        ctx.inputType match
+          case dt: DataType if dt.isResolved =>
+            i.tpe = dt
+          case _ =>
+            ()
+      case other =>
+        TyperRules.exprRules.applyOrElse(other, identity[Expression])
 
   /**
     * Type an expression using TyperRules. Uses in-place traversal for efficiency - only updates

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -31,6 +31,7 @@ import wvlet.lang.model.expr.SubQueryExpression
 import wvlet.lang.model.expr.TupleInRelation
 import wvlet.lang.model.expr.TupleNotInRelation
 import wvlet.lang.model.DataType
+import wvlet.lang.model.RelationType
 import wvlet.lang.model.DataType.NamedType
 import wvlet.lang.model.DataType.SchemaType
 import wvlet.lang.model.expr.Expression
@@ -216,6 +217,9 @@ object Typer extends Phase("typer") with LogSupport:
               m
         TyperRules.typeStatement(typedModelDef)
         typedModelDef
+      // Handle FlowDef - resolve stage bodies with previously-defined stages in scope
+      case f: FlowDef =>
+        resolveFlowDef(f)
       // Handle Relation - propagate input type through relational operators
       case r: Relation =>
         resolveRelation(r)
@@ -322,17 +326,93 @@ object Typer extends Phase("typer") with LogSupport:
     * expressions. Children are processed before their parents (including plans nested inside
     * expressions), so a node's input relation type is fully typed by the time it is read
     */
-  private def prepareRelation(r: Relation)(using ctx: Context): Relation = r
-    .transformUp { case plan: LogicalPlan =>
-      val resolved = structuralResolutionRule.applyOrElse(plan, identity[LogicalPlan])
-      resolved match
-        case rel: Relation =>
-          typeRelationNode(rel)
-          rel
-        case other =>
-          other
-    }
+  private def prepareRelation(r: Relation)(using ctx: Context): Relation = prepare(r, Map.empty)
     .asInstanceOf[Relation]
+
+  /**
+    * Recursive worker for prepareRelation. The scope argument carries locally-defined relation
+    * names (CTE aliases from `with ... as`, flow stage names) that are visible only within the
+    * enclosing query, so references to them are typed in place without symbol registration
+    */
+  private def prepare(plan: LogicalPlan, scope: Map[String, RelationType])(using
+      ctx: Context
+  ): LogicalPlan =
+    plan match
+      case w: WithQuery =>
+        // Each CTE definition sees the aliases defined before it; the query body sees them all
+        var cteScope = scope
+        var changed  = false
+        val newDefs  = w
+          .queryDefs
+          .map { d =>
+            val resolved = prepare(d, cteScope).asInstanceOf[AliasedRelation]
+            if !(resolved eq d) then
+              changed = true
+            cteScope += resolved.alias.fullName -> resolved.relationType
+            resolved
+          }
+        val newBody      = prepare(w.queryBody, cteScope).asInstanceOf[Relation]
+        val resolvedWith =
+          if changed || !(newBody eq w.queryBody) then
+            val neww = w.copy(queryDefs = newDefs, queryBody = newBody)
+            neww.copyMetadataFrom(w)
+            neww
+          else
+            w
+        typeRelationNode(resolvedWith)
+        resolvedWith
+      case ref: TableRef if scope.contains(ref.name.fullName) =>
+        // A reference to a locally-defined relation (CTE alias or flow stage). The node stays a
+        // TableRef so that generated SQL keeps referencing the alias; only its type is assigned
+        ref.tpe = scope(ref.name.fullName)
+        typeRelationNode(ref)
+        ref
+      case other =>
+        val withChildren = other.mapChildren(c => prepare(c, scope))
+        val resolved     = structuralResolutionRule.applyOrElse(withChildren, identity[LogicalPlan])
+        resolved match
+          case rel: Relation =>
+            typeRelationNode(rel)
+            rel
+          case o =>
+            o
+
+  /**
+    * Resolve and type the body of each flow stage, making previously-defined stage names resolvable
+    * from subsequent stages (e.g. `stage output = from entry | ...`)
+    */
+  private def resolveFlowDef(f: FlowDef)(using ctx: Context): FlowDef =
+    var stageScope = Map.empty[String, RelationType]
+    var changed    = false
+    val newStages  = f
+      .stages
+      .map { s =>
+        val newBody     = s.body.map(b => prepare(b, stageScope).asInstanceOf[Relation])
+        val bodyChanged =
+          (newBody, s.body) match
+            case (Some(a), Some(b)) =>
+              !(a eq b)
+            case _ =>
+              false
+        val newStage =
+          if !bodyChanged then
+            s
+          else
+            changed = true
+            val ns = s.copy(body = newBody)
+            ns.copyMetadataFrom(s)
+            ns
+        stageScope += newStage.name.name -> newStage.relationType
+        newStage
+      }
+    if changed then
+      val nf = f.copy(stages = newStages)
+      nf.copyMetadataFrom(f)
+      nf
+    else
+      f
+
+  end resolveFlowDef
 
   /**
     * Type the direct child expressions of a single relation node (the node's children are expected

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -81,6 +81,12 @@ object TyperRules:
     * Rules for typing identifiers
     */
   def identifierRules(using ctx: Context): PartialFunction[Expression, Expression] = {
+    case w: Wildcard =>
+      // A wildcard (*) selects the full input row, so it carries the input relation type
+      if ctx.inputType.isResolved then
+        w.tpe = ctx.inputType
+      w
+
     case id: Identifier =>
       // Look up symbol from scope, imports, and global scope
       ctx.findSymbolByName(id.toTermName) match

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/Expression.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/Expression.scala
@@ -40,12 +40,19 @@ trait Expression extends SyntaxTreeNode with LogSupport:
     * report the type assigned to the tpe field by the Typer, bridging the legacy dataType field and
     * the in-place typing of the new Typer (issue #392)
     */
-  def dataType: DataType =
+  def dataType: DataType = typedOr(DataType.UnknownType)
+
+  /**
+    * Returns the resolved type assigned to the tpe field by the Typer, or the given structural
+    * fallback. dataType overrides use this so that in-place typing takes precedence over a
+    * structural computation that may be unresolved
+    */
+  protected def typedOr(fallback: => DataType): DataType =
     tpe match
       case dt: DataType if dt.isResolved =>
         dt
       case _ =>
-        DataType.UnknownType
+        fallback
 
   def isIdentifier: Boolean =
     this match

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
@@ -134,12 +134,10 @@ abstract trait QualifiedName extends NameExpr:
   * @param dataType
   * @param nodeLocation
   */
-case class DotRef(
-    qualifier: Expression,
-    name: NameExpr,
-    override val dataType: DataType,
-    span: Span
-) extends QualifiedName:
+case class DotRef(qualifier: Expression, name: NameExpr, givenDataType: DataType, span: Span)
+    extends QualifiedName:
+  override def dataType: DataType = typedOr(givenDataType)
+
   override def nameParts: List[String] =
     qualifier match
       case q: NameExpr =>
@@ -318,7 +316,7 @@ case class FunctionApply(
   override def children: Seq[Expression] =
     Seq(base) ++ args ++ window.toSeq ++ filter.toSeq ++ columnAliases.getOrElse(Nil)
 
-  override def dataType: DataType = base.dataType
+  override def dataType: DataType = typedOr(base.dataType)
 
 case class WindowApply(
     base: Expression,
@@ -327,7 +325,7 @@ case class WindowApply(
     span: Span
 ) extends Expression:
   override def children: Seq[Expression] = Seq(base, window)
-  override def dataType: DataType        = base.dataType
+  override def dataType: DataType        = typedOr(base.dataType)
 
 case class FunctionArg(
     name: Option[TermName] = None,

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
@@ -56,7 +56,8 @@ trait FlowOp extends Relation
   * @param span
   *   Source location
   */
-case class ConfigItem(key: Identifier, value: Expression, span: Span) extends LeafExpression
+case class ConfigItem(key: Identifier, value: Expression, span: Span) extends LeafExpression:
+  override def dataType: wvlet.lang.model.DataType = value.dataType
 
 /**
   * StageTrigger represents a condition that determines when a stage should run.

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
@@ -199,7 +199,14 @@ case class TableRef(name: QualifiedName, span: Span) extends TableInput:
   override def sqlExpr: Expression = name
   // TODO Fix to generate a correct Wvlet expression for double-quoted or dot-separated table names
   override def toString: String           = s"TableRef(${name})"
-  override val relationType: RelationType = UnresolvedRelationType(name.fullName)
+  override def relationType: RelationType =
+    // A reference to a locally-scoped relation (e.g. a CTE alias or a flow stage) keeps its
+    // TableRef node and carries the referenced relation type in the tpe field
+    tpe match
+      case r: RelationType if r.isResolved =>
+        r
+      case _ =>
+        UnresolvedRelationType(name.fullName)
 
 case class TableFunctionCall(name: NameExpr, args: List[FunctionArg], span: Span)
     extends TableInput:


### PR DESCRIPTION
## Summary

Third coverage wave for #392 (follows #1779, #1780, #1781). Typing coverage over `spec/basic` rises from 71.8% → **76.4%** of relations and 74.6% → **83.7%** of expressions (59.2% / 70.6% at the start of this series).

### Interleaved resolution and typing (`prepareRelation`)

Several relation nodes memoize `relationType` on first access, so a parent reading a child's relation type before the child's expressions were typed froze it as unresolved forever. Structural resolution and per-node typing now happen in one bottom-up pass, so a node's input is always fully typed when first read. Following dotc's single-traversal typer design.

### Locally-scoped relation references

`with ... as` CTE aliases and flow stage names are visible only within the enclosing query, so they resolve through a scope map threaded through the preparation pass instead of global symbol registration (matching the #93 scope-management direction; also fixes the alias-leak class of bugs hit twice during the #1764 migration). The `TableRef` node is kept so generated SQL still references the alias — only its type is assigned, and `TableRef.relationType` now prefers a resolved `tpe`.

### More typing coverage

- Test expressions (`_.size`, `_.columns`, `_.rows`, `_.output`, `_.json`) typed as the runner's inspection DSL; a bare `_` in a test carries the tested query's relation type
- `dataType` overrides on `DotRef`, `FunctionApply`, `WindowApply` prefer a resolved `tpe` over their structural fallback (`typedOr`), so Typer-assigned types reach relation schemas
- Wildcards (`*`) carry the input relation type; flow `ConfigItem`s type from their value
- Table-value constants refine their declared column types at symbol-labeling time, so alias-qualified columns in joins resolve
- The coverage metric no longer counts `<empty>` name placeholders (structural slots, not expressions)

Ratchet raised to 75% / 82%.

## Verification

`runner/test` 394 passed (all specs incl. TPC-H execution), `langJVM/test` 1440 passed, `projectJVM/test` full pass in 23s, JS/Native compile clean, compile time unchanged (~96ms median).

🤖 Generated with [Claude Code](https://claude.com/claude-code)