### PR TITLE
internal: Add a builtin SQL function signature table for typing (issue #392)

### DIFF
--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
@@ -43,14 +43,9 @@ class TyperCoverageCheck extends UniTest:
     def relationCoverage: Double = relationResolved.toDouble / relationTotal.max(1)
     def exprCoverage: Double     = exprTyped.toDouble / exprTotal.max(1)
 
-  private def isTypedExpr(e: Expression): Boolean =
-    e.dataType.isResolved || (
-      e.tpe match
-        case dt: DataType =>
-          dt.isResolved
-        case _ =>
-          false
-    )
+  // An expression counts as typed when it carries any resolved type: a DataType for value
+  // expressions, or e.g. a FunctionType for references to functions
+  private def isTypedExpr(e: Expression): Boolean = e.dataType.isResolved || e.tpe.isResolved
 
   private def measure(plans: Seq[LogicalPlan]): Coverage =
     var relationTotal    = 0
@@ -142,9 +137,9 @@ class TyperCoverageCheck extends UniTest:
     info(s"top unresolved relations: ${top(c.unresolvedRelations, 10)}")
     info(s"top untyped expressions:  ${top(c.untypedExprs, 10)}")
 
-    // Ratchet (2026-07-03: 88.5% / 84.8%). Raise these as coverage improves toward 1.0
-    val minRelationCoverage = 0.87
-    val minExprCoverage     = 0.83
+    // Ratchet (2026-07-03: 89.6% / 86.8%). Raise these as coverage improves toward 1.0
+    val minRelationCoverage = 0.88
+    val minExprCoverage     = 0.85
     if c.relationCoverage < minRelationCoverage then
       fail(
         f"Relation type coverage regressed: ${c.relationCoverage *

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/BuiltinFunctions.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/BuiltinFunctions.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.typer
+
+import wvlet.lang.model.DataType
+import wvlet.lang.model.DataType.*
+import wvlet.lang.model.expr.FunctionArg
+
+/**
+  * Return-type signatures of well-known SQL functions that have no definition in the standard
+  * library (following the Definitions concept of the Scala 3 compiler). Used by the Typer to assign
+  * a best-effort type to function applications that are passed through to the target database
+  * engine. Only functions whose return type is consistent across the supported engines (DuckDB,
+  * Trino) are listed
+  */
+object BuiltinFunctions:
+
+  private val longFunctions = Set(
+    "count",
+    "row_number",
+    "rank",
+    "dense_rank",
+    "ntile",
+    "length",
+    "strlen",
+    "hash"
+  )
+
+  private val booleanFunctions = Set("regexp_matches", "regexp_like", "contains", "starts_with")
+
+  private val stringFunctions = Set(
+    "concat",
+    "upper",
+    "lower",
+    "trim",
+    "ltrim",
+    "rtrim",
+    "substring",
+    "substr",
+    "replace",
+    "regexp_replace",
+    "reverse",
+    "lpad",
+    "rpad",
+    "string_agg",
+    "strftime"
+  )
+
+  private val doubleFunctions = Set("avg", "stddev", "stddev_samp", "stddev_pop", "sqrt")
+
+  /**
+    * Functions whose return type follows the type of their first argument
+    */
+  private val firstArgTypeFunctions = Set(
+    "min",
+    "max",
+    "sum",
+    "abs",
+    "coalesce",
+    "greatest",
+    "least",
+    "lag",
+    "lead",
+    "first_value",
+    "last_value",
+    "arbitrary",
+    "any_value",
+    "round"
+  )
+
+  /**
+    * Returns the return type of a well-known SQL function, or None when the function is not
+    * recognized or its return type cannot be derived from the arguments
+    */
+  def returnTypeOf(name: String, args: List[FunctionArg]): Option[DataType] =
+    val fn = name.toLowerCase
+    if longFunctions.contains(fn) then
+      Some(LongType)
+    else if booleanFunctions.contains(fn) then
+      Some(BooleanType)
+    else if stringFunctions.contains(fn) then
+      Some(StringType)
+    else if doubleFunctions.contains(fn) then
+      Some(DoubleType)
+    else if firstArgTypeFunctions.contains(fn) then
+      args.headOption.map(_.value.dataType).filter(_.isResolved)
+    else
+      None
+
+end BuiltinFunctions

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -431,6 +431,16 @@ object Typer extends Phase("typer") with LogSupport:
             typeExpression(expr)(using exprCtx)
           }
     rel.tpe = rel.relationType
+    // Type name expressions of aliases and local references as the relation type they denote
+    rel match
+      case a: AliasedRelation if a.relationType.isResolved =>
+        a.alias.tpe = a.relationType
+      case n: NamedRelation if n.relationType.isResolved =>
+        n.name.tpe = n.relationType
+      case t: TableRef if t.relationType.isResolved =>
+        t.name.tpe = t.relationType
+      case _ =>
+        ()
 
   /**
     * A single bottom-up rewrite that resolves table/model/file references into concrete scan nodes,

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -412,19 +412,38 @@ object TyperRules:
     */
   def functionApplyRules(using ctx: Context): PartialFunction[Expression, Expression] = {
     case funcApply: FunctionApply =>
+      // A call whose base is a plain function name passed through to the database engine
+      // (e.g. count(*), regexp_matches(...)) is typed from the builtin signature table. The
+      // base name itself is typed as a function type of the builtin signature
+      def builtinReturnType: Option[DataType] =
+        funcApply.base match
+          case id: Identifier =>
+            BuiltinFunctions
+              .returnTypeOf(id.fullName, funcApply.args)
+              .map { ret =>
+                id.tpe = FunctionType(id.toTermName, Nil, ret, Nil)
+                ret
+              }
+          case _ =>
+            None
+
       // The type of a function application is the function's return type
       funcApply.base.tpe match
         case ft: Type.FunctionType =>
           funcApply.tpe = ft.returnType
         case NoType =>
           // Base not typed yet
-          funcApply.tpe = NoType
+          builtinReturnType.foreach { t =>
+            funcApply.tpe = t
+          }
         case et: ErrorType =>
-          // Propagate error from base
-          funcApply.tpe = et
+          // Propagate error from base unless this is a known builtin function
+          funcApply.tpe = builtinReturnType.getOrElse(et)
         case other =>
           // Not a function type
-          funcApply.tpe = ErrorType(s"Cannot apply non-function type ${other}")
+          funcApply.tpe = builtinReturnType.getOrElse(
+            ErrorType(s"Cannot apply non-function type ${other}")
+          )
       funcApply
   }
 

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/BuiltinFunctionsTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/BuiltinFunctionsTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.typer
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.api.Span.NoSpan
+import wvlet.lang.model.DataType.*
+import wvlet.lang.model.expr.{FunctionArg, LongLiteral}
+
+class BuiltinFunctionsTest extends UniTest:
+
+  private val longArg = FunctionArg(None, LongLiteral(1L, "1", NoSpan), false, Nil, NoSpan)
+
+  test("should type count and window ranking functions as long") {
+    BuiltinFunctions.returnTypeOf("count", Nil) shouldBe Some(LongType)
+    BuiltinFunctions.returnTypeOf("ROW_NUMBER", Nil) shouldBe Some(LongType)
+  }
+
+  test("should type string functions as string") {
+    BuiltinFunctions.returnTypeOf("concat", Nil) shouldBe Some(StringType)
+    BuiltinFunctions.returnTypeOf("regexp_replace", Nil) shouldBe Some(StringType)
+  }
+
+  test("should type predicates as boolean and avg as double") {
+    BuiltinFunctions.returnTypeOf("regexp_matches", Nil) shouldBe Some(BooleanType)
+    BuiltinFunctions.returnTypeOf("avg", Nil) shouldBe Some(DoubleType)
+  }
+
+  test("should derive min/max/coalesce types from the first argument") {
+    BuiltinFunctions.returnTypeOf("max", List(longArg)) shouldBe Some(LongType)
+    BuiltinFunctions.returnTypeOf("coalesce", Nil) shouldBe None
+  }
+
+  test("should return None for unknown functions") {
+    BuiltinFunctions.returnTypeOf("mystery_fn", Nil) shouldBe None
+  }
+
+end BuiltinFunctionsTest


### PR DESCRIPTION
## Summary

Follow-up to #1783. Function calls passed through to the database engine — `count(*)`, `regexp_matches`, window ranking functions, string functions — had no type source: they are not defined in the standard library, so their applications and everything selecting them stayed untyped (the largest remaining expression bucket).

- **`BuiltinFunctions`**: a small signature table, following the `Definitions` concept of the Scala 3 compiler, listing only functions whose return type is consistent across DuckDB and Trino. `min`/`max`/`coalesce`-style functions derive their type from the first argument.
- The **base name** of a builtin call is typed as a `FunctionType` of that signature (so `functionApplyRules`' existing `FunctionType` branch picks up the return type naturally), and **name expressions** of aliases and local relation references (`AliasedRelation.alias`, CTE/stage `TableRef.name`) carry the relation type they denote — name references count as typed the same way method references do in dotc.
- The coverage metric now accepts any resolved `Type` (a `FunctionType` for function references, a `DataType` for values).

| metric | before | after |
|---|---|---|
| relations resolved | 88.5% | **89.6%** |
| expressions typed | 84.8% | **86.8%** |

Ratchet raised to 88% / 85%.

## Verification

`runner/test` 394 passed, `langJVM/test` 1445 passed (adds `BuiltinFunctionsTest`), JS/Native compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)