### PR TITLE
fix: Preserve names of named function arguments in WvletGenerator

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -712,11 +712,16 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
           val window = expr(w.window)
           wl(base, window)
         case f: FunctionArg =>
-          // TODO handle arg name mapping
-          if f.isDistinct then
-            wl("distinct", expr(f.value))
-          else
-            expr(f.value)
+          val v =
+            if f.isDistinct then
+              wl("distinct", expr(f.value))
+            else
+              expr(f.value)
+          f.name match
+            case Some(name) =>
+              wl(text(name.name), text("="), v)
+            case None =>
+              v
         case w: Window =>
           val s = List.newBuilder[Doc]
           if w.partitionBy.nonEmpty then

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -1,0 +1,36 @@
+package wvlet.lang.compiler.codegen
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.compiler.CompilationUnit
+
+class WvletGeneratorTest extends UniTest:
+
+  private def print(wv: String): String =
+    val unit = CompilationUnit.fromWvletString(wv)
+    val plan = ParserPhase.parseOnly(unit)
+    WvletGenerator().print(plan)
+
+  test("should preserve names of named function arguments") {
+    val printed = print("""from t
+        |select approx_percentile(price, percentile = 0.95)""".stripMargin)
+    printed shouldContain "percentile = 0.95"
+
+    // The printed query should parse back to the same named argument
+    val reprinted = print(printed)
+    reprinted shouldContain "percentile = 0.95"
+  }
+
+  test("should print positional and named arguments together") {
+    val printed = print("""from t
+        |select f(a, b, mode = 'fast')""".stripMargin)
+    printed shouldContain "f(a, b, mode = 'fast')"
+  }
+
+  test("should keep distinct arguments without names") {
+    val printed = print("""from t
+        |select count(distinct user_id)""".stripMargin)
+    printed shouldContain "count(distinct user_id)"
+  }
+
+end WvletGeneratorTest


### PR DESCRIPTION
## Summary

Fixes #1835. `WvletGenerator` rendered `FunctionArg` without its name, so a query using named function arguments (`f(x, mode = 'fast')`) round-tripped to `f(x, 'fast')` — silently converting a named argument into a positional one and changing call semantics for functions where argument names matter.

## Changes

- `WvletGenerator`: the generic `FunctionArg` case now prints `name = value` for named arguments (Wvlet's parse syntax), composing with `distinct` handling. The `activate(...)`-specific case is kept, since flow activation params use the documented config style (`name: value`), which differs from general function-call syntax.
- Added `WvletGeneratorTest` covering named-arg preservation across a print→parse→print round trip, mixed positional/named args, and `count(distinct ...)`.

## Testing

- `langJVM/testOnly *WvletGeneratorTest` — 3 new tests pass
- `langJVM/test` — full suite green (226 tests)
- `langJVM/testOnly *RoundTripSpec*` — all round-trip specs green
- `langJS/Test/compile` — Scala.js compilation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)