### PR TITLE
feature: Harden the flow scheduler with live reload, --once, and --catchup

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -330,6 +330,21 @@ through the regular flow executor, so cross-flow dependencies (`depends on`, `if
 still decide whether a triggered run actually executes: the schedule determines *when* to
 check, the dependency determines *if* the flow runs.
 
+The daemon polls the `.wv` files of the working folder (every 5 seconds by default,
+configurable with `--reload-interval <seconds>`, `0` disables it) and reloads the schedules
+when they change, so flows can be added, removed, or rescheduled without restarting. Flows
+whose schedule is unchanged keep their pending fire time across reloads; a compile error
+keeps the previously loaded schedules.
+
+Two flags cover scripting and missed windows:
+
+- `--once`: evaluate the schedules once against the current minute, run the matching flows,
+  and exit. Use this to drive wvlet schedules from an external scheduler such as system cron.
+- `--catchup`: on startup, trigger every scheduled flow whose most recent fire time has no
+  recorded run at or after it (e.g. the fire was missed while the daemon was down). Without
+  this flag, missed windows are skipped silently. Combine with `--once` for a one-shot
+  catch-up run.
+
 `concurrency: N` is enforced through the run store whenever a flow starts (scheduler, CLI, or
 `run flow`): a run atomically claims one of the flow's N slots and is recorded as `skipped`
 when all slots are taken by running runs. With the `sqlite` run store the claim is

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -252,51 +252,85 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
   end session
 
   @command(description = "Start the scheduler daemon that runs flows on their cron schedules")
-  def scheduler(flowOption: WvletFlowOption): Unit =
-    withFlows(flowOption) { (flows, compileResult, workEnv) =>
-      val scheduled = flows.flatMap { (unit, f) =>
-        val config = FlowScheduleConfig.fromFlow(f)
-        config
-          .cron
-          .map { cronExpr =>
-            (unit, ScheduledFlow(f, CronSchedule.parse(cronExpr), config.zoneId))
-          }
-      }
-      if scheduled.isEmpty then
-        println("No flows with a schedule: config were found")
-      else
-        val profile = Profile.getProfile(flowOption.profile, flowOption.catalog, flowOption.schema)
-        Control.withResource(DBConnectorProvider(workEnv)) { dbConnectorProvider =>
-          val connector = dbConnectorProvider.getConnector(profile)
-          Control.withResource(newRunStore(flowOption, workEnv)) { store =>
-            val unitOf = scheduled.map((unit, sf) => sf.name -> unit).toMap
-            // Each triggered flow runs on its own thread so that a long flow does not delay
-            // other schedules; the executor enforces dependencies and concurrency limits
-            val pool = java
-              .util
-              .concurrent
-              .Executors
-              .newCachedThreadPool { (r: Runnable) =>
-                val t = Thread(r, "wvlet-flow-scheduler-run")
-                t.setDaemon(true)
-                t
-              }
-            val flowScheduler = FlowScheduler(
-              scheduled.map(_._2),
-              trigger =
-                flow =>
-                  pool.submit(
-                    new Runnable:
-                      override def run(): Unit =
-                        given ctx: Context = compileResult
-                          .context
-                          .withCompilationUnit(unitOf(flow.name.name))
-                          .newContext(Symbol.NoSymbol)
-                        val result = FlowExecutor(connector, workEnv, registry = Some(store))
-                          .execute(flow)
-                        println(result.toPrettyBox())
-                  )
+  def scheduler(
+      flowOption: WvletFlowOption,
+      @option(
+        prefix = "--once",
+        description = "Evaluate the schedules once against the current minute and exit"
+      )
+      once: Boolean = false,
+      @option(
+        prefix = "--catchup",
+        description =
+          "On startup, trigger flows whose most recent scheduled fire time has no recorded run"
+      )
+      catchup: Boolean = false,
+      @option(
+        prefix = "--reload-interval",
+        description = "Interval (seconds) for polling .wv file changes; 0 disables reloading"
+      )
+      reloadInterval: Int = 5
+  ): Unit =
+    val (flows, compileResult, workEnv) = loadFlows(flowOption)
+    val scheduled                       = scheduledFlowsOf(flows)
+    if scheduled.isEmpty then
+      println("No flows with a schedule: config were found")
+    else
+      val profile = Profile.getProfile(flowOption.profile, flowOption.catalog, flowOption.schema)
+      Control.withResource(DBConnectorProvider(workEnv)) { dbConnectorProvider =>
+        val connector = dbConnectorProvider.getConnector(profile)
+        Control.withResource(newRunStore(flowOption, workEnv)) { store =>
+          // The compile result and defining unit of each scheduled flow, replaced on reload
+          val compiled = java
+            .util
+            .concurrent
+            .atomic
+            .AtomicReference((compileResult, scheduled.map((unit, sf) => sf.name -> unit).toMap))
+          // Each triggered flow runs on its own thread so that a long flow does not delay
+          // other schedules; the executor enforces dependencies and concurrency limits
+          val pool = java
+            .util
+            .concurrent
+            .Executors
+            .newCachedThreadPool { (r: Runnable) =>
+              val t = Thread(r, "wvlet-flow-scheduler-run")
+              t.setDaemon(true)
+              t
+            }
+          val flowScheduler = FlowScheduler(
+            scheduled.map(_._2),
+            trigger =
+              flow =>
+                pool.submit(
+                  new Runnable:
+                    override def run(): Unit =
+                      val (result, unitOf) = compiled.get()
+
+                      given ctx: Context = result
+                        .context
+                        .withCompilationUnit(unitOf(flow.name.name))
+                        .newContext(Symbol.NoSymbol)
+
+                      val runResult = FlowExecutor(connector, workEnv, registry = Some(store))
+                        .execute(flow)
+                      println(runResult.toPrettyBox())
+                )
+          )
+          if catchup then
+            val fired = flowScheduler.catchUp(name =>
+              store.latestRunOf(name).map(_.startedAtMillis)
             )
+            if fired.nonEmpty then
+              println(s"Catch-up triggered ${fired.size} missed flow(s): ${fired.mkString(", ")}")
+          if once then
+            // Evaluate the current minute once and wait for the triggered runs to finish
+            val fired = flowScheduler.runOnce()
+            println(s"Triggered ${fired.size} scheduled flow(s)")
+            pool.shutdown()
+            pool.awaitTermination(365, java.util.concurrent.TimeUnit.DAYS)
+          else
+            if reloadInterval > 0 then
+              startReloader(flowOption, flowScheduler, compiled, reloadInterval)
             Runtime
               .getRuntime
               .addShutdownHook(
@@ -306,10 +340,46 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
               )
             try flowScheduler.runLoop()
             finally pool.shutdownNow()
-          }
+          end if
         }
-      end if
-    }
+      }
+    end if
+
+  end scheduler
+
+  /**
+    * Start a daemon thread that polls the .wv sources of the working folder and reloads the
+    * schedules when they change. A compile failure keeps the previously loaded schedules
+    */
+  private def startReloader(
+      flowOption: WvletFlowOption,
+      flowScheduler: FlowScheduler,
+      compiled: java.util.concurrent.atomic.AtomicReference[
+        (CompileResult, Map[String, CompilationUnit])
+      ],
+      reloadIntervalSeconds: Int
+  ): Unit =
+    val reloader = Thread(
+      () =>
+        var snapshot = sourceSnapshot(flowOption.workFolder)
+        while true do
+          Thread.sleep(reloadIntervalSeconds * 1000L)
+          val latest = sourceSnapshot(flowOption.workFolder)
+          if latest != snapshot then
+            snapshot = latest
+            try
+              val (newFlows, newResult, _) = loadFlows(flowOption)
+              val newScheduled             = scheduledFlowsOf(newFlows)
+              compiled.set((newResult, newScheduled.map((unit, sf) => sf.name -> unit).toMap))
+              flowScheduler.reload(newScheduled.map(_._2))
+            catch
+              case scala.util.control.NonFatal(e) =>
+                warn(s"Failed to reload flows; keeping the current schedules: ${e.getMessage}")
+      ,
+      "wvlet-flow-scheduler-reload"
+    )
+    reloader.setDaemon(true)
+    reloader.start()
 
   @command(description = "Show the plan of a flow")
   def show(
@@ -332,6 +402,13 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
   private def withFlows[A](flowOption: WvletFlowOption)(
       body: (List[(CompilationUnit, FlowDef)], CompileResult, WorkEnv) => A
   ): A =
+    val (flows, compileResult, workEnv) = loadFlows(flowOption)
+    body(flows, compileResult, workEnv)
+
+  /** Compile all .wv files in the working folder and collect flow definitions */
+  private def loadFlows(
+      flowOption: WvletFlowOption
+  ): (List[(CompilationUnit, FlowDef)], CompileResult, WorkEnv) =
     val workEnv  = WorkEnv(flowOption.workFolder, opts.logLevel)
     val compiler = Compiler(
       CompilerOptions(sourceFolders = List(flowOption.workFolder), workEnv = workEnv)
@@ -347,7 +424,38 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
             flows += unit -> f
           }
       }
-    body(flows.result(), compileResult, workEnv)
+    (flows.result(), compileResult, workEnv)
+
+  /** Extract the flows that have a cron schedule, paired with their defining units */
+  private def scheduledFlowsOf(
+      flows: List[(CompilationUnit, FlowDef)]
+  ): List[(CompilationUnit, ScheduledFlow)] = flows.flatMap { (unit, f) =>
+    val config = FlowScheduleConfig.fromFlow(f)
+    config
+      .cron
+      .map { cronExpr =>
+        (unit, ScheduledFlow(f, CronSchedule.parse(cronExpr), config.zoneId))
+      }
+  }
+
+  /**
+    * Snapshot of the .wv sources under the folder (path -> last modified millis), used to detect
+    * changes for scheduler reloading
+    */
+  private def sourceSnapshot(folder: String): Map[String, Long] =
+    val root = java.nio.file.Path.of(folder)
+    if !java.nio.file.Files.isDirectory(root) then
+      Map.empty
+    else
+      Control.withResource(java.nio.file.Files.walk(root)) { stream =>
+        import scala.jdk.CollectionConverters.*
+        stream
+          .iterator()
+          .asScala
+          .filter(p => p.toString.endsWith(".wv") && java.nio.file.Files.isRegularFile(p))
+          .map(p => p.toString -> java.nio.file.Files.getLastModifiedTime(p).toMillis)
+          .toMap
+      }
 
   private def findFlow(
       flows: List[(CompilationUnit, FlowDef)],

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -221,6 +221,46 @@ class WvletFlowCommandTest extends UniTest:
     WvletMain.main(s"flow scheduler -w ${flowDir}")
   }
 
+  test("evaluate schedules once and exit with scheduler --once") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRegistry
+    val dir = Files.createTempDirectory("wvlet-flow-sched-once")
+    Files.writeString(
+      dir.resolve("scheduled.wv"),
+      """flow EveryMinutePipeline with {
+        |  schedule: cron('* * * * *')
+        |} = {
+        |  stage src = from [[1]] as t(id)
+        |}
+        |""".stripMargin
+    )
+    // The cron expression matches every minute, so a single evaluation triggers one run
+    WvletMain.main(s"flow scheduler --once -w ${dir}")
+    val runs = FlowRunRegistry.forWorkEnv(WorkEnv(dir.toString)).list()
+    runs.map(_.flowName) shouldBe List("EveryMinutePipeline")
+    runs.head.state shouldBe "success"
+  }
+
+  test("trigger a missed schedule with scheduler --catchup") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRegistry
+    val dir = Files.createTempDirectory("wvlet-flow-sched-catchup")
+    Files.writeString(
+      dir.resolve("scheduled.wv"),
+      """flow YearlyPipeline with {
+        |  schedule: cron('0 0 1 1 *')
+        |} = {
+        |  stage src = from [[1]] as t(id)
+        |}
+        |""".stripMargin
+    )
+    // No run of the flow is recorded, so the most recent Jan 1 fire counts as missed
+    WvletMain.main(s"flow scheduler --once --catchup -w ${dir}")
+    val runs = FlowRunRegistry.forWorkEnv(WorkEnv(dir.toString)).list()
+    runs.map(_.flowName).distinct shouldBe List("YearlyPipeline")
+    runs.map(_.state).distinct shouldBe List("success")
+  }
+
   test("report an error for an unknown flow name") {
     val e = intercept[WvletLangException] {
       WvletMain.main(s"flow run NoSuchFlow -w ${flowDir}")

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/CronSchedule.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/CronSchedule.scala
@@ -70,6 +70,24 @@ case class CronSchedule(
           .newException(s"Cron expression '${expression}' never fires")
     candidate
 
+  /** The most recent matching time at or before the given time */
+  def prevAtOrBefore(t: ZonedDateTime): ZonedDateTime =
+    var candidate = t.truncatedTo(ChronoUnit.MINUTES)
+    val limit     = t.minusYears(4)
+    while !matches(candidate) do
+      // Skip in day steps while the date cannot match to keep the scan cheap
+      candidate =
+        if !months.contains(candidate.getMonthValue) || !dayMatches(candidate) then
+          // The last minute of the previous day
+          candidate.truncatedTo(ChronoUnit.DAYS).minusMinutes(1)
+        else
+          candidate.minusMinutes(1)
+      if candidate.isBefore(limit) then
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(s"Cron expression '${expression}' never fires")
+    candidate
+
 end CronSchedule
 
 object CronSchedule:

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowScheduler.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowScheduler.scala
@@ -119,6 +119,9 @@ class FlowScheduler(
     clock: () => Instant = () => Instant.now()
 ) extends LogSupport:
 
+  @volatile
+  private var current: List[ScheduledFlow] = scheduled
+
   private val nextFire = mutable.Map.empty[String, ZonedDateTime]
 
   @volatile
@@ -126,22 +129,28 @@ class FlowScheduler(
 
   def stop(): Unit = stopped = true
 
+  /** The currently scheduled flows (replaced by [[reload]]) */
+  def scheduledFlows: List[ScheduledFlow] = current
+
+  private def fire(sf: ScheduledFlow, reason: String): Unit =
+    info(s"Triggering scheduled flow ${sf.name} (${reason})")
+    try
+      trigger(sf.flow)
+    catch
+      case NonFatal(e) =>
+        warn(s"Failed to trigger flow ${sf.name}: ${e.getMessage}")
+
   /**
     * Evaluate all schedules once: trigger the flows whose fire time has passed and return the
     * milliseconds until the earliest next fire
     */
-  def tick(): Long =
+  def tick(): Long = synchronized {
     val now = clock()
-    scheduled.foreach { sf =>
+    current.foreach { sf =>
       val zonedNow = now.atZone(sf.zone)
       val due      = nextFire.getOrElseUpdate(sf.name, sf.cron.nextAfter(zonedNow))
       if !due.toInstant.isAfter(now) then
-        info(s"Triggering scheduled flow ${sf.name} (due: ${due})")
-        try
-          trigger(sf.flow)
-        catch
-          case NonFatal(e) =>
-            warn(s"Failed to trigger flow ${sf.name}: ${e.getMessage}")
+        fire(sf, s"due: ${due}")
         nextFire(sf.name) = sf.cron.nextAfter(zonedNow)
     }
     val nowMillis = clock().toEpochMilli
@@ -150,13 +159,69 @@ class FlowScheduler(
       .map(t => (t.toInstant.toEpochMilli - nowMillis).max(0L))
       .minOption
       .getOrElse(60000L)
+  }
+
+  /**
+    * Replace the scheduled flows (e.g. after the .wv files of the working folder changed). Flows
+    * whose cron expression and time zone are unchanged keep their pending fire time; new or
+    * rescheduled flows are evaluated from the next tick
+    */
+  def reload(newScheduled: List[ScheduledFlow]): Unit = synchronized {
+    val oldByName = current.map(sf => sf.name -> sf).toMap
+    newScheduled.foreach { sf =>
+      oldByName.get(sf.name) match
+        case Some(prev) if prev.cron.expression == sf.cron.expression && prev.zone == sf.zone =>
+        // The schedule is unchanged: keep the pending fire time
+        case _ =>
+          nextFire.remove(sf.name)
+    }
+    (oldByName.keySet -- newScheduled.map(_.name)).foreach(nextFire.remove)
+    current = newScheduled
+    info(
+      s"Reloaded ${newScheduled.size} scheduled flow(s): ${newScheduled
+          .map(sf => s"${sf.name} [${sf.cron.expression}]")
+          .mkString(", ")}"
+    )
+  }
+
+  /**
+    * Trigger every flow whose cron expression matches the current minute and return their names.
+    * Used by `wvlet flow scheduler --once`, where an external scheduler (e.g. system cron) decides
+    * when to evaluate the schedules
+    */
+  def runOnce(): List[String] = synchronized {
+    val now   = clock()
+    val fired = current.filter(sf => sf.cron.matches(now.atZone(sf.zone)))
+    fired.foreach(sf => fire(sf, "once"))
+    fired.map(_.name)
+  }
+
+  /**
+    * Trigger the flows whose most recent scheduled fire time has no run recorded at or after it
+    * (i.e. the fire was missed, e.g. while the scheduler daemon was down) and return their names.
+    * `lastRunStartedAt` supplies the start time of the latest recorded run of a flow
+    */
+  def catchUp(lastRunStartedAt: String => Option[Long]): List[String] = synchronized {
+    val now    = clock()
+    val missed = current.filter { sf =>
+      try
+        val prev = sf.cron.prevAtOrBefore(now.atZone(sf.zone))
+        lastRunStartedAt(sf.name).forall(_ < prev.toInstant.toEpochMilli)
+      catch
+        case NonFatal(_) =>
+          // The cron expression has no fire time within the scan window: nothing was missed
+          false
+    }
+    missed.foreach(sf => fire(sf, "catch-up"))
+    missed.map(_.name)
+  }
 
   /** Run the scheduler loop until stop() is called */
   def runLoop(): Unit =
-    if scheduled.isEmpty then
+    if current.isEmpty then
       throw StatusCode.INVALID_ARGUMENT.newException("No scheduled flows to run")
     info(
-      s"Flow scheduler started with ${scheduled.size} scheduled flow(s): ${scheduled
+      s"Flow scheduler started with ${current.size} scheduled flow(s): ${current
           .map(sf => s"${sf.name} [${sf.cron.expression}]")
           .mkString(", ")}"
     )

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/CronScheduleTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/CronScheduleTest.scala
@@ -76,4 +76,23 @@ class CronScheduleTest extends UniTest:
     e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
   }
 
+  test("find the most recent fire at or before a time") {
+    val cron = CronSchedule.parse("0 2 * * *")
+    cron.prevAtOrBefore(at("2026-01-01T10:00:00Z")) shouldBe at("2026-01-01T02:00:00Z")
+    // A time before today's fire returns yesterday's fire
+    cron.prevAtOrBefore(at("2026-01-01T01:59:00Z")) shouldBe at("2025-12-31T02:00:00Z")
+    // An exact fire time returns itself (seconds are truncated to the minute)
+    cron.prevAtOrBefore(at("2026-01-01T02:00:45Z")) shouldBe at("2026-01-01T02:00:00Z")
+    // Month-restricted schedules skip back across months
+    CronSchedule.parse("30 6 15 3 *").prevAtOrBefore(at("2026-01-10T00:00:00Z")) shouldBe
+      at("2025-03-15T06:30:00Z")
+  }
+
+  test("report schedules that never fired in the past") {
+    val e = intercept[WvletLangException] {
+      CronSchedule.parse("0 0 30 2 *").prevAtOrBefore(at("2026-01-01T00:00:00Z"))
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+  }
+
 end CronScheduleTest

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowSchedulerTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowSchedulerTest.scala
@@ -106,4 +106,81 @@ class FlowSchedulerTest extends UniTest:
     attempts shouldBe 2
   }
 
+  test("trigger only the flows matching the current minute with runOnce") {
+    val flow = compileFlow("""flow OnceFlow = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin)
+    val matching    = ScheduledFlow(flow, CronSchedule.parse("5 0 * * *"), ZoneId.of("UTC"))
+    val notMatching = ScheduledFlow(flow, CronSchedule.parse("0 2 * * *"), ZoneId.of("UTC"))
+
+    val now       = Instant.parse("2026-01-01T00:05:42Z")
+    val triggered = ListBuffer.empty[String]
+    val scheduler = FlowScheduler(
+      List(matching, notMatching),
+      f => triggered += f.name.name,
+      () => now
+    )
+    // Both entries reference the same flow; only the schedule matching 00:05 fires
+    scheduler.runOnce() shouldBe List("OnceFlow")
+    triggered.size shouldBe 1
+  }
+
+  test("catch up flows whose latest scheduled fire was missed") {
+    val flow = compileFlow("""flow CatchUpFlow = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin)
+    val sf = ScheduledFlow(flow, CronSchedule.parse("0 2 * * *"), ZoneId.of("UTC"))
+
+    val now       = Instant.parse("2026-01-01T10:00:00Z")
+    val triggered = ListBuffer.empty[String]
+    val scheduler = FlowScheduler(List(sf), f => triggered += f.name.name, () => now)
+
+    val prevFire = Instant.parse("2026-01-01T02:00:00Z").toEpochMilli
+
+    // A run recorded after the 02:00 fire: nothing was missed
+    scheduler.catchUp(_ => Some(prevFire + 1000)) shouldBe Nil
+    // The latest run predates the 02:00 fire: the flow is triggered
+    scheduler.catchUp(_ => Some(prevFire - 1000)) shouldBe List("CatchUpFlow")
+    // No run was ever recorded: the fire was missed as well
+    scheduler.catchUp(_ => None) shouldBe List("CatchUpFlow")
+    triggered.size shouldBe 2
+  }
+
+  test("reload schedules keeping pending fire times of unchanged flows") {
+    val flowA = compileFlow("""flow ReloadedFlowA = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin)
+    val flowB = compileFlow("""flow ReloadedFlowB = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin)
+    val sfA = ScheduledFlow(flowA, CronSchedule.parse("* * * * *"), ZoneId.of("UTC"))
+    val sfB = ScheduledFlow(flowB, CronSchedule.parse("* * * * *"), ZoneId.of("UTC"))
+
+    var now       = Instant.parse("2026-01-01T00:00:30Z")
+    val triggered = ListBuffer.empty[String]
+    val scheduler = FlowScheduler(List(sfA), f => triggered += f.name.name, () => now)
+
+    // Initialize the pending fire of A (00:01:00), then add B via reload
+    scheduler.tick()
+    scheduler.reload(List(sfA, sfB))
+    scheduler.scheduledFlows.map(_.name) shouldBe List("ReloadedFlowA", "ReloadedFlowB")
+
+    // A kept its pending fire and triggers; B initializes its first fire (00:02:00)
+    now = Instant.parse("2026-01-01T00:01:00Z")
+    scheduler.tick()
+    triggered.toList shouldBe List("ReloadedFlowA")
+
+    // Both flows fire on the next minute
+    now = Instant.parse("2026-01-01T00:02:00Z")
+    scheduler.tick()
+    triggered.toList shouldBe List("ReloadedFlowA", "ReloadedFlowA", "ReloadedFlowB")
+
+    // Removing A stops triggering it
+    scheduler.reload(List(sfB))
+    now = Instant.parse("2026-01-01T00:03:00Z")
+    scheduler.tick()
+    triggered.toList shouldBe
+      List("ReloadedFlowA", "ReloadedFlowA", "ReloadedFlowB", "ReloadedFlowB")
+  }
+
 end FlowSchedulerTest


### PR DESCRIPTION
## Summary

Part of #1833 (item 4: scheduler daemon hardening). Three gaps in `wvlet flow scheduler`:

- **Live reload**: the daemon compiled the working folder once at startup, so flow edits required a restart. It now polls the `.wv` sources (default every 5s, `--reload-interval <seconds>`, `0` disables) and reloads the schedules on change. `FlowScheduler.reload` keeps the pending fire time of flows whose cron expression and time zone are unchanged, drops removed flows, and re-initializes rescheduled ones; a compile error keeps the previously loaded schedules. The compile context used by triggered runs is swapped atomically alongside the schedules.
- **`--catchup`**: a fire window missed while the daemon was down was skipped silently. With `--catchup`, startup triggers every scheduled flow whose most recent fire time (new `CronSchedule.prevAtOrBefore`, mirroring `nextAfter` with the same day-skip scan and 4-year bound) has no run recorded at or after it in the run store.
- **`--once`**: evaluates the schedules against the current minute, runs the matching flows, waits for them, and exits — so wvlet schedules can be driven by an external scheduler such as system cron. Composes with `--catchup` for a one-shot catch-up run.

`tick`/`reload`/`runOnce`/`catchUp` are synchronized so the reloader thread and the scheduler loop share the fire-time state safely.

## Testing

- `CronScheduleTest`: `prevAtOrBefore` across day/month boundaries, exact-minute matches, and never-fires detection
- `FlowSchedulerTest` (injectable clock): `runOnce` fires only matching-minute schedules; `catchUp` distinguishes runs recorded before/after the previous fire and missing runs; `reload` keeps pending fires of unchanged flows, initializes added ones, and stops removed ones
- `WvletFlowCommandTest`: end-to-end `scheduler --once` (every-minute cron records one successful run) and `scheduler --once --catchup` (missed yearly fire is caught up)
- Full `runner` and `cli` suites green; scheduler docs updated in `flow.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)