### PR TITLE
internal: Invalidate the package name cache on unit reload

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
@@ -106,6 +106,8 @@ case class CompilationUnit(sourceFile: SourceFile, isPreset: Boolean = false)
     finishedPhases = Set.empty
     lastError = None
     lastCompiledAt = None
+    // The unit will be re-parsed, so the package declaration may change
+    cachedPackageName = null
     this
 
   def text(span: Span): String =

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -290,8 +290,11 @@ case class Context(
       val importRefs                                    = importDefs.map(_.importRef.fullName)
       def isVisibleUnit(unit: CompilationUnit): Boolean =
         val pkg = unit.packageName
-        pkg.isEmpty || pkg == currentPackage || unit.isPreset ||
-        importRefs.exists(ref => ref == pkg || ref.startsWith(s"${pkg}."))
+        pkg.isEmpty || pkg == currentPackage || unit.isPreset || {
+          // Build the package prefix once per unit, not per import reference
+          val pkgPrefix = s"${pkg}."
+          importRefs.exists(ref => ref == pkg || ref.startsWith(pkgPrefix))
+        }
       for
         ctx <- global.getAllContextsSorted
         if foundSymbol.isEmpty && ctx.isGlobalContext && isVisibleUnit(ctx.compilationUnit)


### PR DESCRIPTION
Addresses Gemini's notes on #1799: `reload()` resets the cached package name (the unit is re-parsed and its package declaration may change, e.g. during incremental compilation), and the package prefix string is built once per unit instead of per import reference.

Verified: `langJVM/test` full pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)