### PR TITLE
doc: Note that adding a CLI @command requires a clean cli build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,7 @@ For error reporting, use WvletLangException and StatusCode enum. If necessary er
 
 ## Debugging
 - To monitor debug logs, use `-l debug` option. For example, ./sbt "langJVM/testOnly *Test -- -l debug"
+- After adding a new `@command` method to a CLI command class (e.g. WvletFlowCommand), run `./sbt cli/clean` once: the `Launcher.of/addModule` macro in WvletMain.scala is not re-expanded by incremental compilation, so the new subcommand fails at runtime with "Unknown command" until a clean build (touching the file does not help — Zinc hashes content)
 
 ## Testing Notes
 - Use `shouldContain "(keyword)"` for checking string fragment in UniTest


### PR DESCRIPTION
## Summary

Documents a development gotcha hit while adding `wvlet flow scheduler` (#1829): after adding a new `@command` method to a CLI command class, the `Launcher.of[WvletMain].addModule[...]` macro expansion in `WvletMain.scala` is not refreshed by incremental compilation, so the new subcommand fails at runtime with `Unknown command` until `./sbt cli/clean`. Touching `WvletMain.scala` does not help because Zinc hashes file content.

CI is unaffected (clean builds), so this only bites local development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)