### PR TITLE
feature: Add a webhook activation sink with ServiceLoader-based sink discovery

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -445,8 +445,13 @@ immediately. Flow operators are
 lowered before scheduling: `route` cases become filter predicates on target stages, `fork`
 stages are flattened into the DAG, `wait` delays materialization, and `end` is a pass-through.
 `activate('target', param: value, ...)` delivers the materialized stage output to the
-activation sink registered for the target name — local file export is built in
-(`activate('file', path: 'out.csv')`, with csv/parquet/json formats), unknown targets fall
+activation sink registered for the target name — local file export
+(`activate('file', path: 'out.csv')`, with csv/parquet/json formats) and webhook delivery
+(`activate('webhook', url: 'https://...')`, posting rows as a JSON array or `format: 'ndjson'`,
+bounded by `max_rows:`, 1000 by default) are built in; external modules can register
+additional sinks through the Java ServiceLoader
+(`META-INF/services/wvlet.lang.runner.ActivationSink`), which take precedence over built-in
+target names. Unknown targets fall
 back to a logging stub, and a sink failure fails the attempt and follows the stage's retry
 policy. Flow runs are recorded
 in a local run registry, and cross-flow dependencies are evaluated against it. A `-> Flow`

--- a/wvlet-api/src/main/scala/wvlet/lang/api/StatusCode.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/StatusCode.scala
@@ -72,6 +72,9 @@ enum StatusCode(statusType: StatusType):
   case TEST_FAILED extends StatusCode(StatusType.UserError)
 
   case INTERNAL_ERROR extends StatusCode(StatusType.InternalError)
+  // A flow activation sink failed to deliver the stage output (e.g. a webhook returned an
+  // error status); the stage attempt is retried per its retry policy
+  case ACTIVATION_FAILED extends StatusCode(StatusType.InternalError)
 
   case RESOURCE_EXHAUSTED extends StatusCode(StatusType.ResourceExhausted)
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/ActivationSink.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/ActivationSink.scala
@@ -14,9 +14,18 @@
 package wvlet.lang.runner
 
 import wvlet.lang.api.StatusCode
