### PR TITLE
internal: Fix visibility of the sorted-context cache and warning order

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -70,14 +70,18 @@ case class GlobalContext(compilerOptions: CompilerOptions):
 
   // Contexts sorted by source file name, cached until a new compilation unit is loaded, so
   // that global symbol lookup stays fast while scanning units in a deterministic order
-  private var sortedContextCache: (Int, List[Context]) = (0, Nil)
+  private val sortedContextCache =
+    new java.util.concurrent.atomic.AtomicReference[(Int, List[Context])]((0, Nil))
 
   def getAllContextsSorted: List[Context] =
-    val size = contextTable.size
-    if sortedContextCache._1 != size then
-      sortedContextCache =
-        (size, contextTable.values.toList.sortBy(_.compilationUnit.sourceFile.fileName))
-    sortedContextCache._2
+    val size   = contextTable.size
+    val cached = sortedContextCache.get()
+    if cached._1 == size then
+      cached._2
+    else
+      val sorted = contextTable.values.toList.sortBy(_.compilationUnit.sourceFile.fileName)
+      sortedContextCache.set((size, sorted))
+      sorted
 
   // Globally available definitions (Name and Symbols)
   var defs: GlobalDefinitions = scala.compiletime.uninitialized
@@ -288,8 +292,9 @@ case class Context(
           val definingFiles =
             (
               for
-                ctx <- global.getAllContexts.filter(_.isGlobalContext)
-                s   <- ctx.compilationUnit.knownSymbols
+                ctx <- global.getAllContextsSorted
+                if ctx.isGlobalContext
+                s <- ctx.compilationUnit.knownSymbols
                 if s.name == name
               yield ctx.compilationUnit.sourceFile.fileName
             ).distinct


### PR DESCRIPTION
Addresses Gemini's review notes on #1793:

- The sorted-context cache is held in an `AtomicReference` for cross-thread visibility (concurrent test execution / language-server usage)
- The duplicate-definition warning collects defining files from the same sorted view, so the warning names the definition that actually wins

Verified: `langJVM/test` full pass, `TyperBench` median unchanged (~90ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)