### PR TITLE
internal: Drop the defensive model-body re-resolution in GenSQL expansion (#1810)

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -417,6 +417,9 @@ object GenSQL extends Phase("generate-sql"):
           ctx.sourceLocationAt(m.span)
         )
 
+    // Force a pending lazy completion so that sym.tree is the typed model definition, with
+    // nested model references already resolved to concrete ModelScans
+    sym.symbolInfo
     sym.tree match
       case md: ModelDef =>
         if m.modelArgs.size > md.params.size then
@@ -450,12 +453,8 @@ object GenSQL extends Phase("generate-sql"):
             newCtx.scope.add(argName, argSym)
           }
 
-        // Resolve the model body first so that nested model references are concrete ModelScans
-        // regardless of how far the defining unit was compiled, then substitute the model
-        // arguments and expand those nested references
         // TODO: How to propagate comments in the model Query body?
-        val resolvedBody = Typer.resolveRelation(md.child.body)(using newCtx)
-        expandRelation(resolvedBody)(using newCtx)
+        expandRelation(md.child.body)(using newCtx)
       case other =>
         warn(s"Unknown model tree for ${m.name}: ${other}")
         m


### PR DESCRIPTION
## What
Closes #1810. `GenSQL.expandModelScan` re-ran `Typer.resolveRelation` on every model body before expansion — added in #1802 as a defense when `symbol.tree` could still be an untyped tree with unresolved nested model references.

Since the #71 redesign that defense is redundant:
- Lazy completers (#1806) type a model on demand in its defining context and link the typed tree
- The Typer completes every model symbol during regular unit typing
- `RemoveUnusedQueries` always retains units containing `ModelDef`/`TypeDef`, so definition units are never skipped before codegen

`expandModelScan` now forces a pending completion (one line, no-op when already completed) and expands `md.child.body` directly.

## Tests
Verified the guarantee empirically before adding the force: with the re-resolution removed, `langJVM/test` (1470 passed, incl. the deterministic StackOverflow reproducer and recursion/diamond expansion tests) and `runner/test` (394 passed) stay green. JS/Native compile clean.

Closes #1810

🤖 Generated with [Claude Code](https://claude.com/claude-code)