### PR TITLE
internal: Cache the unit package name for the symbol lookup hot path

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
@@ -45,16 +45,29 @@ case class CompilationUnit(sourceFile: SourceFile, isPreset: Boolean = false)
   // Untyped plan tree
   var unresolvedPlan: LogicalPlan = LogicalPlan.empty
 
+  // Cached after parsing; symbol lookup reads this on a hot path
+  private var cachedPackageName: String = null
+
   /**
     * The package this unit belongs to, or an empty string when the unit has no package declaration
     * (the shared default package)
     */
   def packageName: String =
-    unresolvedPlan match
-      case p: wvlet.lang.model.plan.PackageDef if p.name.nonEmpty =>
-        p.name.fullName
-      case _ =>
-        ""
+    if cachedPackageName != null then
+      cachedPackageName
+    else
+      unresolvedPlan match
+        case p: wvlet.lang.model.plan.PackageDef =>
+          val name =
+            if p.name.nonEmpty then
+              p.name.fullName
+            else
+              ""
+          cachedPackageName = name
+          name
+        case _ =>
+          // The unit is not parsed yet, so do not cache
+          ""
 
   // Fully-typed plan tree
   var resolvedPlan: LogicalPlan        = LogicalPlan.empty

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -285,13 +285,13 @@ case class Context(
       // defined in multiple files resolves deterministically, and units in a named package are
       // visible only within that package or through an import (#93). Preset (standard library)
       // units and units without a package declaration stay globally visible
-      val currentPackage                                = compilationUnit.packageName
+      val currentPackage = compilationUnit.packageName
+      // Import references are materialized once per lookup; most units have no imports
+      val importRefs                                    = importDefs.map(_.importRef.fullName)
       def isVisibleUnit(unit: CompilationUnit): Boolean =
-        unit.isPreset || unit.packageName.isEmpty || unit.packageName == currentPackage ||
-          importDefs.exists { i =>
-            val ref = i.importRef.fullName
-            ref == unit.packageName || ref.startsWith(s"${unit.packageName}.")
-          }
+        val pkg = unit.packageName
+        pkg.isEmpty || pkg == currentPackage || unit.isPreset ||
+        importRefs.exists(ref => ref == pkg || ref.startsWith(s"${pkg}."))
       for
         ctx <- global.getAllContextsSorted
         if foundSymbol.isEmpty && ctx.isGlobalContext && isVisibleUnit(ctx.compilationUnit)


### PR DESCRIPTION
Addresses Gemini's performance notes on #1798:

- `CompilationUnit.packageName` is computed once after parsing (cached) instead of pattern-matching the plan and rebuilding the name string on every lookup
- Import reference strings are materialized once per lookup, and the cheapest visibility checks run first

Verified: `PackageScopeTest`/`DuplicateDefinitionTest` pass, `langJVM/test` and `runner/test` full pass, `TyperBench` ~89ms median.

🤖 Generated with [Claude Code](https://claude.com/claude-code)