+import wvlet.lang.runner.codec.JDBCCodec
 import wvlet.lang.runner.connector.DBConnector
 import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import scala.collection.immutable.ListMap
 import scala.util.Using
 
 /**
@@ -111,3 +120,102 @@ class FileActivationSink extends ActivationSink with LogSupport:
       None
 
 end FileActivationSink
+
+/**
+  * A built-in sink posting the stage output to an HTTP endpoint:
+  * `activate('webhook', url: 'https://...')`.
+  *
+  * Rows are serialized as a JSON array of objects (`format: 'json'`, the default) or as
+  * newline-delimited JSON (`format: 'ndjson'`) and sent in a single POST request with up to
+  * `max_rows:` rows (1000 by default; a larger result is truncated with a warning). A non-2xx
+  * response or a connection failure fails the stage attempt and follows its regular retry policy
+  */
+class WebhookActivationSink(httpClient: => HttpClient = WebhookActivationSink.defaultHttpClient)
+    extends ActivationSink
+    with LogSupport:
+
+  override def name: String = "webhook"
+
+  override def activate(request: ActivationRequest): Unit =
+    val url = request
+      .params
+      .getOrElse(
+        "url",
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(
+            s"activate('webhook') of stage ${request.stageName} requires a url: parameter"
+          )
+      )
+    val format = request.params.getOrElse("format", "json")
+    if format != "json" && format != "ndjson" then
+      throw StatusCode
+        .INVALID_ARGUMENT
+        .newException(
+          s"activate('webhook') of stage ${request
+              .stageName}: unsupported format '${format}'. Use json or ndjson"
+        )
+    val maxRows = request.params.get("max_rows").map(_.toInt).getOrElse(1000)
+
+    val (rows, truncated) = readRows(request, maxRows)
+    if truncated then
+      warn(
+        s"activate('webhook') of stage ${request
+            .stageName}: sending only the first ${maxRows} rows of ${request.table}"
+      )
+    val (contentType, body) =
+      format match
+        case "ndjson" =>
+          ("application/x-ndjson", rows.mkString("", "\n", "\n"))
+        case _ =>
+          ("application/json", rows.mkString("[", ",", "]"))
+
+    info(
+      s"Posting ${rows.size} row(s) of stage ${request.stageName} output ${request.table} to ${url}"
+    )
+    val httpRequest = HttpRequest
+      .newBuilder(URI.create(url))
+      .timeout(Duration.ofSeconds(30))
+      .header("Content-Type", contentType)
+      .POST(HttpRequest.BodyPublishers.ofString(body))
+      .build()
+    val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+    if response.statusCode() < 200 || response.statusCode() >= 300 then
+      throw StatusCode
+        .ACTIVATION_FAILED
+        .newException(
+          s"activate('webhook') of stage ${request
+              .stageName}: ${url} responded with status ${response.statusCode()}"
+        )
+
+  end activate
+
+  /** Read up to maxRows rows of the stage table as JSON objects, reporting truncation */
+  private def readRows(request: ActivationRequest, maxRows: Int): (List[String], Boolean) =
+    val rowCodec = summon[Weaver[ListMap[String, Any]]]
+    request
+      .connector
+      .withSession { conn =>
+        Using.resource(conn.createStatement()) { stmt =>
+          Using.resource(
+            // Read one extra row to detect truncation
+            stmt.executeQuery(s"""select * from "${request.table}" limit ${maxRows + 1}""")
+          ) { rs =>
+            val codec = JDBCCodec(rs)
+            val it = codec.mapMsgPackMapRows(msgpack => rowCodec.toJson(rowCodec.unweave(msgpack)))
+            val rows = it.take(maxRows + 1).toList
+            if rows.size > maxRows then
+              (rows.take(maxRows), true)
+            else
+              (rows, false)
+          }
+        }
+      }
+
+end WebhookActivationSink
+
+object WebhookActivationSink:
+  private lazy val defaultHttpClient: HttpClient = HttpClient
+    .newBuilder()
+    .connectTimeout(Duration.ofSeconds(10))
+    .build()

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -973,8 +973,15 @@ class FlowExecutor(
 end FlowExecutor
 
 object FlowExecutor:
-  /** The activation sinks available by default: local file export via `activate('file', ...)` */
-  def defaultActivationSinks: List[ActivationSink] = List(FileActivationSink())
+  /**
+    * The activation sinks available by default: sinks registered via the Java ServiceLoader
+    * (`META-INF/services/wvlet.lang.runner.ActivationSink`) followed by the built-in file export
+    * and webhook sinks. ServiceLoader sinks come first, so external modules can override a built-in
+    * target name without touching the executor
+    */
+  def defaultActivationSinks: List[ActivationSink] =
+    val loaded = java.util.ServiceLoader.load(classOf[ActivationSink]).iterator().asScala.toList
+    loaded ++ List(FileActivationSink(), WebhookActivationSink())
 
   /** The run-scoped table name holding the materialized result of a stage */
   def stageTableName(runId: String, stageName: String): String =

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -1035,6 +1035,90 @@ class FlowExecutorTest extends UniTest:
     lines.get(0) shouldBe "id,name"
   }
 
