### PR TITLE
fix: Keep non-stage merge sources out of the run-scoped table rewrite

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -86,6 +86,29 @@ flow my_pipeline = {
 }
 ```
 
+### Merging Stages
+
+`merge` fans in multiple stages with union-all semantics. The merged stage runs after all of its sources succeed, and is skipped when any source fails:
+
+```wvlet
+flow my_pipeline = {
+  stage source_a = from events_us | select user_id, event_time
+  stage source_b = from events_eu | select user_id, event_time
+  stage merged = merge source_a, source_b
+  stage output = from merged | select user_id
+}
+```
+
+Merge sources must be stages defined earlier in the same flow; referencing a plain table is a compile-time error. To include a regular table in a merge, wrap it in a stage first:
+
+```wvlet
+flow my_pipeline = {
+  stage fresh = from [[1], [2]] as t(id)
+  stage archived = from archive_table        -- wrap the table in a stage
+  stage merged = merge fresh, archived
+}
+```
+
 ### Stage Grammar
 
 ```

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -902,7 +902,14 @@ class FlowExecutor(
           stageTableRef(t.name.fullName, t.span)
         case m: FlowMerge =>
           m.sources
-            .map(src => stageTableRef(src.fullName, src.span))
+            .map { src =>
+              // Only stage references map to run-scoped tables; other sources are regular
+              // tables and are read as-is, consistent with `from` inside a stage body
+              if stageNames.contains(src.fullName) then
+                stageTableRef(src.fullName, src.span)
+              else
+                TableRef(UnquotedIdentifier(src.fullName, src.span), src.span)
+            }
             .reduceLeft[Relation] { (l, r) =>
               Union(l, r, isDistinct = false, m.span)
             }

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -340,6 +340,37 @@ class FlowExecutorTest extends UniTest:
     countStageRows(result, "output") shouldBe 3L
   }
 
+  test("report a clear compile-time error when a merge source is a table, not a stage") {
+    // Merge sources must be stages: even when a real table with that name exists, the
+    // compiler rejects it upfront instead of failing at runtime with a missing-table error
+    connector.execute("create or replace table __wv_merge_real as select 1 as id")
+    try
+      val e = intercept[WvletLangException] {
+        runFlow("""flow MergeRealTable = {
+            |  stage src = from [[1]] as t(id)
+            |  stage merged = merge src, __wv_merge_real
+            |}""".stripMargin)
+      }
+      e.statusCode shouldBe StatusCode.STAGE_NOT_FOUND
+      e.getMessage shouldContain "__wv_merge_real"
+    finally
+      connector.execute("drop table if exists __wv_merge_real")
+  }
+
+  test("merge a real table by wrapping it in a stage") {
+    connector.execute("create or replace table __wv_merge_wrapped as select 10 as id")
+    try
+      val result = runFlow("""flow MergeWrappedTable = {
+          |  stage src = from [[1], [2]] as t(id)
+          |  stage tbl = from __wv_merge_wrapped
+          |  stage merged = merge src, tbl
+          |}""".stripMargin)
+      result.isSuccess shouldBe true
+      countStageRows(result, "merged") shouldBe 3L
+    finally
+      connector.execute("drop table if exists __wv_merge_wrapped")
+  }
+
   test("skip a merge stage when one of its sources failed") {
     val result = runFlow("""flow BrokenMergeFlow = {
         |  stage source_a = from [[1]] as t(id)


### PR DESCRIPTION
## Summary

Fixes #1834, with a corrected diagnosis (see [the issue comment](https://github.com/wvlet/wvlet/issues/1834#issuecomment-4880851729)): the reported runtime missing-table failure is not reachable through the normal compile path, because the Typer already rejects non-stage merge sources with a clear `STAGE_NOT_FOUND` error — even when a real table with that name exists. `merge` is stages-only by design, consistent with merge sources acting as state dependencies.

What was still worth fixing:

- **Executor consistency (defense in depth)**: `materializeStage` rewrote *all* merge sources to run-scoped stage tables, unlike the adjacent `TableRef` rewrite and `upstreamStagesOf`, which guard with `stageNames.contains`. The merge rewrite now applies the same guard and passes non-stage sources through as plain table references.
- **Test coverage**: two end-to-end tests pin the contract — merging a real DuckDB table by name fails at compile time with `STAGE_NOT_FOUND` (no confusing runtime error), and wrapping the table in a stage works (`merge` produces the union of both).
- **Docs**: `merge` was undocumented; added a "Merging Stages" section to the flow syntax docs covering union-all semantics, the stages-only rule, and the wrap-a-table-in-a-stage pattern.

Allowing real tables directly in `merge` (option 1 in the issue) is intentionally not done: it would trade the current clear compile-time error for runtime missing-table errors on stage-name typos.

## Testing

- `runner/testOnly *FlowExecutorTest` — 48 tests pass (2 new)
- `runner/test` — full suite green (451 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)