### PR TITLE
internal: Address review feedback on the strict type-check mode

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -90,12 +90,20 @@ object Typer extends Phase("typer") with LogSupport:
           warn(s"  ${err.message} at ${err.sourceLocation(using context)}")
         }
       if context.global.compilerOptions.failOnTypeErrors then
-        val first = preScanCtx.typerErrors.head
-        throw StatusCode.TYPE_ERROR.newException(first.message, first.sourceLocation(using context))
+        preScanCtx
+          .typerErrors
+          .headOption
+          .foreach { first =>
+            throw StatusCode
+              .TYPE_ERROR
+              .newException(first.message, first.sourceLocation(using context))
+          }
 
     // Store the typed plan in CompilationUnit
     unit.resolvedPlan = typed
     unit
+
+  end run
 
   // ============================================
   // Phase 1: Pre-scanning for symbol registration

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -61,10 +61,9 @@ object TyperRules:
     * Catch-all rule so that the materialization above runs for expression classes that no dedicated
     * typing rule matches
     */
-  private def materializeStructuralTypeRules(using
-      ctx: Context
-  ): PartialFunction[Expression, Expression] = { case e: Expression =>
-    e
+  private def materializeStructuralTypeRules: PartialFunction[Expression, Expression] = {
+    case e: Expression =>
+      e
   }
 
   /**


### PR DESCRIPTION
## Summary

Addresses Gemini's two review notes on #1787:

- `headOption.foreach` instead of a guarded `.head` when raising the strict-mode `TYPE_ERROR`
- Drop the unused `ctx` parameter from `materializeStructuralTypeRules`

Verified: `runner/test` 394 passed, `langJVM/test` 1450 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)