### PR TITLE
internal: Index top-level symbols per package for global symbol lookup

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
@@ -124,6 +124,10 @@ case class CompilationUnit(sourceFile: SourceFile, isPreset: Boolean = false)
     // Extract the text in the span range
     sourceFile.getContent.slice(span.start, span.end).mkString
 
+  /**
+    * Record a top-level symbol of this unit. Use [[Context.enterGlobalSymbol]] instead when a
+    * Context is available, so the symbol is also registered to the global symbol index
+    */
   def enter(symbol: Symbol): Unit = knownSymbols = symbol :: knownSymbols
 
   def toSourceLocation(nodeLocation: LinePosition) =

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
@@ -128,7 +128,7 @@ case class CompilationUnit(sourceFile: SourceFile, isPreset: Boolean = false)
     * Record a top-level symbol of this unit. Use [[Context.enterGlobalSymbol]] instead when a
     * Context is available, so the symbol is also registered to the global symbol index
     */
-  def enter(symbol: Symbol): Unit = knownSymbols = symbol :: knownSymbols
+  private[compiler] def enter(symbol: Symbol): Unit = knownSymbols = symbol :: knownSymbols
 
   def toSourceLocation(nodeLocation: LinePosition) =
     val codeLineAt: String = nodeLocation

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
@@ -207,6 +207,9 @@ class Compiler(
     var refinedUnits = units.map { unit =>
       if unit.needsRecompile then
         trace(s"Reloading ${unit.sourceFile.fileName} for recompilation")
+        // Drop the unit's symbols from the global index before its known symbols are reset;
+        // re-labeling the reloaded unit will index the new definitions
+        globalContext.symbolIndex.remove(unit)
         unit.reload()
       else
         unit

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
@@ -207,12 +207,17 @@ class Compiler(
     var refinedUnits = units.map { unit =>
       if unit.needsRecompile then
         trace(s"Reloading ${unit.sourceFile.fileName} for recompilation")
-        // Drop the unit's symbols from the global index before its known symbols are reset;
-        // re-labeling the reloaded unit will index the new definitions
-        globalContext.symbolIndex.remove(unit)
         unit.reload()
       else
         unit
+    }
+    // Register a context for every unit up front, which also indexes the known symbols of
+    // units labeled in a previous compilation run (e.g., preset standard library units shared
+    // between compilers), independently of which phases run on them. Units whose known symbols
+    // changed since their registration snapshot (or were reset by a reload) are re-synced
+    refinedUnits.foreach { unit =>
+      globalContext.getContextOf(unit)
+      globalContext.symbolIndex.refresh(unit)
     }
     for
       phaseGroup <- phases

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -28,7 +28,6 @@ import wvlet.lang.model.plan.Import
 import wvlet.uni.log.LogSupport
 
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicReference
 import scala.jdk.CollectionConverters.*
 
 /**
@@ -69,22 +68,9 @@ case class GlobalContext(compilerOptions: CompilerOptions):
   def addDuplicateDefinition(name: Name, fileNames: List[String]): Unit = duplicateDefinitionQueue
     .add(name -> fileNames)
 
-  // Contexts sorted by source file name, cached until a new compilation unit is loaded, so
-  // that global symbol lookup stays fast while scanning units in a deterministic order
-  private val sortedContextCache = AtomicReference[(Int, List[Context])]((0, Nil))
-
-  def getAllContextsSorted: List[Context] =
-    val cached = sortedContextCache.get()
-    if cached._1 == contextTable.size then
-      cached._2
-    else
-      // Key the cache by the size of the snapshot that was actually sorted, so a concurrent
-      // insertion between reading the size and copying the values cannot leave the cache
-      // permanently inconsistent
-      val snapshot = contextTable.values.toList
-      val sorted   = snapshot.sortBy(_.compilationUnit.sourceFile.fileName)
-      sortedContextCache.set((snapshot.size, sorted))
-      sorted
+  // Package-level index of the top-level symbols of all compilation units, used for global
+  // symbol lookup without scanning every unit (issue #1811)
+  val symbolIndex = GlobalSymbolIndex()
 
   // Globally available definitions (Name and Symbols)
   var defs: GlobalDefinitions = scala.compiletime.uninitialized
@@ -121,7 +107,14 @@ case class GlobalContext(compilerOptions: CompilerOptions):
     * @return
     */
   def getContextOf(unit: CompilationUnit, scope: Scope = Scope.NoScope): Context = contextTable
-    .getOrElseUpdate(unit.sourceFile, Context(global = this, scope = scope, compilationUnit = unit))
+    .getOrElseUpdate(
+      unit.sourceFile, {
+        // The unit may already have been labeled in a previous compilation run (e.g., preset
+        // standard library units shared between compilers), so index its known symbols
+        symbolIndex.addAll(unit)
+        Context(global = this, scope = scope, compilationUnit = unit)
+      }
+    )
 
   def getAllContexts: List[Context]                 = contextTable.values.toList
   def getAllCompilationUnits: List[CompilationUnit] = getAllContexts
@@ -245,6 +238,14 @@ case class Context(
 
   def enter(sym: Symbol): Unit = scope.enter(sym)(using this)
 
+  /**
+    * Register a top-level symbol of the current compilation unit, making it visible to global
+    * symbol lookup from other compilation units
+    */
+  def enterGlobalSymbol(sym: Symbol): Unit =
+    compilationUnit.enter(sym)
+    global.symbolIndex.add(compilationUnit, sym)
+
   def newContext(owner: Symbol): Context = Context(
     global = global,
     outer = this,
@@ -263,65 +264,29 @@ case class Context(
     // Search the current scope first
     var foundSymbol: Option[Symbol] = scope.lookupSymbol(name)
 
-    // Search the imported symbols
-    if foundSymbol.isEmpty then
-      importDefs.collectFirst {
-        case i: Import if i.importRef.leafName == name.name =>
-          for
-            ctx <- global.getAllContexts
-            if foundSymbol.isEmpty
-          do
-            ctx
-              .compilationUnit
-              .knownSymbols
-              .collectFirst {
-                case s: Symbol if s.name == name =>
-                  foundSymbol = Some(s)
-              }
-      }
+    // A name explicitly imported (e.g., import mypkg.model1) resolves across all packages
+    if foundSymbol.isEmpty && importDefs.exists(_.importRef.leafName == name.name) then
+      foundSymbol = global.symbolIndex.findFirstAnywhere(name).map(_.symbol)
 
     if foundSymbol.isEmpty then
-      // Search global symbols. Contexts are scanned in source file name order so that a name
-      // defined in multiple files resolves deterministically, and units in a named package are
-      // visible only within that package or through an import (#93). Preset (standard library)
-      // units and units without a package declaration stay globally visible
-      val currentPackage = compilationUnit.packageName
-      // Import references are materialized once per lookup; most units have no imports
-      val importRefs                                    = importDefs.map(_.importRef.fullName)
-      def isVisibleUnit(unit: CompilationUnit): Boolean =
-        val pkg = unit.packageName
-        pkg.isEmpty || pkg == currentPackage || unit.isPreset || {
-          // Build the package prefix once per unit, not per import reference
-          val pkgPrefix = s"${pkg}."
-          importRefs.exists(ref => ref == pkg || ref.startsWith(pkgPrefix))
-        }
-      for
-        ctx <- global.getAllContextsSorted
-        if foundSymbol.isEmpty && ctx.isGlobalContext && isVisibleUnit(ctx.compilationUnit)
-      do
-        foundSymbol = ctx.compilationUnit.knownSymbols.find(_.name == name)
+      // Search the global symbols visible from this unit's package (#93). The index returns
+      // the definitions in source file name order so that a name defined in multiple files
+      // resolves deterministically
+      val entries = global
+        .symbolIndex
+        .visibleEntries(name, compilationUnit.packageName, importDefs.map(_.importRef.fullName))
+      foundSymbol = entries.headOption.map(_.symbol)
       // A top-level name defined in multiple files still shadows the later definitions
       // (#93). Warn once per name
-      foundSymbol.foreach { sym =>
-        if global.needsDuplicateCheck(name) then
-          val definingFiles =
-            (
-              for
-                ctx <- global.getAllContextsSorted
-                if ctx.isGlobalContext && isVisibleUnit(ctx.compilationUnit)
-                s <- ctx.compilationUnit.knownSymbols
-                if s.name == name
-              yield ctx.compilationUnit.sourceFile.fileName
-            ).distinct
-          if definingFiles.size > 1 then
-            global.addDuplicateDefinition(name, definingFiles)
-            warn(
-              s"Duplicate top-level definition of '${name}' in ${definingFiles.mkString(
-                  ", "
-                )}; the definition in ${definingFiles.head} is used"
-            )
-      }
-    end if
+      if foundSymbol.isDefined && global.needsDuplicateCheck(name) then
+        val definingFiles = entries.map(_.fileName).distinct
+        if definingFiles.size > 1 then
+          global.addDuplicateDefinition(name, definingFiles)
+          warn(
+            s"Duplicate top-level definition of '${name}' in ${definingFiles.mkString(
+                ", "
+              )}; the definition in ${definingFiles.head} is used"
+          )
 
     if isContextCompilationUnit then
       trace(s"Looked up ${name} in ${compilationUnit.sourceFile.fileName} => ${foundSymbol}")

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -106,15 +106,22 @@ case class GlobalContext(compilerOptions: CompilerOptions):
     * @param scope
     * @return
     */
-  def getContextOf(unit: CompilationUnit, scope: Scope = Scope.NoScope): Context = contextTable
-    .getOrElseUpdate(
-      unit.sourceFile, {
-        // The unit may already have been labeled in a previous compilation run (e.g., preset
-        // standard library units shared between compilers), so index its known symbols
-        symbolIndex.addAll(unit)
-        Context(global = this, scope = scope, compilationUnit = unit)
-      }
-    )
+  def getContextOf(unit: CompilationUnit, scope: Scope = Scope.NoScope): Context =
+    contextTable.get(unit.sourceFile) match
+      case Some(ctx) =>
+        ctx
+      case None =>
+        val created = Context(global = this, scope = scope, compilationUnit = unit)
+        contextTable.putIfAbsent(unit.sourceFile, created) match
+          case None =>
+            // The unit may already have been labeled in a previous compilation run (e.g.,
+            // preset standard library units shared between compilers), so index its known
+            // symbols. Registering after winning putIfAbsent seeds the index exactly once
+            // even when multiple threads request the context concurrently
+            symbolIndex.addAll(unit)
+            created
+          case Some(existing) =>
+            existing
 
   def getAllContexts: List[Context]                 = contextTable.values.toList
   def getAllCompilationUnits: List[CompilationUnit] = getAllContexts
@@ -240,7 +247,8 @@ case class Context(
 
   /**
     * Register a top-level symbol of the current compilation unit, making it visible to global
-    * symbol lookup from other compilation units
+    * symbol lookup from other compilation units. The symbol's name must already be recorded (via
+    * its SymbolInfo or completer), since the global index is keyed by name at registration time
     */
   def enterGlobalSymbol(sym: Symbol): Unit =
     compilationUnit.enter(sym)
@@ -264,10 +272,6 @@ case class Context(
     // Search the current scope first
     var foundSymbol: Option[Symbol] = scope.lookupSymbol(name)
 
-    // A name explicitly imported (e.g., import mypkg.model1) resolves across all packages
-    if foundSymbol.isEmpty && importDefs.exists(_.importRef.leafName == name.name) then
-      foundSymbol = global.symbolIndex.findFirstAnywhere(name).map(_.symbol)
-
     if foundSymbol.isEmpty then
       // Search the global symbols visible from this unit's package (#93). The index returns
       // the definitions in source file name order so that a name defined in multiple files
@@ -287,6 +291,11 @@ case class Context(
                 ", "
               )}; the definition in ${definingFiles.head} is used"
           )
+
+    // As a last resort, a name imported by its own name (e.g., import model1) still resolves
+    // across all packages, regardless of package visibility
+    if foundSymbol.isEmpty && importDefs.exists(_.importRef.leafName == name.name) then
+      foundSymbol = global.symbolIndex.findFirstAnywhere(name).map(_.symbol)
 
     if isContextCompilationUnit then
       trace(s"Looked up ${name} in ${compilationUnit.sourceFile.fileName} => ${foundSymbol}")

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/GlobalSymbolIndex.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/GlobalSymbolIndex.scala
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters.*
+
+object GlobalSymbolIndex:
+  /**
+    * A top-level definition of a name: the compilation unit that defines it and its symbol
+    * @param unit
+    * @param symbol
+    */
+  case class Entry(unit: CompilationUnit, symbol: Symbol):
+    def fileName: String = unit.sourceFile.fileName
+
+/**
+  * A package-level index of the top-level symbols of all compilation units, following the
+  * package-denotation design of the Scala 3 compiler (issue #1811).
+  *
+  * Non-preset units are grouped by their package name (an empty string is the shared default
+  * package), while preset (standard library) units are indexed separately because they are visible
+  * from every package. Looking up a name consults only the buckets of the packages visible from the
+  * current unit (preset, default package, the unit's own package, and imported packages) instead of
+  * scanning the known symbols of every compilation unit.
+  */
+class GlobalSymbolIndex:
+  import GlobalSymbolIndex.*
+
+  /**
+    * Index of the top-level names defined in one package. The entries of each name are ordered by
+    * the defining source file name (newest definition first within the same unit) so that a name
+    * defined in multiple files resolves deterministically, regardless of the compilation order
+    */
+  private class PackageIndex:
+    val members = new ConcurrentHashMap[Name, List[Entry]]()
+
+    def add(entry: Entry): Unit = members.compute(
+      entry.symbol.name,
+      (_, current) =>
+        val entries = Option(current).getOrElse(Nil)
+        // Insert ordered by file name. A new entry of an already-indexed unit is placed before
+        // the unit's existing entries, so the most recent definition in a unit wins, matching
+        // the newest-first order of CompilationUnit.knownSymbols
+        val (before, after) = entries.span(_.fileName < entry.fileName)
+        before ::: entry :: after
+    )
+
+    def get(name: Name): List[Entry] = Option(members.get(name)).getOrElse(Nil)
+
+    def removeUnit(unit: CompilationUnit): Unit = members
+      .keySet()
+      .asScala
+      .foreach { name =>
+        members.computeIfPresent(
+          name,
+          (_, entries) =>
+            entries.filterNot(_.unit eq unit) match
+              case Nil =>
+                null
+              case remaining =>
+                remaining
+        )
+      }
+
+  end PackageIndex
+
+  // Top-level symbols of non-preset units, grouped by package name
+  private val packageIndexes = new ConcurrentHashMap[String, PackageIndex]()
+  // Top-level symbols of preset (standard library) units, visible from every package
+  private val presetIndex = PackageIndex()
+
+  private def indexOf(unit: CompilationUnit): PackageIndex =
+    if unit.isPreset then
+      presetIndex
+    else
+      packageIndexes.computeIfAbsent(unit.packageName, _ => PackageIndex())
+
+  /**
+    * Register a top-level symbol of the given compilation unit. Symbols without a name (e.g.,
+    * anonymous command statements) are kept only in the unit's knownSymbols since they can never be
+    * found by name
+    */
+  def add(unit: CompilationUnit, symbol: Symbol): Unit =
+    if !symbol.name.isEmpty then
+      indexOf(unit).add(Entry(unit, symbol))
+
+  /**
+    * Register all known symbols of a unit that was already labeled in a previous compilation run
+    * (e.g., preset standard library units shared between compilers). The symbols are indexed in
+    * their original entry order
+    */
+  def addAll(unit: CompilationUnit): Unit =
+    if unit.knownSymbols.nonEmpty then
+      val index = indexOf(unit)
+      // knownSymbols is newest-first, so replay the entries in chronological order
+      unit
+        .knownSymbols
+        .reverseIterator
+        .foreach { symbol =>
+          if !symbol.name.isEmpty then
+            index.add(Entry(unit, symbol))
+        }
+
+  /**
+    * Remove all symbols of the given unit from the index, e.g., before the unit is reloaded for
+    * recompilation
+    */
+  def remove(unit: CompilationUnit): Unit =
+    presetIndex.removeUnit(unit)
+    packageIndexes.values().asScala.foreach(_.removeUnit(unit))
+
+  /**
+    * All definitions of the given name that are visible from a unit in `currentPackage` with the
+    * given import references, ordered by the defining source file name. Preset units and units in
+    * the default package are always visible; other units are visible only from the same package or
+    * through an import of the package or one of its members (#93)
+    */
+  def visibleEntries(name: Name, currentPackage: String, importRefs: List[String]): List[Entry] =
+    val visiblePackages = List.newBuilder[String]
+    visiblePackages += ""
+    if currentPackage.nonEmpty then
+      visiblePackages += currentPackage
+    // An import of a package or one of its members (e.g., import a.b.c) makes the package and
+    // all of its enclosing packages (a.b.c, a.b, a) visible
+    importRefs.foreach { ref =>
+      visiblePackages += ref
+      var dot = ref.lastIndexOf('.')
+      while dot > 0 do
+        visiblePackages += ref.substring(0, dot)
+        dot = ref.lastIndexOf('.', dot - 1)
+    }
+    val entries = List.newBuilder[Entry]
+    entries ++= presetIndex.get(name)
+    visiblePackages
+      .result()
+      .distinct
+      .foreach { pkg =>
+        Option(packageIndexes.get(pkg)).foreach(index => entries ++= index.get(name))
+      }
+    // Each bucket is already ordered, so a stable sort restores the global file-name order
+    entries.result().sortBy(_.fileName)
+
+  /**
+    * The first definition of the given name across all packages in file-name order, ignoring
+    * package visibility. Used for names explicitly made visible by an import of the name itself
+    */
+  def findFirstAnywhere(name: Name): Option[Entry] =
+    val entries = List.newBuilder[Entry]
+    entries ++= presetIndex.get(name)
+    packageIndexes.values().asScala.foreach(index => entries ++= index.get(name))
+    entries.result().sortBy(_.fileName).headOption
+
+end GlobalSymbolIndex

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/GlobalSymbolIndex.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/GlobalSymbolIndex.scala
@@ -23,7 +23,8 @@ object GlobalSymbolIndex:
     * @param symbol
     */
   case class Entry(unit: CompilationUnit, symbol: Symbol):
-    def fileName: String = unit.sourceFile.fileName
+    // Cached because the file name is the sort key of every lookup
+    val fileName: String = unit.fileName
 
 /**
   * A package-level index of the top-level symbols of all compilation units, following the
@@ -39,22 +40,16 @@ class GlobalSymbolIndex:
   import GlobalSymbolIndex.*
 
   /**
-    * Index of the top-level names defined in one package. The entries of each name are ordered by
-    * the defining source file name (newest definition first within the same unit) so that a name
-    * defined in multiple files resolves deterministically, regardless of the compilation order
+    * Index of the top-level names defined in one package. The entries of each name are kept
+    * newest-first (matching the order of CompilationUnit.knownSymbols); [[sortedByFileName]]
+    * restores the deterministic file-name resolution order on lookup
     */
   private class PackageIndex:
-    val members = new ConcurrentHashMap[Name, List[Entry]]()
+    val members = ConcurrentHashMap[Name, List[Entry]]()
 
     def add(entry: Entry): Unit = members.compute(
       entry.symbol.name,
-      (_, current) =>
-        val entries = Option(current).getOrElse(Nil)
-        // Insert ordered by file name. A new entry of an already-indexed unit is placed before
-        // the unit's existing entries, so the most recent definition in a unit wins, matching
-        // the newest-first order of CompilationUnit.knownSymbols
-        val (before, after) = entries.span(_.fileName < entry.fileName)
-        before ::: entry :: after
+      (_, current) => entry :: Option(current).getOrElse(Nil)
     )
 
     def get(name: Name): List[Entry] = Option(members.get(name)).getOrElse(Nil)
@@ -76,10 +71,20 @@ class GlobalSymbolIndex:
 
   end PackageIndex
 
+  /**
+    * Registration state of one unit: the bucket its symbols were added to (so removal targets the
+    * right bucket even if the unit's package declaration changes), and the knownSymbols list that
+    * was current at registration time (so [[refresh]] can cheaply detect an unchanged unit by
+    * reference, as knownSymbols is an immutable list replaced on every change)
+    */
+  private case class Registration(bucket: PackageIndex, knownSymbols: List[Symbol])
+
   // Top-level symbols of non-preset units, grouped by package name
-  private val packageIndexes = new ConcurrentHashMap[String, PackageIndex]()
+  private val packageIndexes = ConcurrentHashMap[String, PackageIndex]()
   // Top-level symbols of preset (standard library) units, visible from every package
   private val presetIndex = PackageIndex()
+  // The registration state of each indexed unit
+  private val registrations = ConcurrentHashMap[CompilationUnit, Registration]()
 
   private def indexOf(unit: CompilationUnit): PackageIndex =
     if unit.isPreset then
@@ -94,7 +99,9 @@ class GlobalSymbolIndex:
     */
   def add(unit: CompilationUnit, symbol: Symbol): Unit =
     if !symbol.name.isEmpty then
-      indexOf(unit).add(Entry(unit, symbol))
+      val index = indexOf(unit)
+      registrations.put(unit, Registration(index, unit.knownSymbols))
+      index.add(Entry(unit, symbol))
 
   /**
     * Register all known symbols of a unit that was already labeled in a previous compilation run
@@ -102,24 +109,29 @@ class GlobalSymbolIndex:
     * their original entry order
     */
   def addAll(unit: CompilationUnit): Unit =
-    if unit.knownSymbols.nonEmpty then
-      val index = indexOf(unit)
-      // knownSymbols is newest-first, so replay the entries in chronological order
-      unit
-        .knownSymbols
-        .reverseIterator
-        .foreach { symbol =>
-          if !symbol.name.isEmpty then
-            index.add(Entry(unit, symbol))
-        }
+    // knownSymbols is newest-first, so replay the entries in chronological order
+    unit.knownSymbols.reverseIterator.foreach(add(unit, _))
 
   /**
-    * Remove all symbols of the given unit from the index, e.g., before the unit is reloaded for
-    * recompilation
+    * Remove all symbols of the given unit from the index, e.g., when the unit is re-labeled after a
+    * reload
     */
-  def remove(unit: CompilationUnit): Unit =
-    presetIndex.removeUnit(unit)
-    packageIndexes.values().asScala.foreach(_.removeUnit(unit))
+  def remove(unit: CompilationUnit): Unit = Option(registrations.remove(unit)).foreach(
+    _.bucket.removeUnit(unit)
+  )
+
+  /**
+    * Re-index a unit whose known symbols changed since it was registered, e.g., a preset unit
+    * shared between compilers that was labeled after this index took its registration snapshot. A
+    * no-op when the unit's known symbols are unchanged
+    */
+  def refresh(unit: CompilationUnit): Unit =
+    val current = registrations.get(unit)
+    if (current == null && unit.knownSymbols.nonEmpty) ||
+      (current != null && (current.knownSymbols ne unit.knownSymbols))
+    then
+      remove(unit)
+      addAll(unit)
 
   /**
     * All definitions of the given name that are visible from a unit in `currentPackage` with the
@@ -141,25 +153,39 @@ class GlobalSymbolIndex:
         visiblePackages += ref.substring(0, dot)
         dot = ref.lastIndexOf('.', dot - 1)
     }
-    val entries = List.newBuilder[Entry]
-    entries ++= presetIndex.get(name)
-    visiblePackages
+    val visibleIndexes = visiblePackages
       .result()
       .distinct
-      .foreach { pkg =>
-        Option(packageIndexes.get(pkg)).foreach(index => entries ++= index.get(name))
-      }
-    // Each bucket is already ordered, so a stable sort restores the global file-name order
-    entries.result().sortBy(_.fileName)
+      .flatMap(pkg => Option(packageIndexes.get(pkg)))
+    sortedByFileName(entriesIn(name, visibleIndexes))
 
   /**
     * The first definition of the given name across all packages in file-name order, ignoring
     * package visibility. Used for names explicitly made visible by an import of the name itself
     */
-  def findFirstAnywhere(name: Name): Option[Entry] =
+  def findFirstAnywhere(name: Name): Option[Entry] = entriesIn(
+    name,
+    packageIndexes.values().asScala
+  ).minByOption(_.fileName)
+
+  /**
+    * All entries of the given name in the preset index and the given package indexes, in bucket
+    * order (newest definition first within a unit)
+    */
+  private def entriesIn(name: Name, indexes: IterableOnce[PackageIndex]): List[Entry] =
     val entries = List.newBuilder[Entry]
     entries ++= presetIndex.get(name)
-    packageIndexes.values().asScala.foreach(index => entries ++= index.get(name))
-    entries.result().sortBy(_.fileName).headOption
+    indexes.iterator.foreach(index => entries ++= index.get(name))
+    entries.result()
+
+  /**
+    * Order the merged bucket entries by the defining source file name. The sort is stable, so
+    * entries of the same unit stay newest-first
+    */
+  private def sortedByFileName(entries: List[Entry]): List[Entry] =
+    if entries.sizeIs <= 1 then
+      entries
+    else
+      entries.sortBy(_.fileName)
 
 end GlobalSymbolIndex

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Scope.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Scope.scala
@@ -40,6 +40,14 @@ class Scope(outer: Scope | Null, val nestingLevel: Int) extends LogSupport:
     else
       Nil
 
+  // Name-keyed mirror of the entries for O(1) lookup. The immutable map snapshots the outer
+  // scope's map at construction, matching the snapshot semantics of the entries list
+  private var entryMap: Map[Name, ScopeEntry] =
+    if outer != null then
+      outer.entryMap
+    else
+      Map.empty
+
   def isEmpty: Boolean                = entries.isEmpty
   def getAllEntries: List[ScopeEntry] = entries
 
@@ -63,7 +71,7 @@ class Scope(outer: Scope | Null, val nestingLevel: Int) extends LogSupport:
 
   def isNoScope: Boolean = this eq Scope.NoScope
 
-  def lookupEntry(name: Name): Option[ScopeEntry] = entries.find(_.name == name)
+  def lookupEntry(name: Name): Option[ScopeEntry] = entryMap.get(name)
   def lookupSymbol(name: Name): Option[Symbol]    = lookupEntry(name).map(_.symbol)
 
   /**
@@ -92,7 +100,9 @@ class Scope(outer: Scope | Null, val nestingLevel: Int) extends LogSupport:
       throw StatusCode
         .UNEXPECTED_STATE
         .newException(s"Cannot add an entry ${name} -> ${symbol.id} to NoScope")
-    entries = ScopeEntry(name, symbol, this) :: entries
+    val entry = ScopeEntry(name, symbol, this)
+    entries = entry :: entries
+    entryMap = entryMap.updated(name, entry)
     symbol
 
   def newChildScope: Scope = Scope(outer = this, nestingLevel + 1)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
@@ -65,7 +65,6 @@ object SymbolLabeler extends Phase("symbol-labeler"):
       val sym = Symbol(ctx.global.newSymbolId, tree.span)
       tree.symbol = sym
       sym.tree = tree
-      ctx.compilationUnit.enter(sym)
       sym
 
     def iter(tree: LogicalPlan, ctx: Context): Context =
@@ -120,7 +119,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
           )
           v.symbol = sym
           sym.tree = v
-          ctx.compilationUnit.enter(sym)
+          ctx.enterGlobalSymbol(sym)
           ctx
         case s: Save if s.isForTable =>
           iter(s.child, ctx)
@@ -140,6 +139,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
                 TermName.of(s"__query_${sym.id}"),
                 ctx.compilationUnit
               )
+              ctx.enterGlobalSymbol(sym)
               q.traverseOnce {
                 case s: SelectAsAlias =>
                   iter(s.child, ctx)
@@ -150,6 +150,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
               ctx
             case c: Command =>
               val sym = attachNewSymbol(c, ctx)
+              ctx.enterGlobalSymbol(sym)
               ctx
             case _ =>
               ctx
@@ -173,7 +174,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
     )
     t.symbol = sym
     sym.tree = t
-    ctx.compilationUnit.enter(sym)
+    ctx.enterGlobalSymbol(sym)
     sym
 
   /**
@@ -199,7 +200,6 @@ object SymbolLabeler extends Phase("symbol-labeler"):
         s
       case None =>
         val sym = Symbol(ctx.global.newSymbolId, p.span)
-        ctx.compilationUnit.enter(sym)
         sym.tree = p
         sym.symbolInfo = PartialQuerySymbolInfo(
           ctx.owner,
@@ -209,6 +209,8 @@ object SymbolLabeler extends Phase("symbol-labeler"):
           p.body,
           ctx.compilationUnit
         )
+        // Enter after the SymbolInfo assignment so the symbol is indexed with its name
+        ctx.enterGlobalSymbol(sym)
         p.symbol = sym
         trace(s"Created new partial query symbol ${sym} for ${partialQueryName}")
         ctx.scope.add(partialQueryName, sym)
@@ -223,7 +225,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
     sym.symbolInfo = RelationAliasSymbolInfo(ctx.owner, sym, aliasName, ctx.compilationUnit)
     s.symbol = sym
     sym.tree = s.child
-    ctx.compilationUnit.enter(sym)
+    ctx.enterGlobalSymbol(sym)
     sym
 
   private def registerSave(s: Save)(using ctx: Context): Symbol =
@@ -232,7 +234,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
     sym.symbolInfo = SavedRelationSymbolInfo(ctx.owner, sym, targetName, ctx.compilationUnit)
     s.symbol = sym
     sym.tree = s.child
-    ctx.compilationUnit.enter(sym)
+    ctx.enterGlobalSymbol(sym)
     sym
 
   private def registerPackageSymbol(pkgName: NameExpr)(using ctx: Context): Symbol =
@@ -261,7 +263,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
             Scope.newScope(0)
           )
           sym.symbolInfo = pkgSymInfo
-          ctx.compilationUnit.enter(sym)
+          ctx.enterGlobalSymbol(sym)
           // pkgOwner.symbolInfo.declScope.add(pkgLeafName, sym)
           trace(s"Created package symbol for ${pkgName.fullName}, owner ${pkgOwner}")
           pkgOwner.symbolInfo.declScope.add(pkgLeafName, sym)
@@ -342,13 +344,14 @@ object SymbolLabeler extends Phase("symbol-labeler"):
         // Create a new type symbol. Method registration, field parsing, and parent-type
         // resolution are deferred to a completer, so a parent type defined in another
         // compilation unit resolves once all units are labeled, independent of unit order
-        val sym = TypeSymbol(ctx.global.newSymbolId, t.span, ctx.compilationUnit.sourceFile)
-        ctx.compilationUnit.enter(sym)
+        val sym       = TypeSymbol(ctx.global.newSymbolId, t.span, ctx.compilationUnit.sourceFile)
         val typeCtx   = ctx.newContext(sym)
         val typeScope = typeCtx.scope
         sym.setTypeScope(typeScope)
         sym.setCompleter(typeName, s => computeTypeDefSymbolInfo(t, s, typeScope)(using ctx))
         sym.tree = t
+        // Enter after the completer installation so the symbol is indexed with its name
+        ctx.enterGlobalSymbol(sym)
 
         t.symbol = sym
         ctx.scope.add(typeName, sym)
@@ -464,9 +467,9 @@ object SymbolLabeler extends Phase("symbol-labeler"):
         s
       case None =>
         val sym = Symbol(ctx.global.newSymbolId, f.span)
-        ctx.compilationUnit.enter(sym)
         sym.tree = f
         installSymbolInfo(sym)
+        ctx.enterGlobalSymbol(sym)
         f.symbol = sym
         trace(s"Created a new flow symbol ${sym}")
         ctx.scope.add(flowName, sym)
@@ -499,9 +502,9 @@ object SymbolLabeler extends Phase("symbol-labeler"):
         s
       case None =>
         val sym = Symbol(ctx.global.newSymbolId, m.span)
-        ctx.compilationUnit.enter(sym)
         sym.tree = m
         installSymbolInfo(sym)
+        ctx.enterGlobalSymbol(sym)
         m.symbol = sym
         trace(s"Created a new model symbol ${sym}")
         ctx.scope.add(modelName, sym)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
@@ -54,6 +54,9 @@ import wvlet.lang.model.Type
   */
 object SymbolLabeler extends Phase("symbol-labeler"):
   override def run(unit: CompilationUnit, context: Context): CompilationUnit =
+    // Drop any symbols of a previous compilation of this unit (e.g., after a reload) from the
+    // global index before the re-labeling below registers the new definitions
+    context.global.symbolIndex.remove(unit)
     label(unit.unresolvedPlan, context)
     unit
 
@@ -185,7 +188,8 @@ object SymbolLabeler extends Phase("symbol-labeler"):
     val partialQueryName = p.name
     ctx.scope.lookupSymbol(partialQueryName) match
       case Some(s) =>
-        // Update existing symbol (for REPL)
+        // Update the existing symbol (for REPL), and re-enter it so the re-labeled unit stays
+        // visible to global symbol lookup
         s.tree = p
         s.symbolInfo = PartialQuerySymbolInfo(
           ctx.owner,
@@ -195,6 +199,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
           p.body,
           ctx.compilationUnit
         )
+        ctx.enterGlobalSymbol(s)
         p.symbol = s
         trace(s"Updated existing partial query symbol ${s} for ${partialQueryName}")
         s
@@ -459,9 +464,11 @@ object SymbolLabeler extends Phase("symbol-labeler"):
 
     ctx.scope.lookupSymbol(flowName) match
       case Some(s) =>
-        // Update the existing flow symbol to avoid duplicates in REPL
+        // Update the existing flow symbol to avoid duplicates in REPL, and re-enter it so the
+        // re-labeled unit stays visible to global symbol lookup
         s.tree = f
         installSymbolInfo(s)
+        ctx.enterGlobalSymbol(s)
         f.symbol = s
         trace(s"Updated existing flow symbol ${s} for ${flowName}")
         s
@@ -494,9 +501,12 @@ object SymbolLabeler extends Phase("symbol-labeler"):
 
     ctx.scope.lookupSymbol(modelName) match
       case Some(s) =>
-        // Update the existing model symbol to avoid duplicates in REPL
+        // Update the existing model symbol to avoid duplicates in REPL, and re-enter it so
+        // the re-labeled unit (whose known symbols were reset on reload) stays visible to
+        // global symbol lookup
         s.tree = m
         installSymbolInfo(s)
+        ctx.enterGlobalSymbol(s)
         m.symbol = s
         trace(s"Updated existing model symbol ${s} for ${modelName}")
         s

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -464,14 +464,6 @@ object GenSQL extends Phase("generate-sql"):
   private def lookupType(name: Name, ctx: Context): Option[Symbol] = ctx
     .scope
     .lookupSymbol(name)
-    .orElse {
-      var result: Option[Symbol] = None
-      for
-        c <- ctx.global.getAllContexts
-        if result.isEmpty
-      do
-        result = c.compilationUnit.knownSymbols.find(_.name == name)
-      result
-    }
+    .orElse(ctx.global.symbolIndex.findFirstAnywhere(name).map(_.symbol))
 
 end GenSQL

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -110,6 +110,13 @@ object TyperRules:
         w.tpe = ctx.inputType
       w
 
+    case id: Identifier if id.symbol.isDefined && id.symbol.name == id.toTermName =>
+      // The identifier was already resolved in a previous typing pass, so reuse the attached
+      // symbol instead of walking the scopes again (issue #1811). The name guard skips symbols
+      // attached for other purposes (e.g., a type name resolved by the symbol labeler)
+      id.tpe = id.symbol.dataType
+      id
+
     case id: Identifier =>
       // Look up symbol from scope, imports, and global scope
       ctx.findSymbolByName(id.toTermName) match

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperRules.scala
@@ -110,15 +110,10 @@ object TyperRules:
         w.tpe = ctx.inputType
       w
 
-    case id: Identifier if id.symbol.isDefined && id.symbol.name == id.toTermName =>
-      // The identifier was already resolved in a previous typing pass, so reuse the attached
-      // symbol instead of walking the scopes again (issue #1811). The name guard skips symbols
-      // attached for other purposes (e.g., a type name resolved by the symbol labeler)
-      id.tpe = id.symbol.dataType
-      id
-
     case id: Identifier =>
-      // Look up symbol from scope, imports, and global scope
+      // Look up symbol from scope, imports, and global scope. The lookup runs on every typing
+      // pass on purpose: a later pass may see a scope-local definition (e.g., a relation alias
+      // entered during typing) that must shadow a previously attached global symbol
       ctx.findSymbolByName(id.toTermName) match
         case Some(sym) =>
           id.symbol = sym // Attach symbol for named reference

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/GlobalSymbolIndexTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/GlobalSymbolIndexTest.scala
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler
+
+import wvlet.lang.api.Span.NoSpan
+import wvlet.uni.test.UniTest
+
+class GlobalSymbolIndexTest extends UniTest:
+
+  private def newUnit(fileName: String): CompilationUnit = CompilationUnit(
+    SourceFile.fromString(fileName, "")
+  )
+
+  private def newSymbol(id: Int, name: String): Symbol =
+    val sym = Symbol(id, NoSpan)
+    // Install a completer so that the name is recorded eagerly without computing a SymbolInfo
+    sym.setCompleter(Name.termName(name), _ => NoSymbolInfo)
+    sym
+
+  test("order definitions of a name by the defining file name") {
+    val index = GlobalSymbolIndex()
+    val unitB = newUnit("b.wv")
+    val unitA = newUnit("a.wv")
+    val symB  = newSymbol(1, "m1")
+    val symA  = newSymbol(2, "m1")
+    index.add(unitB, symB)
+    index.add(unitA, symA)
+
+    val entries = index.visibleEntries(Name.termName("m1"), currentPackage = "", importRefs = Nil)
+    entries.map(_.fileName) shouldBe List("a.wv", "b.wv")
+    entries.head.symbol shouldBe symA
+  }
+
+  test("prefer the most recent definition within the same unit") {
+    val index = GlobalSymbolIndex()
+    val unit  = newUnit("a.wv")
+    val sym1  = newSymbol(1, "m1")
+    val sym2  = newSymbol(2, "m1")
+    index.add(unit, sym1)
+    index.add(unit, sym2)
+
+    val entries = index.visibleEntries(Name.termName("m1"), currentPackage = "", importRefs = Nil)
+    entries.map(_.symbol) shouldBe List(sym2, sym1)
+  }
+
+  test("skip symbols without a name") {
+    val index   = GlobalSymbolIndex()
+    val unit    = newUnit("a.wv")
+    val unnamed = Symbol(1, NoSpan)
+    index.add(unit, unnamed)
+    index.findFirstAnywhere(Name.NoName) shouldBe None
+  }
+
+  test("keep preset symbols visible from every package") {
+    val index      = GlobalSymbolIndex()
+    val presetUnit = CompilationUnit(SourceFile.fromString("stdlib.wv", ""), isPreset = true)
+    val sym        = newSymbol(1, "count_all")
+    index.add(presetUnit, sym)
+
+    index
+      .visibleEntries(Name.termName("count_all"), currentPackage = "mypkg", importRefs = Nil)
+      .map(_.symbol) shouldBe List(sym)
+  }
+
+  test("remove all symbols of a reloaded unit") {
+    val index = GlobalSymbolIndex()
+    val unitA = newUnit("a.wv")
+    val unitB = newUnit("b.wv")
+    index.add(unitA, newSymbol(1, "m1"))
+    index.add(unitA, newSymbol(2, "m2"))
+    index.add(unitB, newSymbol(3, "m1"))
+
+    index.remove(unitA)
+
+    index
+      .visibleEntries(Name.termName("m1"), currentPackage = "", importRefs = Nil)
+      .map(_.fileName) shouldBe List("b.wv")
+    index.visibleEntries(Name.termName("m2"), currentPackage = "", importRefs = Nil) shouldBe Nil
+  }
+
+  test("replay the known symbols of an already-labeled unit in their entry order") {
+    val index = GlobalSymbolIndex()
+    val unit  = newUnit("a.wv")
+    val sym1  = newSymbol(1, "m1")
+    val sym2  = newSymbol(2, "m1")
+    unit.enter(sym1)
+    unit.enter(sym2)
+
+    index.addAll(unit)
+
+    val entries = index.visibleEntries(Name.termName("m1"), currentPackage = "", importRefs = Nil)
+    // knownSymbols is newest-first, and the replay must preserve that precedence
+    entries.map(_.symbol) shouldBe List(sym2, sym1)
+  }
+
+  test("resolve names across packages only through the package or a member import") {
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+
+    val pkgUnit = CompilationUnit(
+      SourceFile.fromString(
+        "pkg_models.wv",
+        """package mypkg1
+          |model pm1 = {
+          |  from [[1]] as t(id) select id
+          |}
+          |""".stripMargin
+      )
+    )
+    val importingUnit = CompilationUnit(
+      SourceFile.fromString(
+        "importing.wv",
+        """import mypkg1.*
+          |
+          |model imported_ref = {
+          |  from pm1
+          |}
+          |""".stripMargin
+      )
+    )
+    val queryUnit = CompilationUnit.fromWvletString("from imported_ref\n")
+
+    val result = compiler.compileMultipleUnits(List(pkgUnit, importingUnit), queryUnit)
+    result.hasFailures shouldBe false
+
+    // The importing unit compiles because pm1 is visible through the import of mypkg1
+    val importedRef = result.context.findSymbolByName(Name.termName("imported_ref"))
+    importedRef.isDefined shouldBe true
+
+    // The root context has no imports and belongs to the default package, so the packaged
+    // model must stay invisible from it
+    result.context.findSymbolByName(Name.termName("pm1")) shouldBe None
+
+    // Package visibility rules of the index itself
+    val index = result.context.global.symbolIndex
+    val pm1   = Name.termName("pm1")
+    index.visibleEntries(pm1, currentPackage = "", importRefs = Nil) shouldBe Nil
+    index.visibleEntries(pm1, currentPackage = "mypkg1", importRefs = Nil).size shouldBe 1
+    // An import of the package or of one of its members makes the package visible
+    index.visibleEntries(pm1, currentPackage = "", importRefs = List("mypkg1")).size shouldBe 1
+    index.visibleEntries(pm1, currentPackage = "", importRefs = List("mypkg1.pm1")).size shouldBe 1
+    index.visibleEntries(pm1, currentPackage = "", importRefs = List("mypkg2")) shouldBe Nil
+    index.findFirstAnywhere(pm1).map(_.fileName) shouldBe Some("pkg_models.wv")
+  }
+
+  test("warn once for a top-level name defined in multiple files") {
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+
+    val unitA = CompilationUnit(
+      SourceFile.fromString("dup_a.wv", "model dup_m = {\n  from [[1]] as t(id) select id\n}\n")
+    )
+    val unitB = CompilationUnit(
+      SourceFile.fromString("dup_b.wv", "model dup_m = {\n  from [[2]] as t(id) select id\n}\n")
+    )
+    val queryUnit = CompilationUnit.fromWvletString("from dup_m\n")
+
+    val result = compiler.compileMultipleUnits(List(unitB, unitA), queryUnit)
+    result.hasFailures shouldBe false
+
+    // The definition in the first file (by file name) wins regardless of the compilation order
+    val sym = result.context.findSymbolByName(Name.termName("dup_m"))
+    sym.map(_.symbolInfo.compilationUnit.sourceFile.fileName) shouldBe Some("dup_a.wv")
+
+    result
+      .context
+      .global
+      .duplicateDefinitions
+      .find(_._1 == Name.termName("dup_m"))
+      .map(_._2) shouldBe Some(List("dup_a.wv", "dup_b.wv"))
+  }
+
+end GlobalSymbolIndexTest


### PR DESCRIPTION
## Summary

Addresses the "hierarchical scopes for global lookup" item of #1811 (and part of the "symbol references" item), following the package-denotation design of the Scala 3 compiler.

- **Package-level `GlobalSymbolIndex`** (new): top-level symbols are indexed per package as `SymbolLabeler` enters them (via the new `Context.enterGlobalSymbol`), seeded from already-labeled units shared between compilers (preset standard library), purged and re-registered when a unit is re-labeled after a reload, and re-synced when a unit's known symbols changed outside the current compiler run (detected by list reference, so the common case is free). `Context.findSymbolByName` now consults only the buckets visible from the current unit (preset, default package, own package, imported packages) instead of scanning the known symbols of every compilation unit, and the size-keyed `sortedContextCache` workaround is removed. Duplicate top-level definition detection (#93) reads the same buckets instead of re-scanning all units.
- **O(1) `Scope` lookup**: `Scope.lookupEntry` is backed by an immutable name-keyed map that snapshots the outer scope's map at construction, preserving the existing snapshot semantics of the entries list.
- **Deterministic global lookups in codegen**: `GenSQL.lookupType` switches from an unordered scan over all contexts to the index lookup.
- **Reload correctness**: the REPL/incremental redefinition branches of `SymbolLabeler` now re-enter the updated symbol, so a model redefined after a file reload stays resolvable from other units (previously it silently dropped out of `knownSymbols`).

Lookup semantics are preserved: definitions resolve in source file name order (newest definition first within a unit, matching `knownSymbols` order), package visibility rules of #93 are unchanged, and the duplicate-definition warning still fires once per name. One ordering change: a bare-name import (`import model1`) now resolves package-visible definitions first and falls back to the cross-package search only when nothing is visible, so an explicit package import can no longer be shadowed by an unrelated package's same-named definition.

Two candidate optimizations were evaluated and deliberately **not** kept: reusing the symbol attached to an `Identifier` in a previous typing pass (a later pass must be able to rebind to a scope-local definition entered during typing, e.g. a relation alias shadowing a global model), and per-add sorted insertion in the index buckets (both readers already sort at lookup time).

The remaining #1811 item (phase-indexed denotations) is deferred until a consumer (IDE queries / incremental compilation) exists; see the issue comment.

## Testing

- New `GlobalSymbolIndexTest`: file-name ordering, newest-first within a unit, preset visibility, package/import visibility rules, unit removal, replay of already-labeled units, duplicate-definition warning.
- `langJVM/test`, `runner/test` (incl. spec-driven package/import suites), `*TyperCoverageCheck` ratchet: all green.
- `projectJVM/Test/compile`, `projectJS/Test/compile`, `projectNative/Test/compile`: pass.
- `*TyperBench`: median 104.9 ms vs 104.8 ms on main (parity; the bench corpus is single-unit compiles where the global scan was not dominant).
- An 8-angle multi-agent self-review (correctness, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) ran on the diff; all confirmed findings are folded into the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)