### PR TITLE
feature: Add a cron scheduler daemon and flow-level concurrency enforcement

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -295,6 +295,23 @@ flow scheduled_flow with {
 }
 ```
 
+Schedules are evaluated by the scheduler daemon:
+
+```bash
+wvlet flow scheduler -w <dir>
+```
+
+The daemon evaluates the five-field cron expression of every scheduled flow in the working
+folder (in the flow's `timezone:`, defaulting to the system zone) and triggers due flows
+through the regular flow executor, so cross-flow dependencies (`depends on`, `if X.failed`)
+still decide whether a triggered run actually executes: the schedule determines *when* to
+check, the dependency determines *if* the flow runs.
+
+`concurrency: N` is enforced through the run store whenever a flow starts (scheduler, CLI, or
+`run flow`): a run atomically claims one of the flow's N slots and is recorded as `skipped`
+when all slots are taken by running runs. With the `sqlite` run store the claim is
+transactional across processes.
+
 ## Running Flows
 
 Flow definitions are declarations: running a file that contains flows does not execute them.
@@ -379,8 +396,9 @@ logging stub until sink connectors exist, and `end` is a pass-through. Flow runs
 in a local run registry, and cross-flow dependencies are evaluated against it. A `-> Flow`
 jump is a control-only transfer: when the jumping stage succeeds, the target flow is triggered
 as a new run (with its own run id) after the current flow completes, and jump chains are
-bounded by a configurable depth limit to terminate cycles. Flow-level cron schedules and
-`heartbeat` enforcement are parsed but not yet executable.
+bounded by a configurable depth limit to terminate cycles. Flow-level cron schedules are
+evaluated by the `wvlet flow scheduler` daemon, and `concurrency:` limits are enforced through
+run-slot claims in the run store. `heartbeat` enforcement is parsed but not yet executable.
 :::
 
 Each stage progresses through a well-defined state machine:

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -29,9 +29,13 @@ import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.model.plan.DependsOnFlow
 import wvlet.lang.model.plan.FlowDef
 import wvlet.lang.model.plan.FlowStatePredicate
+import wvlet.lang.runner.CronSchedule
 import wvlet.lang.runner.FlowExecutor
 import wvlet.lang.runner.FlowRunRecord
 import wvlet.lang.runner.FlowRunStore
+import wvlet.lang.runner.FlowScheduleConfig
+import wvlet.lang.runner.FlowScheduler
+import wvlet.lang.runner.ScheduledFlow
 import wvlet.lang.runner.connector.DBConnectorProvider
 import wvlet.uni.log.LogSupport
 
@@ -230,6 +234,66 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
       end match
     }
   end session
+
+  @command(description = "Start the scheduler daemon that runs flows on their cron schedules")
+  def scheduler(flowOption: WvletFlowOption): Unit =
+    withFlows(flowOption) { (flows, compileResult, workEnv) =>
+      val scheduled = flows.flatMap { (unit, f) =>
+        val config = FlowScheduleConfig.fromFlow(f)
+        config
+          .cron
+          .map { cronExpr =>
+            (unit, ScheduledFlow(f, CronSchedule.parse(cronExpr), config.zoneId))
+          }
+      }
+      if scheduled.isEmpty then
+        println("No flows with a schedule: config were found")
+      else
+        val profile = Profile.getProfile(flowOption.profile, flowOption.catalog, flowOption.schema)
+        Control.withResource(DBConnectorProvider(workEnv)) { dbConnectorProvider =>
+          val connector = dbConnectorProvider.getConnector(profile)
+          Control.withResource(newRunStore(flowOption, workEnv)) { store =>
+            val unitOf = scheduled.map((unit, sf) => sf.name -> unit).toMap
+            // Each triggered flow runs on its own thread so that a long flow does not delay
+            // other schedules; the executor enforces dependencies and concurrency limits
+            val pool = java
+              .util
+              .concurrent
+              .Executors
+              .newCachedThreadPool { (r: Runnable) =>
+                val t = Thread(r, "wvlet-flow-scheduler-run")
+                t.setDaemon(true)
+                t
+              }
+            val flowScheduler = FlowScheduler(
+              scheduled.map(_._2),
+              trigger =
+                flow =>
+                  pool.submit(
+                    new Runnable:
+                      override def run(): Unit =
+                        given ctx: Context = compileResult
+                          .context
+                          .withCompilationUnit(unitOf(flow.name.name))
+                          .newContext(Symbol.NoSymbol)
+                        val result = FlowExecutor(connector, workEnv, registry = Some(store))
+                          .execute(flow)
+                        println(result.toPrettyBox())
+                  )
+            )
+            Runtime
+              .getRuntime
+              .addShutdownHook(
+                Thread { () =>
+                  flowScheduler.stop()
+                }
+              )
+            try flowScheduler.runLoop()
+            finally pool.shutdownNow()
+          }
+        }
+      end if
+    }
 
   @command(description = "Show the plan of a flow")
   def show(

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -130,6 +130,11 @@ class WvletFlowCommandTest extends UniTest:
       store.close()
   }
 
+  test("report when no scheduled flows exist for the scheduler") {
+    // The working folder has no flows with a schedule: config, so the daemon exits immediately
+    WvletMain.main(s"flow scheduler -w ${flowDir}")
+  }
+
   test("report an error for an unknown flow name") {
     val e = intercept[WvletLangException] {
       WvletMain.main(s"flow run NoSuchFlow -w ${flowDir}")

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/CronSchedule.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/CronSchedule.scala
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.api.StatusCode
+
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+
+/**
+  * A parsed five-field cron expression (minute, hour, day-of-month, month, day-of-week) supporting
+  * `*`, values, ranges (`a-b`), steps (`*&#47;n`, `a-b/n`), and comma lists. Day-of-week accepts
+  * 0-7 with both 0 and 7 meaning Sunday. Following standard cron semantics, when both day fields
+  * are restricted a time matches if *either* field matches
+  */
+case class CronSchedule(
+    expression: String,
+    minutes: Set[Int],
+    hours: Set[Int],
+    daysOfMonth: Set[Int],
+    months: Set[Int],
+    daysOfWeek: Set[Int],
+    domRestricted: Boolean,
+    dowRestricted: Boolean
+):
+  /** True if the given time (truncated to the minute) matches this schedule */
+  def matches(t: ZonedDateTime): Boolean =
+    minutes.contains(t.getMinute) && hours.contains(t.getHour) &&
+      months.contains(t.getMonthValue) && dayMatches(t)
+
+  private def dayMatches(t: ZonedDateTime): Boolean =
+    val domMatch = daysOfMonth.contains(t.getDayOfMonth)
+    // java.time: MONDAY=1 .. SUNDAY=7; cron: SUNDAY=0
+    val dowMatch = daysOfWeek.contains(t.getDayOfWeek.getValue % 7)
+    (domRestricted, dowRestricted) match
+      case (true, true) =>
+        domMatch || dowMatch
+      case (true, false) =>
+        domMatch
+      case (false, true) =>
+        dowMatch
+      case (false, false) =>
+        true
+
+  /** The first matching time strictly after the given time */
+  def nextAfter(t: ZonedDateTime): ZonedDateTime =
+    var candidate = t.truncatedTo(ChronoUnit.MINUTES).plusMinutes(1)
+    val limit     = t.plusYears(4)
+    while !matches(candidate) do
+      // Skip in day steps while the date cannot match to keep the scan cheap
+      candidate =
+        if !months.contains(candidate.getMonthValue) || !dayMatches(candidate) then
+          candidate.plusDays(1).truncatedTo(ChronoUnit.DAYS)
+        else
+          candidate.plusMinutes(1)
+      if candidate.isAfter(limit) then
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(s"Cron expression '${expression}' never fires")
+    candidate
+
+end CronSchedule
+
+object CronSchedule:
+
+  /** Parse a five-field cron expression, e.g. `0 2 * * *` */
+  def parse(expression: String): CronSchedule =
+    val fields = expression.trim.split("""\s+""").toList
+    if fields.size != 5 then
+      throw StatusCode
+        .INVALID_ARGUMENT
+        .newException(
+          s"Invalid cron expression '${expression}': expected 5 fields (minute hour day month weekday), found ${fields
+              .size}"
+        )
+    val List(minF, hourF, domF, monthF, dowF) = fields: @unchecked
+    val (minutes, _)                          = parseField(expression, minF, 0, 59)
+    val (hours, _)                            = parseField(expression, hourF, 0, 23)
+    val (dom, domRestricted)                  = parseField(expression, domF, 1, 31)
+    val (months, _)                           = parseField(expression, monthF, 1, 12)
+    val (dowRaw, dowRestricted)               = parseField(expression, dowF, 0, 7)
+    // Both 0 and 7 mean Sunday
+    val dow = dowRaw.map(d =>
+      if d == 7 then
+        0
+      else
+        d
+    )
+    CronSchedule(expression, minutes, hours, dom, months, dow, domRestricted, dowRestricted)
+
+  /** Parse one cron field into its matching values and whether it restricts the field */
+  private def parseField(
+      expression: String,
+      field: String,
+      min: Int,
+      max: Int
+  ): (Set[Int], Boolean) =
+    def fail(reason: String): Nothing =
+      throw StatusCode
+        .INVALID_ARGUMENT
+        .newException(s"Invalid cron expression '${expression}': ${reason}")
+
+    def parseValue(s: String): Int =
+      val v =
+        try
+          s.toInt
+        catch
+          case _: NumberFormatException =>
+            fail(s"'${s}' is not a number")
+      if v < min || v > max then
+        fail(s"value ${v} is out of range [${min}, ${max}]")
+      v
+
+    // range part: *, a, a-b (before an optional /step)
+    def parseRange(s: String): Range =
+      s match
+        case "*" =>
+          min to max
+        case r if r.contains("-") =>
+          r.split("-", 2) match
+            case Array(a, b) =>
+              val start = parseValue(a)
+              val end   = parseValue(b)
+              if start > end then
+                fail(s"range ${s} is inverted")
+              start to end
+            case _ =>
+              fail(s"cannot parse range '${s}'")
+        case v =>
+          val value = parseValue(v)
+          value to value
+
+    val values =
+      field
+        .split(",")
+        .toList
+        .flatMap { part =>
+          part.split("/", 2) match
+            case Array(range) =>
+              parseRange(range)
+            case Array(range, step) =>
+              val s = parseValue(step)
+              if s <= 0 then
+                fail(s"step must be positive in '${part}'")
+              parseRange(range).by(s)
+            case _ =>
+              fail(s"cannot parse field part '${part}'")
+        }
+        .toSet
+    if values.isEmpty then
+      fail(s"field '${field}' matches no values")
+    (values, field != "*")
+
+  end parseField
+
+end CronSchedule

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -176,9 +176,13 @@ trait FlowStageRunner:
   * triggered as a new run (with its own run id) after the current flow completes. Jump chains are
   * bounded by `maxJumpDepth` to guard against cycles (flow A -> B -> A).
   *
