### PR TITLE
internal: Remove a redundant local import (#1791 review)

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -56,9 +56,7 @@ case class GlobalContext(compilerOptions: CompilerOptions):
   private val duplicateDefinitionQueue =
     new java.util.concurrent.ConcurrentLinkedQueue[(Name, List[String])]()
 
-  def duplicateDefinitions: List[(Name, List[String])] =
-    import scala.jdk.CollectionConverters.*
-    duplicateDefinitionQueue.asScala.toList
+  def duplicateDefinitions: List[(Name, List[String])] = duplicateDefinitionQueue.asScala.toList
 
   /**
     * Record and return whether the given name still needs a duplicate-definition check. The check


### PR DESCRIPTION
Addresses the remaining review note on #1791: `scala.jdk.CollectionConverters.*` is already imported at the top of Context.scala.

🤖 Generated with [Claude Code](https://claude.com/claude-code)