### PR TITLE
feature: Scope named-package definitions to their package (issue #93)

### DIFF
--- a/website/docs/development/compiler-internals.md
+++ b/website/docs/development/compiler-internals.md
@@ -138,7 +138,11 @@ This phase also establishes scopes for packages, types, and methods so later pas
 - Definitions store type on their `SymbolInfo` (authoritative for `ModelDef`, seeded for `ValDef`).
 - Genuine type mismatches are collected as per-unit diagnostics (`CompilationUnit.typerErrors`); `CompilerOptions.failOnTypeErrors` turns them into compile failures.
 
-Ongoing work: unifying `dataType`/`tpe` into a single field (issue #71) and package-level scope management (issue #93); see issue #392 for the overall typing roadmap.
+**Name visibility (issue #93)**
+- Units declaring a named `package` are visible only within that package or through an `import`; standard-library presets and units without a package declaration are globally visible.
+- A top-level name defined in multiple visible files resolves deterministically (source file name order) and reports a duplicate-definition warning.
+
+Ongoing work: unifying `dataType`/`tpe` into a single field (issue #71); see issue #392 for the overall typing roadmap.
 
 ### 4) Normalization / Optimizations (ongoing)
 Tree rewrites are expressed via `RewriteRule` and applied with the `transform*` APIs on plans/exprs. Typical examples:

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
@@ -44,6 +44,18 @@ case class CompilationUnit(sourceFile: SourceFile, isPreset: Boolean = false)
 
   // Untyped plan tree
   var unresolvedPlan: LogicalPlan = LogicalPlan.empty
+
+  /**
+    * The package this unit belongs to, or an empty string when the unit has no package declaration
+    * (the shared default package)
+    */
+  def packageName: String =
+    unresolvedPlan match
+      case p: wvlet.lang.model.plan.PackageDef if p.name.nonEmpty =>
+        p.name.fullName
+      case _ =>
+        ""
+
   // Fully-typed plan tree
   var resolvedPlan: LogicalPlan        = LogicalPlan.empty
   var modelDependencies: DependencyDAG = DependencyDAG.empty

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -282,10 +282,19 @@ case class Context(
 
     if foundSymbol.isEmpty then
       // Search global symbols. Contexts are scanned in source file name order so that a name
-      // defined in multiple files resolves deterministically (#93)
+      // defined in multiple files resolves deterministically, and units in a named package are
+      // visible only within that package or through an import (#93). Preset (standard library)
+      // units and units without a package declaration stay globally visible
+      val currentPackage                                = compilationUnit.packageName
+      def isVisibleUnit(unit: CompilationUnit): Boolean =
+        unit.isPreset || unit.packageName.isEmpty || unit.packageName == currentPackage ||
+          importDefs.exists { i =>
+            val ref = i.importRef.fullName
+            ref == unit.packageName || ref.startsWith(s"${unit.packageName}.")
+          }
       for
         ctx <- global.getAllContextsSorted
-        if foundSymbol.isEmpty && ctx.isGlobalContext
+        if foundSymbol.isEmpty && ctx.isGlobalContext && isVisibleUnit(ctx.compilationUnit)
       do
         foundSymbol = ctx.compilationUnit.knownSymbols.find(_.name == name)
       // A top-level name defined in multiple files still shadows the later definitions
@@ -296,7 +305,7 @@ case class Context(
             (
               for
                 ctx <- global.getAllContextsSorted
-                if ctx.isGlobalContext
+                if ctx.isGlobalContext && isVisibleUnit(ctx.compilationUnit)
                 s <- ctx.compilationUnit.knownSymbols
                 if s.name == name
               yield ctx.compilationUnit.sourceFile.fileName
@@ -309,6 +318,7 @@ case class Context(
                 )}; the definition in ${definingFiles.head} is used"
             )
       }
+    end if
 
     if isContextCompilationUnit then
       trace(s"Looked up ${name} in ${compilationUnit.sourceFile.fileName} => ${foundSymbol}")

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/PackageScopeTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/PackageScopeTest.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, WorkEnv}
+import wvlet.lang.model.plan.Relation
+
+/**
+  * Tests for package-level visibility of top-level definitions (issue #93): units in a named
+  * package are visible only within that package or through an import, while units without a package
+  * declaration stay globally visible
+  */
+class PackageScopeTest extends UniTest:
+
+  private def compileRef(defs: List[String], ref: String): CompilationUnit =
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+    val refUnit  = CompilationUnit.fromWvletString(ref)
+    compiler.compileMultipleUnits(defs.map(CompilationUnit.fromWvletString), contextUnit = refUnit)
+    refUnit
+
+  private def resolvedRelation(unit: CompilationUnit): Boolean =
+    var resolved = false
+    unit
+      .resolvedPlan
+      .traverse {
+        case r: Relation if r.relationType.isResolved =>
+          resolved = true
+      }
+    resolved
+
+  test("share definitions between units of the same package") {
+    val unit = compileRef(
+      List("package scope_a\nmodel pkg_m1 = { from [[1]] as t(id) }"),
+      "package scope_a\nfrom pkg_m1"
+    )
+    resolvedRelation(unit) shouldBe true
+  }
+
+  test("hide a named package's definitions from other packages") {
+    val unit = compileRef(
+      List("package scope_b\nmodel pkg_m2 = { from [[1]] as t(id) }"),
+      "package scope_other\nfrom pkg_m2"
+    )
+    resolvedRelation(unit) shouldBe false
+  }
+
+  test("make a named package's definitions visible through an import") {
+    val unit = compileRef(
+      List("package scope_c\nmodel pkg_m3 = { from [[1]] as t(id) }"),
+      // the val between the import and the query avoids the import's optional
+      // `from "source"` clause consuming the query's from keyword
+      "import scope_c.*\nval one = 1\nfrom pkg_m3"
+    )
+    resolvedRelation(unit) shouldBe true
+  }
+
+  test("keep units without a package declaration globally visible") {
+    val unit = compileRef(
+      List("model pkg_m4 = { from [[1]] as t(id) }"),
+      "package scope_d\nfrom pkg_m4"
+    )
+    resolvedRelation(unit) shouldBe true
+  }
+
+end PackageScopeTest


### PR DESCRIPTION
## Summary

Implements package-level name visibility for issue #93, following dotc's package scoping, and completing the #93 series (#1789 duplicate warning, #1793 deterministic order):

- Top-level definitions of a unit that declares `package X` are visible **only within `X`** or through an `import X.*` / `import X.name`.
- **Standard-library presets and units without a package declaration stay globally visible** — the common workflow of referencing models across plain `.wv` files is unchanged; declaring a package is the opt-in to isolation.
- The duplicate-definition warning considers only visible units, so same-named definitions in *different* packages are correctly not flagged.
- Semantics documented in the compiler-internals page.

`PackageScopeTest` locks the four behaviors (same-package sharing, cross-package hiding, import visibility, default-package sharing).

## Verification

`runner/test` 394 passed (incl. the `package cdp` spec suite), `langJVM/test` 1456 passed, JS/Native compile clean, compile time unchanged (~93ms median).

🤖 Generated with [Claude Code](https://claude.com/claude-code)