+  /** Start a local HTTP server for webhook tests, passing its port to the body */
+  private def withHttpServer(status: Int, received: ListBuffer[(String, String)])(
+      body: Int => Unit
+  ): Unit =
+    val server = com
+      .sun
+      .net
+      .httpserver
+      .HttpServer
+      .create(java.net.InetSocketAddress("localhost", 0), 0)
+    server.createContext(
+      "/hook",
+      exchange =>
+        val requestBody = String(
+          exchange.getRequestBody.readAllBytes(),
+          java.nio.charset.StandardCharsets.UTF_8
+        )
+        received.synchronized {
+          received += exchange.getRequestHeaders.getFirst("Content-Type") -> requestBody
+        }
+        exchange.sendResponseHeaders(status, -1)
+        exchange.close()
+    )
+    server.start()
+    try body(server.getAddress.getPort)
+    finally server.stop(0)
+
+  test("post activated stage outputs to a webhook as a JSON array") {
+    val received = ListBuffer.empty[(String, String)]
+    withHttpServer(status = 200, received) { port =>
+      val result = runFlow(s"""flow WebhookFlow = {
+          |  stage src = from [[1, 'a'], [2, 'b']] as t(id, name)
+          |  stage send = from src | activate('webhook', url: 'http://localhost:${port}/hook')
+          |}""".stripMargin)
+      result.isSuccess shouldBe true
+      received.size shouldBe 1
+      val (contentType, body) = received.head
+      contentType shouldBe "application/json"
+      body shouldContain "\"id\":1"
+      body shouldContain "\"name\":\"a\""
+      body shouldContain "\"id\":2"
+      body.startsWith("[") shouldBe true
+      body.endsWith("]") shouldBe true
+    }
+  }
+
+  test("post newline-delimited rows to a webhook with the ndjson format") {
+    val received = ListBuffer.empty[(String, String)]
+    withHttpServer(status = 200, received) { port =>
+      val result = runFlow(s"""flow NdjsonWebhookFlow = {
+          |  stage src = from [[1], [2], [3]] as t(id)
+          |  stage send = from src |
+          |    activate('webhook', url: 'http://localhost:${port}/hook', format: 'ndjson', max_rows: 2)
+          |}""".stripMargin)
+      result.isSuccess shouldBe true
+      val (contentType, body) = received.head
+      contentType shouldBe "application/x-ndjson"
+      // max_rows bounds the batch: only the first two rows are delivered
+      body.trim.linesIterator.size shouldBe 2
+    }
+  }
+
+  test("fail the stage when the webhook responds with an error status") {
+    val received = ListBuffer.empty[(String, String)]
+    withHttpServer(status = 500, received) { port =>
+      val result = runFlow(s"""flow BrokenWebhookFlow = {
+          |  stage send = from [[1]] as t(id) |
+          |    activate('webhook', url: 'http://localhost:${port}/hook')
+          |}""".stripMargin)
+      result.isSuccess shouldBe false
+      val send = result.stageResult("send").get
+      send.state shouldBe StageState.Failed
+      send.error.get.getMessage shouldContain "status 500"
+    }
+  }
+
+  test("require a url parameter for the webhook sink") {
+    val result = runFlow("""flow UrllessWebhookFlow = {
+        |  stage send = from [[1]] as t(id) | activate('webhook')
+        |}""".stripMargin)
+    result.isSuccess shouldBe false
+    result.stageResult("send").get.error.get.getMessage shouldContain "requires a url"
+  }
+
   test("fail and retry a stage whose activation sink fails") {
     var calls = 0
     val sink  =


### PR DESCRIPTION
## Summary

Part of #1833 (item 3: more activation sinks on the SPI).

- **Webhook sink**: `activate('webhook', url: 'https://...')` posts the materialized stage rows to an HTTP endpoint in a single POST. Rows are serialized as a JSON array of objects (default) or newline-delimited JSON (`format: 'ndjson'`), reusing the existing `JDBCCodec`/`Weaver` row-to-JSON path. The batch is bounded by `max_rows:` (default 1000) — truncation is logged, never silent. A non-2xx response or connection failure throws the new `StatusCode.ACTIVATION_FAILED`, failing the attempt and following the stage's regular retry policy. Timeouts: 10s connect / 30s request.
- **ServiceLoader discovery**: `FlowExecutor.defaultActivationSinks` now loads sinks registered under `META-INF/services/wvlet.lang.runner.ActivationSink` ahead of the built-in file and webhook sinks. Sink matching is first-wins, so external modules can override a built-in target name without touching the executor.

## Testing

- `FlowExecutorTest` (against a local JDK `HttpServer`): JSON-array delivery with content-type and row content asserted, ndjson format with `max_rows` truncation, 500 response failing the stage with the status in the error, and missing `url:` reported as a clear argument error — 54 tests green
- Full `runner` suite and `projectJVM/Test/compile` green; `projectJS/Test/compile` verified for the shared `StatusCode` change
- Docs: activation section of `flow.md` updated with the webhook sink and ServiceLoader registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)