### PR TITLE
feature: Bind runtime flow parameters so parameterized flows are executable

### DIFF
--- a/spec/basic/flow-params.wv
+++ b/spec/basic/flow-params.wv
@@ -1,0 +1,31 @@
+-- Spec-driven tests for runtime flow parameters: `run flow F(param = value)` binds the
+-- declared flow parameters, and unbound parameters take their declared defaults
+
+flow ParamPipeline(target_name: string, min_id: int = 1) = {
+  stage src = from [[1, 'a'], [2, 'b'], [3, 'a']] as t(id, name)
+  stage filtered = from src | where name = target_name and id >= min_id
+  stage output = from filtered | select id
+}
+
+-- Named arguments bind flow parameters; min_id falls back to its default
+run flow ParamPipeline(target_name = 'a')
+| where state = 'success'
+test _.size should be 3
+;
+
+-- Positional arguments bind parameters in declaration order
+run flow ParamPipeline('a', 3)
+| where state = 'success'
+test _.size should be 3
+;
+
+-- A flow whose parameters all have defaults can run without arguments
+flow DefaultedPipeline(label: string = 'x') = {
+  stage src = from [[1, 'x'], [2, 'y']] as t(id, label_col)
+  stage tagged = from src | where label_col = label
+}
+
+run flow DefaultedPipeline
+| where state = 'success'
+test _.size should be 2
+;

--- a/spec/neg/flow-run-missing-param.wv
+++ b/spec/neg/flow-run-missing-param.wv
@@ -1,0 +1,7 @@
+-- Running a flow without binding a required parameter must be reported at compile time
+flow NeedsParamFlow(segment: string) = {
+  stage src = from [[1, 'a']] as t(id, name)
+  stage filtered = from src | where name = segment
+}
+
+run flow NeedsParamFlow

--- a/spec/neg/flow-run-unknown-param.wv
+++ b/spec/neg/flow-run-unknown-param.wv
@@ -1,0 +1,7 @@
+-- Binding an argument that does not match any declared flow parameter must be reported
+flow KnownParamFlow(segment: string = 'a') = {
+  stage src = from [[1, 'a']] as t(id, name)
+  stage filtered = from src | where name = segment
+}
+
+run flow KnownParamFlow(no_such_param = 'x')

