### PR TITLE
feature: Execute -> Flow jumps as new runs with a cycle depth guard

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -376,8 +376,11 @@ immediately. Flow operators are
 lowered before scheduling: `route` cases become filter predicates on target stages, `fork`
 stages are flattened into the DAG, `wait` delays materialization, `activate` is a local
 logging stub until sink connectors exist, and `end` is a pass-through. Flow runs are recorded
-in a local run registry, and cross-flow dependencies are evaluated against it. Flow-level cron
-schedules, `-> Flow` jumps, and `heartbeat` enforcement are parsed but not yet executable.
+in a local run registry, and cross-flow dependencies are evaluated against it. A `-> Flow`
+jump is a control-only transfer: when the jumping stage succeeds, the target flow is triggered
+as a new run (with its own run id) after the current flow completes, and jump chains are
+bounded by a configurable depth limit to terminate cycles. Flow-level cron schedules and
+`heartbeat` enforcement are parsed but not yet executable.
 :::
 
 Each stage progresses through a well-defined state machine:

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -124,12 +124,20 @@ end StageExecutionConfig
   *   Maximum number of stages that can run concurrently
   * @param cancelPollIntervalMillis
   *   Interval for polling the run registry for cross-process cancellation requests
+  * @param maxJumpDepth
+  *   Maximum depth of `-> Flow` jump chains; guards against jump cycles (flow A -> B -> A)
   */
-case class FlowExecutorConfig(maxParallelism: Int = 4, cancelPollIntervalMillis: Long = 500L):
+case class FlowExecutorConfig(
+    maxParallelism: Int = 4,
+    cancelPollIntervalMillis: Long = 500L,
+    maxJumpDepth: Int = 8
+):
   def withMaxParallelism(n: Int): FlowExecutorConfig                 = copy(maxParallelism = n)
   def withCancelPollIntervalMillis(millis: Long): FlowExecutorConfig = copy(
     cancelPollIntervalMillis = millis
   )
+
+  def withMaxJumpDepth(depth: Int): FlowExecutorConfig = copy(maxJumpDepth = depth)
 
 /**
   * Runs the body of a single stage and materializes the result into the given target table.
@@ -164,10 +172,13 @@ trait FlowStageRunner:
   * are flattened, route cases become filter predicates on the target stages' reads, wait becomes a
   * pre-materialization delay, activate is a local logging stub, and end is a pass-through.
   *
+  * A `-> Flow` jump transfers control only: when the jumping stage succeeds, the target flow is
+  * triggered as a new run (with its own run id) after the current flow completes. Jump chains are
+  * bounded by `maxJumpDepth` to guard against cycles (flow A -> B -> A).
+  *
   * Current limitations (to be lifted in future iterations):
   *   - `heartbeat` is parsed but not enforced.
-  *   - `-> Flow` (jump) requires cross-flow orchestration and is not executable yet.
-  *   - Flow-level schedules and cross-flow dependencies are not evaluated here.
+  *   - Flow-level cron schedules are not evaluated here.
   *
   * @param connector
   *   The database connector used to materialize stage results
@@ -241,6 +252,20 @@ class FlowExecutor(
     */
   def execute(flow: FlowDef, resumeFrom: Option[FlowRunRecord] = None)(using
       ctx: Context
+  ): FlowExecutionResult = executeInternal(flow, resumeFrom, jumpDepth = 0)
+
+  /** Resolve a flow referenced by a `-> Flow` jump through the compilation context */
+  private def resolveJumpTarget(name: String)(using ctx: Context): FlowDef =
+    ctx.findTermSymbolByName(name).map(_.tree) match
+      case Some(f: FlowDef) =>
+        f
+      case _ =>
+        throw StatusCode
+          .FLOW_NOT_FOUND
+          .newException(s"Flow '${name}' referenced by a -> jump is not found")
+
+  private def executeInternal(flow: FlowDef, resumeFrom: Option[FlowRunRecord], jumpDepth: Int)(
+      using ctx: Context
   ): FlowExecutionResult =
     val runId     = resumeFrom.map(_.runId).getOrElse(ULID.newULIDString)
     val startedAt = System.currentTimeMillis()
