### PR TITLE
feature: Free concurrency slots of crashed runs via liveness leases

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -403,7 +403,21 @@ Runs are managed with `wvlet flow session` subcommands:
 - `wvlet flow session resume <run_id>`: re-run a failed or cancelled run from its first
   non-successful stage, reusing the materialized tables of stages that already succeeded
 - `wvlet flow session clean`: delete terminal run records and drop their run-scoped
-  `__wv_flow_*` tables
+  `__wv_flow_*` tables. With `--stale`, also remove running records whose liveness lease
+  expired (crashed runs)
+
+### Run Liveness Leases
+
+While a flow runs, the executor periodically refreshes a liveness lease on its run record
+(60 seconds by default). A record left in the `running` state by a crashed process stops
+being refreshed, and once its lease expires the record is treated as failed everywhere it
+is observed:
+
+- it no longer occupies a `concurrency:` slot, so scheduled runs are not blocked forever
+- cross-flow dependencies see it as failed (`if X.failed` recovery flows fire; `depends on X`
+  stays unsatisfied)
+- `wvlet flow session list` marks it as `running (stale)`, `session resume <run_id>` accepts
+  it like a failed run, and `session clean --stale` removes it
 
 ## Stage Execution Model
 

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -133,14 +133,20 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
     }
 
   @command(description =
-    "Manage flow run sessions: session list | show <run_id> | cancel <run_id> | resume <run_id> | clean"
+    "Manage flow run sessions: session list | show <run_id> | cancel <run_id> | resume <run_id> | clean [--stale]"
   )
   def session(
       flowOption: WvletFlowOption,
       @argument(description = "Sub command: list | show | cancel | resume | clean")
       sub: String = "list",
       @argument(description = "Run id (required for show, cancel, and resume)")
-      runId: Option[String] = None
+      runId: Option[String] = None,
+      @option(
+        prefix = "--stale",
+        description =
+          "With clean: also remove running records whose liveness lease expired (crashed runs)"
+      )
+      stale: Boolean = false
   ): Unit =
     val workEnv = WorkEnv(flowOption.workFolder, opts.logLevel)
 
@@ -161,11 +167,17 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
 
       sub match
         case "list" =>
+          val now = System.currentTimeMillis()
           registry
             .list()
             .foreach { r =>
+              val state =
+                if r.isStaleAt(now) then
+                  s"${r.state} (stale)"
+                else
+                  r.state
               println(
-                f"${r.runId}%-28s ${r.flowName}%-24s ${r.state}%-10s started: ${fmtTime(
+                f"${r.runId}%-28s ${r.flowName}%-24s ${state}%-10s started: ${fmtTime(
                     r.startedAtMillis
                   )} (${fmtElapsed(r)})"
               )
@@ -194,7 +206,8 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
           val id = requireRunId("resume <run_id>")
           val r  = recordOf(id)
           r.state match
-            case FlowRunRecord.STATE_RUNNING =>
+            // A stale running record belongs to a crashed process and can be resumed
+            case FlowRunRecord.STATE_RUNNING if !r.isStaleAt(System.currentTimeMillis()) =>
               throw StatusCode
                 .INVALID_ARGUMENT
                 .newException(s"Run ${id} is still running and cannot be resumed")
@@ -211,20 +224,23 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
               executeFlow(flowOption, r.flowName, resumeFrom = Some(r))
         case "clean" =>
           // Remove terminal run records and drop their run-scoped tables. Running flows are kept
