### PR TITLE
feature: Add an activation sink SPI with a built-in file export sink

### DIFF
--- a/spec/basic/flow-syntax.wv
+++ b/spec/basic/flow-syntax.wv
@@ -46,7 +46,7 @@ flow ConditionalRouteFlow = {
 flow JourneyFlow = {
   stage entry = from users | select name, email
   stage delayed = from entry | wait('7 days')
-  stage send = from delayed | activate('email')
+  stage send = from delayed | activate('email', template: 'welcome_v1')
   stage done = from send | end()
 }
 ;

--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -391,8 +391,12 @@ with the configured backoff, and `timeout` bounds each stage attempt — on expi
 cancellation) the running SQL statement is cancelled server-side and its worker slot is freed
 immediately. Flow operators are
 lowered before scheduling: `route` cases become filter predicates on target stages, `fork`
-stages are flattened into the DAG, `wait` delays materialization, `activate` is a local
-logging stub until sink connectors exist, and `end` is a pass-through. Flow runs are recorded
+stages are flattened into the DAG, `wait` delays materialization, and `end` is a pass-through.
+`activate('target', param: value, ...)` delivers the materialized stage output to the
+activation sink registered for the target name — local file export is built in
+(`activate('file', path: 'out.csv')`, with csv/parquet/json formats), unknown targets fall
+back to a logging stub, and a sink failure fails the attempt and follows the stage's retry
+policy. Flow runs are recorded
 in a local run registry, and cross-flow dependencies are evaluated against it. A `-> Flow`
 jump is a control-only transfer: when the jumping stage succeeds, the target flow is triggered
 as a new run (with its own run id) after the current flow completes, and jump chains are

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -521,8 +521,16 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
           }
       case a: FlowActivate =>
         val prev    = relation(a.child)
-        val allArgs = expr(a.target) :: a.params.map(p => expr(p))
-        val params  = paren(cl(allArgs))
+        val allArgs =
+          expr(a.target) ::
+            a.params
+              .map {
+                case f: FunctionArg if f.name.isDefined =>
+                  wl(text(s"${f.name.get.name}:"), expr(f.value))
+                case p =>
+                  expr(p)
+              }
+        val params = paren(cl(allArgs))
         prev /
           code(a) {
             group(wl("activate", params))

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -778,11 +778,35 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     val params =
       if scanner.lookAhead().token == WvletToken.COMMA then
         consume(WvletToken.COMMA)
-        functionArgs()
+        activateParams()
       else
         Nil
     consume(WvletToken.R_PAREN)
     FlowActivate(input, target, params, spanFrom(t))
+  }
+
+  /** Parse activate parameters: `name: value` (config style), `name = value`, or positional */
+  private def activateParams(): List[FunctionArg] =
+    val arg = activateParam()
+    scanner.lookAhead().token match
+      case WvletToken.COMMA =>
+        consume(WvletToken.COMMA)
+        arg :: activateParams()
+      case _ =>
+        List(arg)
+
+  private def activateParam(): FunctionArg = node {
+    val t = scanner.lookAhead()
+    val e = expression()
+    e match
+      case i: Identifier if scanner.lookAhead().token == WvletToken.COLON =>
+        consume(WvletToken.COLON)
+        val value = expression()
+        FunctionArg(Some(Name.termName(i.leafName)), value, false, Nil, spanFrom(t))
+      case Eq(i: Identifier, v: Expression, _) =>
+        FunctionArg(Some(Name.termName(i.leafName)), v, false, Nil, spanFrom(t))
+      case other =>
+        FunctionArg(None, other, false, Nil, spanFrom(t))
   }
 
   /**

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/ActivationSink.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/ActivationSink.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.runner.connector.DBConnector
+import wvlet.uni.log.LogSupport
+
+import scala.util.Using
+
+/**
+  * A delivery request of a materialized stage output to an activation target
+  *
+  * @param target
+  *   The activation target name (e.g. `activate('file', ...)` -> `file`)
+  * @param params
+  *   Named activation parameters (e.g. `activate('file', path: 'out.csv')`)
+  * @param stageName
+  *   The activating stage
+  * @param table
+  *   The run-scoped table holding the materialized stage output
+  * @param connector
+  *   Connector to the database holding the table
+  */
+case class ActivationRequest(
+    target: String,
+    params: Map[String, String],
+    stageName: String,
+    table: String,
+    connector: DBConnector
+)
+
+/**
+  * A sink connector delivering materialized stage outputs to an external activation target
+  * (webhook, file export, etc.). Sinks are matched by name against `activate('<name>', ...)`
+  * operators; an exception thrown from `activate` fails the stage attempt and follows its regular
+  * retry policy
+  */
+trait ActivationSink:
+  /** The target name this sink serves */
+  def name: String
+
+  /** Deliver the materialized stage output to this sink */
+  def activate(request: ActivationRequest): Unit
+
+/**
+  * A built-in sink exporting the stage output to a local file: `activate('file', path: 'out.csv')`.
+  * The format is taken from the `format:` parameter or the path extension (csv, parquet, or json;
+  * csv by default) and written with the engine's `COPY TO` statement
+  */
+class FileActivationSink extends ActivationSink with LogSupport:
+  override def name: String = "file"
+
+  override def activate(request: ActivationRequest): Unit =
+    val path = request
+      .params
+      .getOrElse(
+        "path",
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(
+            s"activate('file') of stage ${request.stageName} requires a path: parameter"
+          )
+      )
+    val format       = request.params.get("format").orElse(extensionOf(path)).getOrElse("csv")
+    val formatClause =
+      format match
+        case "csv" =>
+          "(format csv, header)"
+        case "parquet" =>
+          "(format parquet)"
+        case "json" =>
+          "(format json)"
+        case other =>
+          throw StatusCode
+            .INVALID_ARGUMENT
+            .newException(
+              s"activate('file') of stage ${request.stageName}: unsupported format '${other}'"
+            )
+    val escapedPath = path.replaceAll("'", "''")
+    info(s"Exporting stage ${request.stageName} output ${request.table} to ${path} (${format})")
+    request
+      .connector
+      .withSession { conn =>
+        Using.resource(conn.createStatement()) { stmt =>
+          stmt.execute(
+            s"""copy (select * from "${request.table}") to '${escapedPath}' ${formatClause}"""
+          )
+        }
+      }
+
+  end activate
+
+  private def extensionOf(path: String): Option[String] =
+    val name = path.substring(path.lastIndexOf('/') + 1)
+    val dot  = name.lastIndexOf('.')
+    if dot > 0 then
+      Some(name.substring(dot + 1).toLowerCase)
+    else
+      None
+
+end FileActivationSink

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -188,7 +188,10 @@ trait FlowStageRunner:
   *
   * Flow operators in stage bodies are lowered with [[FlowLowering]] before scheduling: fork stages
   * are flattened, route cases become filter predicates on the target stages' reads, wait becomes a
