### PR TITLE
feature: Lower flow operators so route/fork/wait/activate/end are executable

### DIFF
--- a/spec/basic/flow-run.wv
+++ b/spec/basic/flow-run.wv
@@ -68,3 +68,32 @@ run flow MergePipeline
 | where state = 'success'
 test _.size should be 3
 ;
+
+flow RoutedPipeline = {
+  stage src = from [[1, 25], [2, 15], [3, 40]] as t(id, age)
+  stage gate = from src | route {
+    case _.age >= 18 -> adult
+    else -> minor
+  }
+  stage adult = from gate | select id
+  stage minor = from gate | select id
+}
+
+-- Conditional routing lowers into filters over the route stage output
+run flow RoutedPipeline
+| where state = 'success'
+test _.size should be 4
+;
+
+flow JourneyPipeline = {
+  stage entry = from [[1], [2]] as t(id)
+  stage delayed = from entry | wait('10 ms')
+  stage send = from delayed | activate('email')
+  stage done = from send | end()
+}
+
+-- wait/activate/end operators are executable orchestration steps
+run flow JourneyPipeline
+| where state = 'success'
+test _.size should be 4
+;

--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -341,9 +341,12 @@ wvlet flow run my_pipeline -w ./pipelines
 :::info Implementation status
 The flow executor implements this stage execution model with a DAG scheduler — independent
 stages run in parallel (bounded by executor parallelism), retries are scheduled asynchronously
-with the configured backoff, and `timeout` bounds each stage attempt. Flow-level schedules,
-cross-flow dependencies, `heartbeat` enforcement, and flow operators such as `route`, `fork`,
-`wait`, and `activate` are parsed but not yet executable.
+with the configured backoff, and `timeout` bounds each stage attempt. Flow operators are
+lowered before scheduling: `route` cases become filter predicates on target stages, `fork`
+stages are flattened into the DAG, `wait` delays materialization, `activate` is a local
+logging stub until sink connectors exist, and `end` is a pass-through. Flow-level schedules,
+cross-flow dependencies, `-> Flow` jumps, and `heartbeat` enforcement are parsed but not yet
+executable.
 :::
 
 Each stage progresses through a well-defined state machine:

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -507,6 +507,32 @@ object Typer extends Phase("typer") with LogSupport:
             ref.sourceLocation
           )
 
