### PR TITLE
feature: Warn on duplicate top-level definitions across files (issue #93)

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -50,6 +50,21 @@ case class GlobalContext(compilerOptions: CompilerOptions):
   // Loaded contexts for source .wv files
   private val contextTable = new ConcurrentHashMap[SourceFile, Context]().asScala
 
+  // Names already checked for duplicate top-level definitions across compilation units,
+  // and the confirmed duplicates (name -> defining file names)
+  private val duplicateCheckedNames = new ConcurrentHashMap[Name, Boolean]().asScala
+  var duplicateDefinitions: List[(Name, List[String])] = Nil
+
+  /**
+    * Record and return whether the given name still needs a duplicate-definition check. The check
+    * runs at most once per name to keep symbol lookup fast
+    */
+  def needsDuplicateCheck(name: Name): Boolean =
+    duplicateCheckedNames.putIfAbsent(name, true).isEmpty
+
+  def addDuplicateDefinition(name: Name, fileNames: List[String]): Unit =
+    duplicateDefinitions = (name, fileNames) :: duplicateDefinitions
+
   // Globally available definitions (Name and Symbols)
   var defs: GlobalDefinitions = scala.compiletime.uninitialized
 
@@ -251,6 +266,24 @@ case class Context(
         if foundSymbol.isEmpty
       do
         foundSymbol = ctx.compilationUnit.knownSymbols.find(_.name == name)
+      // The scan above takes the first match in an arbitrary unit order, so a top-level name
+      // defined in multiple files resolves nondeterministically (#93). Warn once per name
+      foundSymbol.foreach { sym =>
+        if global.needsDuplicateCheck(name) then
+          val definingFiles =
+            for
+              ctx <- global.getAllContexts.filter(_.isGlobalContext)
+              s   <- ctx.compilationUnit.knownSymbols
+              if s.name == name
+            yield ctx.compilationUnit.sourceFile.fileName
+          if definingFiles.distinct.size > 1 then
+            global.addDuplicateDefinition(name, definingFiles.distinct)
+            warn(
+              s"Duplicate top-level definition of '${name}' in ${definingFiles
+                  .distinct
+                  .mkString(", ")}; the definition in ${definingFiles.head} is used"
+            )
+      }
 
     if isContextCompilationUnit then
       trace(s"Looked up ${name} in ${compilationUnit.sourceFile.fileName} => ${foundSymbol}")

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/DuplicateDefinitionTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/DuplicateDefinitionTest.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, WorkEnv}
+
+/**
+  * Tests for detecting top-level definitions with the same name in multiple compilation units,
+  * which resolve nondeterministically through the shared global namespace (issue #93)
+  */
+class DuplicateDefinitionTest extends UniTest:
+
+  test("warn once when a model name is defined in multiple files") {
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+    val unit1    = CompilationUnit.fromWvletString("model dup_m = { from [[1]] as t1(id) }")
+    val unit2    = CompilationUnit.fromWvletString("model dup_m = { from [[2]] as t2(id) }")
+    val ref      = CompilationUnit.fromWvletString("from dup_m")
+    val result   = compiler.compileMultipleUnits(List(unit1, unit2), contextUnit = ref)
+    val dups     = result.context.global.duplicateDefinitions
+    dups.exists(_._1.name == "dup_m") shouldBe true
+  }
+
+  test("not warn for a name defined in a single file") {
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+    val unit     = CompilationUnit.fromWvletString("model single_m = { from [[1]] as t1(id) }")
+    val ref      = CompilationUnit.fromWvletString("from single_m")
+    val result   = compiler.compileMultipleUnits(List(unit), contextUnit = ref)
+    result.context.global.duplicateDefinitions.exists(_._1.name == "single_m") shouldBe false
+  }
+
+end DuplicateDefinitionTest


### PR DESCRIPTION
## Summary

A concrete #93 increment that needs no visibility-semantics decision: top-level names defined in multiple compilation units resolve through the shared global namespace in an **arbitrary unit order**, so which definition wins is nondeterministic — the collision class hit twice during the #1764 migration (spec files silently shadowing each other's `val`/`model` definitions).

Symbol lookup now detects when a resolved name is defined in more than one file and **warns once per name** (memoized, so the hot lookup path stays fast), recording the duplicates on `GlobalContext` for tools. Resolution behavior is unchanged — this is detection, not a semantics change; actual scoping rules remain the #93 design discussion.

The check proved itself immediately: it surfaced a real latent collision in the spec corpus (`person` defined in both `spec/basic/model/model1.wv` and `spec/basic/query.wv`).

## Verification

`runner/test` 394 passed (one informative duplicate warning from the corpus), `langJVM/test` 1452 passed (adds `DuplicateDefinitionTest`), JS/Native compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)