### PR TITLE
feature: Add run flow statement, run-scoped stage materialization, and wvlet flow CLI

### DIFF
--- a/spec/basic/flow-run.wv
+++ b/spec/basic/flow-run.wv
@@ -1,0 +1,70 @@
+-- Spec-driven tests for flow execution: `run flow <name>` produces a flow-run summary
+-- relation (stage, state, attempts, error) that can be piped and verified with test statements
+
+flow ExecPipeline = {
+  stage src = from [[1, 'a'], [2, 'b'], [3, 'a']] as t(id, name)
+  stage filtered = from src | where name = 'a'
+  stage output = from filtered | select id
+}
+
+-- All stages of a healthy flow succeed
+run flow ExecPipeline
+test _.size should be 3
+test _.columns should contain 'stage'
+test _.columns should contain 'state'
+test _.columns should contain 'attempts'
+;
+
+-- The summary can be filtered with regular query operators
+run flow ExecPipeline
+| where state = 'success'
+test _.size should be 3
+;
+
+flow FallbackPipeline = {
+  stage broken = from nonexistent_table_xyz
+  stage fallback if broken.failed = from [[0]] as t(id)
+  stage downstream = from broken | select *
+}
+
+-- A failing stage triggers its fallback and skips downstream stages
+run flow FallbackPipeline
+| select stage, state
+test _.output should be """
+┌────────────┬─────────┐
+│   stage    │  state  │
+│   string   │ string  │
+├────────────┼─────────┤
+│ broken     │ failed  │
+│ fallback   │ success │
+│ downstream │ skipped │
+├────────────┴─────────┤
+│ 3 rows               │
+└──────────────────────┘
+"""
+;
+
+flow RetryPipeline = {
+  stage flaky with {
+    retries: 2
+    retry_delay: 1ms
+  } = from nonexistent_table_xyz
+}
+
+-- Retries are exhausted before reaching the failed state
+run flow RetryPipeline
+| where state = 'failed' and attempts = 3
+test _.size should be 1
+;
+
+flow MergePipeline = {
+  stage source_a = from [[1], [2]] as t(id)
+  stage source_b = from [[3]] as t(id)
+  stage merged = merge source_a, source_b
+}
+
+-- Merge (fan-in) stages run with union-all semantics
+run flow MergePipeline
+| where state = 'success'
+test _.size should be 3
+;