+    // All stage names of the flow, including fork-nested stages. Route targets may reference
+    // stages defined later in the flow (forward references), unlike triggers and merge sources
+    val allStageNames: Set[String] =
+      val names = Set.newBuilder[String]
+      f.stages
+        .foreach { s =>
+          names += s.name.name
+          s.body
+            .foreach {
+              _.traverse { case fork: FlowFork =>
+                fork.stages.foreach(ns => names += ns.name.name)
+              }
+            }
+        }
+      names.result()
+
+    def requireRouteTarget(ref: NameExpr, stageName: TermName): Unit =
+      if !allStageNames.contains(ref.fullName) then
+        throw StatusCode
+          .STAGE_NOT_FOUND
+          .newException(
+            s"Stage '${ref.fullName}' referenced as a route target of stage '${stageName
+                .name}' is not defined in flow '${f.name.name}'",
+            ref.sourceLocation
+          )
+
     val newStages = f
       .stages
       .map { s =>
@@ -515,8 +541,12 @@ object Typer extends Phase("typer") with LogSupport:
         s.trigger.foreach(t => stateRefsOf(t).foreach(ref => requireStage(ref, "trigger", s.name)))
         s.body
           .foreach {
-            _.traverse { case m: FlowMerge =>
-              m.sources.foreach(ref => requireStage(ref, "merge sources", s.name))
+            _.traverse {
+              case m: FlowMerge =>
+                m.sources.foreach(ref => requireStage(ref, "merge sources", s.name))
+              case r: FlowRoute =>
+                r.cases.foreach(c => requireRouteTarget(c.target, s.name))
+                r.elseTarget.foreach(t => requireRouteTarget(t, s.name))
             }
           }
         val newBody     = s.body.map(b => prepare(b, stageScope).asInstanceOf[Relation])

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/FlowTypingTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/FlowTypingTest.scala
@@ -91,6 +91,32 @@ class FlowTypingTest extends UniTest:
     e.getMessage shouldContain "missing_stage"
   }
 
+  test("allow route targets to reference stages defined later") {
+    val f = compileFlow(s"""${userType}
+        |flow ForwardRoute = {
+        |  stage gate = from users | route {
+        |    case _.user_id = '1' -> matched
+        |    else -> unmatched
+        |  }
+        |  stage matched = from gate | select name
+        |  stage unmatched = from gate | select name
+        |}""".stripMargin)
+    f.stages.size shouldBe 3
+  }
+
+  test("report an error for a route targeting an undefined stage") {
+    val e = intercept[WvletLangException] {
+      compileFlow(s"""${userType}
+          |flow BrokenRoute = {
+          |  stage gate = from users | route {
+          |    case _.user_id = '1' -> missing_stage
+          |  }
+          |}""".stripMargin)
+    }
+    e.statusCode shouldBe StatusCode.STAGE_NOT_FOUND
+    e.getMessage shouldContain "missing_stage"
+  }
+
   test("report an error for a trigger referencing a stage defined later") {
     val e = intercept[WvletLangException] {
       compileFlow(s"""${userType}

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -152,9 +152,13 @@ trait FlowStageRunner:
   * stage names never collide with real tables and concurrent runs do not interfere. Parallel stages
   * materialize through per-worker sessions sharing the same database instance.
   *
+  * Flow operators in stage bodies are lowered with [[FlowLowering]] before scheduling: fork stages
+  * are flattened, route cases become filter predicates on the target stages' reads, wait becomes a
+  * pre-materialization delay, activate is a local logging stub, and end is a pass-through.
+  *
   * Current limitations (to be lifted in future iterations):
   *   - `heartbeat` is parsed but not enforced.
-  *   - Flow operators such as route/fork/wait/activate/jump/end are not yet executable.
+  *   - `-> Flow` (jump) requires cross-flow orchestration and is not executable yet.
   *   - Flow-level schedules and cross-flow dependencies are not evaluated here.
   *
   * @param connector
@@ -192,24 +196,45 @@ class FlowExecutor(
     val runId = ULID.newULIDString
     workEnv.info(s"Executing flow ${flow.name.name} (run: ${runId})")
 
-    val stageNames                                      = flow.stages.map(_.name.name).toSet
+    // Lower flow operators (fork/route/wait/activate/end) into SQL-expressible stage bodies
+    // plus orchestration metadata
+    val lowered                                         = FlowLowering.lower(flow)
+    val flowStages                                      = lowered.stages
+    val stageNames                                      = lowered.stageNames
+    val routeFilters                                    = lowered.routeFilters
     val stageConfigs: Map[String, StageExecutionConfig] =
-      flow.stages.map(s => s.name.name -> StageExecutionConfig.fromConfigItems(s.config)).toMap
+      flowStages.map(ls => ls.name -> StageExecutionConfig.fromConfigItems(ls.stage.config)).toMap
 
     // Stages materialize into run-scoped tables so that concurrent runs and real tables with the
     // same name never collide
     def tableFor(stageName: String): String = FlowExecutor.stageTableName(runId, stageName)
 
-    val runBody: (StageDef, String) => Unit =
+    val runBody: (FlowLowering.LoweredStage, String) => Unit =
       stageRunner match
         case Some(r) =>
-          (s, table) => r.run(s, table)
+          (ls, table) => r.run(ls.stage, table)
         case None =>
-          (s, table) => materializeStage(s, stageNames, tableFor)
+          (ls, table) =>
+            // A wait operator delays the materialization of this stage. The sleep runs on a
+            // worker thread and is interruptible for cancellation
+            ls.waitMillis
+              .foreach { delay =>
+                workEnv.info(s"Stage ${ls.name} waits for ${delay}ms")
+                Thread.sleep(delay)
+              }
+            materializeStage(ls, stageNames, tableFor, routeFilters)
+            // Activation is a local stub until external sink connectors are available
+            ls.activateTargets
+              .foreach { target =>
+                workEnv.info(
+                  s"[activate] stage ${ls
+                      .name}: sending materialized output ${table} to '${target}'"
+                )
+              }
 
     // All mutable scheduler state below is owned by this (caller) thread; worker threads only
     // post events to the eventQueue
-    val states   = mutable.Map.from(flow.stages.map(s => s.name.name -> StageState.Pending))
+    val states   = mutable.Map.from(flowStages.map(ls => ls.name -> StageState.Pending))
     val attempts = mutable.Map.empty[String, Int].withDefaultValue(0)
     val errors   = mutable.Map.empty[String, Throwable]
     // (stage, attempt) pairs whose outcome has been decided (guards against duplicate events
@@ -262,11 +287,11 @@ class FlowExecutor(
 
     // Upstream stages referenced from this stage via from/merge/depends on. Names that do not
     // match a stage (e.g. real tables or models) impose no state dependency
-    def upstreamStagesOf(s: StageDef): List[String] =
+    def upstreamStagesOf(ls: FlowLowering.LoweredStage): List[String] =
       val refs = List.newBuilder[String]
-      s.inputRefs.foreach(r => refs += r.fullName)
-      s.dependsOn.foreach(r => refs += r.fullName)
-      s.body
+      ls.stage.inputRefs.foreach(r => refs += r.fullName)
+      ls.stage.dependsOn.foreach(r => refs += r.fullName)
+      ls.body
         .foreach {
           _.traverse { case m: FlowMerge =>
             m.sources.foreach(src => refs += src.fullName)
@@ -275,25 +300,27 @@ class FlowExecutor(
       refs.result().distinct.filter(stageNames.contains)
 
     // Stages whose terminal states this stage's scheduling decision depends on
-    def schedulingRefsOf(s: StageDef): List[String] =
-      s.trigger match
+    def schedulingRefsOf(ls: FlowLowering.LoweredStage): List[String] =
+      ls.stage.trigger match
         case Some(t) =>
           // An explicit trigger overrides the implicit success dependency
           triggerRefsOf(t).distinct.filter(stageNames.contains)
         case None =>
-          upstreamStagesOf(s)
+          upstreamStagesOf(ls)
 
-    def isDecidable(s: StageDef): Boolean = schedulingRefsOf(s).forall(n => states(n).isTerminal)
+    def isDecidable(ls: FlowLowering.LoweredStage): Boolean = schedulingRefsOf(ls).forall(n =>
+      states(n).isTerminal
+    )
 
-    def isReady(s: StageDef): Boolean =
-      s.trigger match
+    def isReady(ls: FlowLowering.LoweredStage): Boolean =
+      ls.stage.trigger match
         case Some(t) =>
           evalTrigger(t)
         case None =>
-          upstreamStagesOf(s).forall(up => states(up) == StageState.Success)
+          upstreamStagesOf(ls).forall(up => states(up) == StageState.Success)
 
-    def submitAttempt(s: StageDef, attempt: Int): Unit =
-      val name        = s.name.name
+    def submitAttempt(ls: FlowLowering.LoweredStage, attempt: Int): Unit =
+      val name        = ls.name
       val stageConfig = stageConfigs(name)
       states(name) = StageState.Running
       runningCount += 1
@@ -303,12 +330,12 @@ class FlowExecutor(
           override def run(): Unit =
             val error =
               try
-                runBody(s, tableFor(name))
+                runBody(ls, tableFor(name))
                 None
               catch
                 case NonFatal(e) =>
                   Some(e)
-            eventQueue.put(AttemptResult(s, attempt, error))
+            eventQueue.put(AttemptResult(ls, attempt, error))
       )
       // Bound the attempt duration with the configured timeout. The timed-out attempt is
       // reported as a retryable failure; a late completion event is ignored via handledAttempts
@@ -319,7 +346,7 @@ class FlowExecutor(
             new Runnable:
               override def run(): Unit = eventQueue.put(
                 AttemptResult(
-                  s,
+                  ls,
                   attempt,
                   Some(
                     StatusCode
@@ -342,29 +369,24 @@ class FlowExecutor(
       var progress = true
       while progress do
         progress = false
-        flow
-          .stages
-          .foreach { s =>
-            val name = s.name.name
-            if states(name) == StageState.Pending && isDecidable(s) then
-              if isReady(s) then
-                submitAttempt(s, attempts(name) + 1)
-              else
-                workEnv.info(s"Stage ${name} is skipped")
-                states(name) = StageState.Skipped
-                progress = true
-          }
+        flowStages.foreach { ls =>
+          val name = ls.name
+          if states(name) == StageState.Pending && isDecidable(ls) then
+            if isReady(ls) then
+              submitAttempt(ls, attempts(name) + 1)
+            else
+              workEnv.info(s"Stage ${name} is skipped")
+              states(name) = StageState.Skipped
+              progress = true
+        }
 
     def handleCancellation(): Unit =
       if !cancellationDone then
         cancellationDone = true
-        flow
-          .stages
-          .foreach { s =>
-            val name = s.name.name
-            if !states(name).isTerminal then
-              states(name) = StageState.Cancelled
-          }
+        flowStages.foreach { ls =>
+          if !states(ls.name).isTerminal then
+            states(ls.name) = StageState.Cancelled
+        }
 
     def allTerminal: Boolean = states.values.forall(_.isTerminal)
 
@@ -380,12 +402,11 @@ class FlowExecutor(
         else if runningCount == 0 && scheduledRetries == 0 then
           // Defensive: no outstanding work can change any state. This indicates a scheduling
           // bug (the stage DAG is acyclic by construction), so skip the undecidable remainder
-          flow
-            .stages
-            .filter(s => !states(s.name.name).isTerminal)
-            .foreach { s =>
-              workEnv.warn(s"Stage ${s.name.name} is unschedulable; marking as skipped")
-              states(s.name.name) = StageState.Skipped
+          flowStages
+            .filter(ls => !states(ls.name).isTerminal)
+            .foreach { ls =>
+              workEnv.warn(s"Stage ${ls.name} is unschedulable; marking as skipped")
+              states(ls.name) = StageState.Skipped
             }
           done = true
         else
@@ -394,10 +415,10 @@ class FlowExecutor(
             // handled at the top of the loop via the cancelled flag
             case RetryDue(s, attempt) =>
               scheduledRetries -= 1
-              if states(s.name.name) == StageState.Retrying then
+              if states(s.name) == StageState.Retrying then
                 submitAttempt(s, attempt)
             case AttemptResult(s, attempt, error) =>
-              val name = s.name.name
+              val name = s.name
               if !handledAttempts.contains((name, attempt)) then
                 handledAttempts += name -> attempt
                 runningCount -= 1
@@ -439,26 +460,24 @@ class FlowExecutor(
     end try
 
     // Report results in stage definition order for deterministic summaries
-    val stageResults = flow
-      .stages
-      .map { s =>
-        val name  = s.name.name
-        val state = states(name)
-        StageResult(
-          name,
-          state,
-          attempts(name),
-          if state == StageState.Failed then
-            errors.get(name)
-          else
-            None
-          ,
-          if state == StageState.Success then
-            Some(tableFor(name))
-          else
-            None
-        )
-      }
+    val stageResults = flowStages.map { ls =>
+      val name  = ls.name
+      val state = states(name)
+      StageResult(
+        name,
+        state,
+        attempts(name),
+        if state == StageState.Failed then
+          errors.get(name)
+        else
+          None
+        ,
+        if state == StageState.Success then
+          Some(tableFor(name))
+        else
+          None
+      )
+    }
     val result = FlowExecutionResult(flow.name.name, runId, stageResults)
     workEnv.info(s"Completed flow ${flow.name.name} (run: ${runId})")
     result
@@ -466,37 +485,42 @@ class FlowExecutor(
   end execute
 
   /**
-    * Execute the stage body and materialize the result as a run-scoped table. References to other
-    * stages in the body are rewritten to their run-scoped table names. Materialization runs on a
-    * dedicated session so that parallel stages do not contend on a single connection
+    * Execute the lowered stage body and materialize the result as a run-scoped table. References to
+    * other stages in the body are rewritten to their run-scoped table names (with routing
+    * predicates applied when this stage is a route target). Materialization runs on a dedicated
+    * session so that parallel stages do not contend on a single connection
     */
-  private def materializeStage(s: StageDef, stageNames: Set[String], tableFor: String => String)(
-      using ctx: Context
-  ): Unit =
-    val body = s
+  private def materializeStage(
+      ls: FlowLowering.LoweredStage,
+      stageNames: Set[String],
+      tableFor: String => String,
+      routeFilters: Map[(String, String), Expression]
+  )(using ctx: Context): Unit =
+    val body = ls
       .body
       .getOrElse(
-        throw StatusCode
-          .NOT_IMPLEMENTED
-          .newException(s"Stage ${s.name.name} has no executable body")
+        throw StatusCode.NOT_IMPLEMENTED.newException(s"Stage ${ls.name} has no executable body")
       )
 
-    // Reject flow operators that this executor cannot run yet
-    body.traverse {
-      case op: (FlowRoute | FlowFork | FlowWait | FlowActivate | FlowJump | FlowEnd) =>
-        throw StatusCode
-          .NOT_IMPLEMENTED
-          .newException(
-            s"Flow operator ${op.nodeName} in stage ${s
-                .name
-                .name} is not supported by the flow executor yet"
-          )
+    // Reject flow operators that lowering could not handle (e.g. cross-flow jumps)
+    body.traverse { case op: FlowJump =>
+      throw StatusCode
+        .NOT_IMPLEMENTED
+        .newException(
+          s"Flow operator ${op.nodeName} in stage ${ls
+              .name} is not supported by the flow executor yet"
+        )
     }
 
-    def stageTableRef(stageName: String, span: Span): Relation = TableRef(
-      DoubleQuotedIdentifier(tableFor(stageName), span),
-      span
-    )
+    // Reference a source stage's run-scoped table, filtered with the routing predicate when
+    // this stage is a route target of the source
+    def stageTableRef(stageName: String, span: Span): Relation =
+      val ref = TableRef(DoubleQuotedIdentifier(tableFor(stageName), span), span)
+      routeFilters.get((ls.name, stageName)) match
+        case Some(pred) =>
+          Filter(ref, pred, span)
+        case None =>
+          ref
 
     // Rewrite stage references to their run-scoped tables, and merge (fan-in) into union all
     val executable = body
@@ -517,8 +541,8 @@ class FlowExecutor(
     // Quote the table name: it contains a ULID and stage names may collide with SQL keywords.
     // The table is a regular (non-temp) table because parallel stages materialize on separate
     // sessions, and temp tables are session-scoped
-    val ddl = s"""create or replace table "${tableFor(s.name.name)}" as\n${sql}"""
-    debug(s"Materializing stage ${s.name.name}:\n${ddl}")
+    val ddl = s"""create or replace table "${tableFor(ls.name)}" as\n${sql}"""
+    debug(s"Materializing stage ${ls.name}:\n${ddl}")
     connector.withSession { conn =>
       Using.resource(conn.createStatement()) { stmt =>
         stmt.execute(ddl)
@@ -549,8 +573,8 @@ object FlowExecutor:
     }
 
   private enum FlowEvent:
-    case AttemptResult(stage: StageDef, attempt: Int, error: Option[Throwable])
-    case RetryDue(stage: StageDef, attempt: Int)
+    case AttemptResult(stage: FlowLowering.LoweredStage, attempt: Int, error: Option[Throwable])
+    case RetryDue(stage: FlowLowering.LoweredStage, attempt: Int)
     case CancelRequested
 
 end FlowExecutor

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
@@ -1,0 +1,246 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.api.Span
+import wvlet.lang.api.Span.NoSpan
+import wvlet.lang.api.StatusCode
+import wvlet.lang.model.expr.*
+import wvlet.lang.model.plan.*
+
+/**
+  * Lowers flow operators inside stage bodies into a plain SQL-expressible body plus orchestration
+  * metadata, keeping the flow executor engine-agnostic:
+  *
+  *   - `fork { stage ... }` — nested stages are flattened into top-level scheduler stages; the fork
+  *     node itself becomes a pass-through of its input
+  *   - `route { case cond -> target; else -> other }` — the route stage materializes its input
+  *     unchanged; each *target* stage's read of the route stage is filtered with the case predicate
+  *     (percentage cases become deterministic bucket predicates over the `by` expression)
+  *   - `wait('30 minutes')` — recorded as a pre-materialization delay
+  *   - `activate('target')` — recorded as an activation of the materialized stage output (local
+  *     stub until sink connectors exist)
+  *   - `end()` — pass-through terminal marker
+  *
+  * `-> OtherFlow` (jump) requires cross-flow orchestration and is not lowered yet.
+  */
+object FlowLowering:
+
+  /**
+    * A stage with flow operators stripped from its body
+    *
+    * @param stage
+    *   The original stage definition (fork-nested stages appear as their own entries)
+    * @param body
+    *   The SQL-expressible stage body (pass-through where flow operators were removed)
+    * @param waitMillis
+    *   Delay to apply before materializing the stage
+    * @param activateTargets
+    *   External activation targets to notify with the materialized output
+    */
+  case class LoweredStage(
+      stage: StageDef,
+      body: Option[Relation],
+      waitMillis: Option[Long] = None,
+      activateTargets: List[String] = Nil
+  ):
+    def name: String = stage.name.name
+
+  /**
+    * A flow with all stage bodies lowered
+    *
+    * @param flow
+    *   The original flow definition
+    * @param stages
+    *   Lowered stages in scheduling order (fork-nested stages follow their parent)
+    * @param routeFilters
+    *   Predicate to apply when `readerStage` reads the output of `routeStage`, keyed by
+    *   (readerStage, routeStage)
+    */
+  case class LoweredFlow(
+      flow: FlowDef,
+      stages: List[LoweredStage],
+      routeFilters: Map[(String, String), Expression]
+  ):
+    def stageNames: Set[String] = stages.map(_.name).toSet
+
+  def lower(flow: FlowDef): LoweredFlow =
+    // Flatten fork-nested stages right after their declaring stage
+    val flatStages: List[StageDef] = flow
+      .stages
+      .flatMap { s =>
+        val nested = List.newBuilder[StageDef]
+        s.body
+          .foreach {
+            _.traverse { case f: FlowFork =>
+              nested ++= f.stages
+            }
+          }
+        s :: nested.result()
+      }
+
+    val routeFilters = Map.newBuilder[(String, String), Expression]
+
+    val lowered = flatStages.map { s =>
+      var waitMillis: Option[Long] = None
+      val activations              = List.newBuilder[String]
+      val newBody                  = s
+        .body
+        .map {
+          _.transformUp {
+              case r: FlowRoute =>
+                routePredicatesOf(r).foreach { (target, pred) =>
+                  routeFilters += (target, s.name.name) -> pred
+                }
+                r.child
+              case f: FlowFork =>
+                f.child
+              case w: FlowWait =>
+                waitMillis = Some(waitMillis.getOrElse(0L) + waitDurationMillis(w))
+                w.child
+              case a: FlowActivate =>
+                activations += activationTargetOf(a)
+                a.child
+              case e: FlowEnd =>
+                e.child
+            }
+            .asInstanceOf[Relation]
+        }
+      LoweredStage(s, newBody, waitMillis, activations.result())
+    }
+    LoweredFlow(flow, lowered, routeFilters.result())
+
+  end lower
+
+  /** Compute the per-target routing predicates of a route operator */
+  private def routePredicatesOf(r: FlowRoute): List[(String, Expression)] =
+    val conditionCases  = r.cases.filter(_.condition.isDefined)
+    val percentageCases = r.cases.filter(_.percentage.isDefined)
+
+    val fromConditions: List[(String, Expression)] = conditionCases.map { c =>
+      c.target.fullName -> resolveContextRefs(c.condition.get)
+    }
+
+    val fromPercentages: List[(String, Expression)] =
+      if percentageCases.isEmpty then
+        Nil
+      else
+        val byExpr = r
+          .byExpr
+          .getOrElse(
+            throw StatusCode
+              .NOT_IMPLEMENTED
+              .newException(
+                "Percentage-based route requires a deterministic partitioning key: route by <expr> { ... }"
+              )
+          )
+        // bucket = ((byExpr % 100) + 100) % 100, robust against negative values
+        def lit100 = LongLiteral(100L, "100", NoSpan)
+        val bucket = ArithmeticBinaryExpr(
+          BinaryExprType.Modulus,
+          ArithmeticBinaryExpr(
+            BinaryExprType.Add,
+            ArithmeticBinaryExpr(BinaryExprType.Modulus, byExpr, lit100, NoSpan),
+            lit100,
+            NoSpan
+          ),
+          lit100,
+          NoSpan
+        )
+        var cumulative = 0L
+        percentageCases.map { c =>
+          val start = cumulative
+          val end   = cumulative + c.percentage.get
+          cumulative = end
+          val pred =
+            if start == 0 then
+              LessThan(bucket, LongLiteral(end, end.toString, NoSpan), NoSpan)
+            else
+              And(
+                GreaterThanOrEq(bucket, LongLiteral(start, start.toString, NoSpan), NoSpan),
+                LessThan(bucket, LongLiteral(end, end.toString, NoSpan), NoSpan),
+                NoSpan
+              )
+          c.target.fullName -> pred
+        }
+
+    val explicit = fromConditions ++ fromPercentages
+
+    // The else target receives everything not matched by any explicit case
+    val fromElse: List[(String, Expression)] =
+      r.elseTarget
+        .map { t =>
+          val negated: Expression = explicit
+            .map(_._2)
+            .reduceLeftOption[Expression]((l, rr) => Or(l, rr, NoSpan))
+            .map(all => Not(all, NoSpan))
+            .getOrElse(TrueLiteral(NoSpan))
+          t.fullName -> negated
+        }
+        .toList
+
+    explicit ++ fromElse
+
+  end routePredicatesOf
+
+  /**
+    * Route case predicates reference the input row as `_.column`. When the predicate is applied as
+    * a filter over the materialized route table, the underscore context resolves to that table's
+    * row, so `_.column` becomes a plain column reference
+    */
+  private def resolveContextRefs(e: Expression): Expression = e.transformUpExpression {
+    case d: DotRef if d.qualifier.isInstanceOf[ContextInputRef] =>
+      d.name
+  }
+
+  /** Parse the wait duration: a duration literal (30s) or a string like '30 minutes' */
+  private def waitDurationMillis(w: FlowWait): Long =
+    w.duration match
+      case d: DurationLiteral =>
+        d.toMillis
+      case s: StringLiteral =>
+        parseDurationString(s.unquotedValue.trim)
+      case other =>
+        throw StatusCode.NOT_IMPLEMENTED.newException(s"Unsupported wait duration: ${other}")
+
+  private val durationPattern = """(\d+)\s*([a-zA-Z]+)""".r
+
+  private def parseDurationString(s: String): Long =
+    s match
+      case durationPattern(num, unit) =>
+        val n = num.toLong
+        unit.toLowerCase match
+          case "ms" | "millisecond" | "milliseconds" =>
+            n
+          case "s" | "sec" | "second" | "seconds" =>
+            n * 1000L
+          case "m" | "min" | "minute" | "minutes" =>
+            n * 60000L
+          case "h" | "hour" | "hours" =>
+            n * 3600000L
+          case "d" | "day" | "days" =>
+            n * 86400000L
+          case other =>
+            throw StatusCode.NOT_IMPLEMENTED.newException(s"Unknown duration unit: ${other}")
+      case _ =>
+        throw StatusCode.NOT_IMPLEMENTED.newException(s"Cannot parse wait duration: '${s}'")
+
+  private def activationTargetOf(a: FlowActivate): String =
+    a.target match
+      case s: StringLiteral =>
+        s.unquotedValue
+      case other =>
+        other.toString
+
+end FlowLowering

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -287,14 +287,92 @@ class FlowExecutorTest extends UniTest:
   }
 
   test("fail a stage using unsupported flow operators without retrying") {
-    val result = runFlow("""flow JourneyFlow = {
+    val result = runFlow("""flow JumpFlow = {
         |  stage entry = from [[1]] as t(id)
-        |  stage delayed with { retries: 3 } = from entry | wait('7 days')
+        |  stage jump with { retries: 3 } = from entry | -> OtherFlow
         |}""".stripMargin)
-    val delayed = result.stageResult("delayed").get
-    delayed.state shouldBe StageState.Failed
+    val jump = result.stageResult("jump").get
+    jump.state shouldBe StageState.Failed
     // NOT_IMPLEMENTED errors are not retryable
-    delayed.attempts shouldBe 1
+    jump.attempts shouldBe 1
+  }
+
+  test("route rows to target stages with conditional predicates") {
+    val result = runFlow("""flow RouteFlow = {
+        |  stage src = from [[1, 25], [2, 15], [3, 40]] as t(id, age)
+        |  stage gate = from src | route {
+        |    case _.age >= 18 -> adult
+        |    else -> minor
+        |  }
+        |  stage adult = from gate | select id
+        |  stage minor = from gate | select id
+        |}""".stripMargin)
+    result.isSuccess shouldBe true
+    // The route stage materializes its full input; targets receive the routed subsets
+    countStageRows(result, "gate") shouldBe 3L
+    countStageRows(result, "adult") shouldBe 2L
+    countStageRows(result, "minor") shouldBe 1L
+  }
+
+  test("route rows deterministically with percentage buckets") {
+    val values = (1 to 100).map(i => s"[${i}]").mkString(", ")
+    val flowWv =
+      s"""flow ABTestFlow = {
+         |  stage src = from [${values}] as t(id)
+         |  stage split = from src | route by hash(id) {
+         |    case 50 -> variant_a
+         |    case 50 -> variant_b
+         |  }
+         |  stage variant_a = from split | select id
+         |  stage variant_b = from split | select id
+         |}""".stripMargin
+    val result1 = runFlow(flowWv)
+    result1.isSuccess shouldBe true
+    val a1 = countStageRows(result1, "variant_a")
+    val b1 = countStageRows(result1, "variant_b")
+    // Buckets partition the input: every row lands in exactly one variant
+    a1 + b1 shouldBe 100L
+    // Deterministic partitioning: a re-run produces the identical split
+    val result2 = runFlow(flowWv)
+    countStageRows(result2, "variant_a") shouldBe a1
+    countStageRows(result2, "variant_b") shouldBe b1
+  }
+
+  test("flatten fork stages and run them against the shared input") {
+    val result = runFlow("""flow ForkFlow = {
+        |  stage entry = from [[1], [2]] as t(id)
+        |  stage parallel = from entry | fork {
+        |    stage email = from entry | select id
+        |    stage sms = from entry | select id
+        |  }
+        |}""".stripMargin)
+    result.isSuccess shouldBe true
+    result.stageResults.map(_.name) shouldBe List("entry", "parallel", "email", "sms")
+    countStageRows(result, "email") shouldBe 2L
+    countStageRows(result, "sms") shouldBe 2L
+  }
+
+  test("delay a stage with the wait operator") {
+    val start  = System.nanoTime()
+    val result = runFlow("""flow WaitFlow = {
+        |  stage src = from [[1]] as t(id)
+        |  stage delayed = from src | wait('100 ms')
+        |}""".stripMargin)
+    val elapsedMillis = (System.nanoTime() - start) / 1000000L
+    result.isSuccess shouldBe true
+    elapsedMillis >= 100L shouldBe true
+    countStageRows(result, "delayed") shouldBe 1L
+  }
+
+  test("activate materializes its input and succeeds as a local stub") {
+    val result = runFlow("""flow ActivateFlow = {
+        |  stage src = from [[1], [2]] as t(id)
+        |  stage send = from src | activate('email')
+        |  stage done = from send | end()
+        |}""".stripMargin)
+    result.isSuccess shouldBe true
+    countStageRows(result, "send") shouldBe 2L
+    countStageRows(result, "done") shouldBe 2L
   }
 
   test("cancel remaining stages when cancellation is requested") {


### PR DESCRIPTION
## Summary

Third deliverable of #1817 (after #1819, #1820): a **FlowOp lowering pass** compiles flow operators in stage bodies into SQL-expressible bodies plus orchestration metadata, keeping the DAG scheduler engine-agnostic. `route`, `fork`, `wait`, `activate`, and `end` are now executable.

### FlowLowering
| Operator | SQL-expressible half | Orchestration half |
|----------|---------------------|--------------------|
| `route { case cond -> t; else -> u }` | route stage materializes its full input; each **target's read** of the route stage is filtered with the case predicate; `else` gets the complement of all explicit cases | — |
| `route by <expr> { case 50 -> a; case 50 -> b }` | deterministic bucket predicates `((expr % 100) + 100) % 100` over cumulative ranges | — |
| `fork { stage ... }` | — | nested stages flattened into top-level scheduler stages sharing the declaring stage's input |
| `wait('30 minutes')` | — | interruptible pre-materialization delay (duration literals or `'N unit'` strings) |
| `activate('email')` | input materialized normally | local logging stub until sink connectors exist |
| `end()` | pass-through | terminal marker |
| `-> Flow` (jump) | — | still NOT_IMPLEMENTED; needs cross-flow orchestration (run registry, #1817 item 6) |

Underscore context refs in route predicates (`_.age > 18`) are resolved to plain column references, since the predicate applies over the materialized route table.

### Typer
- Route targets are validated; unlike triggers and merge sources they may reference stages defined **later** in the flow (forward references), matching the documented examples

### Tests
- `FlowExecutorTest`: 27 tests (5 new: conditional route with row-count verification of routed subsets, deterministic 50/50 percentage split over 100 rows verified across two runs, fork flattening, wait delay, activate/end pass-through)
- `FlowTypingTest`: forward route targets allowed; undefined targets → STAGE_NOT_FOUND
- `spec/basic/flow-run.wv`: spec-driven route pipeline and wait/activate/end journey pipeline
- Full matrix green: langJVM 1487, runner 425, cli 86, Scala.js + Native compile, scalafmt

### Next (final PR per #1817)
Session/run registry: persistent run records, `wvlet flow session` commands, cross-flow dependencies and schedules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)