### PR TITLE
internal: Add lazy SymbolCompleter infrastructure and make SymbolInfo immutable (issue #71)

### DIFF
--- a/wvlet-api/src/main/scala/wvlet/lang/api/StatusCode.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/StatusCode.scala
@@ -48,6 +48,7 @@ enum StatusCode(statusType: StatusType):
   case PARTIAL_QUERY_COLUMN_MISSING      extends StatusCode(StatusType.UserError)
   case PARTIAL_QUERY_INVALID_BODY        extends StatusCode(StatusType.UserError)
   case RECURSIVE_MODEL_REFERENCE         extends StatusCode(StatusType.UserError)
+  case CYCLIC_SYMBOL_REFERENCE           extends StatusCode(StatusType.UserError)
   case MODEL_EXPANSION_LIMIT_EXCEEDED    extends StatusCode(StatusType.UserError)
   case RECURSIVE_FUNCTION_REFERENCE      extends StatusCode(StatusType.UserError)
   case RECURSIVE_PARTIAL_QUERY_REFERENCE extends StatusCode(StatusType.UserError)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbol.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbol.scala
@@ -68,7 +68,7 @@ class Symbol(val id: Int, val span: Span) extends LogSupport:
       "NoSymbol"
     else if _symbolInfo == null then
       // Do not force completion from toString (e.g., debug logs)
-      s"Symbol($id)"
+      s"Symbol(${id})"
     else
       _symbolInfo.name.name
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbol.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbol.scala
@@ -39,7 +39,7 @@ object Symbol:
 
   def newPackageSymbol(owner: Symbol, name: Name)(using context: Context): Symbol =
     val symbol = Symbol(context.global.newSymbolId, Span.NoSpan)
-    symbol.symbolInfo = PackageSymbolInfo(symbol, owner, name, PackageType(name), context.scope)
+    symbol.symbolInfo = PackageSymbolInfo(owner, symbol, name, PackageType(name), context.scope)
     symbol
 
   def newImportSymbol(owner: Symbol, i: Import)(using context: Context): Symbol =

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbol.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbol.scala
@@ -14,29 +14,29 @@
 package wvlet.lang.compiler
 
 import wvlet.lang.api.Span
+import wvlet.lang.api.StatusCode
 import wvlet.lang.model.DataType
 import wvlet.lang.model.SyntaxTreeNode
-import wvlet.lang.model.TreeNode
-import wvlet.lang.model.Type
 import wvlet.lang.model.Type.ImportType
 import wvlet.lang.model.Type.PackageType
-import wvlet.lang.model.expr.NameExpr
-import wvlet.lang.model.expr.NameExpr.EmptyName
 import wvlet.lang.model.plan.Import
 import wvlet.lang.model.plan.LogicalPlan
 import wvlet.uni.log.LogSupport
 
-import scala.annotation.compileTimeOnly
+/**
+  * Computes the SymbolInfo of a symbol on first access (following the lazy-completion design of
+  * Scala 3 compiler's Namer/LazyType). A completer is installed by SymbolLabeler when the
+  * SymbolInfo cannot be computed reliably at labeling time (e.g., it requires typing the
+  * definition), and captures whatever context it needs to complete later
+  */
+trait SymbolCompleter:
+  def complete(symbol: Symbol): SymbolInfo
 
 object Symbol:
-  val NoSymbol: Symbol =
-    new Symbol(-1, span = Span.NoSpan):
-      override def computeSymbolInfo(using Context): SymbolInfo = NoSymbolInfo
+  val NoSymbol: Symbol = Symbol(-1, Span.NoSpan)
 
   private val importName = Name.termName("<import>")
-//  lazy val EmptyPackage: Symbol = newPackageSymbol(rootPackageName)
-//  lazy val RootType: Symbol = newTypeDefSymbol(NoSymbol, NoName, DataType.UnknownType)
-//
+
   def newPackageSymbol(owner: Symbol, name: Name)(using context: Context): Symbol =
     val symbol = Symbol(context.global.newSymbolId, Span.NoSpan)
     symbol.symbolInfo = PackageSymbolInfo(symbol, owner, name, PackageType(name), context.scope)
@@ -51,38 +51,35 @@ end Symbol
 
 /**
   * Symbol is a permanent identifier for a TreeNode (e.g., LogicalPlan or Expression nodes). Symbol
-  * holds a cache of the resolved SymbolInfo, which contains DataType for the TreeNode.
+  * holds the resolved SymbolInfo, which contains the DataType of the TreeNode.
   *
-  * @param name
+  * The SymbolInfo is either assigned directly (when it is known at symbol-creation time) or
+  * computed lazily by a [[SymbolCompleter]] on the first access, so that definitions can be typed
+  * on demand independently of the compilation order of their compilation units
   */
 class Symbol(val id: Int, val span: Span) extends LogSupport:
-  private var _symbolInfo: SymbolInfo | Null = null
-  private var _tree: SyntaxTreeNode | Null   = null
+  private var _symbolInfo: SymbolInfo | Null     = null
+  private var _completer: SymbolCompleter | Null = null
+  private var _isCompleting: Boolean             = false
+  private var _tree: SyntaxTreeNode | Null       = null
 
   override def toString =
     if id == -1 then
       "NoSymbol"
     else if _symbolInfo == null then
+      // Do not force completion from toString (e.g., debug logs)
       s"Symbol($id)"
     else
       _symbolInfo.name.name
 
-  def name: Name =
-    if _symbolInfo == null then
-      Name.NoName
-    else
-      symbolInfo.name
+  def name: Name = symbolInfo.name
 
   def isNoSymbol: Boolean = this == Symbol.NoSymbol
 
   def isDefined = !isNoSymbol
   def isEmpty   = !isDefined
 
-  def dataType: DataType =
-    if _symbolInfo == null then
-      DataType.UnknownType
-    else
-      _symbolInfo.dataType
+  def dataType: DataType = symbolInfo.dataType
 
   private def isResolved: Boolean = dataType.isResolved
 
@@ -120,14 +117,51 @@ class Symbol(val id: Int, val span: Span) extends LogSupport:
       case _ =>
     _tree = t
 
+  /**
+    * Returns true when this symbol already has a SymbolInfo or a completer that can produce one
+    */
+  def hasSymbolInfo: Boolean = _symbolInfo != null || _completer != null
+
+  /**
+    * Returns the SymbolInfo of this symbol, forcing the completer on the first access. Never
+    * returns null: an uncompleted symbol without a completer yields [[NoSymbolInfo]]
+    */
   def symbolInfo: SymbolInfo =
-//    if _symbolInfo == null then
-//      _symbolInfo = computeSymbolInfo
-    _symbolInfo
+    if _symbolInfo != null then
+      _symbolInfo
+    else
+      _completer match
+        case null =>
+          NoSymbolInfo
+        case completer =>
+          if _isCompleting then
+            throw StatusCode
+              .CYCLIC_SYMBOL_REFERENCE
+              .newException(s"Cyclic reference detected while resolving symbol ${id}")
+          _isCompleting = true
+          try
+            val info = completer.complete(this)
+            _symbolInfo = info
+            _completer = null
+            info
+          finally
+            _isCompleting = false
 
-  def symbolInfo_=(info: SymbolInfo): Unit = _symbolInfo = info
+  /**
+    * Assign the SymbolInfo directly, discarding any pending completer. Used when the info is known
+    * at creation time or when a definition is replaced (e.g., re-defining a model in REPL)
+    */
+  def symbolInfo_=(info: SymbolInfo): Unit =
+    _symbolInfo = info
+    _completer = null
 
-  def computeSymbolInfo(using Context): SymbolInfo = ???
+  /**
+    * Install a completer that computes the SymbolInfo on the first access, discarding any
+    * previously assigned info (e.g., when a definition is replaced in REPL)
+    */
+  def setCompleter(completer: SymbolCompleter): Unit =
+    _symbolInfo = null
+    _completer = completer
 
 end Symbol
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbolnfo.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbolnfo.scala
@@ -42,19 +42,21 @@ enum SymbolType:
   case FlowDef
 
 /**
-  * SymbolInfo is the result of resolving a name (Symbol) during the compilation phase.
+  * SymbolInfo is the result of resolving a name (Symbol) during the compilation phase. SymbolInfo
+  * is immutable: replacing the resolution result of a symbol (e.g., re-defining a model in REPL)
+  * assigns a new SymbolInfo to the Symbol instead of mutating the existing one
   *
   * @param symbol
   * @param owner
   * @param name
-  * @param dataType
+  * @param tpe
   */
 class SymbolInfo(
     val symbolType: SymbolType,
     val owner: Symbol,
     val symbol: Symbol,
     val name: Name,
-    private var _tpe: Type
+    val tpe: Type
 ):
   override def toString(): String =
     if owner.isDefined then
@@ -62,14 +64,11 @@ class SymbolInfo(
     else
       s"[${symbolType}] ${name}: ${tpe}"
 
-  private var _declScope: Scope | Null = null
-  def declScope: Scope                 = _declScope
-  def declScope_=(s: Scope): Unit      = _declScope = s
-
-  def tpe: Type                    = _tpe
-  def withType(t: Type): this.type =
-    _tpe = t
-    this
+  /**
+    * The scope of the symbols declared inside this symbol (e.g., models in a package, methods in a
+    * type definition)
+    */
+  def declScope: Scope = Scope.NoScope
 
   def dataType =
     tpe match
@@ -77,8 +76,6 @@ class SymbolInfo(
         t
       case _ =>
         DataType.UnknownType
-
-  def withDataType(d: DataType): this.type = withType(d)
 
   def findMember(name: Name): Symbol = NoSymbol
   def members: List[Symbol]          = Nil
@@ -93,7 +90,7 @@ class PackageSymbolInfo(
     override val tpe: PackageType,
     packageScope: Scope
 ) extends SymbolInfo(SymbolType.Package, owner, symbol, name, tpe):
-  this.declScope = packageScope
+  override def declScope: Scope = packageScope
 
   override def toString: String =
     if owner.isNoSymbol then
@@ -119,7 +116,7 @@ class TypeSymbolInfo(
     override val typeParams: Seq[DataType],
     typeScope: Scope
 ) extends SymbolInfo(SymbolType.TypeDef, symbol, owner, name, tpe):
-  this.declScope = typeScope
+  override def declScope: Scope = typeScope
 
   override def toString: String               = s"${owner}.${name}: ${dataType}"
   override def findMember(name: Name): Symbol = typeScope.lookupSymbol(name).getOrElse(NoSymbol)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbolnfo.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbolnfo.scala
@@ -115,7 +115,7 @@ class TypeSymbolInfo(
     tpe: DataType,
     override val typeParams: Seq[DataType],
     typeScope: Scope
-) extends SymbolInfo(SymbolType.TypeDef, symbol, owner, name, tpe):
+) extends SymbolInfo(SymbolType.TypeDef, owner, symbol, name, tpe):
   override def declScope: Scope = typeScope
 
   override def toString: String               = s"${owner}.${name}: ${dataType}"
@@ -143,7 +143,7 @@ case class ModelSymbolInfo(
     override val name: Name,
     override val tpe: DataType,
     compilationUnit: CompilationUnit
-) extends SymbolInfo(SymbolType.ModelDef, symbol, owner, name, tpe):
+) extends SymbolInfo(SymbolType.ModelDef, owner, symbol, name, tpe):
   override def toString: String = s"model ${owner}.${name}: ${dataType}"
 
 /**
@@ -179,7 +179,7 @@ case class ValSymbolInfo(
     override val name: Name,
     override val tpe: DataType,
     expr: Expression
-) extends SymbolInfo(SymbolType.ValDef, Symbol.NoSymbol, symbol, name, tpe):
+) extends SymbolInfo(SymbolType.ValDef, owner, symbol, name, tpe):
   override def toString: String =
     tpe match
       case schemaType: DataType.SchemaType =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
@@ -235,8 +235,8 @@ object SymbolLabeler extends Phase("symbol-labeler"):
         case None =>
           val sym        = Symbol(ctx.global.newSymbolId, pkgName.span)
           val pkgSymInfo = PackageSymbolInfo(
-            sym,
             pkgOwner,
+            sym,
             pkgLeafName,
             PackageType(pkgLeafName),
             // Create a fresh scope for defining global package

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
@@ -300,7 +300,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
                   f.expr,
                   t.defContexts ++ f.defContexts
                 )
-                if funSym.symbolInfo == null then
+                if !funSym.hasSymbolInfo then
                   funSym.symbolInfo = methodSymbolInfo
                 else
                   funSym.symbolInfo = MultipleSymbolInfo(methodSymbolInfo, funSym.symbolInfo)
@@ -336,7 +336,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
               f.expr,
               t.defContexts ++ f.defContexts
             )
-            if funSym.symbolInfo == null then
+            if !funSym.hasSymbolInfo then
               funSym.symbolInfo = newSymbolInfo
             else
               funSym.symbolInfo = MultipleSymbolInfo(newSymbolInfo, funSym.symbolInfo)

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/SymbolCompleterTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/SymbolCompleterTest.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.api.Span
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
+import wvlet.lang.model.DataType
+
+class SymbolCompleterTest extends UniTest:
+
+  private def newSymbolInfo(sym: Symbol, name: String): SymbolInfo = SymbolInfo(
+    SymbolType.ValDef,
+    Symbol.NoSymbol,
+    sym,
+    Name.termName(name),
+    DataType.LongType
+  )
+
+  test("should return NoSymbolInfo for a symbol without info or completer") {
+    val sym = Symbol(1, Span.NoSpan)
+    sym.hasSymbolInfo shouldBe false
+    sym.symbolInfo shouldBeTheSameInstanceAs NoSymbolInfo
+    sym.name shouldBe Name.NoName
+    sym.dataType shouldBe DataType.UnknownType
+  }
+
+  test("should return NoSymbolInfo for NoSymbol") {
+    Symbol.NoSymbol.symbolInfo shouldBeTheSameInstanceAs NoSymbolInfo
+    Symbol.NoSymbol.isNoSymbol shouldBe true
+  }
+
+  test("should complete the symbol info lazily and only once") {
+    val sym            = Symbol(2, Span.NoSpan)
+    var completedCount = 0
+    sym.setCompleter { s =>
+      completedCount += 1
+      newSymbolInfo(s, "lazy_val")
+    }
+    sym.hasSymbolInfo shouldBe true
+    completedCount shouldBe 0
+
+    sym.symbolInfo.name.name shouldBe "lazy_val"
+    completedCount shouldBe 1
+    // The second access must reuse the completed info
+    sym.symbolInfo.name.name shouldBe "lazy_val"
+    completedCount shouldBe 1
+  }
+
+  test("should not force completion from toString") {
+    val sym       = Symbol(3, Span.NoSpan)
+    var completed = false
+    sym.setCompleter { s =>
+      completed = true
+      newSymbolInfo(s, "quiet")
+    }
+    sym.toString shouldBe "Symbol(3)"
+    completed shouldBe false
+  }
+
+  test("should let a direct assignment override a pending completer") {
+    val sym       = Symbol(4, Span.NoSpan)
+    var completed = false
+    sym.setCompleter { s =>
+      completed = true
+      newSymbolInfo(s, "stale")
+    }
+    sym.symbolInfo = newSymbolInfo(sym, "fresh")
+    sym.symbolInfo.name.name shouldBe "fresh"
+    completed shouldBe false
+  }
+
+  test("should let a completer override a previously assigned info (REPL redefinition)") {
+    val sym = Symbol(5, Span.NoSpan)
+    sym.symbolInfo = newSymbolInfo(sym, "old")
+    sym.setCompleter { s =>
+      newSymbolInfo(s, "new")
+    }
+    sym.symbolInfo.name.name shouldBe "new"
+  }
+
+  test("should detect cyclic symbol completion") {
+    val sym = Symbol(6, Span.NoSpan)
+    sym.setCompleter { s =>
+      // A completer that (indirectly) asks for its own symbol info
+      s.symbolInfo
+    }
+    val e = intercept[WvletLangException] {
+      sym.symbolInfo
+    }
+    e.statusCode shouldBe StatusCode.CYCLIC_SYMBOL_REFERENCE
+  }
+
+  test("should recover after a failed completion attempt") {
+    val sym     = Symbol(7, Span.NoSpan)
+    var attempt = 0
+    sym.setCompleter { s =>
+      attempt += 1
+      if attempt == 1 then
+        throw IllegalStateException("transient failure")
+      newSymbolInfo(s, "recovered")
+    }
+    intercept[IllegalStateException] {
+      sym.symbolInfo
+    }
+    // The completer remains installed, so a later access can complete successfully
+    sym.symbolInfo.name.name shouldBe "recovered"
+  }
+
+end SymbolCompleterTest


### PR DESCRIPTION
## What
First step of the Tree–Symbol redesign of #71, following the Namer/LazyType completer design of the Scala 3 compiler.

- **`Symbol.symbolInfo` never returns null**: it forces an installed `SymbolCompleter` once (guarded by cyclic-completion detection via a new `CYCLIC_SYMBOL_REFERENCE` status code) and falls back to `NoSymbolInfo` when neither info nor completer is present. The dead `computeSymbolInfo` stub and the `symbolInfo == null` call-site checks are removed.
- **`SymbolInfo.tpe` becomes an immutable `val`**: the `withType`/`withDataType` mutators had no callers, and subclasses overriding `tpe` as a `val` meant mutating the hidden base-class `_tpe` var silently had no effect on reads — a live trap.
- **`declScope` becomes an overridable accessor** instead of a mutable field set from subclass constructor bodies.
- `Symbol.toString` never forces completion (safe in debug logs), and a failed completion attempt keeps the completer installed so a later access can retry.

## Why
`SymbolInfo` was intended to be lazily computed (the `computeSymbolInfo` stub) but never was, leaving a nullable accessor typed as non-null and mutable state with divergence traps. The completer infrastructure enables the next step: typing model/type definitions **on demand in their defining unit's context**, independent of compilation order — the root cause behind the model-expansion StackOverflow fixed defensively in #1802.

## Tests
- New `SymbolCompleterTest` (8 tests): laziness, single completion, toString non-forcing, assignment/completer override semantics, cycle detection, retry after failed completion
- `langJVM/test` (1465 passed), `runner/test` (394 passed), JS/Native compile clean

Part of #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)