### PR TITLE
feature: Report type mismatches as per-unit diagnostics; type unnest (issue #392)

### DIFF
--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
@@ -137,9 +137,9 @@ class TyperCoverageCheck extends UniTest:
     info(s"top unresolved relations: ${top(c.unresolvedRelations, 10)}")
     info(s"top untyped expressions:  ${top(c.untypedExprs, 10)}")
 
-    // Ratchet (2026-07-03: 89.6% / 86.8%). Raise these as coverage improves toward 1.0
-    val minRelationCoverage = 0.88
-    val minExprCoverage     = 0.85
+    // Ratchet (2026-07-03: 90.7% / 87.0%). Raise these as coverage improves toward 1.0
+    val minRelationCoverage = 0.89
+    val minExprCoverage     = 0.86
     if c.relationCoverage < minRelationCoverage then
       fail(
         f"Relation type coverage regressed: ${c.relationCoverage *

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
@@ -53,6 +53,9 @@ case class CompilationUnit(sourceFile: SourceFile, isPreset: Boolean = false)
 
   var lastError: Option[Throwable] = None
 
+  // Type errors collected by the Typer phase (reported as diagnostics, not compile failures)
+  var typerErrors: List[wvlet.lang.compiler.typer.TyperError] = Nil
+
   // Plans generated for subscriptions
   var subscriptionPlans: List[LogicalPlan] = List.empty[LogicalPlan]
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -177,7 +177,7 @@ case class Context(
   /**
     * Add a typing error
     */
-  def addTyperError(err: TyperError): Context = copy(typerState = typerState.addError(err))
+  def addTyperError(err: TyperError): Unit = typerState.addError(err)
 
   /**
     * Check if there are any typing errors

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/BuiltinFunctions.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/BuiltinFunctions.scala
@@ -85,7 +85,16 @@ object BuiltinFunctions:
     */
   def returnTypeOf(name: String, args: List[FunctionArg]): Option[DataType] =
     val fn = name.toLowerCase
-    if longFunctions.contains(fn) then
+    if fn == "unnest" then
+      // unnest(array(T)) yields values of the element type T
+      args
+        .headOption
+        .map(_.value.dataType)
+        .collect {
+          case ArrayType(elem) if elem.isResolved =>
+            elem
+        }
+    else if longFunctions.contains(fn) then
       Some(LongType)
     else if booleanFunctions.contains(fn) then
       Some(BooleanType)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -80,7 +80,8 @@ object Typer extends Phase("typer") with LogSupport:
     // Phase 2: Type the plan bottom-up with context-aware scope management
     val typed = typePlan(unit.unresolvedPlan)(using preScanCtx)
 
-    // Report any typing errors
+    // Attach the collected type errors to the unit as diagnostics and report them
+    unit.typerErrors = preScanCtx.typerErrors
     if preScanCtx.hasTyperErrors then
       warn(s"Typing errors in ${unit.sourceFile.fileName}:")
       preScanCtx
@@ -439,8 +440,22 @@ object Typer extends Phase("typer") with LogSupport:
         n.name.tpe = n.relationType
       case t: TableRef if t.relationType.isResolved =>
         t.name.tpe = t.relationType
+      case tf: TableFunctionCall if !tf.relationType.isResolved =>
+        // Table functions with a derivable schema, e.g. unnest(array(T)) yields one column
+        // of the element type T
+        BuiltinFunctions
+          .returnTypeOf(tf.name.fullName, tf.args)
+          .foreach { elem =>
+            tf.tpe = SchemaType(
+              parent = None,
+              typeName = Name.typeName(tf.name.leafName),
+              columnTypes = List(NamedType(Name.termName(tf.name.leafName), elem))
+            )
+          }
       case _ =>
         ()
+
+  end typeRelationNode
 
   /**
     * A single bottom-up rewrite that resolves table/model/file references into concrete scan nodes,

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -145,12 +145,30 @@ object TyperRules:
           case (_, FloatType, DoubleType) | (_, DoubleType, FloatType) =>
             DoubleType
 
-          // String concatenation for Add
-          case (BinaryExprType.Add, StringType, StringType) =>
+          // Decimal arithmetic keeps the decimal type
+          case (_, d: DecimalType, _: DecimalType | IntType | LongType | FloatType | DoubleType) =>
+            d
+          case (_, IntType | LongType | FloatType | DoubleType, d: DecimalType) =>
+            d
+
+          // String concatenation for Add: a string operand absorbs the other side, which is
+          // coerced to string (see RewriteExpr.RewriteStringConcat)
+          case (BinaryExprType.Add, StringType, _) | (BinaryExprType.Add, _, StringType) =>
             StringType
 
-          // Type error
+          // Operands not typed yet - defer
+          case (_, NoType, _) | (_, _, NoType) =>
+            NoType
+
+          // Propagate operand errors
+          case (_, e: ErrorType, _) =>
+            e
+          case (_, _, e: ErrorType) =>
+            e
+
+          // Type error between two resolved, incompatible operand types
           case _ =>
+            ctx.addTyperError(TypeMismatch(leftTpe, rightTpe, op))
             ErrorType(s"Type error in ${op.exprType}: $leftTpe ${op.exprType} $rightTpe")
 
       op
@@ -177,8 +195,8 @@ object TyperRules:
         (leftTpe, rightTpe) match
           // Numeric comparisons
           case (
-                IntType | LongType | FloatType | DoubleType,
-                IntType | LongType | FloatType | DoubleType
+                IntType | LongType | FloatType | DoubleType | _: DecimalType,
+                IntType | LongType | FloatType | DoubleType | _: DecimalType
               ) =>
             BooleanType
           // String comparisons
@@ -197,6 +215,7 @@ object TyperRules:
             e
           // Type mismatch
           case _ =>
+            ctx.addTyperError(TypeMismatch(leftTpe, rightTpe, op))
             ErrorType(s"Cannot compare $leftTpe < $rightTpe: incompatible types")
       op
 
@@ -206,8 +225,8 @@ object TyperRules:
       op.tpe =
         (leftTpe, rightTpe) match
           case (
-                IntType | LongType | FloatType | DoubleType,
-                IntType | LongType | FloatType | DoubleType
+                IntType | LongType | FloatType | DoubleType | _: DecimalType,
+                IntType | LongType | FloatType | DoubleType | _: DecimalType
               ) =>
             BooleanType
           case (StringType, StringType) =>
@@ -221,6 +240,7 @@ object TyperRules:
           case (_, e: ErrorType) =>
             e
           case _ =>
+            ctx.addTyperError(TypeMismatch(leftTpe, rightTpe, op))
             ErrorType(s"Cannot compare $leftTpe <= $rightTpe: incompatible types")
       op
 
@@ -230,8 +250,8 @@ object TyperRules:
       op.tpe =
         (leftTpe, rightTpe) match
           case (
-                IntType | LongType | FloatType | DoubleType,
-                IntType | LongType | FloatType | DoubleType
+                IntType | LongType | FloatType | DoubleType | _: DecimalType,
+                IntType | LongType | FloatType | DoubleType | _: DecimalType
               ) =>
             BooleanType
           case (StringType, StringType) =>
@@ -245,6 +265,7 @@ object TyperRules:
           case (_, e: ErrorType) =>
             e
           case _ =>
+            ctx.addTyperError(TypeMismatch(leftTpe, rightTpe, op))
             ErrorType(s"Cannot compare $leftTpe > $rightTpe: incompatible types")
       op
 
@@ -254,8 +275,8 @@ object TyperRules:
       op.tpe =
         (leftTpe, rightTpe) match
           case (
-                IntType | LongType | FloatType | DoubleType,
-                IntType | LongType | FloatType | DoubleType
+                IntType | LongType | FloatType | DoubleType | _: DecimalType,
+                IntType | LongType | FloatType | DoubleType | _: DecimalType
               ) =>
             BooleanType
           case (StringType, StringType) =>
@@ -269,6 +290,7 @@ object TyperRules:
           case (_, e: ErrorType) =>
             e
           case _ =>
+            ctx.addTyperError(TypeMismatch(leftTpe, rightTpe, op))
             ErrorType(s"Cannot compare $leftTpe >= $rightTpe: incompatible types")
       op
 
@@ -281,7 +303,15 @@ object TyperRules:
         (leftTpe, rightTpe) match
           case (BooleanType, BooleanType) =>
             BooleanType
+          case (NoType, _) | (_, NoType) =>
+            // Operands not typed yet - defer
+            NoType
+          case (e: ErrorType, _) =>
+            e
+          case (_, e: ErrorType) =>
+            e
           case _ =>
+            ctx.addTyperError(TypeMismatch(BooleanType, leftTpe, op))
             ErrorType(s"Type error in AND: expected boolean operands, got $leftTpe AND $rightTpe")
 
       op
@@ -294,7 +324,15 @@ object TyperRules:
         (leftTpe, rightTpe) match
           case (BooleanType, BooleanType) =>
             BooleanType
+          case (NoType, _) | (_, NoType) =>
+            // Operands not typed yet - defer
+            NoType
+          case (e: ErrorType, _) =>
+            e
+          case (_, e: ErrorType) =>
+            e
           case _ =>
+            ctx.addTyperError(TypeMismatch(BooleanType, leftTpe, op))
             ErrorType(s"Type error in OR: expected boolean operands, got $leftTpe OR $rightTpe")
 
       op

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperState.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperState.scala
@@ -28,7 +28,8 @@ import wvlet.lang.model.Type
   */
 case class TyperState(
     inputType: RelationType = EmptyRelationType,
-    private val errors: List[TyperError] = Nil
+    private val errors: scala.collection.mutable.ListBuffer[TyperError] =
+      scala.collection.mutable.ListBuffer.empty
 ):
 
   /**
@@ -47,9 +48,14 @@ case class TyperState(
         this
 
   /**
-    * Add a typing error
+    * Report a typing error. The error buffer is mutable and shared across the states derived from
+    * this one (following the reporter of Scala 3's TyperState), so errors reported deep inside
+    * typing rules surface at the compilation unit level. Repeated typing rounds report the same
+    * error again, so duplicates are dropped
     */
-  def addError(err: TyperError): TyperState = copy(errors = err :: errors)
+  def addError(err: TyperError): Unit =
+    if !errors.exists(e => e.span == err.span && e.message == err.message) then
+      errors += err
 
   /**
     * Check if there are any typing errors
@@ -59,7 +65,7 @@ case class TyperState(
   /**
     * Get errors in order they were added
     */
-  def errorsInOrder: List[TyperError] = errors.reverse
+  def errorsInOrder: List[TyperError] = errors.toList
 
 end TyperState
 
@@ -67,4 +73,4 @@ object TyperState:
   /**
     * Empty typer state with no input type and no errors
     */
-  val empty: TyperState = TyperState()
+  def empty: TyperState = TyperState()

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
@@ -212,7 +212,13 @@ case class TableFunctionCall(name: NameExpr, args: List[FunctionArg], span: Span
     extends TableInput:
   override def sqlExpr: Expression        = FunctionApply(name, args, None, None, None, span)
   override def toString: String           = s"TableFunctionCall(${name}, ${args})"
-  override val relationType: RelationType = UnresolvedRelationType(name.fullName)
+  override def relationType: RelationType =
+    // A table function with a derivable schema (e.g. unnest) carries it in the tpe field
+    tpe match
+      case r: RelationType if r.isResolved =>
+        r
+      case _ =>
+        UnresolvedRelationType(name.fullName)
 
 case class FileRef(path: StringLiteral, span: Span) extends TableInput:
   def filePath: String                    = path.unquotedValue

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperDiagnosticsTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperDiagnosticsTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.typer
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, WorkEnv}
+
+/**
+  * Tests for type-mismatch diagnostics collected by the Typer
+  */
+class TyperDiagnosticsTest extends UniTest:
+
+  private def compileErrors(wv: String): List[TyperError] =
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+    val unit     = CompilationUnit.fromWvletString(wv)
+    compiler.compileSingleUnit(unit)
+    unit.typerErrors
+
+  test("report a mismatch between resolved incompatible operand types") {
+    val errors = compileErrors("select 1 - 'a' as v")
+    errors.exists {
+      case t: TypeMismatch =>
+        true
+      case _ =>
+        false
+    } shouldBe true
+  }
+
+  test("report an incomparable comparison between resolved types") {
+    val errors = compileErrors("select 1 < true as v")
+    errors.exists {
+      case t: TypeMismatch =>
+        true
+      case _ =>
+        false
+    } shouldBe true
+  }
+
+  test("allow string concatenation to absorb non-string operands") {
+    compileErrors("select 'v=' + 42 as v") shouldBe Nil
+  }
+
+  test("not report mismatches for unresolved operands") {
+    // unknown_col cannot resolve, so the arithmetic and comparison must stay silent
+    compileErrors("from [[1]] as t(id) | where unknown_col + 1 > 2") shouldBe Nil
+  }
+
+end TyperDiagnosticsTest


### PR DESCRIPTION
## Summary

Implements the "promote type errors from warnings to real diagnostics" item of the #392 [status evaluation](https://github.com/wvlet/wvlet/issues/392#issuecomment-4876651474), plus `unnest` typing.

### Type-mismatch diagnostics

- `TyperState` now carries a **mutable error reporter shared across derived states** (following dotc's `TyperState`), so errors reported deep inside typing rules surface at the unit level — the previous immutable `addError` could never propagate.
- Typing rules report a `TypeMismatch` only when **both operand types are resolved and incompatible**; unresolved operands stay silent, so catalog-less compilation produces no noise (locked by a test).
- Diagnostics attach to the `CompilationUnit` (`unit.typerErrors`) for tools to consume, and are logged as warnings. Compilation still succeeds — hard-failing is a strictness-mode decision left open.

Rolling this out immediately caught three latent gaps in the binary-op rules (a nice validation of the diagnostics themselves), now fixed:
- string concatenation absorbs non-string operands (`"v=" + 42`, matching `RewriteStringConcat`)
- decimal types participate in numeric arithmetic and comparisons (`price + 1`, `price < 100` no longer error-typed)
- arithmetic defers on untyped operands instead of stamping an `ErrorType`

The `spec/basic` corpus compiles with **zero diagnostics** after these fixes.

### unnest typing

`unnest(array(T))` yields element type `T` — both as a table function (`from unnest([1,2,3]) as t(n)`, via a tpe-first `TableFunctionCall.relationType`) and in select position (via the builtin signature table).

| metric | before | after |
|---|---|---|
| relations resolved | 90.0% | **90.7%** |
| expressions typed | 86.8% | **87.0%** |

Ratchet raised to 89% / 86%.

## Verification

`runner/test` 394 passed, `langJVM/test` 1449 passed (adds `TyperDiagnosticsTest`), JS/Native compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)