### PR TITLE
internal: Resolve global symbols in a deterministic unit order (issue #93)

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -68,6 +68,17 @@ case class GlobalContext(compilerOptions: CompilerOptions):
   def addDuplicateDefinition(name: Name, fileNames: List[String]): Unit = duplicateDefinitionQueue
     .add(name -> fileNames)
 
+  // Contexts sorted by source file name, cached until a new compilation unit is loaded, so
+  // that global symbol lookup stays fast while scanning units in a deterministic order
+  private var sortedContextCache: (Int, List[Context]) = (0, Nil)
+
+  def getAllContextsSorted: List[Context] =
+    val size = contextTable.size
+    if sortedContextCache._1 != size then
+      sortedContextCache =
+        (size, contextTable.values.toList.sortBy(_.compilationUnit.sourceFile.fileName))
+    sortedContextCache._2
+
   // Globally available definitions (Name and Symbols)
   var defs: GlobalDefinitions = scala.compiletime.uninitialized
 
@@ -263,14 +274,15 @@ case class Context(
       }
 
     if foundSymbol.isEmpty then
-      // Search global symbols
+      // Search global symbols. Contexts are scanned in source file name order so that a name
+      // defined in multiple files resolves deterministically (#93)
       for
-        ctx <- global.getAllContexts.filter(_.isGlobalContext)
-        if foundSymbol.isEmpty
+        ctx <- global.getAllContextsSorted
+        if foundSymbol.isEmpty && ctx.isGlobalContext
       do
         foundSymbol = ctx.compilationUnit.knownSymbols.find(_.name == name)
-      // The scan above takes the first match in an arbitrary unit order, so a top-level name
-      // defined in multiple files resolves nondeterministically (#93). Warn once per name
+      // A top-level name defined in multiple files still shadows the later definitions
+      // (#93). Warn once per name
       foundSymbol.foreach { sym =>
         if global.needsDuplicateCheck(name) then
           val definingFiles =


### PR DESCRIPTION
## Summary

Second #93 increment (after #1789's duplicate-definition warning). Global symbol lookup scanned compilation units in **hash-map order**, so a top-level name defined in multiple files resolved to an arbitrary definition that could change between runs — the root of the spec flakiness observed during the #1764 migration.

Units are now scanned in **source file name order**, with the sorted list cached until a new unit is loaded (an uncached per-lookup sort cost +43% compile time; with the cache, the corpus compile stays at ~90ms median).

Together with #1789, cross-file collisions are now both **visible** (warned once per name) and **stable** (deterministic winner). Actual scoping semantics remain the open #93 design discussion.

## Verification

`runner/test` 394 passed, `langJVM/test` 1452 passed, JS/Native compile clean, `TyperBench` median unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)