### PR TITLE
fix: Cover the actual vcpkg zlib name (z.lib) in the Windows lib-rename step

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -169,23 +169,27 @@ jobs:
           $libDir = "$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib"
 
           # Scala Native passes @link("X") to the linker as literal `X.lib`. vcpkg's Windows
-          # ports install some libs with a different name (upstream convention), so copy them
-          # under the name Scala Native's javalib / uni bindings request:
-          #   - crypto.lib / ssl.lib  <- OpenSSL   (libcrypto.lib / libssl.lib)
-          #   - curl.lib              <- libcurl   (libcurl.lib, from uni's CurlBindings)
-          #   - zlib.lib              <- zlib      (zlib1.lib if the port emits the versioned name)
-          $renames = @(
-            @{ Src = "libcrypto.lib"; Dst = "crypto.lib" },
-            @{ Src = "libssl.lib";    Dst = "ssl.lib"    },
-            @{ Src = "libcurl.lib";   Dst = "curl.lib"   },
-            @{ Src = "zlib1.lib";     Dst = "zlib.lib"   }
-          )
-          foreach ($r in $renames) {
-            $src = Join-Path $libDir $r.Src
-            $dst = Join-Path $libDir $r.Dst
-            if ((Test-Path $src) -and -not (Test-Path $dst)) {
-              Write-Host "Copying $($r.Src) -> $($r.Dst)"
-              Copy-Item $src $dst -Force
+          # ports install some libs with a different name (upstream convention), so for each
+          # canonical name Scala Native asks for, copy the first candidate that exists:
+          #   - crypto.lib / ssl.lib  <- OpenSSL (libcrypto.lib / libssl.lib)
+          #   - curl.lib              <- libcurl (libcurl.lib, from uni's CurlBindings)
+          #   - zlib.lib              <- zlib    (varies by port revision: zlib1.lib / z.lib / libz.lib)
+          $targets = [ordered]@{
+            "crypto.lib" = @("libcrypto.lib")
+            "ssl.lib"    = @("libssl.lib")
+            "curl.lib"   = @("libcurl.lib")
+            "zlib.lib"   = @("zlib1.lib", "z.lib", "libz.lib", "libzlib.lib")
+          }
+          foreach ($dst in $targets.Keys) {
+            $dstPath = Join-Path $libDir $dst
+            if (Test-Path $dstPath) { continue }
+            foreach ($src in $targets[$dst]) {
+              $srcPath = Join-Path $libDir $src
+              if (Test-Path $srcPath) {
+                Write-Host "Copying $src -> $dst"
+                Copy-Item $srcPath $dstPath -Force
+                break
+              }
             }
           }
 


### PR DESCRIPTION
## Summary

Follow-up to #1815. The first rename step copied `zlib1.lib -> zlib.lib`,
but the arm64 Windows run in
[`Native #28689771397`](https://github.com/wvlet/wvlet/actions/runs/28689771397)
shows vcpkg's `zlib:arm64-windows@1.3.2#1` actually installs the import
lib as **`z.lib`** — the port's `vcpkg-cmake-wrapper.cmake` searches
`find_library(NAMES z zs)`, consistent with that observation. Contents
of `C:\vcpkg\installed\arm64-windows\lib` from the log:

```
crypto.lib      (from libcrypto.lib rename, ✓)
curl.lib        (from libcurl.lib rename, ✓)
ssl.lib         (from libssl.lib rename, ✓)
duckdb.lib      (native name)
gc.lib          (native name)
z.lib           ← not renamed; @link(\"zlib\") wants zlib.lib
```

Result:
```
lld-link: error: could not open 'zlib.lib': no such file or directory
```

Switch to a first-candidate-that-exists list per canonical target, so
`z.lib` (arm64), `zlib1.lib` (older port revisions), `libz.lib`, and
`libzlib.lib` all resolve to `zlib.lib`. Same shape is now applied to
the OpenSSL and curl renames — the diagnostic listing added in #1815
stays in place.

## Test plan

- [ ] Post-merge: `Build native on Windows (arm64)` finds `zlib.lib` and
      the link step completes without `LNK1104`. `x64` (still in-flight
      at time of writing) is expected to succeed either through the same
      `z.lib` path or the existing `zlib1.lib` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)