+  * A flow-level `concurrency: N` config is enforced through the run store: the executor atomically
+  * claims a run slot before scheduling any stage and records the run as skipped when the limit is
+  * already reached. Flow-level cron schedules are evaluated by [[FlowScheduler]], which triggers
+  * runs through this executor.
+  *
   * Current limitations (to be lifted in future iterations):
   *   - `heartbeat` is parsed but not enforced.
-  *   - Flow-level cron schedules are not evaluated here.
   *
   * @param connector
   *   The database connector used to materialize stage results
@@ -449,8 +453,8 @@ class FlowExecutor(
       )
     }
 
-    // Persist a snapshot of the run so that other processes (wvlet flow session) can observe it
-    def persistSnapshot(finished: Boolean = false): Unit = registry.foreach { reg =>
+    // The current run state as a persistable record
+    def currentRecord(finished: Boolean): FlowRunRecord =
       val stageRecords = flowStages.map { ls =>
         val name  = ls.name
         val state = states(name)
@@ -470,20 +474,23 @@ class FlowExecutor(
           FlowRunRecord.flowStateOf(states.values)
         else
           FlowRunRecord.STATE_RUNNING
-      reg.save(
-        FlowRunRecord(
-          runId,
-          flow.name.name,
-          flowState,
-          startedAt,
-          if finished then
-            Some(System.currentTimeMillis())
-          else
-            None
-          ,
-          stageRecords
-        )
+      FlowRunRecord(
+        runId,
+        flow.name.name,
+        flowState,
+        startedAt,
+        if finished then
+          Some(System.currentTimeMillis())
+        else
+          None
+        ,
+        stageRecords
       )
+    end currentRecord
+
+    // Persist a snapshot of the run so that other processes (wvlet flow session) can observe it
+    def persistSnapshot(finished: Boolean = false): Unit = registry.foreach { reg =>
+      reg.save(currentRecord(finished))
     }
 
     def evalTrigger(t: StageTrigger): Boolean =
@@ -619,7 +626,29 @@ class FlowExecutor(
 
     def allTerminal: Boolean = states.values.forall(_.isTerminal)
 
-    persistSnapshot()
+    // Enforce the flow-level concurrency limit by atomically claiming a run slot in the run
+    // store. Resumed runs already own their slot (their record is re-marked as running)
+    val slotClaimed =
+      (registry, FlowScheduleConfig.fromFlow(flow).concurrency) match
+        case (Some(reg), Some(limit)) if resumeFrom.isEmpty =>
+          reg.claimRunSlot(currentRecord(finished = false), limit)
+        case _ =>
+          persistSnapshot()
+          true
+    if !slotClaimed then
+      workEnv.info(s"Flow ${flow.name.name} reached its concurrency limit; skipping run ${runId}")
+      workerPool.shutdownNow()
+      timer.shutdownNow()
+      flowStages.foreach(ls => states(ls.name) = StageState.Skipped)
+      registry.foreach { reg =>
+        reg.save(currentRecord(finished = true).copy(state = FlowRunRecord.STATE_SKIPPED))
+      }
+      return FlowExecutionResult(
+        flow.name.name,
+        runId,
+        flowStages.map(ls => StageResult(ls.name, StageState.Skipped, 0))
+      )
+
     try
       var done = false
       while !done do

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowScheduler.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowScheduler.scala
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.model.expr.*
+import wvlet.lang.model.plan.FlowDef
+import wvlet.uni.log.LogSupport
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+/**
+  * Flow-level orchestration configuration extracted from the flow's `with { ... }` block
+  *
+  * @param cron
+  *   Cron expression of `schedule: cron('...')`
+  * @param timezone
+  *   Time zone in which the cron expression is evaluated (defaults to the system zone)
+  * @param concurrency
+  *   Maximum number of concurrent runs of this flow
+  */
+case class FlowScheduleConfig(
+    cron: Option[String] = None,
+    timezone: Option[String] = None,
+    concurrency: Option[Int] = None
+):
+  def withCron(cron: String): FlowScheduleConfig      = copy(cron = Some(cron))
+  def noCron(): FlowScheduleConfig                    = copy(cron = None)
+  def withTimezone(tz: String): FlowScheduleConfig    = copy(timezone = Some(tz))
+  def noTimezone(): FlowScheduleConfig                = copy(timezone = None)
+  def withConcurrency(limit: Int): FlowScheduleConfig = copy(concurrency = Some(limit))
+  def noConcurrency(): FlowScheduleConfig             = copy(concurrency = None)
+
+  def zoneId: ZoneId = timezone.map(ZoneId.of).getOrElse(ZoneId.systemDefault())
+
+object FlowScheduleConfig:
+  /** Extract schedule, timezone, and concurrency from the flow's config items */
+  def fromFlow(flow: FlowDef): FlowScheduleConfig =
+    flow
+      .config
+      .foldLeft(FlowScheduleConfig()) { (config, item) =>
+        item.key.unquotedValue match
+          case "schedule" =>
+            item.value match
+              // schedule: cron('0 2 * * *')
+              case f: FunctionApply =>
+                val isCron =
+                  f.base match
+                    case n: NameExpr =>
+                      n.fullName == "cron"
+                    case _ =>
+                      false
+                f.args.map(_.value) match
+                  case List(s: StringLiteral) if isCron =>
+                    config.withCron(s.unquotedValue)
+                  case _ =>
+                    config
+              // schedule: '0 2 * * *'
+              case s: StringLiteral =>
+                config.withCron(s.unquotedValue)
+              case _ =>
+                config
+          case "timezone" =>
+            item.value match
+              case s: StringLiteral =>
+                config.withTimezone(s.unquotedValue)
+              case _ =>
+                config
+          case "concurrency" =>
+            item.value match
+              case l: LongLiteral =>
+                config.withConcurrency(l.value.toInt)
+              case _ =>
+                config
+          case _ =>
+            config
+      }
+
+end FlowScheduleConfig
+
+/** A flow with a parsed cron schedule, ready to be evaluated by the scheduler */
+case class ScheduledFlow(flow: FlowDef, cron: CronSchedule, zone: ZoneId):
+  def name: String = flow.name.name
+
+/**
+  * Evaluates cron schedules of flows and triggers due flow runs.
+  *
+  * The scheduler only decides *when* to trigger a run; whether the run actually executes is decided
+  * by the executor, which evaluates cross-flow dependencies and enforces the flow-level
+  * `concurrency:` limit through the run store. The `trigger` function is invoked on the scheduler's
+  * own thread; callers who want overlapping flows should dispatch to a worker pool inside
+  * `trigger`.
+  *
+  * @param scheduled
+  *   The flows with cron schedules to evaluate
+  * @param trigger
+  *   Invoked for each flow whose schedule is due
+  * @param clock
+  *   Time source (injectable for testing)
+  */
+class FlowScheduler(
+    scheduled: List[ScheduledFlow],
+    trigger: FlowDef => Unit,
+    clock: () => Instant = () => Instant.now()
+) extends LogSupport:
+
+  private val nextFire = mutable.Map.empty[String, ZonedDateTime]
+
+  @volatile
+  private var stopped = false
+
+  def stop(): Unit = stopped = true
+
+  /**
+    * Evaluate all schedules once: trigger the flows whose fire time has passed and return the
+    * milliseconds until the earliest next fire
+    */
+  def tick(): Long =
+    val now = clock()
+    scheduled.foreach { sf =>
+      val zonedNow = now.atZone(sf.zone)
+      val due      = nextFire.getOrElseUpdate(sf.name, sf.cron.nextAfter(zonedNow))
+      if !due.toInstant.isAfter(now) then
+        info(s"Triggering scheduled flow ${sf.name} (due: ${due})")
+        try
+          trigger(sf.flow)
+        catch
+          case NonFatal(e) =>
+            warn(s"Failed to trigger flow ${sf.name}: ${e.getMessage}")
+        nextFire(sf.name) = sf.cron.nextAfter(zonedNow)
+    }
+    val nowMillis = clock().toEpochMilli
+    nextFire
+      .values
+      .map(t => (t.toInstant.toEpochMilli - nowMillis).max(0L))
+      .minOption
+      .getOrElse(60000L)
+
+  /** Run the scheduler loop until stop() is called */
+  def runLoop(): Unit =
+    if scheduled.isEmpty then
+      throw StatusCode.INVALID_ARGUMENT.newException("No scheduled flows to run")
+    info(
+      s"Flow scheduler started with ${scheduled.size} scheduled flow(s): ${scheduled
+          .map(sf => s"${sf.name} [${sf.cron.expression}]")
+          .mkString(", ")}"
+    )
+    while !stopped do
+      val delay = tick()
+      // Sleep in bounded slices so that stop() is honored promptly
+      Thread.sleep(delay.min(1000L).max(50L))
+
+end FlowScheduler

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/CronScheduleTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/CronScheduleTest.scala
@@ -1,0 +1,79 @@
+package wvlet.lang.runner
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
+import wvlet.uni.test.UniTest
+
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class CronScheduleTest extends UniTest:
+
+  private val utc = ZoneId.of("UTC")
+
+  private def at(s: String): ZonedDateTime = ZonedDateTime.parse(s)
+
+  test("fire a daily schedule at the configured time") {
+    val cron = CronSchedule.parse("0 2 * * *")
+    cron.nextAfter(at("2026-01-01T00:00:00Z")) shouldBe at("2026-01-01T02:00:00Z")
+    cron.nextAfter(at("2026-01-01T02:00:00Z")) shouldBe at("2026-01-02T02:00:00Z")
+    cron.nextAfter(at("2026-01-01T03:15:00Z")) shouldBe at("2026-01-02T02:00:00Z")
+  }
+
+  test("fire step schedules from the range start") {
+    val cron = CronSchedule.parse("*/15 * * * *")
+    cron.nextAfter(at("2026-01-01T00:07:00Z")) shouldBe at("2026-01-01T00:15:00Z")
+    cron.nextAfter(at("2026-01-01T00:45:00Z")) shouldBe at("2026-01-01T01:00:00Z")
+  }
+
+  test("combine lists, ranges, and steps") {
+    val cron = CronSchedule.parse("0 9-17/4 * * *")
+    cron.nextAfter(at("2026-01-01T08:00:00Z")) shouldBe at("2026-01-01T09:00:00Z")
+    cron.nextAfter(at("2026-01-01T09:00:00Z")) shouldBe at("2026-01-01T13:00:00Z")
+    cron.nextAfter(at("2026-01-01T17:00:00Z")) shouldBe at("2026-01-02T09:00:00Z")
+
+    val listed = CronSchedule.parse("5,35 0 * * *")
+    listed.nextAfter(at("2026-01-01T00:05:00Z")) shouldBe at("2026-01-01T00:35:00Z")
+  }
+
+  test("match day-of-week schedules with 0 and 7 as Sunday") {
+    // 2026-01-01 is a Thursday; the next Sunday is 2026-01-04
+    CronSchedule.parse("0 0 * * 0").nextAfter(at("2026-01-01T00:00:00Z")) shouldBe
+      at("2026-01-04T00:00:00Z")
+    CronSchedule.parse("0 0 * * 7").nextAfter(at("2026-01-01T00:00:00Z")) shouldBe
+      at("2026-01-04T00:00:00Z")
+  }
+
+  test("match either day field when both are restricted") {
+    // Standard cron: day-of-month 1 OR Monday. From Jan 2, Monday Jan 5 comes before Feb 1
+    val cron = CronSchedule.parse("0 0 1 * 1")
+    cron.nextAfter(at("2026-01-02T00:00:00Z")) shouldBe at("2026-01-05T00:00:00Z")
+    // From Jan 27 (after Monday Jan 26), day-of-month 1 (Feb 1, a Sunday) comes first
+    cron.nextAfter(at("2026-01-27T00:00:00Z")) shouldBe at("2026-02-01T00:00:00Z")
+  }
+
+  test("evaluate schedules in the given time zone") {
+    val cron  = CronSchedule.parse("0 2 * * *")
+    val tokyo = ZoneId.of("Asia/Tokyo")
+    val next  = cron.nextAfter(ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, tokyo))
+    next shouldBe ZonedDateTime.of(2026, 1, 1, 2, 0, 0, 0, tokyo)
+  }
+
+  test("reject malformed cron expressions") {
+    List("0 2 * *", "x * * * *", "99 * * * *", "* 30-2 * * *", "*/0 * * * *").foreach { expr =>
+      val e = intercept[WvletLangException] {
+        CronSchedule.parse(expr)
+      }
+      e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    }
+  }
+
+  test("report schedules that can never fire") {
+    // February 30 does not exist
+    val e = intercept[WvletLangException] {
+      CronSchedule.parse("0 0 30 2 *").nextAfter(at("2026-01-01T00:00:00Z"))
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+  }
+
+end CronScheduleTest

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -782,6 +782,53 @@ class FlowExecutorTest extends UniTest:
     registry.list() shouldBe Nil
   }
 
+  test("enforce the flow-level concurrency limit through the run store") {
+    val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val wv       =
+      """flow LimitedFlow with { concurrency: 1 } = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin
+    val (flow, ctx) = compileFlow(wv)
+
+    val started        = CountDownLatch(1)
+    val release        = CountDownLatch(1)
+    val blockingRunner =
+      new FlowStageRunner:
+        override def run(stage: StageDef, targetTable: String)(using Context): Unit =
+          started.countDown()
+          release.await(30, TimeUnit.SECONDS)
+
+    // Hold the single run slot with a long-running first run
+    @volatile
+    var firstResult: Option[FlowExecutionResult] = None
+    val firstRun                                 = Thread { () =>
+      firstResult = Some(
+        FlowExecutor(
+          connector,
+          workEnv,
+          stageRunner = Some(blockingRunner),
+          registry = Some(registry)
+        ).execute(flow)(using ctx)
+      )
+    }
+    firstRun.start()
+    started.await(10, TimeUnit.SECONDS) shouldBe true
+
+    // A second run of the same flow cannot claim a slot and is recorded as skipped
+    val second =
+      FlowExecutor(connector, workEnv, registry = Some(registry)).execute(flow)(using ctx)
+    second.stageResults.map(_.state) shouldBe List(StageState.Skipped)
+    registry.get(second.runId).get.state shouldBe FlowRunRecord.STATE_SKIPPED
+
+    release.countDown()
+    firstRun.join(30000)
+    firstResult.get.isSuccess shouldBe true
+
+    // Once the first run finished, the slot is free again
+    val third = FlowExecutor(connector, workEnv, registry = Some(registry)).execute(flow)(using ctx)
+    third.isSuccess shouldBe true
+  }
+
   test("compute retry delays for backoff strategies") {
     val base = StageExecutionConfig(retryDelayMillis = 100L)
     base.withBackoff("constant").retryDelayFor(1) shouldBe 100L

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowSchedulerTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowSchedulerTest.scala
@@ -1,0 +1,109 @@
+package wvlet.lang.runner
+
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.model.plan.FlowDef
+import wvlet.uni.test.UniTest
+
+import java.time.Instant
+import java.time.ZoneId
+import scala.collection.mutable.ListBuffer
+
+class FlowSchedulerTest extends UniTest:
+
+  private def compileFlow(wv: String): FlowDef =
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+    val unit     = CompilationUnit.fromWvletString(wv)
+    compiler.compileSingleUnit(unit)
+    var flow: Option[FlowDef] = None
+    unit
+      .resolvedPlan
+      .traverse { case f: FlowDef =>
+        if flow.isEmpty then
+          flow = Some(f)
+      }
+    flow.getOrElse(fail("No FlowDef found"))
+
+  test("extract schedule, timezone, and concurrency from the flow config") {
+    val flow = compileFlow("""flow NightlyFlow with {
+        |  schedule: cron('0 2 * * *')
+        |  timezone: 'UTC'
+        |  concurrency: 2
+        |} = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin)
+    val config = FlowScheduleConfig.fromFlow(flow)
+    config.cron shouldBe Some("0 2 * * *")
+    config.timezone shouldBe Some("UTC")
+    config.zoneId shouldBe ZoneId.of("UTC")
+    config.concurrency shouldBe Some(2)
+  }
+
+  test("extract empty schedule config from an unconfigured flow") {
+    val flow = compileFlow("""flow PlainFlow = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin)
+    val config = FlowScheduleConfig.fromFlow(flow)
+    config.cron shouldBe None
+    config.timezone shouldBe None
+    config.concurrency shouldBe None
+  }
+
+  test("trigger due flows once per schedule fire") {
+    val flow = compileFlow("""flow MinutelyFlow = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin)
+    val sf = ScheduledFlow(flow, CronSchedule.parse("* * * * *"), ZoneId.of("UTC"))
+
+    var now       = Instant.parse("2026-01-01T00:00:30Z")
+    val triggered = ListBuffer.empty[String]
+    val scheduler = FlowScheduler(List(sf), f => triggered += f.name.name, () => now)
+
+    // The first evaluation computes the next fire (00:01:00) without triggering
+    val delay = scheduler.tick()
+    triggered.toList shouldBe Nil
+    delay shouldBe 30000L
+
+    // Time passes the fire point: the flow triggers exactly once
+    now = Instant.parse("2026-01-01T00:01:05Z")
+    scheduler.tick()
+    triggered.toList shouldBe List("MinutelyFlow")
+    scheduler.tick()
+    triggered.toList shouldBe List("MinutelyFlow")
+
+    // The next minute boundary triggers again
+    now = Instant.parse("2026-01-01T00:02:00Z")
+    scheduler.tick()
+    triggered.toList shouldBe List("MinutelyFlow", "MinutelyFlow")
+  }
+
+  test("keep the scheduler alive when a trigger fails") {
+    val flow = compileFlow("""flow FailingTriggerFlow = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin)
+    val sf = ScheduledFlow(flow, CronSchedule.parse("* * * * *"), ZoneId.of("UTC"))
+
+    var now       = Instant.parse("2026-01-01T00:00:30Z")
+    var attempts  = 0
+    val scheduler = FlowScheduler(
+      List(sf),
+      _ =>
+        attempts += 1
+        throw IllegalStateException("boom")
+      ,
+      () => now
+    )
+    scheduler.tick()
+    attempts shouldBe 0
+    now = Instant.parse("2026-01-01T00:01:00Z")
+    scheduler.tick()
+    attempts shouldBe 1
+    // The schedule advances despite the failure
+    now = Instant.parse("2026-01-01T00:02:00Z")
+    scheduler.tick()
+    attempts shouldBe 2
+  }
+
+end FlowSchedulerTest


### PR DESCRIPTION
## Summary

Implements item 5 of #1823 (cron `schedule:` daemon), completing the `concurrency:` half of item 3's groundwork.

### Cron parser

- `CronSchedule`: a small dedicated five-field cron parser (`minute hour day month weekday`) supporting `*`, values, ranges, steps, and comma lists; day-of-week accepts 0-7 with both 0 and 7 as Sunday; standard either-matches semantics when both day fields are restricted. `nextAfter` scans minute-wise with day-level skipping, in the flow's time zone, and rejects schedules that can never fire (e.g. `0 0 30 2 *`).

### Scheduler daemon

- `FlowScheduler` evaluates schedules with an injectable clock: `tick()` triggers due flows exactly once per fire and returns the delay to the next fire; a failing trigger does not kill the loop.
- `wvlet flow scheduler -w <dir>`: compiles the working folder, collects flows with `schedule: cron('...')` (+ optional `timezone:`), and runs the loop. Each due flow executes on its own daemon thread through the regular `FlowExecutor` + run store, so **cross-flow dependencies still gate execution**: the schedule determines *when* to check, the dependency determines *if* the flow runs.

### Concurrency enforcement

- `FlowExecutor` now reads the flow-level `concurrency: N` config and atomically claims a run slot via `FlowRunStore.claimRunSlot` before scheduling any stage (transactional across processes with the SQLite store). When the limit is reached the run is recorded as `skipped`. Resumed runs re-use their existing slot.

## Tests

- `CronScheduleTest` (8): daily/step/list/range schedules, DOW 0/7, either-day-field semantics, time zones, malformed expressions, never-fires detection.
- `FlowSchedulerTest` (4): config extraction (`schedule`/`timezone`/`concurrency`), fire-once-per-schedule with a fake clock, trigger-failure resilience.
- `FlowExecutorTest` (40): new test holds the single `concurrency: 1` slot with a blocking run, observes the second run recorded as `skipped`, and verifies the slot frees on completion.
- `WvletFlowCommandTest` (14): `flow scheduler` with no scheduled flows reports and exits.

## Documentation

- `website/docs/syntax/flow.md`: scheduler daemon usage, schedule+dependency semantics, and concurrency-slot behavior.

Refs #1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)