### PR TITLE
internal: Reset all derived compilation state on unit reload

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
@@ -106,6 +106,16 @@ case class CompilationUnit(sourceFile: SourceFile, isPreset: Boolean = false)
     finishedPhases = Set.empty
     lastError = None
     lastCompiledAt = None
+    // Reset all state derived from the previous compilation. In particular, knownSymbols
+    // accumulates via enter(), so keeping it would duplicate symbols across incremental
+    // compilation runs
+    unresolvedPlan = LogicalPlan.empty
+    resolvedPlan = LogicalPlan.empty
+    modelDependencies = DependencyDAG.empty
+    executionPlan = ExecutionPlan.empty
+    knownSymbols = List.empty
+    typerErrors = Nil
+    subscriptionPlans = List.empty
     // The unit will be re-parsed, so the package declaration may change
     cachedPackageName = null
     this


### PR DESCRIPTION
Addresses Gemini's note on #1800 — a genuine pre-existing gap: `reload()` only cleared phase bookkeeping, leaving `unresolvedPlan`/`resolvedPlan`/`knownSymbols`/`typerErrors`/`modelDependencies`/`executionPlan`/`subscriptionPlans` from the previous compilation. `knownSymbols` in particular accumulates via `enter()`, so repeated incremental compilations duplicated symbols and grew memory.

Verified: `langJVM/test` 1456 passed, `runner/test` 394 passed, `server/test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)