### PR TITLE
internal: Rename query.wv's person model to avoid a cross-file collision

### DIFF
--- a/spec/basic/query.wv
+++ b/spec/basic/query.wv
@@ -1,39 +1,39 @@
 -- Define a table from json file
-model person = {
+model person_q = {
   from 'person.json'
 }
 
 -- limit
-from person
+from person_q
 limit 5
 
 -- sorting
-from person
+from person_q
 order by id
 
 --- ascending order
-from person
+from person_q
 order by id asc
 
 -- sort & limit
-from person
+from person_q
 order by id desc
 limit 2
 
 
 -- limit & sort
-from person
+from person_q
 limit 2
 order by id asc
 
 -- projection
-from person
+from person_q
 select
   id,
   name
 
 -- rename column
-from person
+from person_q
 select
   person_id = id,
   person_name = name


### PR DESCRIPTION
## Summary

Follow-up to #1789: its duplicate-definition warning surfaced that both `spec/basic/query.wv` and `spec/basic/model/model1.wv` define a top-level model named `person`, resolving in arbitrary unit order through the shared global namespace (the #93 collision class that caused spec flakiness twice during the #1764 migration). Renames `query.wv`'s model to `person_q`.

Verified: `runner/test` 394 passed with no duplicate-definition warnings, `langJVM/test` full pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)