### PR TITLE
internal: Constructor-assigned types; fix flaky model-expansion StackOverflow; robust type diagnostics

### DIFF
--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/codegen/MultiUnitModelExpansionTest.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/codegen/MultiUnitModelExpansionTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.codegen
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.{CompilationUnit, Compiler, CompilerOptions, WorkEnv}
+
+import java.io.File
+
+/**
+  * Regression test for nested model expansion in a multi-unit compilation (the REPL scenario with a
+  * working folder). The referenced model's unit may not be fully typed when SQL generation runs, so
+  * nested model references can appear only after the body is resolved; a missed nested reference
+  * previously sent the SQL printer into unbounded recursion (StackOverflowError, flaky on CI)
+  */
+class MultiUnitModelExpansionTest extends UniTest:
+
+  test("expand nested model references compiled together with their defining units") {
+    val dir      = File("spec/basic/model")
+    val files    = dir.listFiles().filter(_.getName.endsWith(".wv")).map(_.getPath).toList.sorted
+    val compiler = Compiler(
+      CompilerOptions(sourceFolders = List(dir.getPath), workEnv = WorkEnv(dir.getPath))
+    )
+    val units = files.map(p => CompilationUnit.fromFile(p))
+    val ref   = CompilationUnit.fromWvletString("from person_filter(2)")
+    val res   = compiler.compileMultipleUnits(units, contextUnit = ref)
+    val sql   = GenSQL.generateSQL(ref)(using res.context)
+    sql shouldContain "person.json"
+    sql shouldContain "age_group"
+    // The nested models must be fully expanded away
+    sql shouldNotContain "person_filter"
+    sql shouldNotContain "person_with_age_group"
+  }
+
+end MultiUnitModelExpansionTest

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -442,9 +442,12 @@ object GenSQL extends Phase("generate-sql"):
             newCtx.scope.add(argName, argSym)
           }
 
-        // Substitute the model arguments in the model body, and expand nested model references
+        // Resolve the model body first so that nested model references are concrete ModelScans
+        // regardless of how far the defining unit was compiled, then substitute the model
+        // arguments and expand those nested references
         // TODO: How to propagate comments in the model Query body?
-        expandRelation(md.child.body)(using newCtx)
+        val resolvedBody = Typer.resolveRelation(md.child.body)(using newCtx)
+        expandRelation(resolvedBody)(using newCtx)
       case other =>
         warn(s"Unknown model tree for ${m.name}: ${other}")
         m

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1098,6 +1098,12 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
           )
         )
         selectAll(lateralViewExpr, block)
