### PR TITLE
feature: Add a pluggable FlowRunStore with a SQLite backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -401,6 +401,8 @@ lazy val runner = project
         "com.github.ben-manes.caffeine" % "caffeine"     % "3.2.4",
         "org.apache.arrow"              % "arrow-vector" % "19.0.0",
         "org.duckdb"                    % "duckdb_jdbc"  % DUCKDB_JDBC_VERSION,
+        // SQLite-backed flow run store (cross-process cancellation and concurrency claims)
+        "org.xerial" % "sqlite-jdbc" % "3.49.1.0",
         // trino-jdbc removed in PR-D: TrinoConnector now talks the Trino REST protocol via uni's
         // HttpSyncClient (see wvlet-lang's TrinoSqlConnector). trino-testing stays in test scope
         // for the in-process TestingTrinoServer — that artifact doesn't pull in trino-jdbc.

--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -342,8 +342,14 @@ wvlet flow session list -w ./pipelines
 wvlet flow session show <run_id> -w ./pipelines
 ```
 
-Every flow run is recorded in a local run registry (`target/flow-runs/<run_id>.json` under the
-working folder), updated live as stages change state. Cross-flow dependencies (`depends on X`,
+Every flow run is recorded in a local run store, updated live as stages change state. Two
+store backends are available and can be selected with `--run-store <type>` (or the
+`WVLET_FLOW_STORE` environment variable):
+
+- `file` (default): one JSON file per run (`target/flow-runs/<run_id>.json`), no dependencies
+- `sqlite`: a single SQLite database (`target/flow-runs/registry.db`) in WAL mode. Records are
+  transactional across processes, which a scheduler daemon needs for enforcing flow-level
+  `concurrency:` limits Cross-flow dependencies (`depends on X`,
 `if X.failed`, `if X.done`) are evaluated against the latest recorded run of the referenced
 flow: when the dependency is not satisfied, the flow run is recorded as `skipped` without
 executing any stage.

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -31,7 +31,7 @@ import wvlet.lang.model.plan.FlowDef
 import wvlet.lang.model.plan.FlowStatePredicate
 import wvlet.lang.runner.FlowExecutor
 import wvlet.lang.runner.FlowRunRecord
-import wvlet.lang.runner.FlowRunRegistry
+import wvlet.lang.runner.FlowRunStore
 import wvlet.lang.runner.connector.DBConnectorProvider
 import wvlet.uni.log.LogSupport
 
@@ -43,7 +43,9 @@ case class WvletFlowOption(
     @option(prefix = "--catalog", description = "Context database catalog to use")
     catalog: Option[String] = None,
     @option(prefix = "--schema", description = "Context database schema to use")
-    schema: Option[String] = None
+    schema: Option[String] = None,
+    @option(prefix = "--run-store", description = "Flow run store type: file (default) or sqlite")
+    runStore: Option[String] = None
 )
 
 /**
@@ -78,16 +80,23 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
           .withCompilationUnit(unit)
           .newContext(Symbol.NoSymbol)
 
-        val result = FlowExecutor(
-          connector,
-          workEnv,
-          registry = Some(FlowRunRegistry.forWorkEnv(workEnv))
-        ).execute(flow, resumeFrom)
-        println(result.toPrettyBox())
-        if result.hasError && !WvletMain.isInSbt then
-          System.exit(1)
+        Control.withResource(newRunStore(flowOption, workEnv)) { store =>
+          val result = FlowExecutor(connector, workEnv, registry = Some(store)).execute(
+            flow,
+            resumeFrom
+          )
+          println(result.toPrettyBox())
+          if result.hasError && !WvletMain.isInSbt then
+            System.exit(1)
+        }
       }
     }
+
+  /** Create the run store selected with --run-store (or the WVLET_FLOW_STORE environment) */
+  private def newRunStore(flowOption: WvletFlowOption, workEnv: WorkEnv): FlowRunStore = flowOption
+    .runStore
+    .map(FlowRunStore.ofType(_, workEnv))
+    .getOrElse(FlowRunStore.forWorkEnv(workEnv))
 
   @command(description = "List flows defined in the working folder")
   def list(flowOption: WvletFlowOption): Unit =
@@ -129,8 +138,7 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
       @argument(description = "Run id (required for show, cancel, and resume)")
       runId: Option[String] = None
   ): Unit =
-    val workEnv  = WorkEnv(flowOption.workFolder, opts.logLevel)
-    val registry = FlowRunRegistry.forWorkEnv(workEnv)
+    val workEnv = WorkEnv(flowOption.workFolder, opts.logLevel)
 
     def fmtTime(millis: Long): String        = java.time.Instant.ofEpochMilli(millis).toString
     def fmtElapsed(r: FlowRunRecord): String = r
@@ -142,79 +150,85 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
       throw StatusCode.INVALID_ARGUMENT.newException(s"Usage: wvlet flow session ${usage}")
     )
 
-    def recordOf(id: String): FlowRunRecord = registry
-      .get(id)
-      .getOrElse(throw StatusCode.INVALID_ARGUMENT.newException(s"Flow run '${id}' is not found"))
+    Control.withResource(newRunStore(flowOption, workEnv)) { registry =>
+      def recordOf(id: String): FlowRunRecord = registry
+        .get(id)
+        .getOrElse(throw StatusCode.INVALID_ARGUMENT.newException(s"Flow run '${id}' is not found"))
 
-    sub match
-      case "list" =>
-        registry
-          .list()
-          .foreach { r =>
-            println(
-              f"${r.runId}%-28s ${r.flowName}%-24s ${r.state}%-10s started: ${fmtTime(
-                  r.startedAtMillis
-                )} (${fmtElapsed(r)})"
-            )
-          }
-      case "show" =>
-        val r = recordOf(requireRunId("show <run_id>"))
-        println(s"run:      ${r.runId}")
-        println(s"flow:     ${r.flowName}")
-        println(s"state:    ${r.state}")
-        println(s"started:  ${fmtTime(r.startedAtMillis)}")
-        r.finishedAtMillis.foreach(f => println(s"finished: ${fmtTime(f)}"))
-        r.stages
-          .foreach { s =>
-            val err = s.error.map(e => s" - ${e}").getOrElse("")
-            println(f"  stage ${s.name}%-24s ${s.state}%-14s attempts: ${s.attempts}${err}")
-          }
-      case "cancel" =>
-        val id = requireRunId("cancel <run_id>")
-        val r  = recordOf(id)
-        if r.isTerminal then
-          println(s"Run ${id} is already ${r.state}")
-        else
-          registry.requestCancel(id)
-          println(s"Requested cancellation of run ${id}")
-      case "resume" =>
-        val id = requireRunId("resume <run_id>")
-        val r  = recordOf(id)
-        r.state match
-          case FlowRunRecord.STATE_RUNNING =>
-            throw StatusCode
-              .INVALID_ARGUMENT
-              .newException(s"Run ${id} is still running and cannot be resumed")
-          case FlowRunRecord.STATE_SUCCESS =>
-            println(s"Run ${id} already succeeded; nothing to resume")
-          case FlowRunRecord.STATE_SKIPPED =>
-            throw StatusCode
-              .INVALID_ARGUMENT
-              .newException(
-                s"Run ${id} was skipped (its dependency was not satisfied). Use wvlet flow run ${r
-                    .flowName} to start a new run"
+      sub match
+        case "list" =>
+          registry
+            .list()
+            .foreach { r =>
+              println(
+                f"${r.runId}%-28s ${r.flowName}%-24s ${r.state}%-10s started: ${fmtTime(
+                    r.startedAtMillis
+                  )} (${fmtElapsed(r)})"
               )
-          case _ =>
-            executeFlow(flowOption, r.flowName, resumeFrom = Some(r))
-      case "clean" =>
-        // Remove terminal run records and drop their run-scoped tables. Running flows are kept
-        val terminalRuns = registry.list().filter(_.isTerminal)
-        val profile = Profile.getProfile(flowOption.profile, flowOption.catalog, flowOption.schema)
-        Control.withResource(DBConnectorProvider(workEnv)) { dbConnectorProvider =>
-          val connector = dbConnectorProvider.getConnector(profile)
-          terminalRuns.foreach { r =>
-            FlowExecutor.dropRunTables(connector, r.runId, r.stages.map(_.name))
-            registry.delete(r.runId)
-          }
-        }
-        println(s"Removed ${terminalRuns.size} flow run record(s)")
-      case other =>
-        throw StatusCode
-          .INVALID_ARGUMENT
-          .newException(
-            s"Unknown session sub command: ${other}. Use list, show, cancel, resume, or clean"
+            }
+        case "show" =>
+          val r = recordOf(requireRunId("show <run_id>"))
+          println(s"run:      ${r.runId}")
+          println(s"flow:     ${r.flowName}")
+          println(s"state:    ${r.state}")
+          println(s"started:  ${fmtTime(r.startedAtMillis)}")
+          r.finishedAtMillis.foreach(f => println(s"finished: ${fmtTime(f)}"))
+          r.stages
+            .foreach { s =>
+              val err = s.error.map(e => s" - ${e}").getOrElse("")
+              println(f"  stage ${s.name}%-24s ${s.state}%-14s attempts: ${s.attempts}${err}")
+            }
+        case "cancel" =>
+          val id = requireRunId("cancel <run_id>")
+          val r  = recordOf(id)
+          if r.isTerminal then
+            println(s"Run ${id} is already ${r.state}")
+          else
+            registry.requestCancel(id)
+            println(s"Requested cancellation of run ${id}")
+        case "resume" =>
+          val id = requireRunId("resume <run_id>")
+          val r  = recordOf(id)
+          r.state match
+            case FlowRunRecord.STATE_RUNNING =>
+              throw StatusCode
+                .INVALID_ARGUMENT
+                .newException(s"Run ${id} is still running and cannot be resumed")
+            case FlowRunRecord.STATE_SUCCESS =>
+              println(s"Run ${id} already succeeded; nothing to resume")
+            case FlowRunRecord.STATE_SKIPPED =>
+              throw StatusCode
+                .INVALID_ARGUMENT
+                .newException(
+                  s"Run ${id} was skipped (its dependency was not satisfied). Use wvlet flow run ${r
+                      .flowName} to start a new run"
+                )
+            case _ =>
+              executeFlow(flowOption, r.flowName, resumeFrom = Some(r))
+        case "clean" =>
+          // Remove terminal run records and drop their run-scoped tables. Running flows are kept
+          val terminalRuns = registry.list().filter(_.isTerminal)
+          val profile      = Profile.getProfile(
+            flowOption.profile,
+            flowOption.catalog,
+            flowOption.schema
           )
-    end match
+          Control.withResource(DBConnectorProvider(workEnv)) { dbConnectorProvider =>
+            val connector = dbConnectorProvider.getConnector(profile)
+            terminalRuns.foreach { r =>
+              FlowExecutor.dropRunTables(connector, r.runId, r.stages.map(_.name))
+              registry.delete(r.runId)
+            }
+          }
+          println(s"Removed ${terminalRuns.size} flow run record(s)")
+        case other =>
+          throw StatusCode
+            .INVALID_ARGUMENT
+            .newException(
+              s"Unknown session sub command: ${other}. Use list, show, cancel, resume, or clean"
+            )
+      end match
+    }
   end session
 
   @command(description = "Show the plan of a flow")

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -115,6 +115,21 @@ class WvletFlowCommandTest extends UniTest:
     FlowRunRegistry.forWorkEnv(WorkEnv(flowDir)).list() shouldBe Nil
   }
 
+  test("run a flow and inspect sessions with the SQLite run store") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunStore
+    WvletMain.main(s"flow run SamplePipeline -w ${flowDir} --run-store sqlite")
+    WvletMain.main(s"flow session list -w ${flowDir} --run-store sqlite")
+    val store = FlowRunStore.ofType(FlowRunStore.STORE_TYPE_SQLITE, WorkEnv(flowDir))
+    try
+      val runs = store.list()
+      runs.nonEmpty shouldBe true
+      runs.head.flowName shouldBe "SamplePipeline"
+      WvletMain.main(s"flow session show ${runs.head.runId} -w ${flowDir} --run-store sqlite")
+    finally
+      store.close()
+  }
+
   test("report an error for an unknown flow name") {
     val e = intercept[WvletLangException] {
       WvletMain.main(s"flow run NoSuchFlow -w ${flowDir}")

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -186,7 +186,7 @@ class FlowExecutor(
     config: FlowExecutorConfig = FlowExecutorConfig(),
     stageRunner: Option[FlowStageRunner] = None,
     retryScheduler: Option[(Long, () => Unit) => Unit] = None,
-    registry: Option[FlowRunRegistry] = None
+    registry: Option[FlowRunStore] = None
 ) extends LogSupport:
   import FlowExecutor.FlowEvent
   import FlowExecutor.FlowEvent.*

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
@@ -21,6 +21,7 @@ import wvlet.uni.weaver.Weaver
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import scala.jdk.CollectionConverters.*
 import scala.util.control.NonFatal
 
@@ -83,11 +84,13 @@ object FlowRunRecord:
       STATE_RUNNING
 
 /**
-  * A file-based registry of flow runs. Each run is stored as a single JSON file
-  * (`<registryDir>/<runId>.json`), which keeps reads and writes atomic enough for a local,
-  * single-writer-per-run setup without a database dependency
+  * A file-based flow run store. Each run is stored as a single JSON file
+  * (`<registryDir>/<runId>.json`) written via an atomic rename, which keeps reads and writes safe
+  * for a local, single-writer-per-run setup without a database dependency. Run-slot claims are only
+  * atomic within a single process; use [[SQLiteFlowRunStore]] when cross-process concurrency
+  * enforcement is required
   */
-class FlowRunRegistry(registryDir: Path) extends LogSupport:
+class FlowRunRegistry(registryDir: Path) extends FlowRunStore with LogSupport:
 
   private val weaver = Weaver.of[FlowRunRecord]
 
@@ -97,21 +100,29 @@ class FlowRunRegistry(registryDir: Path) extends LogSupport:
     s"${runId.toLowerCase}.cancel"
   )
 
-  /** Persist (create or overwrite) the record of a run */
-  def save(record: FlowRunRecord): Unit =
+  override def save(record: FlowRunRecord): Unit =
     Files.createDirectories(registryDir)
-    Files.writeString(fileFor(record.runId), weaver.toJson(record))
+    // Write to a temp file first so that concurrent readers never observe a truncated record
+    val tmp = Files.createTempFile(registryDir, record.runId.toLowerCase, ".tmp")
+    try
+      Files.writeString(tmp, weaver.toJson(record))
+      Files.move(
+        tmp,
+        fileFor(record.runId),
+        StandardCopyOption.REPLACE_EXISTING,
+        StandardCopyOption.ATOMIC_MOVE
+      )
+    finally
+      Files.deleteIfExists(tmp)
 
-  /** Read the record of a specific run */
-  def get(runId: String): Option[FlowRunRecord] =
+  override def get(runId: String): Option[FlowRunRecord] =
     val f = fileFor(runId)
     if Files.exists(f) then
       readRecord(f)
     else
       None
 
-  /** List all recorded runs, most recent first */
-  def list(): List[FlowRunRecord] =
+  override def list(): List[FlowRunRecord] =
     if !Files.isDirectory(registryDir) then
       Nil
     else
@@ -124,26 +135,29 @@ class FlowRunRegistry(registryDir: Path) extends LogSupport:
         .toList
         .sortBy(-_.startedAtMillis)
 
-  /** The most recent run of the given flow, if any */
-  def latestRunOf(flowName: String): Option[FlowRunRecord] = list().find(_.flowName == flowName)
+  override def claimRunSlot(record: FlowRunRecord, concurrencyLimit: Int): Boolean =
+    // File-based claims cannot be made atomic across processes without lock files; this
+    // best-effort implementation is atomic within a single process only
+    synchronized {
+      val running = list().count(r => r.flowName == record.flowName && !r.isTerminal)
+      if running < concurrencyLimit then
+        save(record)
+        true
+      else
+        false
+    }
 
-  /**
-    * Request cancellation of a run by placing a marker file next to its record. The marker is
-    * polled by the executor's event loop, so a run can be cancelled from another process (e.g.
-    * `wvlet flow session cancel`)
-    */
-  def requestCancel(runId: String): Unit =
+  override def requestCancel(runId: String): Unit =
     Files.createDirectories(registryDir)
     Files.writeString(cancelMarkerFor(runId), "")
 
-  /** True if cancellation of the given run has been requested */
-  def cancelRequested(runId: String): Boolean = Files.exists(cancelMarkerFor(runId))
+  override def cancelRequested(runId: String): Boolean = Files.exists(cancelMarkerFor(runId))
 
-  /** Remove the cancellation marker of a run (called when the run reaches a terminal state) */
-  def clearCancelRequest(runId: String): Unit = Files.deleteIfExists(cancelMarkerFor(runId))
+  override def clearCancelRequest(runId: String): Unit = Files.deleteIfExists(
+    cancelMarkerFor(runId)
+  )
 
-  /** Delete the record and any cancellation marker of a run */
-  def delete(runId: String): Unit =
+  override def delete(runId: String): Unit =
     Files.deleteIfExists(fileFor(runId))
     Files.deleteIfExists(cancelMarkerFor(runId))
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunStore.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunStore.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.compiler.WorkEnv
+
+import java.nio.file.Path
+
+/**
+  * Persistent store of flow run records, observable across processes so that `wvlet flow session`
+  * commands and schedulers can inspect, cancel, and resume runs.
+  *
+  * Two implementations exist: [[FlowRunRegistry]] (one JSON file per run, no dependencies) and
+  * [[SQLiteFlowRunStore]] (a single SQLite database, transactional across processes). The file
+  * store is the default; select the SQLite store with `--run-store sqlite` or the
+  * `WVLET_FLOW_STORE` environment variable
+  */
+trait FlowRunStore extends AutoCloseable:
+  /** Persist (create or overwrite) the record of a run */
+  def save(record: FlowRunRecord): Unit
+
+  /** Read the record of a specific run */
+  def get(runId: String): Option[FlowRunRecord]
+
+  /** List all recorded runs, most recent first */
+  def list(): List[FlowRunRecord]
+
+  /** The most recent run of the given flow, if any */
+  def latestRunOf(flowName: String): Option[FlowRunRecord] = list().find(_.flowName == flowName)
+
+  /**
+    * Atomically save the given (running) record if fewer than `concurrencyLimit` runs of the same
+    * flow are currently in the running state. Returns true when the slot was claimed and the record
+    * was saved. Schedulers use this to enforce flow-level `concurrency:` limits
+    */
+  def claimRunSlot(record: FlowRunRecord, concurrencyLimit: Int): Boolean
+
+  /**
+    * Request cancellation of a run. The marker is polled by the executor's event loop, so a run can
+    * be cancelled from another process (e.g. `wvlet flow session cancel`)
+    */
+  def requestCancel(runId: String): Unit
+
+  /** True if cancellation of the given run has been requested */
+  def cancelRequested(runId: String): Boolean
+
+  /** Remove the cancellation marker of a run (called when the run reaches a terminal state) */
+  def clearCancelRequest(runId: String): Unit
+
+  /** Delete the record and any cancellation marker of a run */
+  def delete(runId: String): Unit
+
+  override def close(): Unit = ()
+
+end FlowRunStore
+
+object FlowRunStore:
+  val STORE_TYPE_FILE   = "file"
+  val STORE_TYPE_SQLITE = "sqlite"
+
+  /** The environment variable overriding the default run store type */
+  val STORE_TYPE_ENV = "WVLET_FLOW_STORE"
+
+  /**
+    * Create the run store of the given work environment. The store type defaults to the file store
+    * and can be overridden with the WVLET_FLOW_STORE environment variable
+    */
+  def forWorkEnv(workEnv: WorkEnv): FlowRunStore = ofType(
+    sys.env.getOrElse(STORE_TYPE_ENV, STORE_TYPE_FILE),
+    workEnv
+  )
+
+  /** Create a run store of the given type (file or sqlite) under the work environment */
+  def ofType(storeType: String, workEnv: WorkEnv): FlowRunStore =
+    val dir = Path.of(workEnv.targetFolder, "flow-runs")
+    storeType match
+      case STORE_TYPE_FILE =>
+        FlowRunRegistry(dir)
+      case STORE_TYPE_SQLITE =>
+        SQLiteFlowRunStore(dir.resolve("registry.db"))
+      case other =>
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(s"Unknown flow run store type: ${other}. Use file or sqlite")
+
+end FlowRunStore

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -165,12 +165,17 @@ class QueryExecutor(
           // Command produces no QueryResult other than errors
           report(executeCommand(e))
         case ExecuteFlow(flow) =>
-          val flowExecutor = FlowExecutor(
-            getDBConnector(defaultProfile),
-            workEnv,
-            registry = Some(FlowRunRegistry.forWorkEnv(workEnv))
-          )
-          report(flowExecutor.execute(flow))
+          scala
+            .util
+            .Using
+            .resource(FlowRunStore.forWorkEnv(workEnv)) { store =>
+              val flowExecutor = FlowExecutor(
+                getDBConnector(defaultProfile),
+                workEnv,
+                registry = Some(store)
+              )
+              report(flowExecutor.execute(flow))
+            }
         case ExecuteValDef(v) =>
           val expr = ExpressionEvaluator.eval(v.expr)(using context)
           v.symbol.symbolInfo = ValSymbolInfo(
@@ -454,11 +459,13 @@ class QueryExecutor(
     q.transformUp { case rf: RunFlow =>
         val flow       = resolveFlow(rf)
         val connector  = getDBConnector(defaultProfile)
-        val flowResult = FlowExecutor(
-          connector,
-          workEnv,
-          registry = Some(FlowRunRegistry.forWorkEnv(workEnv))
-        ).execute(flow)
+        val flowResult =
+          scala
+            .util
+            .Using
+            .resource(FlowRunStore.forWorkEnv(workEnv)) { store =>
+              FlowExecutor(connector, workEnv, registry = Some(store)).execute(flow)
+            }
 
         given monitor: QueryProgressMonitor = context.queryProgressMonitor
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/SQLiteFlowRunStore.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/SQLiteFlowRunStore.scala
@@ -1,0 +1,262 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.uni.log.LogSupport
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.ResultSet
+import scala.util.Using
+import scala.util.control.NonFatal
+
+/**
+  * A SQLite-backed flow run store (`<targetFolder>/flow-runs/registry.db`). Unlike the JSON file
+  * store, records are transactional across processes: WAL mode supports a writer concurrent with
+  * readers (e.g. a scheduler daemon plus CLI commands), and run-slot claims for `concurrency:`
+  * enforcement are atomic single-statement inserts.
+  *
+  * The store keeps one connection per instance; all operations are synchronized on it
+  */
+class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
+  Option(dbPath.getParent).foreach(Files.createDirectories(_))
+
+  private val conn: Connection = DriverManager.getConnection(s"jdbc:sqlite:${dbPath}")
+
+  Using.resource(conn.createStatement()) { stmt =>
+    stmt.execute("pragma journal_mode = WAL")
+    stmt.execute("pragma busy_timeout = 10000")
+    stmt.execute("""create table if not exists runs(
+        |  run_id           text primary key,
+        |  flow_name        text not null,
+        |  state            text not null,
+        |  started_at       integer not null,
+        |  finished_at      integer,
+        |  cancel_requested integer not null default 0
+        |)""".stripMargin)
+    stmt.execute("""create table if not exists stages(
+        |  run_id     text not null,
+        |  ordinal    integer not null,
+        |  name       text not null,
+        |  state      text not null,
+        |  attempts   integer not null,
+        |  error      text,
+        |  table_name text,
+        |  primary key(run_id, ordinal)
+        |)""".stripMargin)
+  }
+
+  override def save(record: FlowRunRecord): Unit = synchronized {
+    conn.setAutoCommit(false)
+    try
+      Using.resource(
+        conn.prepareStatement("""insert into runs(run_id, flow_name, state, started_at, finished_at)
+            |values(?, ?, ?, ?, ?)
+            |on conflict(run_id) do update set
+            |  flow_name = excluded.flow_name,
+            |  state = excluded.state,
+            |  started_at = excluded.started_at,
+            |  finished_at = excluded.finished_at""".stripMargin)
+      ) { ps =>
+        ps.setString(1, record.runId.toLowerCase)
+        ps.setString(2, record.flowName)
+        ps.setString(3, record.state)
+        ps.setLong(4, record.startedAtMillis)
+        record.finishedAtMillis match
+          case Some(f) =>
+            ps.setLong(5, f)
+          case None =>
+            ps.setNull(5, java.sql.Types.BIGINT)
+        ps.executeUpdate()
+      }
+      saveStages(record)
+      conn.commit()
+    catch
+      case NonFatal(e) =>
+        conn.rollback()
+        throw e
+    finally
+      conn.setAutoCommit(true)
+  }
+
+  private def saveStages(record: FlowRunRecord): Unit =
+    Using.resource(conn.prepareStatement("delete from stages where run_id = ?")) { ps =>
+      ps.setString(1, record.runId.toLowerCase)
+      ps.executeUpdate()
+    }
+    Using.resource(
+      conn.prepareStatement(
+        "insert into stages(run_id, ordinal, name, state, attempts, error, table_name) values(?, ?, ?, ?, ?, ?, ?)"
+      )
+    ) { ps =>
+      record
+        .stages
+        .zipWithIndex
+        .foreach { (s, i) =>
+          ps.setString(1, record.runId.toLowerCase)
+          ps.setInt(2, i)
+          ps.setString(3, s.name)
+          ps.setString(4, s.state)
+          ps.setInt(5, s.attempts)
+          ps.setString(6, s.error.orNull)
+          ps.setString(7, s.table.orNull)
+          ps.addBatch()
+        }
+      ps.executeBatch()
+    }
+
+  override def get(runId: String): Option[FlowRunRecord] = synchronized {
+    queryRuns("where run_id = ?", _.setString(1, runId.toLowerCase)).headOption
+  }
+
+  override def list(): List[FlowRunRecord] = synchronized {
+    queryRuns("order by started_at desc, run_id desc", _ => ())
+  }
+
+  override def claimRunSlot(record: FlowRunRecord, concurrencyLimit: Int): Boolean = synchronized {
+    // A single insert statement is atomic in SQLite, so the running-count check and the claim
+    // cannot interleave with claims from other processes
+    val claimed =
+      Using.resource(
+        conn.prepareStatement("""insert into runs(run_id, flow_name, state, started_at, finished_at)
+          |select ?, ?, ?, ?, ?
+          |where (select count(*) from runs where flow_name = ? and state = ?) < ?""".stripMargin)
+      ) { ps =>
+        ps.setString(1, record.runId.toLowerCase)
+        ps.setString(2, record.flowName)
+        ps.setString(3, record.state)
+        ps.setLong(4, record.startedAtMillis)
+        record.finishedAtMillis match
+          case Some(f) =>
+            ps.setLong(5, f)
+          case None =>
+            ps.setNull(5, java.sql.Types.BIGINT)
+        ps.setString(6, record.flowName)
+        ps.setString(7, FlowRunRecord.STATE_RUNNING)
+        ps.setInt(8, concurrencyLimit)
+        ps.executeUpdate() == 1
+      }
+    if claimed then
+      saveStages(record)
+    claimed
+  }
+
+  override def requestCancel(runId: String): Unit = synchronized {
+    setCancelRequested(runId, requested = true)
+  }
+
+  override def cancelRequested(runId: String): Boolean = synchronized {
+    Using.resource(conn.prepareStatement("select cancel_requested from runs where run_id = ?")) {
+      ps =>
+        ps.setString(1, runId.toLowerCase)
+        Using.resource(ps.executeQuery()) { rs =>
+          rs.next() && rs.getInt(1) != 0
+        }
+    }
+  }
+
+  override def clearCancelRequest(runId: String): Unit = synchronized {
+    setCancelRequested(runId, requested = false)
+  }
+
+  private def setCancelRequested(runId: String, requested: Boolean): Unit =
+    Using.resource(conn.prepareStatement("update runs set cancel_requested = ? where run_id = ?")) {
+      ps =>
+        ps.setInt(
+          1,
+          if requested then
+            1
+          else
+            0
+        )
+        ps.setString(2, runId.toLowerCase)
+        ps.executeUpdate()
+    }
+
+  override def delete(runId: String): Unit = synchronized {
+    Using.resource(conn.prepareStatement("delete from stages where run_id = ?")) { ps =>
+      ps.setString(1, runId.toLowerCase)
+      ps.executeUpdate()
+    }
+    Using.resource(conn.prepareStatement("delete from runs where run_id = ?")) { ps =>
+      ps.setString(1, runId.toLowerCase)
+      ps.executeUpdate()
+    }
+  }
+
+  override def close(): Unit = synchronized {
+    conn.close()
+  }
+
+  private def queryRuns(
+      clause: String,
+      bind: java.sql.PreparedStatement => Unit
+  ): List[FlowRunRecord] =
+    val runs =
+      Using.resource(
+        conn.prepareStatement(
+          s"select run_id, flow_name, state, started_at, finished_at from runs ${clause}"
+        )
+      ) { ps =>
+        bind(ps)
+        Using.resource(ps.executeQuery()) { rs =>
+          val b = List.newBuilder[FlowRunRecord]
+          while rs.next() do
+            val finishedAt = rs.getLong(5)
+            // wasNull refers to the immediately preceding getLong(5) read
+            val finishedAtOpt =
+              if rs.wasNull() then
+                None
+              else
+                Some(finishedAt)
+            b +=
+              FlowRunRecord(
+                runId = rs.getString(1),
+                flowName = rs.getString(2),
+                state = rs.getString(3),
+                startedAtMillis = rs.getLong(4),
+                finishedAtMillis = finishedAtOpt
+              )
+          b.result()
+        }
+      }
+    runs.map(r => r.copy(stages = stagesOf(r.runId)))
+
+  end queryRuns
+
+  private def stagesOf(runId: String): List[StageRunRecord] =
+    Using.resource(
+      conn.prepareStatement(
+        "select name, state, attempts, error, table_name from stages where run_id = ? order by ordinal"
+      )
+    ) { ps =>
+      ps.setString(1, runId.toLowerCase)
+      Using.resource(ps.executeQuery()) { rs =>
+        val b = List.newBuilder[StageRunRecord]
+        while rs.next() do
+          b +=
+            StageRunRecord(
+              name = rs.getString(1),
+              state = rs.getString(2),
+              attempts = rs.getInt(3),
+              error = Option(rs.getString(4)),
+              table = Option(rs.getString(5))
+            )
+        b.result()
+      }
+    }
+
+end SQLiteFlowRunStore

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -54,7 +54,7 @@ class FlowExecutorTest extends UniTest:
       config: FlowExecutorConfig = FlowExecutorConfig(),
       stageRunner: Option[FlowStageRunner] = None,
       retryScheduler: Option[(Long, () => Unit) => Unit] = None,
-      registry: Option[FlowRunRegistry] = None
+      registry: Option[FlowRunStore] = None
   ): FlowExecutionResult =
     val (flow, ctx) = compileFlow(wv)
     FlowExecutor(connector, workEnv, config, stageRunner, retryScheduler, registry).execute(flow)(
@@ -677,6 +677,28 @@ class FlowExecutorTest extends UniTest:
     registry.get(result.runId).get.state shouldBe FlowRunRecord.STATE_CANCELLED
     // The marker is cleared once the run reaches a terminal state
     registry.cancelRequested(result.runId) shouldBe false
+  }
+
+  test("record and cancel flow runs with the SQLite-backed store") {
+    val store = SQLiteFlowRunStore(
+      java.nio.file.Files.createTempDirectory("wv-flow-sqlite").resolve("registry.db")
+    )
+    try
+      val result = runFlow(
+        """flow SqliteRecordedFlow = {
+          |  stage src = from [[1], [2]] as t(id)
+          |  stage out = from src | select id
+          |}""".stripMargin,
+        registry = Some(store)
+      )
+      result.isSuccess shouldBe true
+      val record = store.get(result.runId).get
+      record.flowName shouldBe "SqliteRecordedFlow"
+      record.state shouldBe FlowRunRecord.STATE_SUCCESS
+      record.stages.map(_.state).distinct shouldBe List("success")
+      store.latestRunOf("SqliteRecordedFlow").get.runId shouldBe result.runId
+    finally
+      store.close()
   }
 
   test("manage cancellation markers and record deletion in the registry") {

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowRunStoreTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowRunStoreTest.scala
@@ -1,0 +1,175 @@
+package wvlet.lang.runner
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
+import wvlet.lang.compiler.WorkEnv
+import wvlet.uni.test.UniTest
+
+import java.nio.file.Files
+
+/**
+  * Behavioral tests shared by the file-based and SQLite-backed flow run stores
+  */
+class FlowRunStoreTest extends UniTest:
+
+  private def newStores(): List[(String, FlowRunStore)] =
+    val dir = Files.createTempDirectory("wv-flow-store")
+    List(
+      "file"   -> FlowRunRegistry(dir.resolve("file")),
+      "sqlite" -> SQLiteFlowRunStore(dir.resolve("registry.db"))
+    )
+
+  private def withStores(body: (String, FlowRunStore) => Unit): Unit = newStores().foreach {
+    (kind, store) =>
+      try body(kind, store)
+      finally store.close()
+  }
+
+  private def record(
+      runId: String,
+      flowName: String,
+      state: String,
+      startedAt: Long
+  ): FlowRunRecord = FlowRunRecord(
+    runId,
+    flowName,
+    state,
+    startedAt,
+    finishedAtMillis =
+      if state == FlowRunRecord.STATE_RUNNING then
+        None
+      else
+        Some(startedAt + 10)
+    ,
+    stages = List(
+      StageRunRecord("src", "success", 1, None, Some(s"__wv_flow_${runId}_src")),
+      StageRunRecord("out", "failed", 2, Some("boom"), None)
+    )
+  )
+
+  test("save, get, and list runs most recent first") {
+    withStores { (kind, store) =>
+      store.save(record("run1", "FlowA", FlowRunRecord.STATE_FAILED, 100L))
+      store.save(record("run2", "FlowB", FlowRunRecord.STATE_RUNNING, 200L))
+      store.save(record("run3", "FlowA", FlowRunRecord.STATE_SUCCESS, 300L))
+
+      val r1 = store.get("run1").getOrElse(fail(s"run1 not found in ${kind} store"))
+      r1.flowName shouldBe "FlowA"
+      r1.state shouldBe FlowRunRecord.STATE_FAILED
+      r1.finishedAtMillis shouldBe Some(110L)
+      r1.stages.map(_.name) shouldBe List("src", "out")
+      r1.stages.head.table shouldBe Some("__wv_flow_run1_src")
+      r1.stages.last.error shouldBe Some("boom")
+
+      store.get("run2").get.finishedAtMillis shouldBe None
+      store.list().map(_.runId) shouldBe List("run3", "run2", "run1")
+      store.latestRunOf("FlowA").get.runId shouldBe "run3"
+      store.latestRunOf("NoSuchFlow") shouldBe None
+    }
+  }
+
+  test("overwrite a run record on save") {
+    withStores { (kind, store) =>
+      store.save(record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L))
+      val updated = record("run1", "FlowA", FlowRunRecord.STATE_SUCCESS, 100L).copy(stages =
+        List(StageRunRecord("src", "success", 1))
+      )
+      store.save(updated)
+      val r = store.get("run1").get
+      r.state shouldBe FlowRunRecord.STATE_SUCCESS
+      r.stages.size shouldBe 1
+      store.list().size shouldBe 1
+    }
+  }
+
+  test("track cancellation requests") {
+    withStores { (kind, store) =>
+      store.save(record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L))
+      store.cancelRequested("run1") shouldBe false
+      store.requestCancel("run1")
+      store.cancelRequested("run1") shouldBe true
+      store.clearCancelRequest("run1")
+      store.cancelRequested("run1") shouldBe false
+    }
+  }
+
+  test("delete run records") {
+    withStores { (kind, store) =>
+      store.save(record("run1", "FlowA", FlowRunRecord.STATE_SUCCESS, 100L))
+      store.requestCancel("run1")
+      store.delete("run1")
+      store.get("run1") shouldBe None
+      store.cancelRequested("run1") shouldBe false
+      store.list() shouldBe Nil
+    }
+  }
+
+  test("claim run slots up to the concurrency limit") {
+    withStores { (kind, store) =>
+      val first = record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L)
+      store.claimRunSlot(first, concurrencyLimit = 2) shouldBe true
+      store.get("run1").get.stages.map(_.name) shouldBe List("src", "out")
+      store.claimRunSlot(
+        record("run2", "FlowA", FlowRunRecord.STATE_RUNNING, 200L),
+        concurrencyLimit = 2
+      ) shouldBe true
+      // The limit is reached: the third concurrent run of FlowA is rejected
+      store.claimRunSlot(
+        record("run3", "FlowA", FlowRunRecord.STATE_RUNNING, 300L),
+        concurrencyLimit = 2
+      ) shouldBe false
+      store.get("run3") shouldBe None
+      // Other flows have their own slots
+      store.claimRunSlot(
+        record("runB", "FlowB", FlowRunRecord.STATE_RUNNING, 300L),
+        concurrencyLimit = 1
+      ) shouldBe true
+
+      // Finishing a run frees its slot
+      store.save(record("run1", "FlowA", FlowRunRecord.STATE_SUCCESS, 100L))
+      store.claimRunSlot(
+        record("run3", "FlowA", FlowRunRecord.STATE_RUNNING, 300L),
+        concurrencyLimit = 2
+      ) shouldBe true
+    }
+  }
+
+  test("share state between store instances on the same path") {
+    // Simulates cross-process observation: a second store instance sees runs and cancellation
+    // requests written by the first one
+    val dir = Files.createTempDirectory("wv-flow-store-shared")
+    List(
+      "file"   -> (() => FlowRunRegistry(dir.resolve("file"))),
+      "sqlite" -> (() => SQLiteFlowRunStore(dir.resolve("registry.db")))
+    ).foreach { (kind, newStore) =>
+      val writer = newStore()
+      val reader = newStore()
+      try
+        writer.save(record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L))
+        reader.get("run1").isDefined shouldBe true
+        reader.requestCancel("run1")
+        writer.cancelRequested("run1") shouldBe true
+      finally
+        writer.close()
+        reader.close()
+    }
+  }
+
+  test("create stores via the factory") {
+    val dir = Files.createTempDirectory("wv-flow-store-factory")
+    // A .wv file makes the folder a wvlet workspace, so targetFolder stays under this temp dir
+    Files.writeString(dir.resolve("dummy.wv"), "")
+    val workEnv = WorkEnv(dir.toString)
+    val file    = FlowRunStore.ofType(FlowRunStore.STORE_TYPE_FILE, workEnv)
+    file.close()
+    file.getClass shouldBe classOf[FlowRunRegistry]
+    val sqlite = FlowRunStore.ofType(FlowRunStore.STORE_TYPE_SQLITE, workEnv)
+    sqlite.close()
+    sqlite.getClass shouldBe classOf[SQLiteFlowRunStore]
+    val e = intercept[WvletLangException] {
+      FlowRunStore.ofType("bogus", workEnv)
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+  }
+
+end FlowRunStoreTest


### PR DESCRIPTION
## Summary

Implements item 3 of #1823 (pluggable run store + SQLite backend), the prerequisite for scheduler `concurrency:` enforcement (item 5).

### FlowRunStore trait

- Extracted from `FlowRunRegistry`: `save` / `get` / `list` / `latestRunOf` / `requestCancel` / `cancelRequested` / `clearCancelRequest` / `delete`, plus `claimRunSlot(record, concurrencyLimit)` — atomically save a running record only when fewer than N runs of the same flow are running (what the scheduler daemon will use for `concurrency:` limits).
- `FlowExecutor`, `QueryExecutor`, and the flow CLI now depend on the trait; stores are closed after use.

### File backend hardening

- `FlowRunRegistry.save` now writes via temp file + `ATOMIC_MOVE`, so concurrent readers never observe truncated JSON.
- `claimRunSlot` on the file store is synchronized (atomic within one process only; documented).

### SQLite backend

- `SQLiteFlowRunStore` (`target/flow-runs/registry.db`) via **sqlite-jdbc 3.49.1.0**: WAL mode + `busy_timeout` for daemon-plus-CLI cross-process access; `runs` and `stages` tables; cancellation requests are a `cancel_requested` column; run-slot claims are a single atomic `INSERT ... SELECT ... WHERE count(running) < limit`.
- Store selection: `wvlet flow ... --run-store sqlite` or `WVLET_FLOW_STORE=sqlite`; **file store remains the default**. A Postgres/server-hosted store can implement the same trait later.

## Tests

- `FlowRunStoreTest`: shared behavioral suite over both backends — save/get/list ordering, overwrite, cancellation markers, delete, concurrency-slot claims (limit reached, slot freed on finish, per-flow isolation), cross-instance visibility on the same path, factory validation.
- `FlowExecutorTest`: flow execution recording + cancellation with the SQLite store (36 tests pass).
- `WvletFlowCommandTest`: end-to-end `flow run` / `session list|show` with `--run-store sqlite` (13 tests pass).

## Documentation

- `website/docs/syntax/flow.md`: documented the two store backends and selection.

Refs #1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)