--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -47,14 +47,26 @@ flow my_pipeline = {
 
 ### Flow with Parameters
 
-Flows can accept parameters, similar to functions:
+Flows can accept parameters, similar to functions. A parameter can declare a default value,
+which is used when no argument is bound at run time:
 
 ```wvlet
-flow customer_pipeline(segment: string) = {
-  stage entry = from users | where segment_id = segment
+flow customer_pipeline(segment: string, min_score: int = 0) = {
+  stage entry = from users | where segment_id = segment and score >= min_score
   stage output = from entry | select name, email
 }
 ```
+
+Arguments are bound when the flow is run, with the `run flow` statement or the
+`wvlet flow run` CLI (see [Running Flows](#running-flows)):
+
+```wvlet
+run flow customer_pipeline(segment = 'premium')
+```
+
+Inside stage bodies, a parameter name shadows a column of the same name, so pick parameter
+names that do not collide with the columns you query. Table and stage names (`from`, `merge`
+sources, route targets, and `->` jump targets) are never treated as parameter references.
 
 ### Flow Grammar
 
@@ -464,6 +476,25 @@ Each successful stage is materialized as a run-scoped temporary table
 (`__wv_flow_<run_id>_<stage>`), so stage names never collide with real tables and concurrent
 runs do not interfere with each other.
 
+#### Binding Flow Parameters
+
+A parameterized flow is run by passing arguments in the flow call, positionally or by name.
+Unbound parameters take their declared defaults; a missing required argument, an unknown
+argument name, or a mistyped literal is reported before any stage executes:
+
+```wvlet
+flow customer_pipeline(segment: string, min_score: int = 0) = {
+  stage entry = from users | where segment_id = segment and score >= min_score
+  stage output = from entry | select name, email
+}
+
+run flow customer_pipeline(segment = 'premium', min_score = 50)
+```
+
+Flow identity is by name only: `concurrency:` limits and cross-flow dependencies
+(`depends on X`, `if X.failed`) treat every run of a flow the same, regardless of the
+arguments it was run with.
+
 ### wvlet flow CLI
 
 Flows can be managed from the command line:
@@ -477,6 +508,9 @@ wvlet flow show my_pipeline -w ./pipelines
 
 # Run a flow and print its per-stage results (non-zero exit code when the flow fails)
 wvlet flow run my_pipeline -w ./pipelines
+
+# Run a parameterized flow with a flow call (the same syntax as the run flow statement)
+wvlet flow run "customer_pipeline(segment = 'premium')" -w ./pipelines
 
 # List recorded flow runs (most recent first)
 wvlet flow session list -w ./pipelines

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -26,9 +26,13 @@ import wvlet.lang.compiler.CompilerOptions
 import wvlet.lang.compiler.Context
 import wvlet.lang.compiler.Symbol
 import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.model.expr.FunctionArg
 import wvlet.lang.model.plan.DependsOnFlow
 import wvlet.lang.model.plan.FlowDef
 import wvlet.lang.model.plan.FlowStatePredicate
+import wvlet.lang.model.plan.Query
+import wvlet.lang.model.plan.RunFlow
 import wvlet.lang.runner.CronSchedule
 import wvlet.lang.runner.FlowExecutor
 import wvlet.lang.runner.FlowRunRecord
@@ -63,15 +67,40 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
   @command(description = "Run a flow defined in the working folder")
   def run(
       flowOption: WvletFlowOption,
-      @argument(description = "Name of the flow to run")
+      @argument(description = "Flow to run: a name or a flow call like \"F(segment = 'a')\"")
       name: String
-  ): Unit = executeFlow(flowOption, name, resumeFrom = None)
+  ): Unit =
+    val (flowName, args) = parseFlowCall(name)
+    executeFlow(flowOption, flowName, resumeFrom = None, args = args)
+
+  /**
+    * Parse the flow argument of `wvlet flow run` as a flow-call expression (`F` or `F(segment =
+    * 'a')`) with the regular wvlet parser, so the CLI and the `run flow` statement share one syntax
+    */
+  private def parseFlowCall(input: String): (String, List[FunctionArg]) =
+    val unit = CompilationUnit.fromWvletString(s"run flow ${input}")
+    val plan = ParserPhase.parseOnly(unit)
+    var parsed: Option[(String, List[FunctionArg])] = None
+    plan.traverse { case q: Query =>
+      q.child match
+        case r: RunFlow =>
+          parsed = Some((r.flowName.fullName, r.args))
+        case _ =>
+    }
+    parsed.getOrElse(
+      throw StatusCode
+        .INVALID_ARGUMENT
+        .newException(
+          s"Invalid flow reference '${input}': expected a flow name or a flow call like \"F(param = 'value')\""
+        )
+    )
 
   /** Compile the flows in the working folder and execute the given flow */
   private def executeFlow(
       flowOption: WvletFlowOption,
       name: String,
-      resumeFrom: Option[FlowRunRecord]
+      resumeFrom: Option[FlowRunRecord],
+      args: List[FunctionArg] = Nil
   ): Unit =
     withFlows(flowOption) { (flows, compileResult, workEnv) =>
       val (unit, flow) = findFlow(flows, name)
@@ -87,7 +116,8 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
         Control.withResource(newRunStore(flowOption, workEnv)) { store =>
           val result = FlowExecutor(connector, workEnv, registry = Some(store)).execute(
             flow,
-            resumeFrom
+            resumeFrom,
+            args
           )
           println(result.toPrettyBox())
           if result.hasError && !WvletMain.isInSbt then

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -24,6 +24,11 @@ class WvletFlowCommandTest extends UniTest:
         |  stage primary = from nonexistent_table_xyz
         |  stage fallback if primary.failed = from [[0]] as t(id)
         |}
+        |
+        |flow ParamPipeline(target_name: string, min_id: int = 1) = {
+        |  stage src = from [[1, 'a'], [2, 'b'], [3, 'a']] as t(id, name)
+        |  stage filtered = from src | where name = target_name and id >= min_id
+        |}
         |""".stripMargin
     )
     dir.toAbsolutePath.toString
@@ -43,6 +48,27 @@ class WvletFlowCommandTest extends UniTest:
   test("run a flow with failing and fallback stages") {
     // In sbt, failing flows do not System.exit; this verifies fallback execution completes
     WvletMain.main(s"flow run FallbackPipeline -w ${flowDir}")
+  }
+
+  test("run a parameterized flow with a flow-call argument") {
+    WvletMain.main(Array("flow", "run", "ParamPipeline(target_name = 'a')", "-w", flowDir))
+  }
+
+  test("report an error when a required flow parameter is not bound") {
+    val e = intercept[WvletLangException] {
+      WvletMain.main(s"flow run ParamPipeline -w ${flowDir}")
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    e.getMessage shouldContain "target_name"
+  }
+
+  test("reject a flow argument that is not a plain flow call") {
+    val e = intercept[WvletLangException] {
+      WvletMain.main(
+        Array("flow", "run", "ParamPipeline(target_name = 'a') | select 1", "-w", flowDir)
+      )
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
   }
 
   test("list and show flow run sessions") {

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -454,7 +454,12 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
         }
       case r: RunFlow =>
         code(r) {
-          wl("run", "flow", expr(r.flowName))
+          val call =
+            if r.args.isEmpty then
+              expr(r.flowName)
+            else
+              expr(r.flowName) + paren(cl(r.args.map(a => expr(a))))
+          wl("run", "flow", call)
         }
       // Flow-related relations
       case s: StageDef =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -366,7 +366,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
   }
 
   /**
-    * Parse a run-flow statement: `run flow Name`
+    * Parse a run-flow statement: `run flow Name` or `run flow Name(param = value, ...)`
     *
     * The statement produces a flow-run summary relation (one row per stage), so it can be followed
     * by query operators or test statements like a regular query
@@ -374,9 +374,18 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
   def runFlowStatement(): LogicalPlan = node {
     val t = consume(WvletToken.RUN)
     consume(WvletToken.FLOW)
-    val name = identifier()
-    val r    = RunFlow(name, spanFrom(t))
-    val q    = queryBlock(r)
+    val name                    = identifier()
+    val args: List[FunctionArg] =
+      scanner.lookAhead().token match
+        case WvletToken.L_PAREN =>
+          consume(WvletToken.L_PAREN)
+          val a = functionArgs()
+          consume(WvletToken.R_PAREN)
+          a
+        case _ =>
+          Nil
+    val r = RunFlow(name, args, spanFrom(t))
+    val q = queryBlock(r)
     Query(q, spanFrom(t))
   }
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/transform/FlowParams.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/transform/FlowParams.scala
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.transform
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.model.DataType
+import wvlet.lang.model.expr.*
+import wvlet.lang.model.plan.*
+
+/**
+  * Binds run-time flow arguments (`run flow F(segment = 'a')`, `wvlet flow run "F(segment = 'a')"`)
+  * to the parameters declared on the flow definition (`flow F(segment: string) = ...`).
+  *
+  * Binding resolves positional and named arguments against `FlowDef.params`, fills in declared
+  * default values, and rejects unknown, duplicate, missing, or mistyped arguments with clear
+  * errors. Substitution then replaces parameter references in the stage bodies with the bound
+  * expressions, so that the lowered stage SQL contains concrete values. Parameter names shadow
+  * columns of the same name inside stage bodies (the same semantics as model arguments), while
+  * structural names (table/stage references in `from`/`merge`, route targets, and `->` jump
+  * targets) are never treated as parameter references.
+  */
+object FlowParams:
+
+  /**
+    * Resolve the given arguments against the flow's declared parameters, returning the complete
+    * parameter-name-to-expression binding with defaults applied. Throws INVALID_ARGUMENT with a
+    * descriptive message for unknown/duplicate/missing/mistyped arguments
+    */
+  def bind(flow: FlowDef, args: List[FunctionArg]): Map[String, Expression] =
+    val flowName                   = flow.name.name
+    def fail(msg: String): Nothing = throw StatusCode.INVALID_ARGUMENT.newException(msg)
+    def signature: String          =
+      if flow.params.isEmpty then
+        s"flow ${flowName} takes no parameters"
+      else
+        s"flow ${flowName}(${flow
+            .params
+            .map(p => s"${p.name.name}: ${p.givenDataType.typeDescription}")
+            .mkString(", ")})"
+
+    if args.size > flow.params.size then
+      fail(s"Too many arguments for flow '${flowName}': ${args.size} given, but ${signature}")
+
+    var bound     = Map.empty[String, Expression]
+    var seenNamed = false
+    args
+      .zipWithIndex
+      .foreach { (arg, index) =>
+        arg.name match
+          case Some(n) =>
+            seenNamed = true
+            if !flow.params.exists(_.name.name == n.name) then
+              fail(s"Unknown parameter '${n.name}' for flow '${flowName}': ${signature}")
+            if bound.contains(n.name) then
+              fail(s"Duplicate argument for parameter '${n.name}' of flow '${flowName}'")
+            bound += n.name -> arg.value
+          case None =>
+            if seenNamed then
+              fail(
+                s"Positional argument after a named argument in the arguments of flow '${flowName}'"
+              )
+            bound += flow.params(index).name.name -> arg.value
+      }
+
+    flow
+      .params
+      .map { p =>
+        bound.get(p.name.name) match
+          case Some(v) =>
+            if !typeCompatible(p.givenDataType, v) then
+              fail(
+                s"Parameter '${p.name.name}' of flow '${flowName}' expects ${p
+                    .givenDataType
+                    .typeDescription}, but got ${v.dataTypeName}"
+              )
+            p.name.name -> v
+          case None =>
+            p.defaultValue match
+              case Some(d) =>
+                p.name.name -> d
+              case None =>
+                fail(
+                  s"Missing argument for parameter '${p.name.name}: ${p
+                      .givenDataType
+                      .typeDescription}' of flow '${flowName}'"
+                )
+      }
+      .toMap
+  end bind
+
+  /**
+    * Replace parameter references in the stage bodies of the flow with the bound expressions.
+    * Structural name positions (from/merge sources, route targets, jump targets, fork stage
+    * metadata) are left untouched
+    */
+  def substitute(flow: FlowDef, bindings: Map[String, Expression]): FlowDef =
+    if bindings.isEmpty then
+      flow
+    else
+      val rule: PartialFunction[Expression, Expression] =
+        case i: Identifier if bindings.contains(i.leafName) =>
+          bindings(i.leafName)
+
+      val newStages = flow
+        .stages
+        .map { s =>
+          s.body.map(b => substituteInBody(b, rule)) match
+            case Some(nb) if s.body.exists(b => !(nb eq b)) =>
+              val ns = s.copy(body = Some(nb))
+              ns.copyMetadataFrom(s)
+              ns
+            case _ =>
+              s
+        }
+      val nf = flow.copy(stages = newStages)
+      nf.copyMetadataFrom(flow)
+      nf
+
+  /**
+    * Bind the arguments and substitute parameter references in one step, returning the flow ready
+    * for lowering and execution
+    */
+  def apply(flow: FlowDef, args: List[FunctionArg]): FlowDef = substitute(flow, bind(flow, args))
+
+  private def substituteInBody(
+      body: Relation,
+      rule: PartialFunction[Expression, Expression]
+  ): Relation = body
+    .transformUp {
+      case t: TableRef =>
+        // A `from <name>` source is a table or stage reference, never a parameter
+        t
+      case m: FlowMerge =>
+        // Merge sources are stage names
+        m
+      case j: FlowJump =>
+        // `-> Flow` targets are flow names
+        j
+      case s: StageDef =>
+        // A fork-nested stage: its body has already been transformed by the recursion; its
+        // inputRefs/trigger reference stage names and must not be substituted
+        s
+      case r: FlowRoute =>
+        // Substitute inside routing predicates only; case targets and elseTarget are stage names
+        val newBy    = r.byExpr.map(_.transformUpExpression(rule))
+        val newCases = r
+          .cases
+          .map(c => c.copy(condition = c.condition.map(_.transformUpExpression(rule))))
+        val changed =
+          r.byExpr.zip(newBy).exists((a, b) => !(a eq b)) ||
+            r.cases
+              .zip(newCases)
+              .exists((a, b) => a.condition.zip(b.condition).exists((x, y) => !(x eq y)))
+        if changed then
+          val nr = r.copy(byExpr = newBy, cases = newCases)
+          nr.copyMetadataFrom(r)
+          nr
+        else
+          r
+      case p: LogicalPlan =>
+        p.transformChildExpressions { case e: Expression =>
+          e.transformUpExpression(rule)
+        }
+    }
+    .asInstanceOf[Relation]
+
+  /**
+    * A lightweight compatibility check between a declared parameter type and a literal argument.
+    * Non-literal arguments and non-primitive declared types are accepted as-is
+    */
+  private def typeCompatible(declared: DataType, value: Expression): Boolean =
+    value match
+      case _: NullLiteral =>
+        true
+      case l: Literal =>
+        declared match
+          case DataType.StringType | DataType.VarcharType(_) | DataType.CharType(_) =>
+            l.isInstanceOf[StringLiteral]
+          case n if n.isNumeric =>
+            l.dataType.isNumeric
+          case DataType.BooleanType =>
+            l.isInstanceOf[BooleanLiteral]
+          case _ =>
+            true
+      case _ =>
+        true
+
+end FlowParams

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -24,6 +24,7 @@ import wvlet.lang.model.expr.NameExpr
 import wvlet.lang.compiler.analyzer.AggregationResolver
 import wvlet.lang.compiler.analyzer.FunctionInliner
 import wvlet.lang.compiler.analyzer.RelationRefResolver
+import wvlet.lang.compiler.transform.FlowParams
 import wvlet.lang.model.expr.ArithmeticBinaryExpr
 import wvlet.lang.model.expr.ConditionalExpression
 import wvlet.lang.model.expr.ContextInputRef
@@ -450,13 +451,15 @@ object Typer extends Phase("typer") with LogSupport:
         ref
       case r: RunFlow =>
         // Validate that the flow reference resolves to a flow definition
-        val isFlow = ctx
-          .findTermSymbolByName(r.flowName.fullName)
-          .exists(_.tree.isInstanceOf[FlowDef])
-        if !isFlow then
-          throw StatusCode
-            .FLOW_NOT_FOUND
-            .newException(s"Flow '${r.flowName.fullName}' is not found", r.sourceLocation)
+        ctx.findTermSymbolByName(r.flowName.fullName).map(_.tree) match
+          case Some(f: FlowDef) =>
+            // Validate the run-time arguments against the declared flow parameters, so that
+            // unknown/missing/mistyped arguments are reported at compile time
+            FlowParams.bind(f, r.args)
+          case _ =>
+            throw StatusCode
+              .FLOW_NOT_FOUND
+              .newException(s"Flow '${r.flowName.fullName}' is not found", r.sourceLocation)
         typeRelationNode(r)
         r
       case m: FlowMerge =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
@@ -262,7 +262,8 @@ case class FlowMerge(sources: List[NameExpr], joinCondition: Option[Expression],
         EmptyRelationType
 
 /**
-  * RunFlow triggers the execution of a flow definition by name.
+  * RunFlow triggers the execution of a flow definition by name, optionally binding flow parameters:
+  * `run flow F(segment = 'a')`.
   *
   * It is a leaf relation whose output is the flow-run summary (one row per stage), so that the
   * result can be piped through query operators or verified with test statements:
@@ -273,10 +274,14 @@ case class FlowMerge(sources: List[NameExpr], joinCondition: Option[Expression],
   *
   * @param flowName
   *   The name of the flow to run
+  * @param args
+  *   Arguments bound to the flow parameters (positional or named)
   * @param span
   *   Source location
   */
-case class RunFlow(flowName: NameExpr, span: Span) extends Relation with LeafPlan:
+case class RunFlow(flowName: NameExpr, args: List[FunctionArg], span: Span)
+    extends Relation
+    with LeafPlan:
   override def children: List[LogicalPlan] = Nil
   override def relationType: RelationType  = RunFlow.summaryType
 

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -33,4 +33,18 @@ class WvletGeneratorTest extends UniTest:
     printed shouldContain "count(distinct user_id)"
   }
 
+  test("should print run flow arguments") {
+    val printed = print("run flow F('a', min_id = 10)")
+    printed shouldContain "run flow F('a', min_id = 10)"
+
+    // The printed statement should parse back to the same flow call
+    print(printed) shouldContain "run flow F('a', min_id = 10)"
+  }
+
+  test("should print a run flow statement without arguments as a bare name") {
+    val printed = print("run flow F")
+    printed shouldContain "run flow F"
+    printed.contains("F()") shouldBe false
+  }
+
 end WvletGeneratorTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/transform/FlowParamsTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/transform/FlowParamsTest.scala
@@ -1,0 +1,97 @@
+package wvlet.lang.compiler.transform
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.model.expr.SingleQuoteString
+import wvlet.lang.model.plan.FlowDef
+import wvlet.lang.model.plan.RunFlow
+import wvlet.lang.model.plan.TableRef
+import wvlet.uni.test.UniTest
+
+class FlowParamsTest extends UniTest:
+
+  private def parseFlow(wv: String): FlowDef =
+    val plan                  = ParserPhase.parseOnly(CompilationUnit.fromWvletString(wv))
+    var flow: Option[FlowDef] = None
+    plan.traverse { case f: FlowDef =>
+      if flow.isEmpty then
+        flow = Some(f)
+    }
+    flow.getOrElse(fail("No FlowDef found"))
+
+  private def parseRunFlow(wv: String): RunFlow =
+    val plan                 = ParserPhase.parseOnly(CompilationUnit.fromWvletString(wv))
+    var run: Option[RunFlow] = None
+    plan.traverse { case q: wvlet.lang.model.plan.Query =>
+      q.child match
+        case r: RunFlow =>
+          run = Some(r)
+        case _ =>
+    }
+    run.getOrElse(fail("No RunFlow found"))
+
+  private val flow = parseFlow("""flow F(segment: string, min_id: int = 1) = {
+      |  stage src = from users | where name = segment and id >= min_id
+      |}""".stripMargin)
+
+  test("bind named arguments and apply defaults") {
+    val bindings = FlowParams.bind(flow, parseRunFlow("run flow F(segment = 'a')").args)
+    bindings.keySet shouldBe Set("segment", "min_id")
+    bindings("segment").asInstanceOf[SingleQuoteString].unquotedValue shouldBe "a"
+  }
+
+  test("bind positional arguments in declaration order") {
+    val bindings = FlowParams.bind(flow, parseRunFlow("run flow F('a', 5)").args)
+    bindings("segment").asInstanceOf[SingleQuoteString].unquotedValue shouldBe "a"
+  }
+
+  test("reject a duplicate named argument") {
+    val e = intercept[WvletLangException] {
+      FlowParams.bind(flow, parseRunFlow("run flow F(segment = 'a', segment = 'b')").args)
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    e.getMessage shouldContain "Duplicate"
+  }
+
+  test("reject a positional argument after a named argument") {
+    val e = intercept[WvletLangException] {
+      FlowParams.bind(flow, parseRunFlow("run flow F(segment = 'a', 5)").args)
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    e.getMessage shouldContain "Positional argument"
+  }
+
+  test("reject too many arguments") {
+    val e = intercept[WvletLangException] {
+      FlowParams.bind(flow, parseRunFlow("run flow F('a', 5, 'extra')").args)
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    e.getMessage shouldContain "Too many arguments"
+  }
+
+  test("substitute parameter references but never table references") {
+    // The parameter shares its name with the source table: the filter reference is
+    // substituted while the `from` clause keeps referencing the table
+    val f = parseFlow("""flow G(users: string) = {
+        |  stage src = from users | where name = users
+        |}""".stripMargin)
+    val bound = FlowParams.substitute(
+      f,
+      FlowParams.bind(f, parseRunFlow("run flow G(users = 'a')").args)
+    )
+    val body               = bound.stages.head.body.get
+    var tableNames         = List.empty[String]
+    var substitutedLiteral = false
+    body.traverse { case t: TableRef =>
+      tableNames = tableNames :+ t.name.fullName
+    }
+    body.traverseExpressions { case s: SingleQuoteString =>
+      substitutedLiteral = true
+    }
+    tableNames shouldBe List("users")
+    substitutedLiteral shouldBe true
+  }
+
+end FlowParamsTest

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -20,6 +20,7 @@ import wvlet.lang.api.v1.flow.StageState
 import wvlet.lang.compiler.Context
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.compiler.codegen.GenSQL
+import wvlet.lang.compiler.transform.FlowParams
 import wvlet.lang.model.expr.*
 import wvlet.lang.model.plan.*
 import wvlet.lang.runner.connector.DBConnector
@@ -284,11 +285,19 @@ class FlowExecutor(
     * Execute the given flow. When `resumeFrom` holds the record of a previous failed or cancelled
     * run, the run is resumed under the same run id: stages recorded as successful keep their
     * materialized run-scoped tables and are not re-executed, and the remaining stages run with a
-    * fresh retry budget
+    * fresh retry budget. `args` binds the declared flow parameters (positional or named); declared
+    * defaults fill in unbound parameters, and a missing required parameter fails the run before any
+    * stage executes
     */
-  def execute(flow: FlowDef, resumeFrom: Option[FlowRunRecord] = None)(using
-      ctx: Context
-  ): FlowExecutionResult = executeInternal(flow, resumeFrom, jumpDepth = 0)
+  def execute(
+      flow: FlowDef,
+      resumeFrom: Option[FlowRunRecord] = None,
+      args: List[FunctionArg] = Nil
+  )(using ctx: Context): FlowExecutionResult = executeInternal(
+    FlowParams(flow, args),
+    resumeFrom,
+    jumpDepth = 0
+  )
 
   /** Resolve a flow referenced by a `-> Flow` jump through the compilation context */
   private def resolveJumpTarget(name: String)(using ctx: Context): FlowDef =
@@ -893,7 +902,12 @@ class FlowExecutor(
             )
           else
             workEnv.info(s"Jumping from flow ${flow.name.name} to flow ${target}")
-            executeInternal(jumpTargetFlows(target), resumeFrom = None, jumpDepth = jumpDepth + 1)
+            // A jump carries no arguments, so the target flow runs with its parameter defaults
+            executeInternal(
+              FlowParams(jumpTargetFlows(target), Nil),
+              resumeFrom = None,
+              jumpDepth = jumpDepth + 1
+            )
         }
 
     result

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -464,7 +464,7 @@ class QueryExecutor(
             .util
             .Using
             .resource(FlowRunStore.forWorkEnv(workEnv)) { store =>
-              FlowExecutor(connector, workEnv, registry = Some(store)).execute(flow)
+              FlowExecutor(connector, workEnv, registry = Some(store)).execute(flow, args = rf.args)
             }
 
         given monitor: QueryProgressMonitor = context.queryProgressMonitor

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -1,5 +1,6 @@
 package wvlet.lang.runner
 
+import wvlet.lang.api.Span
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.api.v1.flow.StageState
@@ -8,9 +9,14 @@ import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Compiler
 import wvlet.lang.compiler.CompilerOptions
 import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.Name
 import wvlet.lang.compiler.Symbol
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.compiler.planner.ExecutionPlanner
+import wvlet.lang.model.expr.Expression
+import wvlet.lang.model.expr.FunctionArg
+import wvlet.lang.model.expr.LongLiteral
+import wvlet.lang.model.expr.SingleQuoteString
 import wvlet.lang.model.plan.FlowDef
 import wvlet.lang.model.plan.StageDef
 import wvlet.lang.runner.connector.DBConnectorProvider
@@ -54,12 +60,15 @@ class FlowExecutorTest extends UniTest:
       config: FlowExecutorConfig = FlowExecutorConfig(),
       stageRunner: Option[FlowStageRunner] = None,
       retryScheduler: Option[(Long, () => Unit) => Unit] = None,
-      registry: Option[FlowRunStore] = None
+      registry: Option[FlowRunStore] = None,
+      args: List[FunctionArg] = Nil
   ): FlowExecutionResult =
     val (flow, ctx) = compileFlow(wv)
-    FlowExecutor(connector, workEnv, config, stageRunner, retryScheduler, registry).execute(flow)(
-      using ctx
-    )
+    FlowExecutor(connector, workEnv, config, stageRunner, retryScheduler, registry).execute(
+      flow,
+      resumeFrom = None,
+      args = args
+    )(using ctx)
 
   /** Compile a unit possibly containing multiple flows and return them by name */
   private def compileFlows(wv: String): (Map[String, FlowDef], Context) =
@@ -1154,6 +1163,92 @@ class FlowExecutorTest extends UniTest:
     base.retryDelayFor(2) shouldBe 200L
     base.retryDelayFor(4) shouldBe 800L
     base.withMaxRetryDelayMillis(150L).retryDelayFor(4) shouldBe 150L
+  }
+
+  // --- Runtime flow parameters ---
+
+  private def namedArg(name: String, value: Expression): FunctionArg = FunctionArg(
+    Some(Name.termName(name)),
+    value,
+    isDistinct = false,
+    Nil,
+    Span.NoSpan
+  )
+
+  private def positionalArg(value: Expression): FunctionArg = FunctionArg(
+    None,
+    value,
+    isDistinct = false,
+    Nil,
+    Span.NoSpan
+  )
+
+  private def str(v: String): Expression = SingleQuoteString(v, Span.NoSpan)
+  private def num(v: Long): Expression   = LongLiteral(v, v.toString, Span.NoSpan)
+
+  private val paramFlow =
+    """flow ParamFlow(target_name: string, min_id: int = 1) = {
+      |  stage src = from [[1, 'a'], [2, 'b'], [3, 'a']] as t(id, name)
+      |  stage filtered = from src | where name = target_name and id >= min_id
+      |}""".stripMargin
+
+  test("bind named flow arguments and fill unbound parameters with defaults") {
+    val result = runFlow(paramFlow, args = List(namedArg("target_name", str("a"))))
+    result.isSuccess shouldBe true
+    countStageRows(result, "filtered") shouldBe 2L
+  }
+
+  test("bind positional flow arguments") {
+    val result = runFlow(paramFlow, args = List(positionalArg(str("a")), positionalArg(num(3))))
+    result.isSuccess shouldBe true
+    countStageRows(result, "filtered") shouldBe 1L
+  }
+
+  test("fail before any stage runs when a required flow parameter is missing") {
+    val e = intercept[WvletLangException] {
+      runFlow(paramFlow)
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    e.getMessage shouldContain "target_name"
+  }
+
+  test("fail on an unknown flow argument name") {
+    val e = intercept[WvletLangException] {
+      runFlow(
+        paramFlow,
+        args = List(namedArg("target_name", str("a")), namedArg("no_such_param", str("x")))
+      )
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    e.getMessage shouldContain "no_such_param"
+  }
+
+  test("fail on a mistyped flow argument") {
+    val e = intercept[WvletLangException] {
+      runFlow(paramFlow, args = List(namedArg("target_name", num(1))))
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    e.getMessage shouldContain "expects string"
+  }
+
+  test("substitute parameters into route predicates") {
+    // Note: the parameter is written on the left of the comparison because a route condition
+    // ending with a bare identifier would parse `<identifier> -> <target>` as a lambda
+    val result = runFlow(
+      """flow RouteParamFlow(adult_age: int) = {
+        |  stage src = from [[1, 25], [2, 15], [3, 40]] as t(id, age)
+        |  stage gate = from src | route {
+        |    case adult_age <= _.age -> adult
+        |    else -> minor
+        |  }
+        |  stage adult = from gate | select id
+        |  stage minor = from gate | select id
+        |}""".stripMargin,
+      args = List(namedArg("adult_age", num(18)))
+    )
+    result.isSuccess shouldBe true
+    countStageRows(result, "adult") shouldBe 2L
+    countStageRows(result, "minor") shouldBe 1L
   }
 
 end FlowExecutorTest


### PR DESCRIPTION
## Summary

Item 1 of #1845: `flow F(segment: string)` parsed but arguments could not be bound at run time, so parameterized flows were effectively decorative. This PR makes them executable with one shared syntax for the statement and the CLI:

- **`run flow F(segment = 'a')`**: `RunFlow` now carries an argument list (positional and named, parsed with the existing `functionArgs()` grammar). The Typer validates arguments against `FlowDef.params` at compile time, so unknown/duplicate/missing/mistyped arguments are reported before anything executes.
- **`wvlet flow run "F(segment = 'a')"`**: the CLI argument is parsed as a `run flow` statement with the regular wvlet parser, so the CLI and the in-language statement share one syntax and one code path. A bare flow name (`wvlet flow run F`) stays valid.
- **`FlowParams`** (new, `wvlet.lang.compiler.transform`): resolves arguments against declared parameters (defaults fill unbound parameters; clear `INVALID_ARGUMENT` errors otherwise) and substitutes parameter references in stage bodies before lowering. Parameter names shadow same-named columns (the same semantics as model arguments), while structural names — `from`/`merge` sources, route targets, `->` jump targets, fork stage metadata — are never treated as parameter references.
- **Execution paths**: `FlowExecutor.execute` takes the argument list (CLI + embedded `run flow`); scheduler-triggered runs and `->` jumps bind parameter defaults.
- **Identity semantics** (decided + documented): flow identity stays per flow name — `concurrency:` slots and cross-flow dependencies treat all runs of a flow the same regardless of arguments.

## Tests

- `FlowParamsTest` (new): binding defaults, positional order, duplicate/positional-after-named/too-many errors, and substitution leaving a `from` table untouched when it shares the parameter's name
- `FlowExecutorTest`: named + default binding, positional binding, missing/unknown/mistyped argument failures before any stage runs, substitution into route predicates (all verified against materialized DuckDB row counts)
- `WvletFlowCommandTest`: flow-call CLI run, missing-parameter error, rejection of non-flow-call arguments
- `WvletGeneratorTest`: `run flow F('a', min_id = 10)` round-trips through print/parse
- `spec/basic/flow-params.wv`: end-to-end named/positional/default runs; `spec/neg/flow-run-{missing,unknown}-param.wv`: compile-time rejection

All of the above plus `RunnerSpecBasic`/`RunnerSpecNeg` and the full cli test suite pass locally.

## Documentation

`website/docs/syntax/flow.md`: expanded *Flow with Parameters* (defaults, shadowing rule), new *Binding Flow Parameters* subsection under *Running Flows* with a runnable example and the identity-semantics note, and a CLI example for the flow-call form.

Refs #1845 (item 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)