+      case m: ModelScan =>
+        // An unexpanded model reference must not reach the generic fallback below, which would
+        // re-dispatch the same leaf node forever. Print the model name as a table reference;
+        // executing the SQL then reports a clear missing-table error
+        warn(s"Unexpanded model reference in SQL generation: ${m.name.fullName}")
+        selectAll(text(m.name.fullName), block)
       case r: Relation =>
         selectExpr(
           // Start a new nested SQLBlock

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -21,6 +21,8 @@ import wvlet.lang.compiler.Phase
 import wvlet.lang.compiler.analyzer.AggregationResolver
 import wvlet.lang.compiler.analyzer.FunctionInliner
 import wvlet.lang.compiler.analyzer.RelationRefResolver
+import wvlet.lang.model.expr.ArithmeticBinaryExpr
+import wvlet.lang.model.expr.ConditionalExpression
 import wvlet.lang.model.expr.ContextInputRef
 import wvlet.lang.model.expr.DotRef
 import wvlet.lang.model.expr.FunctionApply
@@ -80,6 +82,11 @@ object Typer extends Phase("typer") with LogSupport:
     // Phase 2: Type the plan bottom-up with context-aware scope management
     val typed = typePlan(unit.unresolvedPlan)(using preScanCtx)
 
+    // Validate the settled tree: only mismatches that survived the typing fixpoint count,
+    // so intermediate states (pre-inlining aggregation shorthands, unresolved operands) do
+    // not produce false diagnostics
+    collectTypeMismatches(typed)(using preScanCtx)
+
     // Attach the collected type errors to the unit as diagnostics and report them
     unit.typerErrors = preScanCtx.typerErrors
     if preScanCtx.hasTyperErrors then
@@ -104,6 +111,47 @@ object Typer extends Phase("typer") with LogSupport:
     unit
 
   end run
+
+  /**
+    * Returns true for a concrete scalar SQL type. Type-mismatch diagnostics only fire when both
+    * operands are concrete scalars: aggregation contexts type their columns as virtual arrays by
+    * design, and unbound generic parameters can slip through isResolved, so anything beyond plain
+    * scalars would produce false diagnostics
+    */
+  private def isConcreteScalar(t: DataType): Boolean =
+    t match
+      case DataType.IntType | DataType.LongType | DataType.FloatType | DataType.DoubleType |
+          DataType.StringType | DataType.BooleanType | DataType.NullType | DataType.JsonType |
+          DataType.DateType =>
+        true
+      case d: DataType.DecimalType =>
+        d.isResolved
+      case t: DataType.TimestampType =>
+        true
+      case _ =>
+        false
+
+  /**
+    * Report type mismatches remaining in the fully typed tree. A binary operation whose result type
+    * is an ErrorType while both operand types are concrete scalars is a genuine user error; error
+    * results over unresolved or virtual operand types are deferred states, not diagnostics
+    */
+  private def collectTypeMismatches(plan: LogicalPlan)(using ctx: Context): Unit = plan
+    .traverseExpressions {
+      case op: ArithmeticBinaryExpr if op.tpe.isInstanceOf[Type.ErrorType] =>
+        if isConcreteScalar(op.left.dataType) && isConcreteScalar(op.right.dataType) then
+          ctx.addTyperError(TypeMismatch(op.left.dataType, op.right.dataType, op))
+      case op: ConditionalExpression if op.tpe.isInstanceOf[Type.ErrorType] =>
+        val types = op.children.map(_.dataType).toList
+        if types.nonEmpty && types.forall(isConcreteScalar) then
+          ctx.addTyperError(
+            TypeMismatch(
+              types.headOption.getOrElse(DataType.UnknownType),
+              types.lastOption.getOrElse(DataType.UnknownType),
+              op
+            )
+          )
+    }
 
   // ============================================
   // Phase 1: Pre-scanning for symbol registration

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -182,6 +182,11 @@ object TyperRules:
           // Operands not typed yet - defer
           case (_, NoType, _) | (_, _, NoType) =>
             NoType
+          // Defer when either operand type is not fully resolved yet
+          case (_, l: DataType, _) if !l.isResolved =>
+            NoType
+          case (_, _, r: DataType) if !r.isResolved =>
+            NoType
 
           // Propagate operand errors
           case (_, e: ErrorType, _) =>
@@ -191,7 +196,6 @@ object TyperRules:
 
           // Type error between two resolved, incompatible operand types
           case _ =>
-            ctx.addTyperError(TypeMismatch(leftTpe, rightTpe, op))
             ErrorType(s"Type error in ${op.exprType}: $leftTpe ${op.exprType} $rightTpe")
 
       op
@@ -231,6 +235,10 @@ object TyperRules:
           // NoType means untyped yet - allow it
           case (NoType, _) | (_, NoType) =>
             BooleanType
+          // Defer when either operand type is not fully resolved yet (e.g. unknown columns,
+          // unbound generic type parameters, or pre-inlining aggregation shorthands)
+          case (l, r) if !l.isResolved || !r.isResolved =>
+            BooleanType
           // Propagate errors
           case (e: ErrorType, _) =>
             e
@@ -238,7 +246,6 @@ object TyperRules:
             e
           // Type mismatch
           case _ =>
-            ctx.addTyperError(TypeMismatch(leftTpe, rightTpe, op))
             ErrorType(s"Cannot compare $leftTpe < $rightTpe: incompatible types")
       op
 
@@ -258,12 +265,15 @@ object TyperRules:
             BooleanType
           case (NoType, _) | (_, NoType) =>
             BooleanType
+          // Defer when either operand type is not fully resolved yet (e.g. unknown columns,
+          // unbound generic type parameters, or pre-inlining aggregation shorthands)
+          case (l, r) if !l.isResolved || !r.isResolved =>
+            BooleanType
           case (e: ErrorType, _) =>
             e
           case (_, e: ErrorType) =>
             e
           case _ =>
-            ctx.addTyperError(TypeMismatch(leftTpe, rightTpe, op))
             ErrorType(s"Cannot compare $leftTpe <= $rightTpe: incompatible types")
       op
 
@@ -283,12 +293,15 @@ object TyperRules:
             BooleanType
           case (NoType, _) | (_, NoType) =>
             BooleanType
+          // Defer when either operand type is not fully resolved yet (e.g. unknown columns,
+          // unbound generic type parameters, or pre-inlining aggregation shorthands)
+          case (l, r) if !l.isResolved || !r.isResolved =>
+            BooleanType
           case (e: ErrorType, _) =>
             e
           case (_, e: ErrorType) =>
             e
           case _ =>
-            ctx.addTyperError(TypeMismatch(leftTpe, rightTpe, op))
             ErrorType(s"Cannot compare $leftTpe > $rightTpe: incompatible types")
       op
 
@@ -308,12 +321,15 @@ object TyperRules:
             BooleanType
           case (NoType, _) | (_, NoType) =>
             BooleanType
+          // Defer when either operand type is not fully resolved yet (e.g. unknown columns,
+          // unbound generic type parameters, or pre-inlining aggregation shorthands)
+          case (l, r) if !l.isResolved || !r.isResolved =>
+            BooleanType
           case (e: ErrorType, _) =>
             e
           case (_, e: ErrorType) =>
             e
           case _ =>
-            ctx.addTyperError(TypeMismatch(leftTpe, rightTpe, op))
             ErrorType(s"Cannot compare $leftTpe >= $rightTpe: incompatible types")
       op
 
@@ -329,12 +345,15 @@ object TyperRules:
           case (NoType, _) | (_, NoType) =>
             // Operands not typed yet - defer
             NoType
+          case (l: DataType, _) if !l.isResolved =>
+            NoType
+          case (_, r: DataType) if !r.isResolved =>
+            NoType
           case (e: ErrorType, _) =>
             e
           case (_, e: ErrorType) =>
             e
           case _ =>
-            ctx.addTyperError(TypeMismatch(BooleanType, leftTpe, op))
             ErrorType(s"Type error in AND: expected boolean operands, got $leftTpe AND $rightTpe")
 
       op
@@ -350,12 +369,15 @@ object TyperRules:
           case (NoType, _) | (_, NoType) =>
             // Operands not typed yet - defer
             NoType
+          case (l: DataType, _) if !l.isResolved =>
+            NoType
+          case (_, r: DataType) if !r.isResolved =>
+            NoType
           case (e: ErrorType, _) =>
             e
           case (_, e: ErrorType) =>
             e
           case _ =>
-            ctx.addTyperError(TypeMismatch(BooleanType, leftTpe, op))
             ErrorType(s"Type error in OR: expected boolean operands, got $leftTpe OR $rightTpe")
 
       op

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
@@ -42,8 +42,7 @@ case class TypedExpression(child: Expression, targetType: DataType, span: Span)
     extends UnaryExpression:
   override def dataType: DataType = targetType
 
-case class TableAlias(name: NameExpr, alias: NameExpr, span: Span) extends LeafExpression:
-  override def dataType: DataType = DataType.UnknownType
+case class TableAlias(name: NameExpr, alias: NameExpr, span: Span) extends LeafExpression
 
 /**
   * variable name, function name, type name, etc. The name might have a qualifier.
@@ -352,7 +351,8 @@ case class ListExpr(exprs: List[Expression], span: Span) extends Expression:
 
 // Conditional expression
 sealed trait ConditionalExpression extends Expression:
-  override def dataType: DataType = DataType.BooleanType
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.BooleanType
 
 case class NoOp(span: Span) extends ConditionalExpression with LeafExpression
 
@@ -522,7 +522,8 @@ enum TestType(val expr: String):
 
 case class ShouldExpr(testType: TestType, left: Expression, right: Expression, span: Span)
     extends Expression:
-  override def dataType: DataType        = DataType.BooleanType
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.BooleanType
   override def children: Seq[Expression] = Seq(left, right)
 
 // Arithmetic expr
@@ -672,11 +673,13 @@ sealed trait Literal extends Expression:
   def unquotedValue: String = stringValue
 
 case class NullLiteral(span: Span) extends Literal with LeafExpression:
-  override def dataType: DataType  = DataType.NullType
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.NullType
   override def stringValue: String = "null"
 
 sealed trait BooleanLiteral extends Literal:
-  override def dataType: DataType = DataType.BooleanType
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.BooleanType
   def booleanValue: Boolean
 
 case class TrueLiteral(span: Span) extends BooleanLiteral with LeafExpression:
@@ -688,7 +691,8 @@ case class FalseLiteral(span: Span) extends BooleanLiteral with LeafExpression:
   override def booleanValue: Boolean = false
 
 sealed trait StringLiteral extends Literal with LeafExpression:
-  override def dataType: DataType = DataType.StringType
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.StringType
 
 object StringLiteral:
   def fromString(s: String, span: Span = NoSpan): StringLiteral =
@@ -728,19 +732,23 @@ case class TripleQuoteString(override val unquotedValue: String, span: Span) ext
     parts.mkString(" || ")
 
 case class StringPart(value: String, span: Span) extends Literal with LeafExpression:
-  override def dataType: DataType  = DataType.StringType
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.StringType
   override def stringValue: String = value
 
 case class JsonLiteral(value: String, span: Span) extends Literal with LeafExpression:
-  override def dataType: DataType  = DataType.JsonType
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.JsonType
   override def stringValue: String = value
 
 case class TimeLiteral(value: String, span: Span) extends Literal with LeafExpression:
-  override def dataType: DataType  = DataType.TimestampType(TimestampField.TIME, false)
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.TimestampType(TimestampField.TIME, false)
   override def stringValue: String = value
 
 case class TimestampLiteral(value: String, span: Span) extends Literal with LeafExpression:
-  override def dataType: DataType  = DataType.TimestampType(TimestampField.TIMESTAMP, false)
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.TimestampType(TimestampField.TIMESTAMP, false)
   override def stringValue: String = value
 
 case class DecimalLiteral(value: String, override val stringValue: String, span: Span)
@@ -761,20 +769,23 @@ case class DecimalLiteral(value: String, override val stringValue: String, span:
         )
 
 case class CharLiteral(value: String, span: Span) extends Literal with LeafExpression:
-  override def dataType: DataType  = DataType.CharType(None)
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.CharType(None)
   override def stringValue: String = value
 
 case class DoubleLiteral(value: Double, override val stringValue: String, span: Span)
     extends Literal
     with LeafExpression:
-  override def dataType: DataType = DataType.DoubleType
-  override def sqlExpr: String    = value.toString
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.DoubleType
+  override def sqlExpr: String = value.toString
 
 case class LongLiteral(value: Long, override val stringValue: String, span: Span)
     extends Literal
     with LeafExpression:
-  override def dataType: DataType = DataType.LongType
-  override def sqlExpr: String    = value.toString
+  // Statically known type, assigned at construction (issue #71)
+  this.tpe = DataType.LongType
+  override def sqlExpr: String = value.toString
 
 case class GenericLiteral(literalType: DataType, value: Literal, span: Span)
     extends Literal
@@ -990,8 +1001,7 @@ case class GroupingSets(groupingSets: List[List[GroupingKey]], span: Span) exten
     .flatMap(_.headOption)
     .getOrElse(NameExpr.EmptyName)
 
-  override def dataType: DataType = DataType.UnknownType
-  override def toString: String   =
+  override def toString: String =
     s"GROUPING SETS(${groupingSets.map(set => s"(${set.mkString(",")})").mkString(",")})"
 
   override lazy val resolved: Boolean    = groupingSets.forall(_.forall(_.resolved))
@@ -1001,7 +1011,6 @@ case class Cube(groupingKeys: List[GroupingKey], span: Span) extends GroupingKey
   override def name: NameExpr            = NameExpr.EmptyName
   override def index: Option[Int]        = None
   override def child: Expression         = groupingKeys.headOption.getOrElse(NameExpr.EmptyName)
-  override def dataType: DataType        = DataType.UnknownType
   override def toString: String          = s"CUBE(${groupingKeys.mkString(",")})"
   override lazy val resolved: Boolean    = groupingKeys.forall(_.resolved)
   override def children: Seq[Expression] = groupingKeys
@@ -1010,7 +1019,6 @@ case class Rollup(groupingKeys: List[GroupingKey], span: Span) extends GroupingK
   override def name: NameExpr            = NameExpr.EmptyName
   override def index: Option[Int]        = None
   override def child: Expression         = groupingKeys.headOption.getOrElse(NameExpr.EmptyName)
-  override def dataType: DataType        = DataType.UnknownType
   override def toString: String          = s"ROLLUP(${groupingKeys.mkString(",")})"
   override lazy val resolved: Boolean    = groupingKeys.forall(_.resolved)
   override def children: Seq[Expression] = groupingKeys

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperTest.scala
@@ -54,12 +54,12 @@ class TyperTest extends UniTest:
   test("tpe field should be accessible on all SyntaxTreeNode instances"):
     val lit = LongLiteral(42, "42", Span.NoSpan)
 
-    // Should initially have NoType
-    lit.tpe.shouldBe(NoType)
+    // Literals carry their statically known type from construction (issue #71)
+    lit.tpe.shouldBe(LongType)
 
     // Should be settable
-    lit.tpe = LongType
-    lit.tpe.shouldBe(LongType)
+    lit.tpe = DataType.DoubleType
+    lit.tpe.shouldBe(DataType.DoubleType)
 
     // isTyped should work
     lit.isTyped.shouldBe(true)


### PR DESCRIPTION
## Summary

Three commits (the first was already under review; the CI hang it hit led to finding the other two):

### 1. Constructor-assigned static types (issue #71, first slice)

Expressions whose type is a static constant (literals, boolean predicates, string/timestamp variants) assign `tpe` at construction; 13 structural `dataType` overrides removed, 3 `UnknownType` overrides deleted. Follows dotc's model where literal trees carry their constant type from the parser.

### 2. Fix: flaky StackOverflow in model expansion (the "stuck CI" hangs)

This PR's CI run hung with looping `StackOverflowError`s in the REPL test (`from person_filter(2)`). Root cause is a **long-standing bug (reproduced back to at least June 20)**, now deterministic via `MultiUnitModelExpansionTest`:

- `GenSQL.expandModelScan` expanded a model body **before resolving it**. When the defining unit wasn't fully typed yet (a compilation-order condition — hence CI/local nondeterminism), nested model references were still `TableRef`s during the expansion pass and only became `ModelScan`s in the post-expansion re-resolution.
- The SQL printer has **no case for `ModelScan`** — its generic fallback re-dispatched the same leaf node forever.

Fixes: resolve the model body before expanding, plus a terminating `ModelScan` printer case as a safety net. This also explains today's earlier "stuck" CI run (#1781's first attempt) and likely older flaky hangs.

### 3. Fix: type-mismatch diagnostics only for settled, concrete scalars

The rule-time reporting from #1786 produced false diagnostics across TPC-H (mid-fixpoint captures before aggregation inlining, virtual array-typed agg columns, unbound generics). Mismatches are now collected in a **final validation pass** over the fully typed tree, only when the residual type is an `ErrorType` and every operand is a concrete scalar. Rules defer (`NoType`) on unresolved operands.

## Verification

`langJVM/test` 1459 passed, `runner/test` 394 passed, `cli/test` full pass with **zero** StackOverflow and **zero** typing-error warnings across the TPC-H compile corpus, JS/Native compile clean, coverage ratchets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)