### PR TITLE
internal: Raise typing-coverage ratchets and fix stale testing notes in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ pnpm --filter website run build
 
 ## Testing Framework
 
-- Uses AirSpec testing framework https://wvlet.org/airspec/
+- Tests extend `wvlet.uni.test.UniTest` (AirSpec-style assertions: `shouldBe`, `shouldContain`, `shouldBeTheSameInstanceAs`, `intercept[...]`, `shouldMatch`). Importing `wvlet.airspec.AirSpec` in wvlet-lang fails to compile; check a neighboring test's imports first
 - Test files end with `Test.scala` or `Spec.scala`
 - Avoid using mock as it increases maintenance cost and creates brittle tests that break when internal implementation changes
 - Ensure tests cover new functionality and bug fixes with good test coverage
@@ -297,7 +297,7 @@ For error reporting, use WvletLangException and StatusCode enum. If necessary er
 - To monitor debug logs, use `-l debug` option. For example, ./sbt "langJVM/testOnly *Test -- -l debug"
 
 ## Testing Notes
-- Use `shouldContain "(keyword)"` for checking string fragment in AirSpec
+- Use `shouldContain "(keyword)"` for checking string fragment in UniTest
 - To debug SQL generator, add -L *GenSQL=trace to the test option
 - Typing coverage over spec/basic is guarded by a CI ratchet: `./sbt "langJVM/testOnly *TyperCoverageCheck"` (raise its thresholds when improving type resolution; never lower them)
 - For compiler performance work, compare before/after with `./sbt "langJVM/testOnly *TyperBench"` (log-only timing probe)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -120,7 +120,7 @@ pnpm --filter website run build
 
 ## Testing Framework
 
-- Uses AirSpec testing framework https://wvlet.org/airspec/
+- Tests extend `wvlet.uni.test.UniTest` (AirSpec-style assertions: `shouldBe`, `shouldContain`, `shouldBeTheSameInstanceAs`, `intercept[...]`, `shouldMatch`). Importing `wvlet.airspec.AirSpec` in wvlet-lang fails to compile; check a neighboring test's imports first
 - Test files end with `Test.scala` or `Spec.scala`
 - Avoid using mock as it increases maintenance cost and creates brittle tests that break when internal implementation changes
 - Ensure tests cover new functionality and bug fixes with good test coverage
@@ -274,4 +274,4 @@ For error reporting, use WvletLangException and StatusCode enum. If necessary er
 - To monitor debug logs, use `-l debug` option. For example, ./sbt "langJVM/testOnly *Test -- -l debug"
 
 ## Testing Notes
-- Use `shouldContain "(keyword)"` for checking string fragment in AirSpec
+- Use `shouldContain "(keyword)"` for checking string fragment in UniTest

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
@@ -137,10 +137,10 @@ class TyperCoverageCheck extends UniTest:
     info(s"top unresolved relations: ${top(c.unresolvedRelations, 10)}")
     info(s"top untyped expressions:  ${top(c.untypedExprs, 10)}")
 
-    // Ratchet (2026-07-03: 90.7% / 87.1% / 89.1%). Raise these as coverage improves toward 1.0
-    val minRelationCoverage = 0.89
-    val minExprCoverage     = 0.86
-    val minTpeSetCoverage   = 0.88
+    // Ratchet (2026-07-03: 91.0% / 87.4% / 90.3%). Raise these as coverage improves toward 1.0
+    val minRelationCoverage = 0.90
+    val minExprCoverage     = 0.87
+    val minTpeSetCoverage   = 0.89
     if c.relationCoverage < minRelationCoverage then
       fail(
         f"Relation type coverage regressed: ${c.relationCoverage *


### PR DESCRIPTION
## What
- Raises the `TyperCoverageCheck` ratchet thresholds 0.89/0.86/0.88 → **0.90/0.87/0.89**, locking in the coverage gains from the #71 typer/symbol work (measured on main: relations 91.0%, expressions 87.4%, tpe-set 90.3%)
- Fixes stale testing notes in CLAUDE.md: tests extend `wvlet.uni.test.UniTest` (AirSpec-style assertions), not `wvlet.airspec.AirSpec`, which no longer compiles in wvlet-lang

## Tests
`langJVM/testOnly *TyperCoverageCheck` passes with the new thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)