-  * pre-materialization delay, activate is a local logging stub, and end is a pass-through.
+  * pre-materialization delay, and end is a pass-through. Activate operators deliver the
+  * materialized stage output to the [[ActivationSink]] registered for the target name (local file
+  * export is built in), falling back to a logging stub for unknown targets; a sink failure fails
+  * the attempt and follows the stage's retry policy.
   *
   * A `-> Flow` jump transfers control only: when the jumping stage succeeds, the target flow is
   * triggered as a new run (with its own run id) after the current flow completes. Jump chains are
@@ -216,7 +219,8 @@ class FlowExecutor(
     config: FlowExecutorConfig = FlowExecutorConfig(),
     stageRunner: Option[FlowStageRunner] = None,
     retryScheduler: Option[(Long, () => Unit) => Unit] = None,
-    registry: Option[FlowRunStore] = None
+    registry: Option[FlowRunStore] = None,
+    activationSinks: List[ActivationSink] = FlowExecutor.defaultActivationSinks
 ) extends LogSupport:
   import FlowExecutor.FlowEvent
   import FlowExecutor.FlowEvent.*
@@ -405,13 +409,26 @@ class FlowExecutor(
                   activeStatements.remove(attemptKey)
                   beat(attemptKey)
             )
-            // Activation is a local stub until external sink connectors are available
+            // Deliver the materialized output to activation sinks. A missing sink logs the
+            // delivery instead of failing (local stub); a sink exception fails the attempt
+            // and follows the stage's retry policy
             ls.activateTargets
-              .foreach { target =>
-                workEnv.info(
-                  s"[activate] stage ${ls
-                      .name}: sending materialized output ${table} to '${target}'"
-                )
+              .foreach { spec =>
+                beat(attemptKey)
+                activationSinks.find(_.name == spec.target) match
+                  case Some(sink) =>
+                    workEnv.info(
+                      s"[activate] stage ${ls
+                          .name}: delivering materialized output ${table} to '${spec.target}'"
+                    )
+                    sink.activate(
+                      ActivationRequest(spec.target, spec.params, ls.name, table, connector)
+                    )
+                  case None =>
+                    workEnv.info(
+                      s"[activate] stage ${ls.name}: sending materialized output ${table} to '${spec
+                          .target}'"
+                    )
               }
 
     // Stages recorded as successful in the resumed run keep their materialized tables and are