-          val terminalRuns = registry.list().filter(_.isTerminal)
-          val profile      = Profile.getProfile(
+          // unless --stale is given, which also removes runs whose liveness lease expired
+          // (their process died mid-run and left the record in the running state)
+          val now         = System.currentTimeMillis()
+          val cleanedRuns = registry.list().filter(r => r.isTerminal || (stale && r.isStaleAt(now)))
+          val profile     = Profile.getProfile(
             flowOption.profile,
             flowOption.catalog,
             flowOption.schema
           )
           Control.withResource(DBConnectorProvider(workEnv)) { dbConnectorProvider =>
             val connector = dbConnectorProvider.getConnector(profile)
-            terminalRuns.foreach { r =>
+            cleanedRuns.foreach { r =>
               FlowExecutor.dropRunTables(connector, r.runId, r.stages.map(_.name))
               registry.delete(r.runId)
             }
           }
-          println(s"Removed ${terminalRuns.size} flow run record(s)")
+          println(s"Removed ${cleanedRuns.size} flow run record(s)")
         case other =>
           throw StatusCode
             .INVALID_ARGUMENT

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -115,6 +115,92 @@ class WvletFlowCommandTest extends UniTest:
     FlowRunRegistry.forWorkEnv(WorkEnv(flowDir)).list() shouldBe Nil
   }
 
+  test("clean stale running records with --stale") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRecord
+    import wvlet.lang.runner.FlowRunRegistry
+    val registry = FlowRunRegistry.forWorkEnv(WorkEnv(flowDir))
+    val now      = System.currentTimeMillis()
+    // A crashed process left this record running with an expired lease; another run is live
+    registry.save(
+      FlowRunRecord(
+        "stalerun",
+        "SamplePipeline",
+        FlowRunRecord.STATE_RUNNING,
+        now - 60000,
+        leaseExpiresAtMillis = Some(now - 30000)
+      )
+    )
+    registry.save(
+      FlowRunRecord(
+        "liverun",
+        "SamplePipeline",
+        FlowRunRecord.STATE_RUNNING,
+        now,
+        leaseExpiresAtMillis = Some(now + 60000)
+      )
+    )
+
+    // Plain clean keeps both running records
+    WvletMain.main(s"flow session clean -w ${flowDir}")
+    registry.get("stalerun").isDefined shouldBe true
+
+    // clean --stale removes the crashed run but keeps the live one
+    WvletMain.main(s"flow session clean --stale -w ${flowDir}")
+    registry.get("stalerun") shouldBe None
+    registry.get("liverun").isDefined shouldBe true
+    registry.delete("liverun")
+  }
+
+  test("resume a stale running record as a crashed run") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRecord
+    import wvlet.lang.runner.FlowRunRegistry
+    import wvlet.lang.runner.StageRunRecord
+    val registry = FlowRunRegistry.forWorkEnv(WorkEnv(flowDir))
+    val now      = System.currentTimeMillis()
+    registry.save(
+      FlowRunRecord(
+        "crashedrun",
+        "SamplePipeline",
+        FlowRunRecord.STATE_RUNNING,
+        now - 60000,
+        stages = List(StageRunRecord("src", "running", 1)),
+        leaseExpiresAtMillis = Some(now - 30000)
+      )
+    )
+    try
+      // A running record with an expired lease belongs to a dead process, so resume is allowed
+      WvletMain.main(s"flow session resume crashedrun -w ${flowDir}")
+      registry.get("crashedrun").get.state shouldBe FlowRunRecord.STATE_SUCCESS
+    finally
+      registry.delete("crashedrun")
+  }
+
+  test("reject resuming a run that is still running with a live lease") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRecord
+    import wvlet.lang.runner.FlowRunRegistry
+    val registry = FlowRunRegistry.forWorkEnv(WorkEnv(flowDir))
+    val now      = System.currentTimeMillis()
+    registry.save(
+      FlowRunRecord(
+        "activerun",
+        "SamplePipeline",
+        FlowRunRecord.STATE_RUNNING,
+        now,
+        leaseExpiresAtMillis = Some(now + 60000)
+      )
+    )
+    try
+      val e = intercept[WvletLangException] {
+        WvletMain.main(s"flow session resume activerun -w ${flowDir}")
+      }
+      e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    finally
+      registry.delete("activerun")
+  }
+
   test("run a flow and inspect sessions with the SQLite run store") {
     import wvlet.lang.compiler.WorkEnv
     import wvlet.lang.runner.FlowRunStore

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -132,11 +132,16 @@ end StageExecutionConfig
   *   Interval for polling the run registry for cross-process cancellation requests
   * @param maxJumpDepth
   *   Maximum depth of `-> Flow` jump chains; guards against jump cycles (flow A -> B -> A)
+  * @param leaseTimeoutMillis
+  *   Liveness lease duration of the run record. The executor refreshes the lease periodically while
+  *   running; a running record whose lease has expired (e.g. after a process crash) frees its
+  *   `concurrency:` slot and is treated as failed by cross-flow dependency evaluation
   */
 case class FlowExecutorConfig(
     maxParallelism: Int = 4,
     cancelPollIntervalMillis: Long = 500L,
-    maxJumpDepth: Int = 8
+    maxJumpDepth: Int = 8,
+    leaseTimeoutMillis: Long = 60_000L
 ):
   def withMaxParallelism(n: Int): FlowExecutorConfig                 = copy(maxParallelism = n)
   def withCancelPollIntervalMillis(millis: Long): FlowExecutorConfig = copy(
@@ -144,6 +149,8 @@ case class FlowExecutorConfig(
   )
 
   def withMaxJumpDepth(depth: Int): FlowExecutorConfig = copy(maxJumpDepth = depth)
+
+  def withLeaseTimeoutMillis(millis: Long): FlowExecutorConfig = copy(leaseTimeoutMillis = millis)
 
 /**
   * Runs the body of a single stage and materializes the result into the given target table.
@@ -257,13 +264,19 @@ class FlowExecutor(
             )
             false
           case Some(reg) =>
+            // A running record whose liveness lease expired belongs to a dead process and is
+            // observed as failed, so dependent flows are not blocked by a phantom run forever
+            val now                                         = System.currentTimeMillis()
+            def latestStateOf(name: String): Option[String] = reg
+              .latestRunOf(name)
+              .map(_.effectiveStateAt(now))
             dep match
               case DependsOnFlow(flowName, _) =>
-                reg.latestRunOf(flowName.fullName).exists(_.state == FlowRunRecord.STATE_SUCCESS)
+                latestStateOf(flowName.fullName).contains(FlowRunRecord.STATE_SUCCESS)
               case FlowStatePredicate(flowName, "failed", _) =>
-                reg.latestRunOf(flowName.fullName).exists(_.state == FlowRunRecord.STATE_FAILED)
+                latestStateOf(flowName.fullName).contains(FlowRunRecord.STATE_FAILED)
               case FlowStatePredicate(flowName, "done", _) =>
-                reg.latestRunOf(flowName.fullName).exists(_.isTerminal)
+                latestStateOf(flowName.fullName).exists(_ != FlowRunRecord.STATE_RUNNING)
               case FlowStatePredicate(_, _, _) =>
                 false
 
@@ -502,6 +515,23 @@ class FlowExecutor(
         interval,
         TimeUnit.MILLISECONDS
       )
+      // Refresh the run's liveness lease so that other processes can distinguish this run from
+      // one whose process died mid-run. Refresh well before expiry to tolerate delays
+      val leaseInterval = (config.leaseTimeoutMillis / 3).max(1L)
+      timer.scheduleAtFixedRate(
+        new Runnable:
+          override def run(): Unit =
+            // Keep the periodic task alive on transient store failures
+            try
+              reg.refreshLease(runId, System.currentTimeMillis() + config.leaseTimeoutMillis)
+            catch
+              case NonFatal(e) =>
+                warn(s"Failed to refresh the lease of run ${runId}: ${e.getMessage}")
+        ,
+        leaseInterval,
+        leaseInterval,
+        TimeUnit.MILLISECONDS
+      )
     }
     val scheduleRetry: (Long, () => Unit) => Unit = retryScheduler.getOrElse { (delay, action) =>
       timer.schedule(
@@ -544,7 +574,12 @@ class FlowExecutor(
         else
           None
         ,
-        stageRecords
+        stageRecords,
+        leaseExpiresAtMillis =
+          if finished then
+            None
+          else
+            Some(System.currentTimeMillis() + config.leaseTimeoutMillis)
       )
     end currentRecord
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
@@ -53,6 +53,10 @@ case class StageRunRecord(
   *   Epoch millis when the run reached a terminal state
   * @param stages
   *   Per-stage records in stage definition order
+  * @param leaseExpiresAtMillis
+  *   Liveness lease of a running record, refreshed periodically by the executor. A running record
+  *   whose lease has expired belongs to a dead process (e.g. a crash mid-run) and is treated as
+  *   failed by run-slot claims and cross-flow dependency evaluation
   */
 case class FlowRunRecord(
     runId: String,
@@ -60,9 +64,21 @@ case class FlowRunRecord(
     state: String,
     startedAtMillis: Long,
     finishedAtMillis: Option[Long] = None,
-    stages: List[StageRunRecord] = Nil
+    stages: List[StageRunRecord] = Nil,
+    leaseExpiresAtMillis: Option[Long] = None
 ):
   def isTerminal: Boolean = state != FlowRunRecord.STATE_RUNNING
+
+  /** True when the record claims to be running but its liveness lease has expired */
+  def isStaleAt(nowMillis: Long): Boolean =
+    !isTerminal && leaseExpiresAtMillis.exists(_ < nowMillis)
+
+  /** The observable state at the given time: a stale running record is treated as failed */
+  def effectiveStateAt(nowMillis: Long): String =
+    if isStaleAt(nowMillis) then
+      FlowRunRecord.STATE_FAILED
+    else
+      state
 
 object FlowRunRecord:
   val STATE_RUNNING   = "running"
@@ -139,7 +155,10 @@ class FlowRunRegistry(registryDir: Path) extends FlowRunStore with LogSupport:
     // File-based claims cannot be made atomic across processes without lock files; this
     // best-effort implementation is atomic within a single process only
     synchronized {
-      val running = list().count(r => r.flowName == record.flowName && !r.isTerminal)
+      val now     = System.currentTimeMillis()
+      val running = list().count(r =>
+        r.flowName == record.flowName && !r.isTerminal && !r.isStaleAt(now)
+      )
       if running < concurrencyLimit then
         save(record)
         true

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunStore.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunStore.scala
@@ -48,6 +48,15 @@ trait FlowRunStore extends AutoCloseable:
   def claimRunSlot(record: FlowRunRecord, concurrencyLimit: Int): Boolean
 
   /**
+    * Extend the liveness lease of a running run. The executor refreshes the lease periodically
+    * while the run is in progress; a running record whose lease has expired belongs to a dead
+    * process and is treated as failed by [[claimRunSlot]] and cross-flow dependency evaluation
+    */
+  def refreshLease(runId: String, leaseExpiresAtMillis: Long): Unit = get(runId).foreach(r =>
+    save(r.copy(leaseExpiresAtMillis = Some(leaseExpiresAtMillis)))
+  )
+
+  /**
     * Request cancellation of a run. The marker is polled by the executor's event loop, so a run can
     * be cancelled from another process (e.g. `wvlet flow session cancel`)
     */

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/SQLiteFlowRunStore.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/SQLiteFlowRunStore.scala
@@ -45,8 +45,19 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
         |  state            text not null,
         |  started_at       integer not null,
         |  finished_at      integer,
-        |  cancel_requested integer not null default 0
+        |  cancel_requested integer not null default 0,
+        |  lease_expires_at integer
         |)""".stripMargin)
+    // Migrate databases created before the lease column was introduced
+    val hasLeaseColumn =
+      Using.resource(stmt.executeQuery("pragma table_info(runs)")) { rs =>
+        Iterator
+          .continually(rs)
+          .takeWhile(_.next())
+          .exists(_.getString("name") == "lease_expires_at")
+      }
+    if !hasLeaseColumn then
+      stmt.execute("alter table runs add column lease_expires_at integer")
     stmt.execute("""create table if not exists stages(
         |  run_id     text not null,
         |  ordinal    integer not null,
@@ -63,23 +74,18 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
     conn.setAutoCommit(false)
     try
       Using.resource(
-        conn.prepareStatement("""insert into runs(run_id, flow_name, state, started_at, finished_at)
-            |values(?, ?, ?, ?, ?)
+        conn.prepareStatement(
+          """insert into runs(run_id, flow_name, state, started_at, finished_at, lease_expires_at)
+            |values(?, ?, ?, ?, ?, ?)
             |on conflict(run_id) do update set
             |  flow_name = excluded.flow_name,
             |  state = excluded.state,
             |  started_at = excluded.started_at,
-            |  finished_at = excluded.finished_at""".stripMargin)
+            |  finished_at = excluded.finished_at,
+            |  lease_expires_at = excluded.lease_expires_at""".stripMargin
+        )
       ) { ps =>
-        ps.setString(1, record.runId.toLowerCase)
-        ps.setString(2, record.flowName)
-        ps.setString(3, record.state)
-        ps.setLong(4, record.startedAtMillis)
-        record.finishedAtMillis match
-          case Some(f) =>
-            ps.setLong(5, f)
-          case None =>
-            ps.setNull(5, java.sql.Types.BIGINT)
+        bindRunColumns(ps, record)
         ps.executeUpdate()
       }
       saveStages(record)
@@ -91,6 +97,22 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
     finally
       conn.setAutoCommit(true)
   }
+
+  private def bindRunColumns(ps: java.sql.PreparedStatement, record: FlowRunRecord): Unit =
+    ps.setString(1, record.runId.toLowerCase)
+    ps.setString(2, record.flowName)
+    ps.setString(3, record.state)
+    ps.setLong(4, record.startedAtMillis)
+    record.finishedAtMillis match
+      case Some(f) =>
+        ps.setLong(5, f)
+      case None =>
+        ps.setNull(5, java.sql.Types.BIGINT)
+    record.leaseExpiresAtMillis match
+      case Some(l) =>
+        ps.setLong(6, l)
+      case None =>
+        ps.setNull(6, java.sql.Types.BIGINT)
 
   private def saveStages(record: FlowRunRecord): Unit =
     Using.resource(conn.prepareStatement("delete from stages where run_id = ?")) { ps =>
@@ -128,30 +150,37 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
 
   override def claimRunSlot(record: FlowRunRecord, concurrencyLimit: Int): Boolean = synchronized {
     // A single insert statement is atomic in SQLite, so the running-count check and the claim
-    // cannot interleave with claims from other processes
+    // cannot interleave with claims from other processes. Running records whose liveness lease
+    // has expired belong to dead processes and do not occupy a slot
     val claimed =
       Using.resource(
-        conn.prepareStatement("""insert into runs(run_id, flow_name, state, started_at, finished_at)
-          |select ?, ?, ?, ?, ?
-          |where (select count(*) from runs where flow_name = ? and state = ?) < ?""".stripMargin)
+        conn.prepareStatement(
+          """insert into runs(run_id, flow_name, state, started_at, finished_at, lease_expires_at)
+            |select ?, ?, ?, ?, ?, ?
+            |where (select count(*) from runs
+            |       where flow_name = ? and state = ?
+            |         and (lease_expires_at is null or lease_expires_at >= ?)) < ?""".stripMargin
+        )
       ) { ps =>
-        ps.setString(1, record.runId.toLowerCase)
-        ps.setString(2, record.flowName)
-        ps.setString(3, record.state)
-        ps.setLong(4, record.startedAtMillis)
-        record.finishedAtMillis match
-          case Some(f) =>
-            ps.setLong(5, f)
-          case None =>
-            ps.setNull(5, java.sql.Types.BIGINT)
-        ps.setString(6, record.flowName)
-        ps.setString(7, FlowRunRecord.STATE_RUNNING)
-        ps.setInt(8, concurrencyLimit)
+        bindRunColumns(ps, record)
+        ps.setString(7, record.flowName)
+        ps.setString(8, FlowRunRecord.STATE_RUNNING)
+        ps.setLong(9, System.currentTimeMillis())
+        ps.setInt(10, concurrencyLimit)
         ps.executeUpdate() == 1
       }
     if claimed then
       saveStages(record)
     claimed
+  }
+
+  override def refreshLease(runId: String, leaseExpiresAtMillis: Long): Unit = synchronized {
+    Using.resource(conn.prepareStatement("update runs set lease_expires_at = ? where run_id = ?")) {
+      ps =>
+        ps.setLong(1, leaseExpiresAtMillis)
+        ps.setString(2, runId.toLowerCase)
+        ps.executeUpdate()
+    }
   }
 
   override def requestCancel(runId: String): Unit = synchronized {
@@ -208,27 +237,30 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
     val runs =
       Using.resource(
         conn.prepareStatement(
-          s"select run_id, flow_name, state, started_at, finished_at from runs ${clause}"
+          s"select run_id, flow_name, state, started_at, finished_at, lease_expires_at from runs ${clause}"
         )
       ) { ps =>
         bind(ps)
         Using.resource(ps.executeQuery()) { rs =>
+          // wasNull refers to the immediately preceding column read
+          def nullableLong(column: Int): Option[Long] =
+            val v = rs.getLong(column)
+            if rs.wasNull() then
+              None
+            else
+              Some(v)
           val b = List.newBuilder[FlowRunRecord]
           while rs.next() do
-            val finishedAt = rs.getLong(5)
-            // wasNull refers to the immediately preceding getLong(5) read
-            val finishedAtOpt =
-              if rs.wasNull() then
-                None
-              else
-                Some(finishedAt)
+            val finishedAtOpt = nullableLong(5)
+            val leaseOpt      = nullableLong(6)
             b +=
               FlowRunRecord(
                 runId = rs.getString(1),
                 flowName = rs.getString(2),
                 state = rs.getString(3),
                 startedAtMillis = rs.getLong(4),
-                finishedAtMillis = finishedAtOpt
+                finishedAtMillis = finishedAtOpt,
+                leaseExpiresAtMillis = leaseOpt
               )
           b.result()
         }

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -699,6 +699,84 @@ class FlowExecutorTest extends UniTest:
     registry.latestRunOf("Orphan").get.state shouldBe FlowRunRecord.STATE_SKIPPED
   }
 
+  test("treat a stale running record as failed in cross-flow dependency evaluation") {
+    val registry     = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val (flows, ctx) = compileFlows("""flow LeaseUpstream = {
+        |  stage src = from [[1]] as t(id)
+        |}
+        |
+        |flow LeaseRecovery if LeaseUpstream.failed = {
+        |  stage alert = from [[1]] as t(id)
+        |}""".stripMargin)
+
+    def run(name: String): FlowExecutionResult =
+      FlowExecutor(connector, workEnv, registry = Some(registry)).execute(flows(name))(using ctx)
+
+    val now = System.currentTimeMillis()
+    // The upstream flow is running and holds a live lease: the recovery flow does not fire
+    registry.save(
+      FlowRunRecord(
+        "upstreamrun",
+        "LeaseUpstream",
+        FlowRunRecord.STATE_RUNNING,
+        now,
+        leaseExpiresAtMillis = Some(now + 60000)
+      )
+    )
+    run("LeaseRecovery").stageResults.map(_.state) shouldBe List(StageState.Skipped)
+
+    // The lease expired (the upstream process crashed): the phantom running record is observed
+    // as failed, so the recovery flow fires instead of waiting forever
+    registry.save(
+      FlowRunRecord(
+        "upstreamrun",
+        "LeaseUpstream",
+        FlowRunRecord.STATE_RUNNING,
+        now,
+        leaseExpiresAtMillis = Some(now - 10000)
+      )
+    )
+    run("LeaseRecovery").stageResults.map(_.state) shouldBe List(StageState.Success)
+  }
+
+  test("maintain a liveness lease on the run record while running") {
+    val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    @volatile
+    var leaseAtStart: Option[Long] = None
+    @volatile
+    var refreshedLease: Option[Long] = None
+    val runner                       =
+      new FlowStageRunner:
+        override def run(stage: StageDef, targetTable: String)(using Context): Unit =
+          def currentLease = registry.list().headOption.flatMap(_.leaseExpiresAtMillis)
+          leaseAtStart = currentLease
+          // The refresh interval is leaseTimeout / 3 = 50ms; wait until the timer extends the
+          // lease beyond the value observed at stage start
+          val deadline = System.currentTimeMillis() + 10000
+          var current  = currentLease
+          while current == leaseAtStart && System.currentTimeMillis() < deadline do
+            Thread.sleep(20)
+            current = currentLease
+          refreshedLease = current
+
+    val result = runFlow(
+      """flow LeasedFlow = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin,
+      config = FlowExecutorConfig().withLeaseTimeoutMillis(150),
+      stageRunner = Some(runner),
+      registry = Some(registry)
+    )
+    result.isSuccess shouldBe true
+    // The run record carried a lease from the very first snapshot, and the timer refreshed it
+    leaseAtStart.isDefined shouldBe true
+    (refreshedLease.get > leaseAtStart.get) shouldBe true
+    // The terminal record carries no lease and is never considered stale
+    val terminal = registry.get(result.runId).get
+    terminal.leaseExpiresAtMillis shouldBe None
+    terminal.isStaleAt(System.currentTimeMillis() + 1000000) shouldBe false
+  }
+
   test("resume a failed run reusing successful stage materializations") {
     val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
     val wv       =

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowRunStoreTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowRunStoreTest.scala
@@ -134,6 +134,62 @@ class FlowRunStoreTest extends UniTest:
     }
   }
 
+  test("persist and refresh run leases") {
+    withStores { (kind, store) =>
+      store.save(
+        record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L).copy(leaseExpiresAtMillis =
+          Some(1000L)
+        )
+      )
+      store.get("run1").get.leaseExpiresAtMillis shouldBe Some(1000L)
+
+      store.refreshLease("run1", 5000L)
+      val r = store.get("run1").get
+      r.leaseExpiresAtMillis shouldBe Some(5000L)
+      // The stage records survive a lease refresh
+      r.stages.map(_.name) shouldBe List("src", "out")
+      r.isStaleAt(4000L) shouldBe false
+      r.isStaleAt(6000L) shouldBe true
+      r.effectiveStateAt(6000L) shouldBe FlowRunRecord.STATE_FAILED
+
+      // Terminal records are never stale, regardless of their lease
+      store.save(
+        record("run2", "FlowA", FlowRunRecord.STATE_SUCCESS, 100L).copy(leaseExpiresAtMillis =
+          Some(10L)
+        )
+      )
+      store.get("run2").get.isStaleAt(6000L) shouldBe false
+      // A running record without a lease (e.g. written by an older version) is not stale
+      store.save(record("run3", "FlowA", FlowRunRecord.STATE_RUNNING, 100L))
+      store.get("run3").get.isStaleAt(6000L) shouldBe false
+    }
+  }
+
+  test("free the run slot of a running record whose lease expired") {
+    withStores { (kind, store) =>
+      val now = System.currentTimeMillis()
+      // A crashed process left this record running, but its lease has expired
+      store.save(
+        record("crashed", "FlowA", FlowRunRecord.STATE_RUNNING, 100L).copy(leaseExpiresAtMillis =
+          Some(now - 10000)
+        )
+      )
+      store.claimRunSlot(
+        record("run2", "FlowA", FlowRunRecord.STATE_RUNNING, 200L).copy(leaseExpiresAtMillis =
+          Some(now + 60000)
+        ),
+        concurrencyLimit = 1
+      ) shouldBe true
+      // A run holding a live lease still occupies its slot
+      store.claimRunSlot(
+        record("run3", "FlowA", FlowRunRecord.STATE_RUNNING, 300L).copy(leaseExpiresAtMillis =
+          Some(now + 60000)
+        ),
+        concurrencyLimit = 1
+      ) shouldBe false
+    }
+  }
+
   test("share state between store instances on the same path") {
     // Simulates cross-process observation: a second store instance sees runs and cancellation
     // requests written by the first one


### PR DESCRIPTION
## Summary

Part of #1833 (item 1: stale `running` record leases / GC).

A process that crashes mid-run leaves its run record in the `running` state forever: it permanently holds a `concurrency:` slot, cross-flow dependencies see a phantom in-progress run, `session resume` refuses to touch it, and `session clean` (terminal-only) never removes it.

This PR adds a run-level liveness lease:

- **Record**: `FlowRunRecord` gains `leaseExpiresAtMillis` plus `isStaleAt(now)` / `effectiveStateAt(now)` helpers — a running record whose lease expired is observed as failed. Terminal records carry no lease and are never stale; running records without a lease (written by older versions) are conservatively treated as live.
- **Executor**: refreshes the lease on a timer at `leaseTimeout / 3` (default lease 60s, configurable via `FlowExecutorConfig.withLeaseTimeoutMillis`); every snapshot save also renews it, and the terminal save clears it.
- **Run stores**: new `FlowRunStore.refreshLease` (lightweight `UPDATE` in SQLite, read-copy-save default for the file store). `claimRunSlot` no longer counts expired-lease running records — in SQLite the staleness check is folded into the existing single atomic `INSERT ... SELECT ... WHERE count < limit` statement, so cross-process claims stay race-free. Existing SQLite databases are migrated with `ALTER TABLE` on open.
- **Dependency evaluation**: `depends on X` / `if X.failed` / `if X.done` observe the effective state, so a crashed upstream unblocks recovery flows instead of blocking forever.
- **CLI**: `session list` marks crashed runs as `running (stale)`, `session resume` accepts a stale running record like a failed run, and `session clean --stale` also removes stale records (plain `clean` still keeps all running records).

## Testing

- `FlowRunStoreTest` (both backends): lease persistence/refresh with stage records surviving, staleness semantics (terminal/no-lease records never stale), and slot claims freeing expired leases while honoring live ones
- `FlowExecutorTest`: the run record carries a lease from the first snapshot, the timer observably extends it mid-run, the terminal record has none; a stale upstream record fires `if X.failed` recovery while a live one is skipped
- `WvletFlowCommandTest`: `clean` vs `clean --stale`, resume of a crashed run, rejection of resume for a live running record
- Full `runner` and `cli` suites green; docs updated (`flow.md`: Run Liveness Leases section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)