@@ -277,6 +302,11 @@ class FlowExecutor(
     val routeFilters                                    = lowered.routeFilters
     val stageConfigs: Map[String, StageExecutionConfig] =
       flowStages.map(ls => ls.name -> StageExecutionConfig.fromConfigItems(ls.stage.config)).toMap
+
+    // Resolve jump targets eagerly so that a reference to an undefined flow fails the run
+    // before any stage executes
+    val jumpTargetFlows: Map[String, FlowDef] =
+      flowStages.flatMap(_.jumpTargets).distinct.map(name => name -> resolveJumpTarget(name)).toMap
 
     // Stages materialize into run-scoped tables so that concurrent runs and real tables with the
     // same name never collide
@@ -381,6 +411,8 @@ class FlowExecutor(
     var scheduledRetries = 0
     var runningCount     = 0
     var cancellationDone = false
+    // Jump targets of successfully completed stages, triggered after this flow completes
+    val pendingJumps = mutable.ListBuffer.empty[String]
 
     val threadFactory =
       new ThreadFactory:
@@ -631,6 +663,7 @@ class FlowExecutor(
                   error match
                     case None =>
                       states(name) = StageState.Success
+                      pendingJumps ++= s.jumpTargets
                     case Some(e) =>
                       errors(name) = e
                       val stageConfig  = stageConfigs(name)
@@ -689,9 +722,26 @@ class FlowExecutor(
     }
     val result = FlowExecutionResult(flow.name.name, runId, stageResults)
     workEnv.info(s"Completed flow ${flow.name.name} (run: ${runId})")
+
+    // Trigger the control-only jumps recorded by successful stages, each as a new run of the
+    // target flow. Jump chains are bounded by maxJumpDepth to terminate cycles (A -> B -> A)
+    if pendingJumps.nonEmpty && !cancelled then
+      pendingJumps
+        .toList
+        .distinct
+        .foreach { target =>
+          if jumpDepth + 1 > config.maxJumpDepth then
+            workEnv.warn(
+              s"Skipping jump to flow ${target}: max jump depth (${config.maxJumpDepth}) reached"
+            )
+          else
+            workEnv.info(s"Jumping from flow ${flow.name.name} to flow ${target}")
+            executeInternal(jumpTargetFlows(target), resumeFrom = None, jumpDepth = jumpDepth + 1)
+        }
+
     result
 
-  end execute
+  end executeInternal
 
   /**
     * Execute the lowered stage body and materialize the result as a run-scoped table. References to
@@ -712,16 +762,6 @@ class FlowExecutor(
       .getOrElse(
         throw StatusCode.NOT_IMPLEMENTED.newException(s"Stage ${ls.name} has no executable body")
       )
-
-    // Reject flow operators that lowering could not handle (e.g. cross-flow jumps)
-    body.traverse { case op: FlowJump =>
-      throw StatusCode
-        .NOT_IMPLEMENTED
-        .newException(
-          s"Flow operator ${op.nodeName} in stage ${ls
-              .name} is not supported by the flow executor yet"
-        )
-    }
 
     // Reference a source stage's run-scoped table, filtered with the routing predicate when
     // this stage is a route target of the source

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
@@ -32,8 +32,8 @@ import wvlet.lang.model.plan.*
   *   - `activate('target')` — recorded as an activation of the materialized stage output (local
   *     stub until sink connectors exist)
   *   - `end()` — pass-through terminal marker
-  *
-  * `-> OtherFlow` (jump) requires cross-flow orchestration and is not lowered yet.
+  *   - `-> OtherFlow` (jump) — recorded as a control-only jump target; the executor triggers the
+  *     target flow as a new run after the jumping stage's flow completes
   */
 object FlowLowering:
 
@@ -48,12 +48,15 @@ object FlowLowering:
     *   Delay to apply before materializing the stage
     * @param activateTargets
     *   External activation targets to notify with the materialized output
+    * @param jumpTargets
+    *   Flows to trigger as new runs when this stage succeeds (control-only transfer)
     */
   case class LoweredStage(
       stage: StageDef,
       body: Option[Relation],
       waitMillis: Option[Long] = None,
-      activateTargets: List[String] = Nil
+      activateTargets: List[String] = Nil,
+      jumpTargets: List[String] = Nil
   ):
     def name: String = stage.name.name
 
@@ -95,6 +98,7 @@ object FlowLowering:
     val lowered = flatStages.map { s =>
       var waitMillis: Option[Long] = None
       val activations              = List.newBuilder[String]
+      val jumps                    = List.newBuilder[String]
       val newBody                  = s
         .body
         .map {
@@ -114,10 +118,13 @@ object FlowLowering:
                 a.child
               case e: FlowEnd =>
                 e.child
+              case j: FlowJump =>
+                jumps += j.targetFlow.fullName
+                j.child
             }
             .asInstanceOf[Relation]
         }
-      LoweredStage(s, newBody, waitMillis, activations.result())
+      LoweredStage(s, newBody, waitMillis, activations.result(), jumps.result())
     }
     LoweredFlow(flow, lowered, routeFilters.result())
 

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -349,15 +349,81 @@ class FlowExecutorTest extends UniTest:
     result.stageResult("merged").get.state shouldBe StageState.Skipped
   }
 
-  test("fail a stage using unsupported flow operators without retrying") {
-    val result = runFlow("""flow JumpFlow = {
-        |  stage entry = from [[1]] as t(id)
-        |  stage jump with { retries: 3 } = from entry | -> OtherFlow
-        |}""".stripMargin)
-    val jump = result.stageResult("jump").get
-    jump.state shouldBe StageState.Failed
-    // NOT_IMPLEMENTED errors are not retryable
-    jump.attempts shouldBe 1
+  test("fail fast when a jump references an undefined flow") {
+    val e = intercept[WvletLangException] {
+      runFlow("""flow JumpFlow = {
+          |  stage entry = from [[1]] as t(id)
+          |  stage jump = from entry | -> NoSuchFlow
+          |}""".stripMargin)
+    }
+    e.statusCode shouldBe StatusCode.FLOW_NOT_FOUND
+  }
+
+  test("trigger the jump target flow as a new run") {
+    val registry     = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val (flows, ctx) = compileFlows("""flow MainFlow = {
+        |  stage entry = from [[1], [2]] as t(id)
+        |  stage jump = from entry | -> Downstream
+        |}
+        |
+        |flow Downstream = {
+        |  stage report = from [[1], [2], [3]] as t(id)
+        |}
+        |""".stripMargin)
+    val result =
+      FlowExecutor(connector, workEnv, registry = Some(registry)).execute(flows("MainFlow"))(using
+        ctx
+      )
+    result.isSuccess shouldBe true
+    // The jumping stage materializes its input like a regular stage
+    countStageRows(result, "jump") shouldBe 2L
+    // The target flow ran as its own recorded run
+    val downstream = registry.latestRunOf("Downstream").get
+    downstream.state shouldBe FlowRunRecord.STATE_SUCCESS
+    downstream.runId shouldNotBe result.runId
+    countRows(downstream.stages.head.table.get) shouldBe 3L
+  }
+
+  test("skip jumps of failed stages") {
+    val registry     = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val (flows, ctx) = compileFlows("""flow BrokenJumpFlow = {
+        |  stage jump = from nonexistent_table_xyz | -> Downstream
+        |}
+        |
+        |flow Downstream = {
+        |  stage report = from [[1]] as t(id)
+        |}
+        |""".stripMargin)
+    val result =
+      FlowExecutor(connector, workEnv, registry = Some(registry)).execute(flows("BrokenJumpFlow"))(
+        using ctx
+      )
+    result.isSuccess shouldBe false
+    registry.latestRunOf("Downstream") shouldBe None
+  }
+
+  test("bound jump chains with the max jump depth") {
+    val registry     = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val (flows, ctx) = compileFlows("""flow PingFlow = {
+        |  stage ping = from [[1]] as t(id) | -> PongFlow
+        |}
+        |
+        |flow PongFlow = {
+        |  stage pong = from [[1]] as t(id) | -> PingFlow
+        |}
+        |""".stripMargin)
+    // Depth limit 3 permits runs at depths 0..3 and then stops the cycle
+    FlowExecutor(
+      connector,
+      workEnv,
+      config = FlowExecutorConfig(maxJumpDepth = 3),
+      registry = Some(registry)
+    ).execute(flows("PingFlow"))(using ctx)
+    val runs = registry.list()
+    runs.size shouldBe 4
+    runs.count(_.flowName == "PingFlow") shouldBe 2
+    runs.count(_.flowName == "PongFlow") shouldBe 2
+    runs.forall(_.state == FlowRunRecord.STATE_SUCCESS) shouldBe true
   }
 
   test("route rows to target stages with conditional predicates") {


### PR DESCRIPTION
## Summary

Implements item 4 of #1823 (`-> Flow` jump execution).

### Semantics

- A `-> Flow` jump is a **control-only transfer** (matching the `FlowJump` AST contract): when the jumping stage succeeds, the target flow is triggered as a **new run with its own run id** after the current flow completes. The jumping stage still materializes its input like a regular stage; the target flow does not implicitly receive it as input.
- Jump targets are resolved **eagerly** through the compilation context (like `run flow`), so a jump to an undefined flow fails the run with `FLOW_NOT_FOUND` before any stage executes.
- Jumps recorded by failed/skipped/cancelled stages do not fire, and a cancelled flow triggers no jumps.
- **Cycle guard**: jump chains are bounded by `FlowExecutorConfig.maxJumpDepth` (default 8); a cycle like flow A -> B -> A terminates with a warning once the depth is reached.

### Implementation

- `FlowLowering` now strips `FlowJump` from stage bodies and records `jumpTargets` on the lowered stage (the previous NOT_IMPLEMENTED rejection is gone).
- `FlowExecutor.execute` delegates to an internal method carrying the jump depth; successful stages append their targets to a pending list, executed sequentially after the parent run's record is finalized. Each jumped run is recorded in the run store like any other run.

## Tests

- Jump triggers the target flow as a new recorded run (verified via the run store, distinct run ids, materialized rows).
- Jumps of failed stages do not fire.
- Ping/pong cycle with `maxJumpDepth = 3` terminates with exactly 4 recorded runs.
- Jump to an undefined flow fails fast with `FLOW_NOT_FOUND` (replaces the old NOT_IMPLEMENTED test).
- All 39 FlowExecutorTest tests pass.

## Documentation

- Updated the implementation-status note and jump semantics in `website/docs/syntax/flow.md`, and the `FlowExecutor` scaladoc.

Refs #1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)