### PR TITLE
feature: Materialize structural types into tpe; strict type-check mode (issue #392)

### DIFF
--- a/wvlet-api/src/main/scala/wvlet/lang/api/StatusCode.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/StatusCode.scala
@@ -35,6 +35,7 @@ enum StatusCode(statusType: StatusType):
 
   // User errors
   case SYNTAX_ERROR               extends StatusCode(StatusType.UserError)
+  case TYPE_ERROR                 extends StatusCode(StatusType.UserError)
   case UNEXPECTED_TOKEN           extends StatusCode(StatusType.UserError)
   case UNCLOSED_MULTILINE_LITERAL extends StatusCode(StatusType.UserError)
 

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
@@ -137,9 +137,10 @@ class TyperCoverageCheck extends UniTest:
     info(s"top unresolved relations: ${top(c.unresolvedRelations, 10)}")
     info(s"top untyped expressions:  ${top(c.untypedExprs, 10)}")
 
-    // Ratchet (2026-07-03: 90.7% / 87.0%). Raise these as coverage improves toward 1.0
+    // Ratchet (2026-07-03: 90.7% / 87.1% / 89.1%). Raise these as coverage improves toward 1.0
     val minRelationCoverage = 0.89
     val minExprCoverage     = 0.86
+    val minTpeSetCoverage   = 0.88
     if c.relationCoverage < minRelationCoverage then
       fail(
         f"Relation type coverage regressed: ${c.relationCoverage *
@@ -149,6 +150,12 @@ class TyperCoverageCheck extends UniTest:
       fail(
         f"Expression type coverage regressed: ${c.exprCoverage *
             100}%.1f%% (expected >= ${minExprCoverage * 100}%.0f%%)"
+      )
+    val tpeSetCoverage = c.exprTpeSet.toDouble / c.exprTotal.max(1)
+    if tpeSetCoverage < minTpeSetCoverage then
+      fail(
+        f"tpe-field coverage regressed: ${tpeSetCoverage *
+            100}%.1f%% (expected >= ${minTpeSetCoverage * 100}%.0f%%)"
       )
   }
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
@@ -101,9 +101,15 @@ case class CompilerOptions(
     // context database schema
     schema: Option[String] = None,
     // Database type (e.g., DuckDB, Trino)
-    dbType: DBType = DBType.DuckDB
+    dbType: DBType = DBType.DuckDB,
+    // When true, type mismatches found by the Typer fail the compilation instead of being
+    // reported as warning-level diagnostics
+    failOnTypeErrors: Boolean = false
 ):
-  def withDBType(dbType: DBType): CompilerOptions = copy(dbType = dbType)
+  def withDBType(dbType: DBType): CompilerOptions                      = copy(dbType = dbType)
+  def withFailOnTypeErrors(failOnTypeErrors: Boolean): CompilerOptions = copy(failOnTypeErrors =
+    failOnTypeErrors
+  )
 
 class Compiler(
     val compilerOptions: CompilerOptions,

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -89,6 +89,9 @@ object Typer extends Phase("typer") with LogSupport:
         .foreach { err =>
           warn(s"  ${err.message} at ${err.sourceLocation(using context)}")
         }
+      if context.global.compilerOptions.failOnTypeErrors then
+        val first = preScanCtx.typerErrors.head
+        throw StatusCode.TYPE_ERROR.newException(first.message, first.sourceLocation(using context))
 
     // Store the typed plan in CompilationUnit
     unit.resolvedPlan = typed

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -38,10 +38,34 @@ object TyperRules:
   /**
     * All typing rules for expressions
     */
-  def exprRules(using ctx: Context): PartialFunction[Expression, Expression] =
+  def exprRules(using ctx: Context): PartialFunction[Expression, Expression] = (
     literalRules orElse identifierRules orElse binaryOpRules orElse castRules orElse
       caseExprRules orElse interpolatedStringRules orElse parenRules orElse dotRefRules orElse
-      functionApplyRules
+      functionApplyRules orElse materializeStructuralTypeRules
+  ) andThen materializeStructuralType
+
+  /**
+    * Record a structurally computed dataType in the tpe field so that tpe becomes the
+    * authoritative, per-node type record (the first step of unifying the two fields, #71 / issue
+    * #392). Applies to nodes with a structural dataType override (e.g. SingleColumn delegating to
+    * its expression) that no dedicated typing rule covers yet
+    */
+  private def materializeStructuralType(e: Expression): Expression =
+    if !e.isTyped then
+      val dt = e.dataType
+      if dt.isResolved then
+        e.tpe = dt
+    e
+
+  /**
+    * Catch-all rule so that the materialization above runs for expression classes that no dedicated
+    * typing rule matches
+    */
+  private def materializeStructuralTypeRules(using
+      ctx: Context
+  ): PartialFunction[Expression, Expression] = { case e: Expression =>
+    e
+  }
 
   /**
     * All typing rules for relations. Sets tpe field from relationType.

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperDiagnosticsTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperDiagnosticsTest.scala
@@ -14,6 +14,7 @@
 package wvlet.lang.compiler.typer
 
 import wvlet.uni.test.UniTest
+import wvlet.lang.api.{StatusCode, WvletLangException}
 import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, WorkEnv}
 
 /**
@@ -54,6 +55,15 @@ class TyperDiagnosticsTest extends UniTest:
   test("not report mismatches for unresolved operands") {
     // unknown_col cannot resolve, so the arithmetic and comparison must stay silent
     compileErrors("from [[1]] as t(id) | where unknown_col + 1 > 2") shouldBe Nil
+  }
+
+  test("fail the compilation on type errors when failOnTypeErrors is set") {
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")).withFailOnTypeErrors(true))
+    val unit     = CompilationUnit.fromWvletString("select 1 - 'a' as v")
+    val e        = intercept[WvletLangException] {
+      compiler.compileSingleUnit(unit)
+    }
+    e.statusCode shouldBe StatusCode.TYPE_ERROR
   }
 
 end TyperDiagnosticsTest


### PR DESCRIPTION
## Summary

Two steps toward the `dataType`/`tpe` unification (#71), continuing the #392 series.

### tpe as the authoritative type record

After the typing rules run on an expression, a structurally computed `dataType` (e.g. `SingleColumn` delegating to its expression) is recorded in the `tpe` field. Coverage of the `tpe` field rises from **60% to 89%** of expressions over `spec/basic`, now guarded by a third CI ratchet (≥88%). This is the precondition for removing structural `dataType` overrides one class at a time: once every node's type lives in `tpe`, the legacy field becomes derivable.

### Opt-in strict type checking

`CompilerOptions.failOnTypeErrors` turns the Typer's type-mismatch diagnostics (#1786) into compilation failures with the new `TYPE_ERROR` status code, for tools that want strict checking. The default remains warning-level reporting, so catalog-less compilation keeps working unchanged.

## Verification

`runner/test` 394 passed, `langJVM/test` 1450 passed (adds a strict-mode test), JS/Native compile clean, compile time unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)