@@ -914,6 +931,9 @@ class FlowExecutor(
 end FlowExecutor
 
 object FlowExecutor:
+  /** The activation sinks available by default: local file export via `activate('file', ...)` */
+  def defaultActivationSinks: List[ActivationSink] = List(FileActivationSink())
+
   /** The run-scoped table name holding the materialized result of a stage */
   def stageTableName(runId: String, stageName: String): String =
     s"__wv_flow_${runId.toLowerCase}_${stageName}"

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
@@ -29,12 +29,15 @@ import wvlet.lang.model.plan.*
   *     unchanged; each *target* stage's read of the route stage is filtered with the case predicate
   *     (percentage cases become deterministic bucket predicates over the `by` expression)
   *   - `wait('30 minutes')` — recorded as a pre-materialization delay
-  *   - `activate('target')` — recorded as an activation of the materialized stage output (local
-  *     stub until sink connectors exist)
+  *   - `activate('target', param: value, ...)` — recorded as an activation of the materialized
+  *     stage output, delivered by the executor to the matching [[ActivationSink]]
   *   - `end()` — pass-through terminal marker
   *   - `-> OtherFlow` (jump) — recorded as a control-only jump target; the executor triggers the
   *     target flow as a new run after the jumping stage's flow completes
   */
+/** An activation target with its named parameters */
+case class ActivationSpec(target: String, params: Map[String, String] = Map.empty)
+
 object FlowLowering:
 
   /**
@@ -47,7 +50,7 @@ object FlowLowering:
     * @param waitMillis
     *   Delay to apply before materializing the stage
     * @param activateTargets
-    *   External activation targets to notify with the materialized output
+    *   External activation targets (with named parameters) to deliver the materialized output to
     * @param jumpTargets
     *   Flows to trigger as new runs when this stage succeeds (control-only transfer)
     */
@@ -55,7 +58,7 @@ object FlowLowering:
       stage: StageDef,
       body: Option[Relation],
       waitMillis: Option[Long] = None,
-      activateTargets: List[String] = Nil,
+      activateTargets: List[ActivationSpec] = Nil,
       jumpTargets: List[String] = Nil
   ):
     def name: String = stage.name.name
@@ -97,7 +100,7 @@ object FlowLowering:
 
     val lowered = flatStages.map { s =>
       var waitMillis: Option[Long] = None
-      val activations              = List.newBuilder[String]
+      val activations              = List.newBuilder[ActivationSpec]
       val jumps                    = List.newBuilder[String]
       val newBody                  = s
         .body
@@ -114,7 +117,7 @@ object FlowLowering:
                 waitMillis = Some(waitMillis.getOrElse(0L) + waitDurationMillis(w))
                 w.child
               case a: FlowActivate =>
-                activations += activationTargetOf(a)
+                activations += activationSpecOf(a)
                 a.child
               case e: FlowEnd =>
                 e.child
@@ -243,11 +246,29 @@ object FlowLowering:
       case _ =>
         throw StatusCode.NOT_IMPLEMENTED.newException(s"Cannot parse wait duration: '${s}'")
 
-  private def activationTargetOf(a: FlowActivate): String =
-    a.target match
-      case s: StringLiteral =>
-        s.unquotedValue
-      case other =>
-        other.toString
+  /** The activation target and its named parameters, e.g. activate('file', path: 'out.csv') */
+  private def activationSpecOf(a: FlowActivate): ActivationSpec =
+    val target =
+      a.target match
+        case s: StringLiteral =>
+          s.unquotedValue
+        case other =>
+          other.toString
+    val params =
+      a.params
+        .collect {
+          case arg: FunctionArg if arg.name.isDefined =>
+            val value =
+              arg.value match
+                case s: StringLiteral =>
+                  s.unquotedValue
+                case l: Literal =>
+                  l.stringValue
+                case other =>
+                  other.toString
+            arg.name.get.name -> value
+        }
+        .toMap
+    ActivationSpec(target, params)
 
 end FlowLowering

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -892,6 +892,65 @@ class FlowExecutorTest extends UniTest:
     countStageRows(result, "delayed") shouldBe 2L
   }
 
