### PR TITLE
feature: Add flow session cancel/resume commands and registry lifecycle

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -348,6 +348,17 @@ working folder), updated live as stages change state. Cross-flow dependencies (`
 flow: when the dependency is not satisfied, the flow run is recorded as `skipped` without
 executing any stage.
 
+Runs are managed with `wvlet flow session` subcommands:
+
+- `wvlet flow session list` / `show <run_id>`: inspect recorded runs and per-stage states
+- `wvlet flow session cancel <run_id>`: request cancellation of a running flow, even from
+  another process. The executor polls the registry and stops in-flight stage attempts
+  (cancelling their SQL statements server-side)
+- `wvlet flow session resume <run_id>`: re-run a failed or cancelled run from its first
+  non-successful stage, reusing the materialized tables of stages that already succeeded
+- `wvlet flow session clean`: delete terminal run records and drop their run-scoped
+  `__wv_flow_*` tables
+
 ## Stage Execution Model
 
 :::info Implementation status

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -59,6 +59,13 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
       flowOption: WvletFlowOption,
       @argument(description = "Name of the flow to run")
       name: String
+  ): Unit = executeFlow(flowOption, name, resumeFrom = None)
+
+  /** Compile the flows in the working folder and execute the given flow */
+  private def executeFlow(
+      flowOption: WvletFlowOption,
+      name: String,
+      resumeFrom: Option[FlowRunRecord]
   ): Unit =
     withFlows(flowOption) { (flows, compileResult, workEnv) =>
       val (unit, flow) = findFlow(flows, name)
@@ -75,7 +82,7 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
           connector,
           workEnv,
           registry = Some(FlowRunRegistry.forWorkEnv(workEnv))
-        ).execute(flow)
+        ).execute(flow, resumeFrom)
         println(result.toPrettyBox())
         if result.hasError && !WvletMain.isInSbt then
           System.exit(1)
@@ -112,12 +119,14 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
       }
     }
 
-  @command(description = "Manage flow run sessions: session list | session show <run_id>")
+  @command(description =
+    "Manage flow run sessions: session list | show <run_id> | cancel <run_id> | resume <run_id> | clean"
+  )
   def session(
       flowOption: WvletFlowOption,
-      @argument(description = "Sub command: list | show")
+      @argument(description = "Sub command: list | show | cancel | resume | clean")
       sub: String = "list",
-      @argument(description = "Run id (required for show)")
+      @argument(description = "Run id (required for show, cancel, and resume)")
       runId: Option[String] = None
   ): Unit =
     val workEnv  = WorkEnv(flowOption.workFolder, opts.logLevel)
@@ -128,6 +137,14 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
       .finishedAtMillis
       .map(f => s"${f - r.startedAtMillis}ms")
       .getOrElse("-")
+
+    def requireRunId(usage: String): String = runId.getOrElse(
+      throw StatusCode.INVALID_ARGUMENT.newException(s"Usage: wvlet flow session ${usage}")
+    )
+
+    def recordOf(id: String): FlowRunRecord = registry
+      .get(id)
+      .getOrElse(throw StatusCode.INVALID_ARGUMENT.newException(s"Flow run '${id}' is not found"))
 
     sub match
       case "list" =>
@@ -141,27 +158,62 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
             )
           }
       case "show" =>
-        val id = runId.getOrElse(
-          throw StatusCode.INVALID_ARGUMENT.newException("Usage: wvlet flow session show <run_id>")
-        )
-        registry.get(id) match
-          case Some(r) =>
-            println(s"run:      ${r.runId}")
-            println(s"flow:     ${r.flowName}")
-            println(s"state:    ${r.state}")
-            println(s"started:  ${fmtTime(r.startedAtMillis)}")
-            r.finishedAtMillis.foreach(f => println(s"finished: ${fmtTime(f)}"))
-            r.stages
-              .foreach { s =>
-                val err = s.error.map(e => s" - ${e}").getOrElse("")
-                println(f"  stage ${s.name}%-24s ${s.state}%-14s attempts: ${s.attempts}${err}")
-              }
-          case None =>
-            throw StatusCode.INVALID_ARGUMENT.newException(s"Flow run '${id}' is not found")
+        val r = recordOf(requireRunId("show <run_id>"))
+        println(s"run:      ${r.runId}")
+        println(s"flow:     ${r.flowName}")
+        println(s"state:    ${r.state}")
+        println(s"started:  ${fmtTime(r.startedAtMillis)}")
+        r.finishedAtMillis.foreach(f => println(s"finished: ${fmtTime(f)}"))
+        r.stages
+          .foreach { s =>
+            val err = s.error.map(e => s" - ${e}").getOrElse("")
+            println(f"  stage ${s.name}%-24s ${s.state}%-14s attempts: ${s.attempts}${err}")
+          }
+      case "cancel" =>
+        val id = requireRunId("cancel <run_id>")
+        val r  = recordOf(id)
+        if r.isTerminal then
+          println(s"Run ${id} is already ${r.state}")
+        else
+          registry.requestCancel(id)
+          println(s"Requested cancellation of run ${id}")
+      case "resume" =>
+        val id = requireRunId("resume <run_id>")
+        val r  = recordOf(id)
+        r.state match
+          case FlowRunRecord.STATE_RUNNING =>
+            throw StatusCode
+              .INVALID_ARGUMENT
+              .newException(s"Run ${id} is still running and cannot be resumed")
+          case FlowRunRecord.STATE_SUCCESS =>
+            println(s"Run ${id} already succeeded; nothing to resume")
+          case FlowRunRecord.STATE_SKIPPED =>
+            throw StatusCode
+              .INVALID_ARGUMENT
+              .newException(
+                s"Run ${id} was skipped (its dependency was not satisfied). Use wvlet flow run ${r
+                    .flowName} to start a new run"
+              )
+          case _ =>
+            executeFlow(flowOption, r.flowName, resumeFrom = Some(r))
+      case "clean" =>
+        // Remove terminal run records and drop their run-scoped tables. Running flows are kept
+        val terminalRuns = registry.list().filter(_.isTerminal)
+        val profile = Profile.getProfile(flowOption.profile, flowOption.catalog, flowOption.schema)
+        Control.withResource(DBConnectorProvider(workEnv)) { dbConnectorProvider =>
+          val connector = dbConnectorProvider.getConnector(profile)
+          terminalRuns.foreach { r =>
+            FlowExecutor.dropRunTables(connector, r.runId, r.stages.map(_.name))
+            registry.delete(r.runId)
+          }
+        }
+        println(s"Removed ${terminalRuns.size} flow run record(s)")
       case other =>
         throw StatusCode
           .INVALID_ARGUMENT
-          .newException(s"Unknown session sub command: ${other}. Use list or show")
+          .newException(
+            s"Unknown session sub command: ${other}. Use list, show, cancel, resume, or clean"
+          )
     end match
   end session
 

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -64,6 +64,57 @@ class WvletFlowCommandTest extends UniTest:
     e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
   }
 
+  test("report an error when cancelling an unknown run") {
+    val e = intercept[WvletLangException] {
+      WvletMain.main(s"flow session cancel nosuchrun -w ${flowDir}")
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+  }
+
+  test("report the terminal state when cancelling a finished run") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRegistry
+    WvletMain.main(s"flow run SamplePipeline -w ${flowDir}")
+    val runs = FlowRunRegistry.forWorkEnv(WorkEnv(flowDir)).list()
+    // Cancelling an already-finished run reports its state without failing
+    WvletMain.main(s"flow session cancel ${runs.head.runId} -w ${flowDir}")
+  }
+
+  test("resume a failed flow run from the CLI") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRegistry
+    WvletMain.main(s"flow run FallbackPipeline -w ${flowDir}")
+    val registry = FlowRunRegistry.forWorkEnv(WorkEnv(flowDir))
+    val failed   =
+      registry.list().find(r => r.flowName == "FallbackPipeline" && r.state == "failed").get
+    // The primary stage fails again on resume, but the resume path completes and updates
+    // the same run record
+    WvletMain.main(s"flow session resume ${failed.runId} -w ${flowDir}")
+    registry.get(failed.runId).get.state shouldBe "failed"
+  }
+
+  test("reject resuming a run that never failed") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRegistry
+    WvletMain.main(s"flow run SamplePipeline -w ${flowDir}")
+    val succeeded =
+      FlowRunRegistry
+        .forWorkEnv(WorkEnv(flowDir))
+        .list()
+        .find(r => r.flowName == "SamplePipeline" && r.state == "success")
+        .get
+    // Resuming a successful run is a no-op message, not an error
+    WvletMain.main(s"flow session resume ${succeeded.runId} -w ${flowDir}")
+  }
+
+  test("clean terminal flow run records") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRegistry
+    WvletMain.main(s"flow run SamplePipeline -w ${flowDir}")
+    WvletMain.main(s"flow session clean -w ${flowDir}")
+    FlowRunRegistry.forWorkEnv(WorkEnv(flowDir)).list() shouldBe Nil
+  }
+
   test("report an error for an unknown flow name") {
     val e = intercept[WvletLangException] {
       WvletMain.main(s"flow run NoSuchFlow -w ${flowDir}")

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -122,9 +122,14 @@ end StageExecutionConfig
   *
   * @param maxParallelism
   *   Maximum number of stages that can run concurrently
+  * @param cancelPollIntervalMillis
+  *   Interval for polling the run registry for cross-process cancellation requests
   */
-case class FlowExecutorConfig(maxParallelism: Int = 4):
-  def withMaxParallelism(n: Int): FlowExecutorConfig = copy(maxParallelism = n)
+case class FlowExecutorConfig(maxParallelism: Int = 4, cancelPollIntervalMillis: Long = 500L):
+  def withMaxParallelism(n: Int): FlowExecutorConfig                 = copy(maxParallelism = n)
+  def withCancelPollIntervalMillis(millis: Long): FlowExecutorConfig = copy(
+    cancelPollIntervalMillis = millis
+  )
 
 /**
   * Runs the body of a single stage and materializes the result into the given target table.
@@ -228,13 +233,22 @@ class FlowExecutor(
               case FlowStatePredicate(_, _, _) =>
                 false
 
-  def execute(flow: FlowDef)(using ctx: Context): FlowExecutionResult =
-    val runId     = ULID.newULIDString
+  /**
+    * Execute the given flow. When `resumeFrom` holds the record of a previous failed or cancelled
+    * run, the run is resumed under the same run id: stages recorded as successful keep their
+    * materialized run-scoped tables and are not re-executed, and the remaining stages run with a
+    * fresh retry budget
+    */
+  def execute(flow: FlowDef, resumeFrom: Option[FlowRunRecord] = None)(using
+      ctx: Context
+  ): FlowExecutionResult =
+    val runId     = resumeFrom.map(_.runId).getOrElse(ULID.newULIDString)
     val startedAt = System.currentTimeMillis()
     workEnv.info(s"Executing flow ${flow.name.name} (run: ${runId})")
 
-    // Evaluate cross-flow dependencies against the run registry before scheduling any stage
-    if !dependencySatisfied(flow) then
+    // Evaluate cross-flow dependencies against the run registry before scheduling any stage.
+    // A resumed run already passed this gate when it originally started
+    if resumeFrom.isEmpty && !dependencySatisfied(flow) then
       workEnv.info(s"Flow ${flow.name.name} dependency is not satisfied; skipping all stages")
       val skipped = FlowExecutionResult(
         flow.name.name,
@@ -323,11 +337,44 @@ class FlowExecutor(
                 )
               }
 
+    // Stages recorded as successful in the resumed run keep their materialized tables and are
+    // not re-executed. Stage records that no longer match a stage of the flow are ignored
+    val resumedStages: Map[String, StageRunRecord] = resumeFrom
+      .map {
+        _.stages
+          .filter { s =>
+            s.state == StageState.Success.stateName && s.table.isDefined &&
+            stageNames.contains(s.name)
+          }
+          .map(s => s.name -> s)
+          .toMap
+      }
+      .getOrElse(Map.empty)
+    if resumedStages.nonEmpty then
+      workEnv.info(
+        s"Resuming run ${runId}: reusing ${resumedStages.size} successful stage(s): ${resumedStages
+            .keys
+            .mkString(", ")}"
+      )
+
     // All mutable scheduler state below is owned by this (caller) thread; worker threads only
     // post events to the eventQueue
-    val states   = mutable.Map.from(flowStages.map(ls => ls.name -> StageState.Pending))
+    val states = mutable
+      .Map
+      .from(
+        flowStages.map(ls =>
+          ls.name -> (
+            if resumedStages.contains(ls.name) then
+              StageState.Success
+            else
+              StageState.Pending
+          )
+        )
+      )
+    // Re-executed stages get a fresh retry budget; reused stages keep their recorded attempts
     val attempts = mutable.Map.empty[String, Int].withDefaultValue(0)
-    val errors   = mutable.Map.empty[String, Throwable]
+    resumedStages.foreach((name, s) => attempts(name) = s.attempts)
+    val errors = mutable.Map.empty[String, Throwable]
     // (stage, attempt) pairs whose outcome has been decided (guards against duplicate events
     // from a timed-out attempt completing later)
     val handledAttempts  = mutable.Set.empty[(String, Int)]
@@ -344,6 +391,22 @@ class FlowExecutor(
 
     val workerPool = Executors.newFixedThreadPool(config.maxParallelism.max(1), threadFactory)
     val timer      = Executors.newSingleThreadScheduledExecutor(threadFactory)
+
+    // Poll the registry for a cross-process cancellation request (wvlet flow session cancel)
+    registry.foreach { reg =>
+      val interval = config.cancelPollIntervalMillis.max(1L)
+      timer.scheduleAtFixedRate(
+        new Runnable:
+          override def run(): Unit =
+            if !cancelled && reg.cancelRequested(runId) then
+              workEnv.info(s"Cancellation of run ${runId} was requested; cancelling")
+              cancel()
+        ,
+        interval,
+        interval,
+        TimeUnit.MILLISECONDS
+      )
+    }
     val scheduleRetry: (Long, () => Unit) => Unit = retryScheduler.getOrElse { (delay, action) =>
       timer.schedule(
         new Runnable:
@@ -602,6 +665,8 @@ class FlowExecutor(
     end try
 
     persistSnapshot(finished = true)
+    // The run reached a terminal state; a pending cancellation request is no longer relevant
+    registry.foreach(_.clearCancelRequest(runId))
 
     // Report results in stage definition order for deterministic summaries
     val stageResults = flowStages.map { ls =>

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
@@ -93,6 +93,10 @@ class FlowRunRegistry(registryDir: Path) extends LogSupport:
 
   private def fileFor(runId: String): Path = registryDir.resolve(s"${runId.toLowerCase}.json")
 
+  private def cancelMarkerFor(runId: String): Path = registryDir.resolve(
+    s"${runId.toLowerCase}.cancel"
+  )
+
   /** Persist (create or overwrite) the record of a run */
   def save(record: FlowRunRecord): Unit =
     Files.createDirectories(registryDir)
@@ -122,6 +126,26 @@ class FlowRunRegistry(registryDir: Path) extends LogSupport:
 
   /** The most recent run of the given flow, if any */
   def latestRunOf(flowName: String): Option[FlowRunRecord] = list().find(_.flowName == flowName)
+
+  /**
+    * Request cancellation of a run by placing a marker file next to its record. The marker is
+    * polled by the executor's event loop, so a run can be cancelled from another process (e.g.
+    * `wvlet flow session cancel`)
+    */
+  def requestCancel(runId: String): Unit =
+    Files.createDirectories(registryDir)
+    Files.writeString(cancelMarkerFor(runId), "")
+
+  /** True if cancellation of the given run has been requested */
+  def cancelRequested(runId: String): Boolean = Files.exists(cancelMarkerFor(runId))
+
+  /** Remove the cancellation marker of a run (called when the run reaches a terminal state) */
+  def clearCancelRequest(runId: String): Unit = Files.deleteIfExists(cancelMarkerFor(runId))
+
+  /** Delete the record and any cancellation marker of a run */
+  def delete(runId: String): Unit =
+    Files.deleteIfExists(fileFor(runId))
+    Files.deleteIfExists(cancelMarkerFor(runId))
 
   private def readRecord(f: Path): Option[FlowRunRecord] =
     try

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -602,6 +602,98 @@ class FlowExecutorTest extends UniTest:
     registry.latestRunOf("Orphan").get.state shouldBe FlowRunRecord.STATE_SKIPPED
   }
 
+  test("resume a failed run reusing successful stage materializations") {
+    val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val wv       =
+      """flow ResumableFlow = {
+        |  stage src = from [[1], [2]] as t(id)
+        |  stage out = from src cross join __wv_resume_dep as d | select id
+        |}""".stripMargin
+    connector.execute("drop table if exists __wv_resume_dep")
+    val first = runFlow(wv, registry = Some(registry))
+    first.isSuccess shouldBe false
+    first.stageResult("src").get.state shouldBe StageState.Success
+    first.stageResult("out").get.state shouldBe StageState.Failed
+
+    try
+      // Create the dependency that was missing in the first run, and tag the recorded src
+      // materialization so that re-execution of src would be detectable
+      connector.execute("create or replace table __wv_resume_dep as select 10 as x")
+      val srcTable = first.stageResult("src").get.table.get
+      connector.execute(s"""insert into "${srcTable}" values (99)""")
+
+      val record = registry.get(first.runId).get
+      record.state shouldBe FlowRunRecord.STATE_FAILED
+      val (flow, ctx) = compileFlow(wv)
+      val resumed     =
+        FlowExecutor(connector, workEnv, registry = Some(registry)).execute(
+          flow,
+          resumeFrom = Some(record)
+        )(using ctx)
+      resumed.runId shouldBe first.runId
+      resumed.isSuccess shouldBe true
+      resumed.stageResult("out").get.state shouldBe StageState.Success
+      // out read the src table recorded in the first run (2 rows + 1 tagged row), proving
+      // that the successful stage was reused instead of re-executed
+      countStageRows(resumed, "out") shouldBe 3L
+      registry.get(first.runId).get.state shouldBe FlowRunRecord.STATE_SUCCESS
+    finally
+      connector.execute("drop table if exists __wv_resume_dep")
+  }
+
+  test("cancel a run across processes via the registry cancel marker") {
+    val registry     = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val stageStarted = CountDownLatch(1)
+    val runner       =
+      new FlowStageRunner:
+        override def run(stage: StageDef, targetTable: String)(using Context): Unit =
+          stageStarted.countDown()
+          Thread.sleep(30000)
+    val (flow, ctx) = compileFlow("""flow MarkerCancelFlow = {
+        |  stage slow = from [[1]] as t(id)
+        |}""".stripMargin)
+    val executor = FlowExecutor(
+      connector,
+      workEnv,
+      config = FlowExecutorConfig(cancelPollIntervalMillis = 10L),
+      stageRunner = Some(runner),
+      registry = Some(registry)
+    )
+    // Simulate another process: locate the running record via the registry and place the
+    // cancellation marker
+    val canceller = Thread { () =>
+      stageStarted.await(10, TimeUnit.SECONDS)
+      var runId: Option[String] = None
+      while runId.isEmpty do
+        runId = registry.list().headOption.map(_.runId)
+        if runId.isEmpty then
+          Thread.sleep(10)
+      registry.requestCancel(runId.get)
+    }
+    canceller.start()
+    val result = executor.execute(flow)(using ctx)
+    canceller.join()
+    result.stageResults.map(_.state) shouldBe List(StageState.Cancelled)
+    registry.get(result.runId).get.state shouldBe FlowRunRecord.STATE_CANCELLED
+    // The marker is cleared once the run reaches a terminal state
+    registry.cancelRequested(result.runId) shouldBe false
+  }
+
+  test("manage cancellation markers and record deletion in the registry") {
+    val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    registry.save(FlowRunRecord("run1", "F", FlowRunRecord.STATE_RUNNING, 100L))
+    registry.cancelRequested("run1") shouldBe false
+    registry.requestCancel("run1")
+    registry.cancelRequested("run1") shouldBe true
+    registry.clearCancelRequest("run1")
+    registry.cancelRequested("run1") shouldBe false
+    registry.requestCancel("run1")
+    registry.delete("run1")
+    registry.get("run1") shouldBe None
+    registry.cancelRequested("run1") shouldBe false
+    registry.list() shouldBe Nil
+  }
+
   test("compute retry delays for backoff strategies") {
     val base = StageExecutionConfig(retryDelayMillis = 100L)
     base.withBackoff("constant").retryDelayFor(1) shouldBe 100L


### PR DESCRIPTION
## Summary

Implements item 2 of #1823 (`wvlet flow session cancel/resume` + registry lifecycle), building on the cancellable attempts from #1825.

### Cross-process cancel

- `FlowRunRegistry` gains cancellation markers (`<run_id>.cancel` next to the run record): `requestCancel` / `cancelRequested` / `clearCancelRequest` / `delete`.
- `FlowExecutor` polls the registry (configurable `cancelPollIntervalMillis`, default 500ms) and triggers `cancel()` when a marker appears; in-flight statements are cancelled server-side via the #1825 mechanism. The marker is cleared when the run reaches a terminal state.
- `wvlet flow session cancel <run_id>` places the marker; cancelling an already-terminal run just reports its state.

### Resume

- `FlowExecutor.execute(flow, resumeFrom = Some(record))` resumes under the **same run id**: stages recorded successful keep their materialized `__wv_flow_<run_id>_<stage>` tables and start pre-marked as `Success`; remaining stages run with a fresh retry budget. Stage records that no longer match the flow definition are ignored.
- `wvlet flow session resume <run_id>` recompiles the working folder and resumes failed/cancelled runs; still-running and dependency-skipped runs are rejected with clear errors, resuming a successful run is a no-op message.

### Lifecycle

- `wvlet flow session clean` deletes terminal run records (keeping running ones) and drops their run-scoped tables via `FlowExecutor.dropRunTables`.

## Tests

- Executor: resume reuses the recorded materialization (proven by tagging the first run's table and observing the extra row downstream), cross-process cancel via marker polling (10ms poll, another thread discovers the run through `registry.list()`), registry marker/delete unit test.
- CLI: cancel unknown-run error, cancel finished run, resume failed run updates the same record, resume-success no-op, clean empties the registry.
- All FlowExecutorTest (35) and WvletFlowCommandTest (12) tests pass.

## Documentation

- `website/docs/syntax/flow.md`: documented the `wvlet flow session` subcommands.

Refs #1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)