### PR TITLE
fix: Unblock Scala Native Windows builds (uni 2026.1.15 + vcpkg lib-name renames)

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -167,13 +167,33 @@ jobs:
         run: |
           $triplet = if ("${{ matrix.arch }}" -eq "arm64") { "arm64-windows" } else { "x64-windows" }
           $libDir = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib"
-          # Create symlinks for OpenSSL libraries (Scala Native looks for crypto.lib, vcpkg provides libcrypto.lib)
-          if (Test-Path "$libDir\libcrypto.lib") {
-            Copy-Item "$libDir\libcrypto.lib" "$libDir\crypto.lib" -Force
+
+          # Scala Native passes @link("X") to the linker as literal `X.lib`. vcpkg's Windows
+          # ports install some libs with a different name (upstream convention), so copy them
+          # under the name Scala Native's javalib / uni bindings request:
+          #   - crypto.lib / ssl.lib  <- OpenSSL   (libcrypto.lib / libssl.lib)
+          #   - curl.lib              <- libcurl   (libcurl.lib, from uni's CurlBindings)
+          #   - zlib.lib              <- zlib      (zlib1.lib if the port emits the versioned name)
+          $renames = @(
+            @{ Src = "libcrypto.lib"; Dst = "crypto.lib" },
+            @{ Src = "libssl.lib";    Dst = "ssl.lib"    },
+            @{ Src = "libcurl.lib";   Dst = "curl.lib"   },
+            @{ Src = "zlib1.lib";     Dst = "zlib.lib"   }
+          )
+          foreach ($r in $renames) {
+            $src = Join-Path $libDir $r.Src
+            $dst = Join-Path $libDir $r.Dst
+            if ((Test-Path $src) -and -not (Test-Path $dst)) {
+              Write-Host "Copying $($r.Src) -> $($r.Dst)"
+              Copy-Item $src $dst -Force
+            }
           }
-          if (Test-Path "$libDir\libssl.lib") {
-            Copy-Item "$libDir\libssl.lib" "$libDir\ssl.lib" -Force
-          }
+
+          # Log the lib directory contents so we can diagnose future missing-lib errors.
+          Write-Host "Contents of ${libDir}:"
+          Get-ChildItem -Path $libDir -Filter *.lib -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty Name | Sort-Object
+
           echo "C_INCLUDE_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\include" >> $env:GITHUB_ENV
           echo "VCPKG_LIB_PATH=$libDir" >> $env:GITHUB_ENV
         shell: pwsh

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,15 @@ val buildSettings = Seq[Setting[?]](
 val scalajsJavaSecureRandom: ModuleID =
   "org.scala-js" % "scalajs-java-securerandom_sjs1_2.13" % "1.0.0"
 
+// uni-native ships `uni_curl_shim.c` in its resources, which is unconditionally compiled into
+// every downstream Scala Native binary and calls `curl_easy_setopt` / `curl_easy_getinfo`.
+// Scala Native's `@link("curl")` on `CurlBindings` only fires when the Extern object is
+// reachable through DCE — test binaries that don't touch the HTTP client would otherwise link
+// the shim without `-lcurl` and fail with `undefined reference to curl_easy_setopt`.
+val uniNativeCurlLinking = nativeConfig ~= { c =>
+  c.withLinkingOptions(c.linkingOptions :+ "-lcurl")
+}
+
 lazy val jvmProjects: Seq[ProjectReference] = Seq(
   api.jvm,
   httpServer,
@@ -110,6 +119,7 @@ lazy val api = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     libraryDependencies += "org.wvlet.uni" %%% "uni" % UNI_VERSION
   )
   .jsSettings(libraryDependencies += scalajsJavaSecureRandom)
+  .nativeSettings(uniNativeCurlLinking)
 
 def generateWvletLib(path: File, packageName: String, className: String): String = {
   val srcDir      = path
@@ -203,6 +213,7 @@ lazy val lang = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       _.withModuleKind(ModuleKind.CommonJSModule)
     }
   )
+  .nativeSettings(uniNativeCurlLinking)
   .dependsOn(api)
 
 val specRunnerSettings = Seq(
@@ -487,13 +498,15 @@ lazy val cliCore = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       (ThisBuild / baseDirectory).value / "sdks" / "cli-node" / "lib"
   )
   .nativeSettings(
-    // The C wrapper in `lang.native`'s `src/main/resources/scala-native/` is unconditionally
-    // compiled and linked into every downstream Native binary, so its `duckdb_*` references
-    // need `-lduckdb` available at the final link step. Scala Native's `@link("duckdb")`
-    // annotation on `DuckDBApi` only triggers when that extern object is reachable, and
-    // cli-core tests / binaries typically don't reach the DuckDB code path. Add the flag
-    // explicitly here. (Local macOS linker tolerates the missing flag because the dylib is
-    // already on the search path; GNU ld on Linux is strict.)
+    // The C wrappers in `lang.native`'s `src/main/resources/scala-native/` (duckdb helpers)
+    // and uni-native's resources (`uni_curl_shim.c`) are unconditionally compiled and linked
+    // into every downstream Native binary, so their `duckdb_*` / `curl_easy_*` references
+    // need `-lduckdb` / `-lcurl` available at the final link step. Scala Native's
+    // `@link("duckdb")` / `@link("curl")` annotations only trigger when their extern objects
+    // are reachable, and cli-core tests / binaries typically don't reach those code paths.
+    // Add the flags explicitly here. (Local macOS linker tolerates the missing flags because
+    // the dylibs are already on the search path; GNU ld on Linux is strict.)
+    uniNativeCurlLinking,
     nativeConfig ~= { c =>
       c.withLinkingOptions(c.linkingOptions :+ "-lduckdb")
     }

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import scala.scalanative.build.GC
 import scala.scalanative.build.Mode
 import scala.scalanative.build.NativeConfig
 
-val UNI_VERSION = "2026.1.11"
+val UNI_VERSION = "2026.1.15"
 
 val TRINO_VERSION          = "476"
 val AWS_SDK_VERSION        = "2.20.146"

--- a/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
@@ -12,7 +12,7 @@ import wvlet.uni.cli.launcher.option
 import wvlet.uni.control.Control.withResource
 import wvlet.uni.io.IO
 import wvlet.uni.design.{Design, Session}
-import wvlet.uni.http.netty.{NettyHttpServer, NettyServerConfig, RxHttpHandler}
+import wvlet.uni.http.netty.{NettyHttpServer, NettyServerConfig}
 import wvlet.uni.http.rpc.{RPCRoute, RPCRouter, RPCStatus}
 import wvlet.uni.http.{
   Http,
@@ -21,7 +21,8 @@ import wvlet.uni.http.{
   HttpStatus,
   JVMHttpChannelFactory,
   Request,
-  Response
+  Response,
+  RxHttpHandler
 }
 import wvlet.uni.log.LogSupport
 import wvlet.uni.rx.Rx


### PR DESCRIPTION
## Summary

Windows Scala Native builds have been broken on `main` since
[`6d017517`](https://github.com/wvlet/wvlet/commit/6d017517c4fd364c4c0f66af1f5dbe8b355bf808)
(#1687), which moved `wvlet-lang`'s file I/O onto `wvlet.uni.io.IO`. The
underlying `FileSystemNative` referenced POSIX-only symbols (`readlink`,
`symlink`, `stat`/`lstat`, `chmod`, `getpwuid`, `getgrgid`) that MSVC's
CRT does not export, so the linker failed with
`LNK2019: unresolved external symbol readlink / scalanative_stat / …`
([first broken run](https://github.com/wvlet/wvlet/actions/runs/25527054437/job/74540961637)).

After DuckDB (#1695) and the Trino/uni HTTP client (#1708) entered the
link list, a second CI-side issue surfaced:
`LNK1104: cannot open file 'zlib.lib' / 'curl.lib'`
([recent run](https://github.com/wvlet/wvlet/actions/runs/28680546619/job/82060570737)) —
vcpkg's Windows ports install these under names that Scala Native's
`@link(\"…\")` doesn't request (`libcurl.lib`; `zlib1.lib` in newer port
revisions).

This PR fixes both:

- **Bump `UNI_VERSION` to `2026.1.15`** — picks up
  [wvlet/uni#629](https://github.com/wvlet/uni/pull/629), which gates
  every POSIX code path in `FileSystemNative` on
  `LinktimeInfo.isWindows` so those symbols are DCE'd on Windows.
  Same pattern as the earlier `localtime_r` fix (wvlet/uni#519).
- **Update `WvletServer.scala`** — uni#572 moved `RxHttpHandler` out of
  `wvlet.uni.http.netty` into the shared `wvlet.uni.http` package as
  part of the cross-platform HTTP server abstraction.
- **Extend `native.yml`'s vcpkg lib-name rename step** — copies
  `libcurl.lib → curl.lib` and `zlib1.lib → zlib.lib` (in addition to
  the existing `libcrypto.lib → crypto.lib` / `libssl.lib → ssl.lib`),
  and logs the `*.lib` names in the vcpkg triplet's `lib/` dir so any
  future \"cannot open X.lib\" errors are diagnosable directly from
  the CI log.

## Windows FileSystem behaviour after the uni bump

| Operation | Non-Windows | Windows |
|---|---|---|
| `isSymlinkPath` | `unistd.readlink` probe | returns `false` |
| `doStatFileInfo` | POSIX `stat`/`lstat` + `getpwuid`/`getgrgid` | returns `(None, None, None)` |
| `createSymlink` / `readSymlink` | `unistd.symlink`/`readlink` | throws `UnsupportedOperationException` |
| `setPermissions` | `stat.chmod` | throws `UnsupportedOperationException` |
| `permissions` / `owner` / `group` | POSIX values | throws (via existing `getOrElse`) |

`info(path)` still returns a useful `FileInfo` on Windows (size,
`lastModified`, readable/writable/executable/hidden all via
`java.io.File`). Wvlet's compiler doesn't rely on POSIX-only fields.

## Test plan

- [x] `./sbt projectJVM/Test/compile` — clean with 2026.1.15
- [x] `./sbt projectJS/Test/compile` — clean
- [x] `./sbt projectNative/Test/compile` — clean
- [x] `./sbt scalafmtCheck` — clean
- [ ] Post-merge: `Build native on Windows (x64/arm64)` reaches the
      link step, resolves POSIX symbols cleanly, and finds
      `curl.lib` / `zlib.lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)