+  test("deliver activated stage outputs to a matching sink with parameters") {
+    val requests = ListBuffer.empty[ActivationRequest]
+    val sink     =
+      new ActivationSink:
+        override def name: String                               = "collector"
+        override def activate(request: ActivationRequest): Unit = requests += request
+    val (flow, ctx) = compileFlow("""flow SinkFlow = {
+        |  stage src = from [[1], [2]] as t(id)
+        |  stage send = from src | activate('collector', channel: 'sales', batch: 10)
+        |}""".stripMargin)
+    val result =
+      FlowExecutor(connector, workEnv, activationSinks = List(sink)).execute(flow)(using ctx)
+    result.isSuccess shouldBe true
+    requests.size shouldBe 1
+    val r = requests.head
+    r.target shouldBe "collector"
+    r.stageName shouldBe "send"
+    r.params shouldBe Map("channel" -> "sales", "batch" -> "10")
+    // The sink receives the materialized run-scoped table of the activating stage
+    countRows(r.table) shouldBe 2L
+  }
+
+  test("export activated stage outputs with the built-in file sink") {
+    val out    = java.nio.file.Files.createTempDirectory("wv-activate").resolve("out.csv")
+    val result = runFlow(s"""flow ExportFlow = {
+        |  stage src = from [[1, 'a'], [2, 'b']] as t(id, name)
+        |  stage export = from src | activate('file', path: '${out}')
+        |}""".stripMargin)
+    result.isSuccess shouldBe true
+    val lines = java.nio.file.Files.readAllLines(out)
+    lines.size shouldBe 3
+    lines.get(0) shouldBe "id,name"
+  }
+
+  test("fail and retry a stage whose activation sink fails") {
+    var calls = 0
+    val sink  =
+      new ActivationSink:
+        override def name: String                               = "flaky_sink"
+        override def activate(request: ActivationRequest): Unit =
+          calls += 1
+          throw IllegalStateException("sink unavailable")
+    val (flow, ctx) = compileFlow("""flow SinkFailFlow = {
+        |  stage send with { retries: 1, retry_delay: 1ms } = from [[1]] as t(id) | activate('flaky_sink')
+        |}""".stripMargin)
+    val result =
+      FlowExecutor(
+        connector,
+        workEnv,
+        activationSinks = List(sink),
+        retryScheduler = Some((_, action) => action())
+      ).execute(flow)(using ctx)
+    val send = result.stageResult("send").get
+    send.state shouldBe StageState.Failed
+    send.attempts shouldBe 2
+    send.error.get.getMessage shouldContain "sink unavailable"
+    calls shouldBe 2
+  }
+
   test("compute retry delays for backoff strategies") {
     val base = StageExecutionConfig(retryDelayMillis = 100L)
     base.withBackoff("constant").retryDelayFor(1) shouldBe 100L


### PR DESCRIPTION
## Summary

Implements item 7 of #1823 (real `activate` sink connectors), the final item of the flow orchestration round 3 roadmap.

### Sink SPI

- `ActivationSink` trait: matched by name against `activate('<name>', ...)`; receives an `ActivationRequest` carrying the target, named parameters, the activating stage, the materialized run-scoped table, and the connector.
- `FlowExecutor` takes an `activationSinks` list (defaulting to the built-in sinks). Unknown targets keep the previous logging-stub behavior, so `activate('email')` remains a safe no-op until an email sink exists.
- A sink exception fails the stage attempt and follows the stage's regular retry policy.

### Built-in file export sink

- `activate('file', path: 'out.csv')` exports the stage output with the engine's `COPY TO`; the format comes from the `format:` parameter or the path extension (csv with header, parquet, json).

### Parser fix: config-style named parameters

- The documented syntax `activate('email', template: 'promo_v1')` previously failed to parse (`functionArgs` only accepts `name = value`). `activate` now accepts `name: value` (config style), `name = value`, and positional parameters; the Wvlet generator prints named params back in colon form, and `spec/basic/flow-syntax.wv` covers the round-trip.
- `FlowLowering` now carries `ActivationSpec(target, params)` instead of bare target names.

## Tests

- Custom sink receives target, params (`channel: 'sales', batch: 10` → string map), stage name, and a queryable materialized table.
- Built-in file sink exports a CSV with header (verified file contents).
- A failing sink fails the stage and retries per its policy (attempts = 2).
- Existing stub test (`activate('email')`) unchanged; 46 FlowExecutorTest tests and 129 parser round-trip tests pass; Scala.js compiles.

## Documentation

- Updated the activate semantics in `website/docs/syntax/flow.md` and the `FlowExecutor`/`FlowLowering` scaladocs.

Refs #1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)