### PR TITLE
fix: Evaluate default run times in the flow timezone and respect backfill boundaries

### DIFF
--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -105,6 +105,8 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
     withFlows(flowOption) { (flows, compileResult, workEnv) =>
       val (unit, flow) = findFlow(flows, name)
       val profile = Profile.getProfile(flowOption.profile, flowOption.catalog, flowOption.schema)
+      // System.exit is deferred until the resource blocks release the connector and run store
+      var failed = false
       Control.withResource(DBConnectorProvider(workEnv)) { dbConnectorProvider =>
         val connector = dbConnectorProvider.getConnector(profile)
 
@@ -120,10 +122,11 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
             args
           )
           println(result.toPrettyBox())
-          if result.hasError && !WvletMain.isInSbt then
-            System.exit(1)
+          failed = result.hasError
         }
       }
+      if failed && !WvletMain.isInSbt then
+        System.exit(1)
     }
 
   /** Create the run store selected with --run-store (or the WVLET_FLOW_STORE environment) */
@@ -175,11 +178,12 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
           .INVALID_ARGUMENT
           .newException(s"--from (${fromTime}) is after --to (${toTime})")
 
-      // Schedule fire times within [fromTime, toTime]
+      // Schedule fire times within [fromTime, toTime]. The truncated start only counts when it
+      // does not precede --from (e.g. --from 00:00:05 must not include the 00:00:00 fire)
       val windows = List.newBuilder[java.time.ZonedDateTime]
       var t       =
         val start = fromTime.truncatedTo(java.time.temporal.ChronoUnit.MINUTES)
-        if cron.matches(start) then
+        if cron.matches(start) && !start.isBefore(fromTime) then
           start
         else
           cron.nextAfter(fromTime)
@@ -196,6 +200,8 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
               .last}"
         )
         val profile = Profile.getProfile(flowOption.profile, flowOption.catalog, flowOption.schema)
+        // System.exit is deferred until the resource blocks release the connector and run store
+        var failed = false
         Control.withResource(DBConnectorProvider(workEnv)) { dbConnectorProvider =>
           val connector = dbConnectorProvider.getConnector(profile)
 
@@ -207,7 +213,6 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
           Control.withResource(newRunStore(flowOption, workEnv)) { store =>
             val executor = FlowExecutor(connector, workEnv, registry = Some(store))
             val it       = runTimes.iterator
-            var failed   = false
             while !failed && it.hasNext do
               val runTime = it.next()
               println(s"=== ${flowName} @ ${runTime}")
@@ -220,10 +225,10 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
                   s"Backfill of ${flowName} aborted at window ${runTime}; resolve the failure and re-run with --from ${runTime
                       .toLocalDate}"
                 )
-            if failed && !WvletMain.isInSbt then
-              System.exit(1)
           }
         }
+        if failed && !WvletMain.isInSbt then
+          System.exit(1)
       end if
     }
 

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -96,6 +96,34 @@ class WvletFlowCommandTest extends UniTest:
     runs.forall(_.stages.forall(_.state == "success")) shouldBe true
   }
 
+  test("exclude fire times before an intra-minute --from boundary") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRegistry
+    val dir = Files.createTempDirectory("wvlet-flow-backfill-boundary")
+    Files.writeString(
+      dir.resolve("daily.wv"),
+      """flow BoundaryPipeline with { schedule: cron('0 0 * * *') } = {
+        |  stage src = from [[1]] as t(id)
+        |}
+        |""".stripMargin
+    )
+    // --from lies 30s after the 07-01 00:00 fire, so only the 07-02 window runs
+    WvletMain.main(
+      Array(
+        "flow",
+        "backfill",
+        "BoundaryPipeline",
+        "--from",
+        "2026-07-01T00:00:30",
+        "--to",
+        "2026-07-02",
+        "-w",
+        dir.toString
+      )
+    )
+    FlowRunRegistry.forWorkEnv(WorkEnv(dir.toString)).list().size shouldBe 1
+  }
+
   test("reject backfill of a flow without a schedule") {
     val e = intercept[WvletLangException] {
       WvletMain.main(

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -303,8 +303,11 @@ class FlowExecutor(
       runTime: Option[ZonedDateTime] = None
   )(using ctx: Context): FlowExecutionResult =
     val bindings =
-      FlowExecutor.runTimeBindings(runTime.getOrElse(ZonedDateTime.now())) ++
-        FlowParams.bind(flow, args)
+      // A manual run evaluates "now" in the flow's configured timezone, so that run_date
+      // agrees with what the flow's schedule would produce
+      FlowExecutor.runTimeBindings(
+        runTime.getOrElse(ZonedDateTime.now(FlowScheduleConfig.fromFlow(flow).zoneId))
+      ) ++ FlowParams.bind(flow, args)
     executeInternal(FlowParams.substitute(flow, bindings), resumeFrom, jumpDepth = 0)
 
   /** Resolve a flow referenced by a `-> Flow` jump through the compilation context */
@@ -914,7 +917,9 @@ class FlowExecutor(
             // and the current wall clock as its run time
             val targetFlow = jumpTargetFlows(target)
             val bindings   =
-              FlowExecutor.runTimeBindings(ZonedDateTime.now()) ++ FlowParams.bind(targetFlow, Nil)
+              FlowExecutor.runTimeBindings(
+                ZonedDateTime.now(FlowScheduleConfig.fromFlow(targetFlow).zoneId)
+              ) ++ FlowParams.bind(targetFlow, Nil)
             executeInternal(
               FlowParams.substitute(targetFlow, bindings),
               resumeFrom = None,


### PR DESCRIPTION
## Summary

Follow-up to #1848 addressing the three high-priority and one medium Gemini review comments:

- **Flow-timezone defaults**: manual runs (`FlowExecutor.execute` without `runTime`) and `-> Flow` jump targets now evaluate the current time in the flow's `timezone:` config (`FlowScheduleConfig.fromFlow(flow).zoneId`) instead of the host default, so `run_date` agrees with what the flow's schedule would produce.
- **Backfill `--from` boundary**: an intra-minute `--from` (e.g. `2026-07-01T00:00:30`) no longer includes the fire time of its own truncated minute — the truncated start only counts when it does not precede `--from`. Regression-tested: a daily cron backfilled from `00:00:30` to the next day produces exactly one run.
- **Deferred `System.exit`**: a failed `flow run` / `flow backfill` now exits *after* the `withResource` blocks close the DB connector and run store (relevant for SQLite WAL), for both the backfill loop and the pre-existing `run` path.

## Tests

New `WvletFlowCommandTest` boundary test; full cli suite (106) and `FlowExecutorTest` pass locally.

Refs #1845, #1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)