--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -295,14 +295,55 @@ flow scheduled_flow with {
 }
 ```
 
+## Running Flows
+
+Flow definitions are declarations: running a file that contains flows does not execute them.
+Flows are triggered explicitly with the `run flow` statement or the `wvlet flow` CLI.
+
+### run flow Statement
+
+`run flow <name>` executes a flow and produces a **flow-run summary** relation with one row per
+stage (`stage`, `state`, `attempts`, `error`). The summary can be piped through query operators
+or verified with test statements:
+
+```wvlet
+flow my_pipeline = {
+  stage src = from [[1, 'a'], [2, 'b']] as t(id, name)
+  stage filtered = from src | where name = 'a'
+}
+
+run flow my_pipeline
+| where state = 'success'
+test _.size should be 2
+```
+
+Each successful stage is materialized as a run-scoped temporary table
+(`__wv_flow_<run_id>_<stage>`), so stage names never collide with real tables and concurrent
+runs do not interfere with each other.
+
+### wvlet flow CLI
+
+Flows can be managed from the command line:
+
+```bash
+# List flows defined in the working folder
+wvlet flow list -w ./pipelines
+
+# Show the plan of a flow
+wvlet flow show my_pipeline -w ./pipelines
+
+# Run a flow and print its per-stage results (non-zero exit code when the flow fails)
+wvlet flow run my_pipeline -w ./pipelines
+```
+
 ## Stage Execution Model
 
 :::info Implementation status
-Flow definitions are declarations: running a file that contains flows does not execute them.
-The initial flow executor implements this stage execution model — sequential stage execution
-with data/trigger dependencies, retries with backoff, and per-stage materialization. Flow-level
-schedules, cross-flow dependencies, `timeout`/`heartbeat` enforcement, and flow operators such
-as `route`, `fork`, `wait`, and `activate` are parsed but not yet executable.
+The flow executor implements this stage execution model — sequential stage execution
+with data/trigger dependencies, retries with backoff, and run-scoped per-stage
+materialization. Flow-level schedules, cross-flow dependencies, `timeout`/`heartbeat`
+enforcement, and flow operators such as `route`, `fork`, `wait`, and `activate` are parsed but
+not yet executable.
 :::
 
 Each stage progresses through a well-defined state machine:

--- a/wvlet-api/src/main/scala/wvlet/lang/api/StatusCode.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/StatusCode.scala
@@ -46,6 +46,7 @@ enum StatusCode(statusType: StatusType):
   case COLUMN_NOT_FOUND                  extends StatusCode(StatusType.UserError)
   case PARTIAL_QUERY_NOT_FOUND           extends StatusCode(StatusType.UserError)
   case STAGE_NOT_FOUND                   extends StatusCode(StatusType.UserError)
+  case FLOW_NOT_FOUND                    extends StatusCode(StatusType.UserError)
   case PARTIAL_QUERY_COLUMN_MISSING      extends StatusCode(StatusType.UserError)
   case PARTIAL_QUERY_INVALID_BODY        extends StatusCode(StatusType.UserError)
   case RECURSIVE_MODEL_REFERENCE         extends StatusCode(StatusType.UserError)

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.cli
+
+import wvlet.uni.cli.launcher.argument
+import wvlet.uni.cli.launcher.command
+import wvlet.uni.cli.launcher.option
+import wvlet.uni.control.Control
+import wvlet.lang.api.StatusCode
+import wvlet.lang.catalog.Profile
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.CompileResult
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.Symbol
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.model.plan.DependsOnFlow
+import wvlet.lang.model.plan.FlowDef
+import wvlet.lang.model.plan.FlowStatePredicate
+import wvlet.lang.runner.FlowExecutor
+import wvlet.lang.runner.connector.DBConnectorProvider
+import wvlet.uni.log.LogSupport
+
+case class WvletFlowOption(
+    @option(prefix = "-w", description = "Working folder containing .wv files")
+    workFolder: String = ".",
+    @option(prefix = "--profile", description = "Profile to use")
+    profile: Option[String] = None,
+    @option(prefix = "--catalog", description = "Context database catalog to use")
+    catalog: Option[String] = None,
+    @option(prefix = "--schema", description = "Context database schema to use")
+    schema: Option[String] = None
+)
+
+/**
+  * `wvlet flow` subcommands for managing and running flows from the CLI
+  */
+class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
+
+  @command(description = "Run a flow and print its stage results", isDefault = true)
+  def help: Unit = info("Usage: wvlet flow <run|list|show> ...")
+
+  @command(description = "Run a flow defined in the working folder")
+  def run(
+      flowOption: WvletFlowOption,
+      @argument(description = "Name of the flow to run")
+      name: String
+  ): Unit =
+    withFlows(flowOption) { (flows, compileResult, workEnv) =>
+      val (unit, flow) = findFlow(flows, name)
+      val profile = Profile.getProfile(flowOption.profile, flowOption.catalog, flowOption.schema)
+      Control.withResource(DBConnectorProvider(workEnv)) { dbConnectorProvider =>
+        val connector = dbConnectorProvider.getConnector(profile)
+
+        given ctx: Context = compileResult
+          .context
+          .withCompilationUnit(unit)
+          .newContext(Symbol.NoSymbol)
+
+        val result = FlowExecutor(connector, workEnv).execute(flow)
+        println(result.toPrettyBox())
+        if result.hasError && !WvletMain.isInSbt then
+          System.exit(1)
+      }
+    }
+
+  @command(description = "List flows defined in the working folder")
+  def list(flowOption: WvletFlowOption): Unit =
+    withFlows(flowOption) { (flows, _, _) =>
+      flows.foreach { (unit, f) =>
+        val params =
+          if f.params.isEmpty then
+            ""
+          else
+            s"(${f.params.map(p => s"${p.name.name}").mkString(", ")})"
+        val dependency =
+          f.dependency match
+            case Some(DependsOnFlow(flowName, _)) =>
+              s" depends on ${flowName.fullName}"
+            case Some(FlowStatePredicate(flowName, stateName, _)) =>
+              s" if ${flowName.fullName}.${stateName}"
+            case None =>
+              ""
+        val schedule = f
+          .config
+          .find(_.key.unquotedValue == "schedule")
+          .map(c => s" [schedule: ${c.value}]")
+          .getOrElse("")
+        println(
+          f"${f.name.name}%-30s ${f.stages.size}%2d stages${params}${dependency}${schedule} - ${unit
+              .sourceFile
+              .relativeFilePath}"
+        )
+      }
+    }
+
+  @command(description = "Show the plan of a flow")
+  def show(
+      flowOption: WvletFlowOption,
+      @argument(description = "Name of the flow to show")
+      name: String
+  ): Unit =
+    withFlows(flowOption) { (flows, compileResult, _) =>
+      val (unit, flow) = findFlow(flows, name)
+
+      given Context = compileResult.context.withCompilationUnit(unit)
+
+      println(flow.pp)
+    }
+
+  /**
+    * Compile all .wv files in the working folder and collect flow definitions with their defining
+    * units
+    */
+  private def withFlows[A](flowOption: WvletFlowOption)(
+      body: (List[(CompilationUnit, FlowDef)], CompileResult, WorkEnv) => A
+  ): A =
+    val workEnv  = WorkEnv(flowOption.workFolder, opts.logLevel)
+    val compiler = Compiler(
+      CompilerOptions(sourceFolders = List(flowOption.workFolder), workEnv = workEnv)
+    )
+    val compileResult = compiler.compile()
+    val flows         = List.newBuilder[(CompilationUnit, FlowDef)]
+    compileResult
+      .units
+      .foreach { unit =>
+        unit
+          .resolvedPlan
+          .traverse { case f: FlowDef =>
+            flows += unit -> f
+          }
+      }
+    body(flows.result(), compileResult, workEnv)
+
+  private def findFlow(
+      flows: List[(CompilationUnit, FlowDef)],
+      name: String
+  ): (CompilationUnit, FlowDef) = flows
+    .find(_._2.name.name == name)
+    .getOrElse(
+      throw StatusCode
+        .FLOW_NOT_FOUND
+        .newException(
+          s"Flow '${name}' is not found. Available flows: ${flows
+              .map(_._2.name.name)
+              .mkString(", ")}"
+        )
+    )
+
+end WvletFlowCommand

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletMain.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletMain.scala
@@ -13,7 +13,9 @@ import wvlet.lang.server.WvletServerConfig
 import wvlet.uni.log.LogSupport
 
 object WvletMain:
-  private def launcher: Launcher = Launcher.of[WvletMain]
+  private def launcher: Launcher = Launcher
+    .of[WvletMain]
+    .addModule[WvletFlowCommand]("flow", "Manage and run flows")
 
   private def wrap(body: => Unit): Unit =
     def findCause(e: Throwable): Throwable =

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -1,0 +1,55 @@
+package wvlet.lang.cli
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
+import wvlet.uni.test.UniTest
+
+import java.nio.file.Files
+
+/**
+  * Tests for `wvlet flow run|list|show` subcommands
+  */
+class WvletFlowCommandTest extends UniTest:
+
+  private lazy val flowDir: String =
+    val dir = Files.createTempDirectory("wvlet-flow-test")
+    Files.writeString(
+      dir.resolve("pipeline.wv"),
+      """flow SamplePipeline = {
+        |  stage src = from [[1, 'a'], [2, 'b']] as t(id, name)
+        |  stage filtered = from src | where name = 'a'
+        |}
+        |
+        |flow FallbackPipeline = {
+        |  stage primary = from nonexistent_table_xyz
+        |  stage fallback if primary.failed = from [[0]] as t(id)
+        |}
+        |""".stripMargin
+    )
+    dir.toAbsolutePath.toString
+
+  test("list flows in the working folder") {
+    WvletMain.main(s"flow list -w ${flowDir}")
+  }
+
+  test("show a flow plan") {
+    WvletMain.main(s"flow show SamplePipeline -w ${flowDir}")
+  }
+
+  test("run a flow from the CLI") {
+    WvletMain.main(s"flow run SamplePipeline -w ${flowDir}")
+  }
+
+  test("run a flow with failing and fallback stages") {
+    // In sbt, failing flows do not System.exit; this verifies fallback execution completes
+    WvletMain.main(s"flow run FallbackPipeline -w ${flowDir}")
+  }
+
+  test("report an error for an unknown flow name") {
+    val e = intercept[WvletLangException] {
+      WvletMain.main(s"flow run NoSuchFlow -w ${flowDir}")
+    }
+    e.statusCode shouldBe StatusCode.FLOW_NOT_FOUND
+  }
+
+end WvletFlowCommandTest

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbolnfo.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Symbolnfo.scala
@@ -181,6 +181,27 @@ case class PartialQuerySymbolInfo(
 ) extends SymbolInfo(SymbolType.PartialQueryDef, owner, symbol, name, DataType.UnknownType):
   override def toString: String = s"partial ${owner}.${name}(${params.map(_.name).mkString(", ")})"
 
+/**
+  * Symbol info for flow definitions. Flows are orchestration containers of stages that are
+  * triggered explicitly (run flow), by schedules, or by dependencies.
+  *
+  * @param owner
+  *   The owning symbol (typically package)
+  * @param symbol
+  *   The symbol for this flow
+  * @param name
+  *   The name of the flow
+  * @param compilationUnit
+  *   The compilation unit where this flow is defined
+  */
+case class FlowSymbolInfo(
+    override val owner: Symbol,
+    override val symbol: Symbol,
+    override val name: Name,
+    override val compilationUnit: CompilationUnit
+) extends SymbolInfo(SymbolType.FlowDef, owner, symbol, name, DataType.UnknownType):
+  override def toString: String = s"flow ${owner}.${name}"
+
 case class ValSymbolInfo(
     override val owner: Symbol,
     override val symbol: Symbol,

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RemoveUnusedQueries.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RemoveUnusedQueries.scala
@@ -16,6 +16,7 @@ package wvlet.lang.compiler.analyzer
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Context
 import wvlet.lang.compiler.Phase
+import wvlet.lang.model.plan.FlowDef
 import wvlet.lang.model.plan.ModelDef
 import wvlet.lang.model.plan.TypeDef
 
@@ -51,6 +52,10 @@ class RemoveUnusedQueries extends Phase("check-unused"):
           case p: TypeDef =>
             hasDef = true
           case m: ModelDef =>
+            hasDef = true
+          case f: FlowDef =>
+            // Flow definitions must remain compilable so they can be run by name
+            // (run flow <name> statements or the wvlet flow CLI)
             hasDef = true
         }
       if hasDef then

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
@@ -16,6 +16,7 @@ package wvlet.lang.compiler.analyzer
 import wvlet.lang.compiler.ValSymbolInfo
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.FlowSymbolInfo
 import wvlet.lang.compiler.MethodSymbolInfo
 import wvlet.lang.compiler.ModelSymbolInfo
 import wvlet.lang.compiler.MultipleSymbolInfo
@@ -90,6 +91,9 @@ object SymbolLabeler extends Phase("symbol-labeler"):
         case m: ModelDef =>
           registerModelSymbol(m)(using ctx)
           iter(m.child, ctx)
+        case f: FlowDef =>
+          registerFlowSymbol(f)(using ctx)
+          ctx
         case f: TopLevelFunctionDef =>
           registerTopLevelFunction(f)(using ctx)
           ctx
@@ -443,6 +447,32 @@ object SymbolLabeler extends Phase("symbol-labeler"):
         )
         parent.symbol = sym
         sym
+
+  private def registerFlowSymbol(f: FlowDef)(using ctx: Context): Symbol =
+    val flowName = Name.termName(f.name.name)
+
+    def installSymbolInfo(sym: Symbol): Unit =
+      sym.symbolInfo = FlowSymbolInfo(ctx.owner, sym, flowName, ctx.compilationUnit)
+
+    ctx.scope.lookupSymbol(flowName) match
+      case Some(s) =>
+        // Update the existing flow symbol to avoid duplicates in REPL
+        s.tree = f
+        installSymbolInfo(s)
+        f.symbol = s
+        trace(s"Updated existing flow symbol ${s} for ${flowName}")
+        s
+      case None =>
+        val sym = Symbol(ctx.global.newSymbolId, f.span)
+        ctx.compilationUnit.enter(sym)
+        sym.tree = f
+        installSymbolInfo(sym)
+        f.symbol = sym
+        trace(s"Created a new flow symbol ${sym}")
+        ctx.scope.add(flowName, sym)
+        sym
+
+  end registerFlowSymbol
 
   private def registerModelSymbol(m: ModelDef)(using ctx: Context): Symbol =
     val modelName = Name.termName(m.name.name)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -452,6 +452,10 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
         code(s) {
           wl("show", s.showType.toString, s.inExpr.map(x => wl("in", expr(x))))
         }
+      case r: RunFlow =>
+        code(r) {
+          wl("run", "flow", expr(r.flowName))
+        }
       // Flow-related relations
       case s: StageDef =>
         // Note: inputRefs are tracked for dependency analysis but the body already contains

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -366,6 +366,21 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
   }
 
   /**
+    * Parse a run-flow statement: `run flow Name`
+    *
+    * The statement produces a flow-run summary relation (one row per stage), so it can be followed
+    * by query operators or test statements like a regular query
+    */
+  def runFlowStatement(): LogicalPlan = node {
+    val t = consume(WvletToken.RUN)
+    consume(WvletToken.FLOW)
+    val name = identifier()
+    val r    = RunFlow(name, spanFrom(t))
+    val q    = queryBlock(r)
+    Query(q, spanFrom(t))
+  }
+
+  /**
     * Parse a flow definition: `flow Name(params) = { stage ... }`
     *
     * Supports:
@@ -804,6 +819,8 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         defStatement()
       case WvletToken.FLOW =>
         flowDef()
+      case WvletToken.RUN =>
+        runFlowStatement()
       case WvletToken.VAL =>
         valDef()
       case WvletToken.SHOW =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -448,6 +448,17 @@ object Typer extends Phase("typer") with LogSupport:
         ref.tpe = scope(ref.name.fullName)
         typeRelationNode(ref)
         ref
+      case r: RunFlow =>
+        // Validate that the flow reference resolves to a flow definition
+        val isFlow = ctx
+          .findTermSymbolByName(r.flowName.fullName)
+          .exists(_.tree.isInstanceOf[FlowDef])
+        if !isFlow then
+          throw StatusCode
+            .FLOW_NOT_FOUND
+            .newException(s"Flow '${r.flowName.fullName}' is not found", r.sourceLocation)
+        typeRelationNode(r)
+        r
       case m: FlowMerge =>
         // Fan-in of multiple flow stages. The merged relation takes the type of the first source
         // that resolves in the stage scope (merge has union semantics over same-schema stages)

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
@@ -262,6 +262,43 @@ case class FlowMerge(sources: List[NameExpr], joinCondition: Option[Expression],
         EmptyRelationType
 
 /**
+  * RunFlow triggers the execution of a flow definition by name.
+  *
+  * It is a leaf relation whose output is the flow-run summary (one row per stage), so that the
+  * result can be piped through query operators or verified with test statements:
+  * {{{
+  * run flow my_pipeline
+  * test _.columns should contain 'state'
+  * }}}
+  *
+  * @param flowName
+  *   The name of the flow to run
+  * @param span
+  *   Source location
+  */
+case class RunFlow(flowName: NameExpr, span: Span) extends Relation with LeafPlan:
+  override def children: List[LogicalPlan] = Nil
+  override def relationType: RelationType  = RunFlow.summaryType
+
+object RunFlow:
+  import wvlet.lang.compiler.Name
+  import wvlet.lang.model.DataType
+
+  /**
+    * The relation type of a flow-run summary: one row per stage with its terminal state
+    */
+  val summaryType: SchemaType = SchemaType(
+    None,
+    Name.typeName("flow_run"),
+    List(
+      NamedType(Name.termName("stage"), DataType.StringType),
+      NamedType(Name.termName("state"), DataType.StringType),
+      NamedType(Name.termName("attempts"), DataType.LongType),
+      NamedType(Name.termName("error"), DataType.StringType)
+    )
+  )
+
+/**
   * FlowWait represents a time-based delay in the flow.
   *
   * Pauses execution for a specified duration.

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.lang.runner
 
+import wvlet.lang.api.Span
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.api.v1.flow.StageState
@@ -24,6 +25,7 @@ import wvlet.lang.model.expr.*
 import wvlet.lang.model.plan.*
 import wvlet.lang.runner.connector.DBConnector
 import wvlet.uni.log.LogSupport
+import wvlet.uni.util.ULID
 
 import scala.util.control.NonFatal
 
@@ -151,10 +153,15 @@ class FlowExecutor(
   def cancel(): Unit = cancelled = true
 
   def execute(flow: FlowDef)(using ctx: Context): FlowExecutionResult =
-    workEnv.info(s"Executing flow ${flow.name.name}")
+    val runId = ULID.newULIDString
+    workEnv.info(s"Executing flow ${flow.name.name} (run: ${runId})")
     val stageNames = flow.stages.map(_.name.name).toSet
     var states     = flow.stages.map(s => s.name.name -> StageState.Pending).to(Map)
     val results    = List.newBuilder[StageResult]
+
+    // Stages materialize into run-scoped tables so that concurrent runs and real tables with the
+    // same name never collide
+    def tableFor(stageName: String): String = FlowExecutor.stageTableName(runId, stageName)
 
     def evalTrigger(t: StageTrigger): Boolean =
       t match
@@ -199,15 +206,15 @@ class FlowExecutor(
                 case None =>
                   upstreamStagesOf(s).forall(up => states.get(up).contains(StageState.Success))
             if ready then
-              runStage(s)
+              runStage(s, stageNames, tableFor)
             else
               workEnv.info(s"Stage ${name} is skipped")
               StageResult(name, StageState.Skipped, 0)
         states += name -> stageResult.state
         results += stageResult
       }
-    val result = FlowExecutionResult(flow.name.name, results.result())
-    workEnv.info(s"Completed flow ${flow.name.name}")
+    val result = FlowExecutionResult(flow.name.name, runId, results.result())
+    workEnv.info(s"Completed flow ${flow.name.name} (run: ${runId})")
     result
 
   end execute
@@ -216,7 +223,9 @@ class FlowExecutor(
     * Run a single stage with retries: running -> success, or running -> attempt_failed -> (retrying
     * -> running)* -> failed
     */
-  private def runStage(s: StageDef)(using ctx: Context): StageResult =
+  private def runStage(s: StageDef, stageNames: Set[String], tableFor: String => String)(using
+      ctx: Context
+  ): StageResult =
     val name        = s.name.name
     val config      = StageExecutionConfig.fromConfigItems(s.config)
     val maxAttempts = config.retries + 1
@@ -230,7 +239,7 @@ class FlowExecutor(
       attempts += 1
       workEnv.info(s"Running stage ${name} (attempt ${attempts}/${maxAttempts})")
       try
-        materializeStage(s)
+        materializeStage(s, stageNames, tableFor)
         state = StageState.Success
       catch
         case e: WvletLangException if e.statusCode == StatusCode.NOT_IMPLEMENTED =>
@@ -258,14 +267,22 @@ class FlowExecutor(
         lastError
       else
         None
+      ,
+      if state == StageState.Success then
+        Some(tableFor(name))
+      else
+        None
     )
 
   end runStage
 
   /**
-    * Execute the stage body and materialize the result as a temporary table named after the stage
+    * Execute the stage body and materialize the result as a run-scoped temporary table. References
+    * to other stages in the body are rewritten to their run-scoped table names
     */
-  private def materializeStage(s: StageDef)(using ctx: Context): Unit =
+  private def materializeStage(s: StageDef, stageNames: Set[String], tableFor: String => String)(
+      using ctx: Context
+  ): Unit =
     val body = s
       .body
       .getOrElse(
@@ -286,14 +303,22 @@ class FlowExecutor(
           )
     }
 
-    // Rewrite merge (fan-in) into union all over the materialized stage tables
+    def stageTableRef(stageName: String, span: Span): Relation = TableRef(
+      DoubleQuotedIdentifier(tableFor(stageName), span),
+      span
+    )
+
+    // Rewrite stage references to their run-scoped tables, and merge (fan-in) into union all
     val executable = body
-      .transformUp { case m: FlowMerge =>
-        m.sources
-          .map(stageTableRef(_, m))
-          .reduceLeft[Relation] { (l, r) =>
-            Union(l, r, isDistinct = false, m.span)
-          }
+      .transformUp {
+        case t: TableRef if stageNames.contains(t.name.fullName) =>
+          stageTableRef(t.name.fullName, t.span)
+        case m: FlowMerge =>
+          m.sources
+            .map(src => stageTableRef(src.fullName, src.span))
+            .reduceLeft[Relation] { (l, r) =>
+              Union(l, r, isDistinct = false, m.span)
+            }
       }
       .asInstanceOf[Relation]
 
@@ -301,16 +326,16 @@ class FlowExecutor(
 
     given QueryProgressMonitor = ctx.queryProgressMonitor
 
-    // Quote the table name as stage names may collide with reserved SQL keywords (e.g. primary)
-    connector.execute(s"""create or replace temp table "${s.name.name}" as\n${sql}""")
+    // Quote the table name: it contains a ULID and stage names may collide with SQL keywords
+    val ddl = s"""create or replace temp table "${tableFor(s.name.name)}" as\n${sql}"""
+    debug(s"Materializing stage ${s.name.name}:\n${ddl}")
+    connector.execute(ddl)
 
   end materializeStage
 
-  private def stageTableRef(src: NameExpr, m: FlowMerge): Relation =
-    src match
-      case q: QualifiedName =>
-        TableRef(q, src.span)
-      case other =>
-        TableRef(UnquotedIdentifier(other.fullName, other.span), other.span)
-
 end FlowExecutor
+
+object FlowExecutor:
+  /** The run-scoped table name holding the materialized result of a stage */
+  def stageTableName(runId: String, stageName: String): String =
+    s"__wv_flow_${runId.toLowerCase}_${stageName}"

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -424,11 +424,60 @@ class QueryExecutor(
 
   end executeSaveToLocalFileViaDuckDB
 
+  /**
+    * Resolve a `run flow <name>` reference to its flow definition via the symbol table
+    */
+  private def resolveFlow(rf: RunFlow)(using context: Context): FlowDef =
+    context.findTermSymbolByName(rf.flowName.fullName).map(_.tree) match
+      case Some(f: FlowDef) =>
+        f
+      case _ =>
+        throw StatusCode
+          .FLOW_NOT_FOUND
+          .newException(
+            s"Flow '${rf.flowName.fullName}' is not found",
+            rf.sourceLocation(using context)
+          )
+
+  /**
+    * Execute flow runs embedded in a query plan and replace each RunFlow node with a reference to a
+    * materialized flow-run summary table (stage, state, attempts, error), so that downstream query
+    * operators and test statements work on the summary rows via regular SQL
+    */
+  private def runEmbeddedFlows(q: Relation)(using context: Context): Relation =
+    def sqlLit(s: String): String = s"'${s.replaceAll("'", "''")}'"
+
+    q.transformUp { case rf: RunFlow =>
+        val flow       = resolveFlow(rf)
+        val connector  = getDBConnector(defaultProfile)
+        val flowResult = FlowExecutor(connector, workEnv).execute(flow)
+
+        given monitor: QueryProgressMonitor = context.queryProgressMonitor
+
+        val summaryTable = s"__wv_flow_run_${flowResult.runId.toLowerCase}"
+        connector.execute(
+          s"""create or replace temp table "${summaryTable}" ("stage" varchar, "state" varchar, "attempts" bigint, "error" varchar)"""
+        )
+        if flowResult.stageResults.nonEmpty then
+          val rows = flowResult
+            .stageResults
+            .map { s =>
+              val err = s.error.map(e => sqlLit(e.getMessage)).getOrElse("null")
+              s"(${sqlLit(s.name)}, ${sqlLit(s.state.stateName)}, ${s.attempts}, ${err})"
+            }
+            .mkString(", ")
+          connector.execute(s"""insert into "${summaryTable}" values ${rows}""")
+        TableRef(DoubleQuotedIdentifier(summaryTable, rf.span), rf.span)
+      }
+      .asInstanceOf[Relation]
+
   private def executeQuery(plan: LogicalPlan)(using context: Context): QueryResult =
     trace(s"Executing query: ${plan.pp}")
     workEnv.trace(s"Executing plan: ${plan.pp}")
     plan match
-      case q: Relation =>
+      case q0: Relation =>
+        // Execute any embedded flow runs first, replacing them with their summary tables
+        val q = runEmbeddedFlows(q0)
         // Decide whether to auto-switch to DuckDB for simple local file reads
         def isRemotePath(p: String): Boolean = p.startsWith("s3://") || p.startsWith("https://")
         def prefersDuckDBForLocalRead(r: Relation): Boolean =

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryResult.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryResult.scala
@@ -110,19 +110,29 @@ case class TestFailure(msg: String, loc: SourceLocation) extends QueryResult:
   *   The number of execution attempts made (0 for skipped/cancelled stages)
   * @param error
   *   The last error if the stage failed
+  * @param table
+  *   The run-scoped table holding the materialized stage result (for successful stages)
   */
 case class StageResult(
     name: String,
     state: StageState,
     attempts: Int,
-    error: Option[Throwable] = None
+    error: Option[Throwable] = None,
+    table: Option[String] = None
 )
 
 /**
   * The result of executing a flow with the stage execution model. The flow is considered failed
   * when any of its stages ends in the failed state
+  *
+  * @param flowName
+  *   The name of the executed flow
+  * @param runId
+  *   A unique identifier of this flow run, used to scope stage materializations
+  * @param stageResults
+  *   Per-stage results in stage definition order
   */
-case class FlowExecutionResult(flowName: String, stageResults: List[StageResult])
+case class FlowExecutionResult(flowName: String, runId: String, stageResults: List[StageResult])
     extends QueryResult:
   def stageResult(stageName: String): Option[StageResult] = stageResults.find(_.name == stageName)
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryResultPrinter.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryResultPrinter.scala
@@ -202,7 +202,7 @@ object QueryResultPrinter extends LogSupport:
             s"  stage ${s.name}: ${s.state.stateName} (attempts: ${s.attempts})${err}"
           }
           .mkString("\n")
-        s"flow ${f.flowName}:\n${stages}"
+        s"flow ${f.flowName} (run: ${f.runId}):\n${stages}"
 
 end QueryResultPrinter
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/GenericConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/GenericConnector.scala
@@ -9,11 +9,11 @@ import wvlet.lang.runner.connector.duckdb.DuckDBConnector
 import java.sql.Connection
 
 class GenericConnector(workEnv: WorkEnv) extends DBConnector(Generic, workEnv):
-  private var _connector: DBConnector = null
+  private var _connector: DuckDBConnector = null
 
   override def close(): Unit = Option(_connector).foreach(_.close())
 
-  private def getConnector: DBConnector =
+  private def getConnector: DuckDBConnector =
     if _connector == null then
       // Use DuckDB as a fallback connector, but initialize it only when necessary
       // as loading duckdb-jdbc takes a few seconds
@@ -21,6 +21,12 @@ class GenericConnector(workEnv: WorkEnv) extends DBConnector(Generic, workEnv):
     _connector
 
   override private[connector] def newConnection: DBConnection = getConnector.newConnection
+
+  // Delegate to DuckDBConnector, which reuses a single connection. This preserves
+  // connection-scoped state (in-memory and temp tables) across statements, which flow stage
+  // materialization and multi-statement scripts rely on
+  override protected def withConnection[U](body: DBConnection => U): U = getConnector
+    .withConnection(body)
 
   override def listFunctions(catalog: String): List[SQLFunction] = getConnector.listFunctions(
     catalog

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -1,5 +1,7 @@
 package wvlet.lang.runner
 
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
 import wvlet.lang.api.v1.flow.StageState
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.CompilationUnit
@@ -49,10 +51,18 @@ class FlowExecutorTest extends UniTest:
     FlowExecutor(connector, workEnv, sleeper).execute(flow)(using ctx)
 
   private def countRows(table: String): Long =
-    connector.runQuery(s"select count(*) cnt from ${table}") { rs =>
+    connector.runQuery(s"""select count(*) cnt from "${table}"""") { rs =>
       rs.next()
       rs.getLong(1)
     }
+
+  /** Count rows in the run-scoped materialization of the given stage */
+  private def countStageRows(result: FlowExecutionResult, stage: String): Long = countRows(
+    result
+      .stageResult(stage)
+      .flatMap(_.table)
+      .getOrElse(fail(s"Stage ${stage} has no materialized table"))
+  )
 
   test("run all stages of a successful flow in order") {
     val result = runFlow("""flow SimpleFlow = {
@@ -64,9 +74,10 @@ class FlowExecutorTest extends UniTest:
     result.stageResults.map(_.state) shouldBe
       List(StageState.Success, StageState.Success, StageState.Success)
     result.stageResults.map(_.attempts) shouldBe List(1, 1, 1)
-    // Each stage is materialized as a queryable temp table
-    countRows("filtered") shouldBe 2L
-    countRows("output") shouldBe 2L
+    // Each stage is materialized as a queryable run-scoped temp table
+    result.stageResults.forall(_.table.exists(_.contains(result.runId.toLowerCase))) shouldBe true
+    countStageRows(result, "filtered") shouldBe 2L
+    countStageRows(result, "output") shouldBe 2L
   }
 
   test("skip downstream stages when an upstream stage fails") {
@@ -151,8 +162,8 @@ class FlowExecutorTest extends UniTest:
         |  stage output = from merged | select id
         |}""".stripMargin)
     result.isSuccess shouldBe true
-    countRows("merged") shouldBe 3L
-    countRows("output") shouldBe 3L
+    countStageRows(result, "merged") shouldBe 3L
+    countStageRows(result, "output") shouldBe 3L
   }
 
   test("skip a merge stage when one of its sources failed") {
@@ -218,6 +229,38 @@ class FlowExecutorTest extends UniTest:
         f.stageResults.map(_.state) shouldBe List(StageState.Success, StageState.Success)
       case other =>
         fail(s"Expected FlowExecutionResult, but got: ${other}")
+  }
+
+  test("execute a flow with the run flow statement and query its summary") {
+    val (unit, _, ctx) = compileFlowUnit("""flow StmtFlow = {
+        |  stage src = from [[1], [2]] as t(id)
+        |  stage doubled = from src | select id * 2 as id2
+        |}
+        |
+        |run flow StmtFlow
+        |""".stripMargin)
+    val executionPlan = ExecutionPlanner.plan(unit, ctx)
+    val queryExecutor = QueryExecutor(dbConnectorProvider, profile, workEnv)
+    val result        = queryExecutor.execute(executionPlan, ctx)
+    result match
+      case t: TableRows =>
+        t.rows.size shouldBe 2
+        t.rows.map(_("stage")) shouldBe Seq("src", "doubled")
+        t.rows.map(_("state")) shouldBe Seq("success", "success")
+      case other =>
+        fail(s"Expected TableRows summary, but got: ${other}")
+  }
+
+  test("report an error when running an undefined flow") {
+    val e = intercept[WvletLangException] {
+      compileFlowUnit("""flow DefinedFlow = {
+          |  stage src = from [[1]] as t(id)
+          |}
+          |
+          |run flow NoSuchFlow
+          |""".stripMargin)
+    }
+    e.statusCode shouldBe StatusCode.FLOW_NOT_FOUND
   }
 
   test("not execute flow definitions on whole-file execution") {


### PR DESCRIPTION
## Summary

Phase 1 of #1817: flows become executable end-to-end from `.wv` files and the CLI.

### `run flow <name>` statement
- New `RunFlow` leaf relation producing a **flow-run summary** (`stage`, `state`, `attempts`, `error`), one row per stage
- Parses like `show`-style statements and goes through `queryBlock`, so the summary can be piped through query operators and verified with `test` statements — this is what enables spec-driven executor tests:
  ```wvlet
  run flow my_pipeline
  | where state = 'success'
  test _.size should be 2
  ```
- At execution, `RunFlow` nodes are replaced by a materialized summary temp table, so downstream operators work via regular SQL
- Flow definitions are now registered as symbols (`FlowSymbolInfo` via `SymbolLabeler`), so flows resolve by name across compilation units; undefined references fail at compile time with the new `FLOW_NOT_FOUND` status code

### Run-scoped stage materialization (#1817 item 2)
- Stages materialize into `__wv_flow_<run_id>_<stage>` temp tables (run id = ULID)
- Stage references in bodies (and merge sources) are rewritten to the run-scoped names at SQL generation time — stage names never collide with real tables, and concurrent runs do not interfere
- `StageResult.table` exposes the materialized table name; `FlowExecutionResult.runId` identifies the run

### `wvlet flow` CLI subcommands (#1817 item 1)
- `wvlet flow run <name> -w <dir>` — compile, run, print per-stage results; non-zero exit code when the flow fails
- `wvlet flow list -w <dir>` — enumerate flows with stage counts, params, dependencies, and schedules
- `wvlet flow show <name> -w <dir>` — print the flow plan (LogicalPlanPrinter rendering)
- Registered as a launcher sub-module (`Launcher.of[WvletMain].addModule[WvletFlowCommand]`)

### Bug fixes surfaced by this work
- **`RemoveUnusedQueries` dropped flow-only compilation units** (only `TypeDef`/`ModelDef` counted as definitions), making flows invisible to whole-folder compilation
- **`GenericConnector` (default CLI profile) opened a new in-memory DuckDB connection per statement**, losing temp tables and in-memory state between statements; it now delegates to `DuckDBConnector`'s single-connection handling

### Tests
- `spec/basic/flow-run.wv`: spec-driven execution tests (success chain, filtered summary, fallback + skip verification via `test _.output`, retry exhaustion, merge)
- `FlowExecutorTest`: 17 tests including `run flow` end-to-end, FLOW_NOT_FOUND, run-scoped table assertions
- `WvletFlowCommandTest`: CLI run/list/show/unknown-flow coverage
- Full matrix green: langJVM 1485, runner 415, cli 86, Scala.js + Native compile, scalafmt

### Next (separate PRs per #1817)
Ready-set DAG scheduler, FlowOp lowering (route/fork/wait/activate), session/run registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)