### PR TITLE
internal: Declare table types in flow specs so stage bodies type-check (issue #392)

### DIFF
--- a/spec/basic/flow-syntax.wv
+++ b/spec/basic/flow-syntax.wv
@@ -1,5 +1,21 @@
 -- Test flow syntax parsing (design only - execution support to be added later)
 
+-- Table types referenced by the flows below, so that stage bodies type-check
+type users = {
+  user_id: string
+  name: string
+  email: string
+  region: string
+  segment_id: string
+  age: int
+  active: boolean
+}
+
+type source = {
+  id: string
+  value: string
+}
+
 -- Basic flow definition with stages
 flow SimpleFlow = {
   stage entry = from users

--- a/spec/basic/flow-task-syntax.wv
+++ b/spec/basic/flow-task-syntax.wv
@@ -1,5 +1,26 @@
 -- Test task-oriented flow syntax (Phase 1)
 
+-- Table types referenced by the flows below, so that stage bodies type-check
+type users = {
+  name: string
+  segment_id: string
+}
+
+type source = {
+  id: string
+  value: string
+}
+
+type backup = {
+  id: string
+  value: string
+}
+
+type warehouse = {
+  id: string
+  value: string
+}
+
 -- Stage with config block
 flow ConfiguredStage = {
   stage extract with {

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
@@ -142,9 +142,9 @@ class TyperCoverageCheck extends UniTest:
     info(s"top unresolved relations: ${top(c.unresolvedRelations, 10)}")
     info(s"top untyped expressions:  ${top(c.untypedExprs, 10)}")
 
-    // Ratchet (2026-07-03: 76.4% / 83.5%). Raise these as coverage improves toward 1.0
-    val minRelationCoverage = 0.75
-    val minExprCoverage     = 0.82
+    // Ratchet (2026-07-03: 88.5% / 84.8%). Raise these as coverage improves toward 1.0
+    val minRelationCoverage = 0.87
+    val minExprCoverage     = 0.83
     if c.relationCoverage < minRelationCoverage then
       fail(
         f"Relation type coverage regressed: ${c.relationCoverage *


### PR DESCRIPTION
## Summary

Follow-up to #1782. The flow DSL specs referenced undefined external tables (`users`, `source`, `backup`, `warehouse`), leaving every downstream stage node untyped — the largest remaining block of unresolved relations. This declares their schemas at the top of the spec files, the same pattern `spec/tpch/schema.wv` uses, so the flow corpus exercises typed stage resolution end-to-end (stage-to-stage references already resolve since #1782).

| metric | before | after |
|---|---|---|
| relations resolved | 76.4% | **88.5%** |
| expressions typed | 83.7% | **84.8%** |

Ratchet raised to 87% / 83%.

The remaining tail is mostly untyped builtin SQL function calls (`count(*)`, `regexp_matches`, `map`, window functions), tracked as a follow-up (function signature registry), plus `RawSQL`/`sql"..."` fragments that are dynamically typed by design.

## Verification

`runner/test` 394 passed, `langJVM/test` full pass, `ParserSpecBasic` 127 passed (flows still parse identically; flows define no executable statements so runner behavior is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)