### PR TITLE
feature: Add a flow run registry with session CLI and cross-flow dependency evaluation

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -334,7 +334,19 @@ wvlet flow show my_pipeline -w ./pipelines
 
 # Run a flow and print its per-stage results (non-zero exit code when the flow fails)
 wvlet flow run my_pipeline -w ./pipelines
+
+# List recorded flow runs (most recent first)
+wvlet flow session list -w ./pipelines
+
+# Show the per-stage details of a recorded run
+wvlet flow session show <run_id> -w ./pipelines
 ```
+
+Every flow run is recorded in a local run registry (`target/flow-runs/<run_id>.json` under the
+working folder), updated live as stages change state. Cross-flow dependencies (`depends on X`,
+`if X.failed`, `if X.done`) are evaluated against the latest recorded run of the referenced
+flow: when the dependency is not satisfied, the flow run is recorded as `skipped` without
+executing any stage.
 
 ## Stage Execution Model
 
@@ -344,9 +356,9 @@ stages run in parallel (bounded by executor parallelism), retries are scheduled 
 with the configured backoff, and `timeout` bounds each stage attempt. Flow operators are
 lowered before scheduling: `route` cases become filter predicates on target stages, `fork`
 stages are flattened into the DAG, `wait` delays materialization, `activate` is a local
-logging stub until sink connectors exist, and `end` is a pass-through. Flow-level schedules,
-cross-flow dependencies, `-> Flow` jumps, and `heartbeat` enforcement are parsed but not yet
-executable.
+logging stub until sink connectors exist, and `end` is a pass-through. Flow runs are recorded
+in a local run registry, and cross-flow dependencies are evaluated against it. Flow-level cron
+schedules, `-> Flow` jumps, and `heartbeat` enforcement are parsed but not yet executable.
 :::
 
 Each stage progresses through a well-defined state machine:

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -30,6 +30,8 @@ import wvlet.lang.model.plan.DependsOnFlow
 import wvlet.lang.model.plan.FlowDef
 import wvlet.lang.model.plan.FlowStatePredicate
 import wvlet.lang.runner.FlowExecutor
+import wvlet.lang.runner.FlowRunRecord
+import wvlet.lang.runner.FlowRunRegistry
 import wvlet.lang.runner.connector.DBConnectorProvider
 import wvlet.uni.log.LogSupport
 
@@ -69,7 +71,11 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
           .withCompilationUnit(unit)
           .newContext(Symbol.NoSymbol)
 
-        val result = FlowExecutor(connector, workEnv).execute(flow)
+        val result = FlowExecutor(
+          connector,
+          workEnv,
+          registry = Some(FlowRunRegistry.forWorkEnv(workEnv))
+        ).execute(flow)
         println(result.toPrettyBox())
         if result.hasError && !WvletMain.isInSbt then
           System.exit(1)
@@ -105,6 +111,59 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
         )
       }
     }
+
+  @command(description = "Manage flow run sessions: session list | session show <run_id>")
+  def session(
+      flowOption: WvletFlowOption,
+      @argument(description = "Sub command: list | show")
+      sub: String = "list",
+      @argument(description = "Run id (required for show)")
+      runId: Option[String] = None
+  ): Unit =
+    val workEnv  = WorkEnv(flowOption.workFolder, opts.logLevel)
+    val registry = FlowRunRegistry.forWorkEnv(workEnv)
+
+    def fmtTime(millis: Long): String        = java.time.Instant.ofEpochMilli(millis).toString
+    def fmtElapsed(r: FlowRunRecord): String = r
+      .finishedAtMillis
+      .map(f => s"${f - r.startedAtMillis}ms")
+      .getOrElse("-")
+
+    sub match
+      case "list" =>
+        registry
+          .list()
+          .foreach { r =>
+            println(
+              f"${r.runId}%-28s ${r.flowName}%-24s ${r.state}%-10s started: ${fmtTime(
+                  r.startedAtMillis
+                )} (${fmtElapsed(r)})"
+            )
+          }
+      case "show" =>
+        val id = runId.getOrElse(
+          throw StatusCode.INVALID_ARGUMENT.newException("Usage: wvlet flow session show <run_id>")
+        )
+        registry.get(id) match
+          case Some(r) =>
+            println(s"run:      ${r.runId}")
+            println(s"flow:     ${r.flowName}")
+            println(s"state:    ${r.state}")
+            println(s"started:  ${fmtTime(r.startedAtMillis)}")
+            r.finishedAtMillis.foreach(f => println(s"finished: ${fmtTime(f)}"))
+            r.stages
+              .foreach { s =>
+                val err = s.error.map(e => s" - ${e}").getOrElse("")
+                println(f"  stage ${s.name}%-24s ${s.state}%-14s attempts: ${s.attempts}${err}")
+              }
+          case None =>
+            throw StatusCode.INVALID_ARGUMENT.newException(s"Flow run '${id}' is not found")
+      case other =>
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(s"Unknown session sub command: ${other}. Use list or show")
+    end match
+  end session
 
   @command(description = "Show the plan of a flow")
   def show(

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -45,6 +45,25 @@ class WvletFlowCommandTest extends UniTest:
     WvletMain.main(s"flow run FallbackPipeline -w ${flowDir}")
   }
 
+  test("list and show flow run sessions") {
+    WvletMain.main(s"flow run SamplePipeline -w ${flowDir}")
+    WvletMain.main(s"flow session list -w ${flowDir}")
+
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRegistry
+    val runs = FlowRunRegistry.forWorkEnv(WorkEnv(flowDir)).list()
+    runs.nonEmpty shouldBe true
+    runs.head.flowName shouldBe "SamplePipeline"
+    WvletMain.main(s"flow session show ${runs.head.runId} -w ${flowDir}")
+  }
+
+  test("report an error for an unknown session sub command") {
+    val e = intercept[WvletLangException] {
+      WvletMain.main(s"flow session frobnicate -w ${flowDir}")
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+  }
+
   test("report an error for an unknown flow name") {
     val e = intercept[WvletLangException] {
       WvletMain.main(s"flow run NoSuchFlow -w ${flowDir}")

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -177,7 +177,8 @@ class FlowExecutor(
     workEnv: WorkEnv,
     config: FlowExecutorConfig = FlowExecutorConfig(),
     stageRunner: Option[FlowStageRunner] = None,
-    retryScheduler: Option[(Long, () => Unit) => Unit] = None
+    retryScheduler: Option[(Long, () => Unit) => Unit] = None,
+    registry: Option[FlowRunRegistry] = None
 ) extends LogSupport:
   import FlowExecutor.FlowEvent
   import FlowExecutor.FlowEvent.*
@@ -192,9 +193,60 @@ class FlowExecutor(
     cancelled = true
     eventQueue.put(CancelRequested)
 
+  /**
+    * Check whether the flow's cross-flow dependency (`depends on X` or `if X.failed/done`) is
+    * satisfied by the latest recorded run of the referenced flow
+    */
+  private def dependencySatisfied(flow: FlowDef): Boolean =
+    flow.dependency match
+      case None =>
+        true
+      case Some(dep) =>
+        registry match
+          case None =>
+            workEnv.warn(
+              s"Flow ${flow
+                  .name
+                  .name} has a cross-flow dependency, but no run registry is available; skipping"
+            )
+            false
+          case Some(reg) =>
+            dep match
+              case DependsOnFlow(flowName, _) =>
+                reg.latestRunOf(flowName.fullName).exists(_.state == FlowRunRecord.STATE_SUCCESS)
+              case FlowStatePredicate(flowName, "failed", _) =>
+                reg.latestRunOf(flowName.fullName).exists(_.state == FlowRunRecord.STATE_FAILED)
+              case FlowStatePredicate(flowName, "done", _) =>
+                reg.latestRunOf(flowName.fullName).exists(_.isTerminal)
+              case FlowStatePredicate(_, _, _) =>
+                false
+
   def execute(flow: FlowDef)(using ctx: Context): FlowExecutionResult =
-    val runId = ULID.newULIDString
+    val runId     = ULID.newULIDString
+    val startedAt = System.currentTimeMillis()
     workEnv.info(s"Executing flow ${flow.name.name} (run: ${runId})")
+
+    // Evaluate cross-flow dependencies against the run registry before scheduling any stage
+    if !dependencySatisfied(flow) then
+      workEnv.info(s"Flow ${flow.name.name} dependency is not satisfied; skipping all stages")
+      val skipped = FlowExecutionResult(
+        flow.name.name,
+        runId,
+        flow.stages.map(s => StageResult(s.name.name, StageState.Skipped, 0))
+      )
+      registry.foreach {
+        _.save(
+          FlowRunRecord(
+            runId,
+            flow.name.name,
+            FlowRunRecord.STATE_SKIPPED,
+            startedAt,
+            Some(System.currentTimeMillis()),
+            skipped.stageResults.map(r => StageRunRecord(r.name, r.state.stateName, r.attempts))
+          )
+        )
+      }
+      return skipped
 
     // Lower flow operators (fork/route/wait/activate/end) into SQL-expressible stage bodies
     // plus orchestration metadata
@@ -260,6 +312,43 @@ class FlowExecutor(
         ,
         delay,
         TimeUnit.MILLISECONDS
+      )
+    }
+
+    // Persist a snapshot of the run so that other processes (wvlet flow session) can observe it
+    def persistSnapshot(finished: Boolean = false): Unit = registry.foreach { reg =>
+      val stageRecords = flowStages.map { ls =>
+        val name  = ls.name
+        val state = states(name)
+        StageRunRecord(
+          name,
+          state.stateName,
+          attempts(name),
+          errors.get(name).map(_.getMessage),
+          if state == StageState.Success then
+            Some(tableFor(name))
+          else
+            None
+        )
+      }
+      val flowState =
+        if finished then
+          FlowRunRecord.flowStateOf(states.values)
+        else
+          FlowRunRecord.STATE_RUNNING
+      reg.save(
+        FlowRunRecord(
+          runId,
+          flow.name.name,
+          flowState,
+          startedAt,
+          if finished then
+            Some(System.currentTimeMillis())
+          else
+            None
+          ,
+          stageRecords
+        )
       )
     }
 
@@ -390,6 +479,7 @@ class FlowExecutor(
 
     def allTerminal: Boolean = states.values.forall(_.isTerminal)
 
+    persistSnapshot()
     try
       var done = false
       while !done do
@@ -453,11 +543,14 @@ class FlowExecutor(
                         scheduleRetry(delay, () => eventQueue.put(RetryDue(s, attempt + 1)))
               end if
         end if
+        persistSnapshot()
       end while
     finally
       workerPool.shutdownNow()
       timer.shutdownNow()
     end try
+
+    persistSnapshot(finished = true)
 
     // Report results in stage definition order for deterministic summaries
     val stageResults = flowStages.map { ls =>

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.api.v1.flow.StageState
+import wvlet.lang.compiler.WorkEnv
+import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
+
+/**
+  * The persisted state of a single stage within a flow run
+  */
+case class StageRunRecord(
+    name: String,
+    state: String,
+    attempts: Int,
+    error: Option[String] = None,
+    table: Option[String] = None
+)
+
+/**
+  * The persisted record of a flow run. Records are written on run start, on every stage state
+  * change, and on completion, so that `wvlet flow session` commands (and future schedulers) can
+  * observe runs across processes
+  *
+  * @param runId
+  *   Unique run identifier (ULID)
+  * @param flowName
+  *   Name of the executed flow
+  * @param state
+  *   Flow-level state: running, success, failed, or cancelled
+  * @param startedAtMillis
+  *   Epoch millis when the run started
+  * @param finishedAtMillis
+  *   Epoch millis when the run reached a terminal state
+  * @param stages
+  *   Per-stage records in stage definition order
+  */
+case class FlowRunRecord(
+    runId: String,
+    flowName: String,
+    state: String,
+    startedAtMillis: Long,
+    finishedAtMillis: Option[Long] = None,
+    stages: List[StageRunRecord] = Nil
+):
+  def isTerminal: Boolean = state != FlowRunRecord.STATE_RUNNING
+
+object FlowRunRecord:
+  val STATE_RUNNING   = "running"
+  val STATE_SUCCESS   = "success"
+  val STATE_FAILED    = "failed"
+  val STATE_CANCELLED = "cancelled"
+  // The flow was not started because its cross-flow dependency was not satisfied
+  val STATE_SKIPPED = "skipped"
+
+  /** Derive the flow-level state from its stage states */
+  def flowStateOf(stageStates: Iterable[StageState]): String =
+    if stageStates.exists(_ == StageState.Failed) then
+      STATE_FAILED
+    else if stageStates.exists(_ == StageState.Cancelled) then
+      STATE_CANCELLED
+    else if stageStates.forall(_.isTerminal) then
+      STATE_SUCCESS
+    else
+      STATE_RUNNING
+
+/**
+  * A file-based registry of flow runs. Each run is stored as a single JSON file
+  * (`<registryDir>/<runId>.json`), which keeps reads and writes atomic enough for a local,
+  * single-writer-per-run setup without a database dependency
+  */
+class FlowRunRegistry(registryDir: Path) extends LogSupport:
+
+  private val weaver = Weaver.of[FlowRunRecord]
+
+  private def fileFor(runId: String): Path = registryDir.resolve(s"${runId.toLowerCase}.json")
+
+  /** Persist (create or overwrite) the record of a run */
+  def save(record: FlowRunRecord): Unit =
+    Files.createDirectories(registryDir)
+    Files.writeString(fileFor(record.runId), weaver.toJson(record))
+
+  /** Read the record of a specific run */
+  def get(runId: String): Option[FlowRunRecord] =
+    val f = fileFor(runId)
+    if Files.exists(f) then
+      readRecord(f)
+    else
+      None
+
+  /** List all recorded runs, most recent first */
+  def list(): List[FlowRunRecord] =
+    if !Files.isDirectory(registryDir) then
+      Nil
+    else
+      Files
+        .list(registryDir)
+        .iterator()
+        .asScala
+        .filter(_.getFileName.toString.endsWith(".json"))
+        .flatMap(readRecord)
+        .toList
+        .sortBy(-_.startedAtMillis)
+
+  /** The most recent run of the given flow, if any */
+  def latestRunOf(flowName: String): Option[FlowRunRecord] = list().find(_.flowName == flowName)
+
+  private def readRecord(f: Path): Option[FlowRunRecord] =
+    try
+      Some(weaver.fromJson(Files.readString(f, StandardCharsets.UTF_8)))
+    catch
+      case NonFatal(e) =>
+        warn(s"Failed to read flow run record ${f}: ${e.getMessage}")
+        None
+
+end FlowRunRegistry
+
+object FlowRunRegistry:
+  /** The registry folder of the given work environment */
+  def forWorkEnv(workEnv: WorkEnv): FlowRunRegistry = FlowRunRegistry(
+    Path.of(workEnv.targetFolder, "flow-runs")
+  )

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -165,7 +165,11 @@ class QueryExecutor(
           // Command produces no QueryResult other than errors
           report(executeCommand(e))
         case ExecuteFlow(flow) =>
-          val flowExecutor = FlowExecutor(getDBConnector(defaultProfile), workEnv)
+          val flowExecutor = FlowExecutor(
+            getDBConnector(defaultProfile),
+            workEnv,
+            registry = Some(FlowRunRegistry.forWorkEnv(workEnv))
+          )
           report(flowExecutor.execute(flow))
         case ExecuteValDef(v) =>
           val expr = ExpressionEvaluator.eval(v.expr)(using context)
@@ -450,7 +454,11 @@ class QueryExecutor(
     q.transformUp { case rf: RunFlow =>
         val flow       = resolveFlow(rf)
         val connector  = getDBConnector(defaultProfile)
-        val flowResult = FlowExecutor(connector, workEnv).execute(flow)
+        val flowResult = FlowExecutor(
+          connector,
+          workEnv,
+          registry = Some(FlowRunRegistry.forWorkEnv(workEnv))
+        ).execute(flow)
 
         given monitor: QueryProgressMonitor = context.queryProgressMonitor
 
@@ -470,6 +478,8 @@ class QueryExecutor(
         TableRef(DoubleQuotedIdentifier(summaryTable, rf.span), rf.span)
       }
       .asInstanceOf[Relation]
+
+  end runEmbeddedFlows
 
   private def executeQuery(plan: LogicalPlan)(using context: Context): QueryResult =
     trace(s"Executing query: ${plan.pp}")

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -53,10 +53,27 @@ class FlowExecutorTest extends UniTest:
       wv: String,
       config: FlowExecutorConfig = FlowExecutorConfig(),
       stageRunner: Option[FlowStageRunner] = None,
-      retryScheduler: Option[(Long, () => Unit) => Unit] = None
+      retryScheduler: Option[(Long, () => Unit) => Unit] = None,
+      registry: Option[FlowRunRegistry] = None
   ): FlowExecutionResult =
     val (flow, ctx) = compileFlow(wv)
-    FlowExecutor(connector, workEnv, config, stageRunner, retryScheduler).execute(flow)(using ctx)
+    FlowExecutor(connector, workEnv, config, stageRunner, retryScheduler, registry).execute(flow)(
+      using ctx
+    )
+
+  /** Compile a unit possibly containing multiple flows and return them by name */
+  private def compileFlows(wv: String): (Map[String, FlowDef], Context) =
+    val compiler = Compiler(CompilerOptions(workEnv = workEnv))
+    val unit     = CompilationUnit.fromWvletString(wv)
+    val result   = compiler.compileSingleUnit(unit)
+    val ctx      = result.context.withCompilationUnit(unit).newContext(Symbol.NoSymbol)
+    val flows    = Map.newBuilder[String, FlowDef]
+    unit
+      .resolvedPlan
+      .traverse { case f: FlowDef =>
+        flows += f.name.name -> f
+      }
+    (flows.result(), ctx)
 
   private def countRows(table: String): Long =
     connector.runQuery(s"""select count(*) cnt from "${table}"""") { rs =>
@@ -461,6 +478,82 @@ class FlowExecutorTest extends UniTest:
     // The flow contains a failing stage, but merely defining it must not run it
     val result = queryExecutor.execute(executionPlan, ctx)
     result.hasError shouldBe false
+  }
+
+  test("record flow runs in the registry") {
+    val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val result   = runFlow(
+      """flow RecordedFlow = {
+        |  stage src = from [[1], [2]] as t(id)
+        |  stage out = from src | select id
+        |}""".stripMargin,
+      registry = Some(registry)
+    )
+    val record = registry.get(result.runId).get
+    record.flowName shouldBe "RecordedFlow"
+    record.state shouldBe FlowRunRecord.STATE_SUCCESS
+    record.finishedAtMillis.isDefined shouldBe true
+    record.stages.map(_.name) shouldBe List("src", "out")
+    record.stages.map(_.state).distinct shouldBe List("success")
+    registry.latestRunOf("RecordedFlow").get.runId shouldBe result.runId
+  }
+
+  test("record failed flow runs with stage errors") {
+    val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val result   = runFlow(
+      """flow BrokenRecordedFlow = {
+        |  stage broken = from nonexistent_table_xyz
+        |}""".stripMargin,
+      registry = Some(registry)
+    )
+    val record = registry.get(result.runId).get
+    record.state shouldBe FlowRunRecord.STATE_FAILED
+    record.stages.head.state shouldBe "failed"
+    record.stages.head.error.isDefined shouldBe true
+  }
+
+  test("evaluate cross-flow dependencies against the run registry") {
+    val registry     = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val (flows, ctx) = compileFlows("""flow Upstream = {
+        |  stage src = from [[1]] as t(id)
+        |}
+        |
+        |flow Downstream depends on Upstream = {
+        |  stage report = from [[1]] as t(id)
+        |}
+        |
+        |flow Recovery if Upstream.failed = {
+        |  stage alert = from [[1]] as t(id)
+        |}
+        |
+        |flow Cleanup if Upstream.done = {
+        |  stage archive = from [[1]] as t(id)
+        |}
+        |
+        |flow Orphan depends on NeverRunFlow = {
+        |  stage x = from [[1]] as t(id)
+        |}
+        |""".stripMargin)
+
+    def run(name: String): FlowExecutionResult =
+      FlowExecutor(connector, workEnv, registry = Some(registry)).execute(flows(name))(using ctx)
+
+    // Before any upstream run, dependent flows are skipped entirely
+    run("Downstream").stageResults.map(_.state) shouldBe List(StageState.Skipped)
+
+    run("Upstream").isSuccess shouldBe true
+
+    // depends on: runs only after the upstream flow succeeded
+    run("Downstream").stageResults.map(_.state) shouldBe List(StageState.Success)
+    // if Upstream.failed: upstream succeeded, so the recovery flow is skipped
+    run("Recovery").stageResults.map(_.state) shouldBe List(StageState.Skipped)
+    // if Upstream.done: upstream reached a terminal state, so cleanup runs
+    run("Cleanup").stageResults.map(_.state) shouldBe List(StageState.Success)
+    // depends on a flow that never ran
+    run("Orphan").stageResults.map(_.state) shouldBe List(StageState.Skipped)
+
+    // Dependency-skipped runs are recorded with the skipped state
+    registry.latestRunOf("Orphan").get.state shouldBe FlowRunRecord.STATE_SKIPPED
   }
 
   test("compute retry delays for backoff strategies") {


### PR DESCRIPTION
## Summary

Final deliverable of #1817 (after #1819, #1820, #1821): a **flow run registry** makes runs observable across processes and turns cross-flow orchestration (`depends on`, `if Flow.failed/done`) into working semantics.

### FlowRunRegistry
- Each run persists as `target/flow-runs/<run_id>.json` (JSON via uni weaver) — no database dependency, single-writer-per-run
- Written on run start, on **every stage state change**, and on completion, so `wvlet flow session` (and future schedulers/UIs) observe live progress
- `FlowRunRecord`: flow-level state (`running`/`success`/`failed`/`cancelled`/`skipped`), timestamps, and per-stage states, attempts, errors, and materialized table names

### Cross-flow dependency evaluation
Evaluated against the latest recorded run of the referenced flow before any stage is scheduled:

| Dependency | Runs when |
|------------|-----------|
| `depends on X` | latest run of X succeeded |
| `if X.failed` | latest run of X failed |
| `if X.done` | latest run of X reached any terminal state |

Unsatisfied dependencies skip all stages and record the run as `skipped` (per the documented trigger-evaluation table).

### CLI
- `wvlet flow session list -w <dir>` — recorded runs, most recent first, with state and elapsed time
- `wvlet flow session show <run_id> -w <dir>` — per-stage states, attempts, and errors
- `run flow` statements, `ExecuteFlow` plans, and `wvlet flow run` all record automatically

### Tests
- `FlowExecutorTest` (30 tests): run recording (success + failed with errors), registry round-trip, and a five-flow cross-flow scenario (depends-on before/after upstream, failed/done predicates, never-run upstream)
- `WvletFlowCommandTest`: session list/show against real recorded runs, invalid subcommand
- Full matrix green: langJVM 1487, runner 428, cli 88, Scala.js + Native compile, scalafmt

### Remaining future work (beyond #1817's scope)
Cron `schedule:` daemon, `-> Flow` jumps, `heartbeat`, server-side SQL cancellation for timeouts, session `cancel`/`resume`.

Closes #1817

🤖 Generated with [Claude Code](https://claude.com/claude-code)