### PR TITLE
internal: Type method-style function calls with a DotRef base (issue #392)

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -414,7 +414,9 @@ object TyperRules:
     case funcApply: FunctionApply =>
       // A call whose base is a plain function name passed through to the database engine
       // (e.g. count(*), regexp_matches(...)) is typed from the builtin signature table. The
-      // base name itself is typed as a function type of the builtin signature
+      // base name itself is typed as a function type of the builtin signature. Method-style
+      // calls of builtins (e.g. x.lower()) have a DotRef base and are looked up by the member
+      // name
       def builtinReturnType: Option[DataType] =
         funcApply.base match
           case id: Identifier =>
@@ -424,6 +426,8 @@ object TyperRules:
                 id.tpe = FunctionType(id.toTermName, Nil, ret, Nil)
                 ret
               }
+          case d: DotRef =>
+            BuiltinFunctions.returnTypeOf(d.name.leafName, funcApply.args)
           case _ =>
             None
 
@@ -431,6 +435,10 @@ object TyperRules:
       funcApply.base.tpe match
         case ft: Type.FunctionType =>
           funcApply.tpe = ft.returnType
+        case dt: DataType if dt.isResolved && funcApply.base.isInstanceOf[DotRef] =>
+          // A method reference typed by dotRefRules carries its declared return type, which
+          // is also the type of applying it
+          funcApply.tpe = dt
         case NoType =>
           // Base not typed yet
           builtinReturnType.foreach { t =>


### PR DESCRIPTION
## Summary

Addresses [Gemini's review note on #1784](https://github.com/wvlet/wvlet/pull/1784#discussion): builtin calls in dot notation (e.g. `x.lower()`) parse as a `FunctionApply` with a `DotRef` base and were left untyped or marked with an `ErrorType`.

- A method reference typed by `dotRefRules` carries its declared return type, so applying it yields that same type — `functionApplyRules` now uses it directly.
- Unknown members fall back to the `BuiltinFunctions` signature table looked up by member name.

Relations resolved over `spec/basic`: 89.6% → **90.0%**.

Verified: `runner/test` 394 passed, `langJVM/test` full pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)