### PR TITLE
feature: Add on_failure/on_success/on_finish run notification hooks

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -185,6 +185,30 @@ flow daily_etl with {
 | `timezone` | String | Timezone for schedule evaluation |
 | `concurrency` | Int | Max concurrent flow executions |
 | `timeout` | Duration | Total flow timeout |
+| `on_failure` | Activation | Notification hook fired when a run fails |
+| `on_success` | Activation | Notification hook fired when a run succeeds |
+| `on_finish` | Activation | Notification hook fired for both outcomes |
+
+### Run Notifications
+
+The `on_failure:`, `on_success:`, and `on_finish:` hooks deliver a **run summary** — one row
+per stage with `flow`, `run_id`, `stage`, `state`, `attempts`, and `error` columns — to an
+[activation target](#delivering-results-with-activate) after the run reaches its terminal
+state, so operators hear about failures without polling `wvlet flow session list`:
+
+```wvlet
+flow nightly_etl with {
+  schedule: cron('0 2 * * *')
+  on_failure: activate('webhook', url: 'https://alerts.example.com/wvlet')
+} = {
+  stage extract = from source | select *
+  stage load = from extract | save to warehouse
+}
+```
+
+The same targets as `activate` inside stages are available (`file`, `webhook`, and
+custom-registered sinks). A hook that fails to deliver is logged and never changes the
+result of the run.
 
 ### Combining Parameters and Configuration
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -601,6 +601,27 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
   private def configValue(): Expression =
     val t = scanner.lookAhead()
     t.token match
+      case WvletToken.ACTIVATE =>
+        // An activation hook value, e.g. `on_failure: activate('webhook', url: '...')`,
+        // represented as a regular function-apply expression on the `activate` name
+        val at = consume(WvletToken.ACTIVATE)
+        consume(WvletToken.L_PAREN)
+        val target = FunctionArg(None, expression(), false, Nil, spanFrom(at))
+        val params =
+          if scanner.lookAhead().token == WvletToken.COMMA then
+            consume(WvletToken.COMMA)
+            activateParams()
+          else
+            Nil
+        consume(WvletToken.R_PAREN)
+        FunctionApply(
+          UnquotedIdentifier("activate", at.span),
+          target :: params,
+          None,
+          None,
+          None,
+          spanFrom(at)
+        )
       case WvletToken.INTEGER_LITERAL =>
         val numToken = consumeToken()
         val numValue = numToken.str.replaceAll("_", "").toLong
@@ -619,6 +640,9 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
             LongLiteral(numValue, numToken.str, spanFrom(numToken))
       case _ =>
         expression()
+    end match
+
+  end configValue
 
   /**
     * Parse a stage trigger: `if stage.failed` or `if stage.done`

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -900,6 +900,10 @@ class FlowExecutor(
     val result = FlowExecutionResult(flow.name.name, runId, stageResults)
     workEnv.info(s"Completed flow ${flow.name.name} (run: ${runId})")
 
+    // Fire the flow-level notification hooks now that the terminal snapshot is persisted.
+    // A notification failure is logged and never changes the run result
+    notifyRunResult(flow, result)
+
     // Trigger the control-only jumps recorded by successful stages, each as a new run of the
     // target flow. Jump chains are bounded by maxJumpDepth to terminate cycles (A -> B -> A)
     if pendingJumps.nonEmpty && !cancelled then
@@ -930,6 +934,85 @@ class FlowExecutor(
     result
 
   end executeInternal
+
+  /**
+    * Fire the flow-level notification hooks (`on_failure:` / `on_success:` / `on_finish:`) of a
+    * terminal run. The run summary (flow, run_id, stage, state, attempts, error) is materialized as
+    * a short-lived table so that the regular activation sinks (file, webhook, ServiceLoader) can
+    * deliver it like a stage output; any failure here is logged and never changes the run result
+    */
+  private def notifyRunResult(flow: FlowDef, result: FlowExecutionResult): Unit =
+    val hooks = FlowNotifyConfig.fromFlow(flow).hooksFor(result.hasError)
+    if hooks.nonEmpty then
+      val summaryTable              = s"__wv_flow_notify_${result.runId.toLowerCase}"
+      def sqlLit(s: String): String = s"'${s.replaceAll("'", "''")}'"
+      try
+        connector.withSession { conn =>
+          Using.resource(conn.createStatement()) { stmt =>
+            stmt.execute(
+              s"""create or replace table "${summaryTable}" ("flow" varchar, "run_id" varchar, "stage" varchar, "state" varchar, "attempts" bigint, "error" varchar)"""
+            )
+            if result.stageResults.nonEmpty then
+              val rows = result
+                .stageResults
+                .map { s =>
+                  val err = s.error.map(e => sqlLit(e.getMessage)).getOrElse("null")
+                  s"(${sqlLit(result.flowName)}, ${sqlLit(result.runId)}, ${sqlLit(
+                      s.name
+                    )}, ${sqlLit(s.state.stateName)}, ${s.attempts}, ${err})"
+                }
+                .mkString(", ")
+              stmt.execute(s"""insert into "${summaryTable}" values ${rows}""")
+          }
+        }
+        hooks.foreach { spec =>
+          try
+            activationSinks.find(_.name == spec.target) match
+              case Some(sink) =>
+                workEnv.info(
+                  s"[notify] flow ${result.flowName} (run: ${result
+                      .runId}): delivering the run summary to '${spec.target}'"
+                )
+                sink.activate(
+                  ActivationRequest(
+                    spec.target,
+                    spec.params,
+                    result.flowName,
+                    summaryTable,
+                    connector
+                  )
+                )
+              case None =>
+                workEnv.warn(
+                  s"[notify] flow ${result.flowName}: no activation sink named '${spec
+                      .target}' is registered"
+                )
+          catch
+            case NonFatal(e) =>
+              workEnv.warn(
+                s"[notify] flow ${result.flowName}: notification to '${spec.target}' failed: ${e
+                    .getMessage}"
+              )
+        }
+      catch
+        case NonFatal(e) =>
+          workEnv.warn(
+            s"[notify] flow ${result.flowName}: failed to prepare the run summary: ${e.getMessage}"
+          )
+      finally
+        try
+          connector.withSession { conn =>
+            Using.resource(conn.createStatement()) { stmt =>
+              stmt.execute(s"""drop table if exists "${summaryTable}"""")
+            }
+          }
+        catch
+          case NonFatal(_) =>
+        end try
+      end try
+    end if
+
+  end notifyRunResult
 
   /**
     * Execute the lowered stage body and materialize the result as a run-scoped table. References to

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
@@ -38,6 +38,92 @@ import wvlet.lang.model.plan.*
 /** An activation target with its named parameters */
 case class ActivationSpec(target: String, params: Map[String, String] = Map.empty)
 
+object ActivationSpec:
+  /**
+    * Extract an activation spec from an `activate('target', name: value, ...)` expression used as a
+    * flow config value (e.g. `on_failure: activate('webhook', url: '...')`)
+    */
+  def fromExpression(e: Expression): Option[ActivationSpec] =
+    e match
+      case f: FunctionApply =>
+        val isActivate =
+          f.base match
+            case n: NameExpr =>
+              n.fullName == "activate"
+            case _ =>
+              false
+        val target = f
+          .args
+          .collectFirst {
+            case arg: FunctionArg if arg.name.isEmpty =>
+              arg.value match
+                case s: StringLiteral =>
+                  s.unquotedValue
+                case other =>
+                  other.toString
+          }
+        if isActivate then
+          val params =
+            f.args
+              .collect {
+                case arg: FunctionArg if arg.name.isDefined =>
+                  val value =
+                    arg.value match
+                      case s: StringLiteral =>
+                        s.unquotedValue
+                      case l: Literal =>
+                        l.stringValue
+                      case other =>
+                        other.toString
+                  arg.name.get.name -> value
+              }
+              .toMap
+          target.map(ActivationSpec(_, params))
+        else
+          None
+      case _ =>
+        None
+
+end ActivationSpec
+
+/**
+  * Flow-level notification hooks extracted from the flow's `with { ... }` block: activation specs
+  * fired after a run reaches its terminal state. `on_failure` fires for failed runs, `on_success`
+  * for successful runs, and `on_finish` for both
+  */
+case class FlowNotifyConfig(
+    onFailure: List[ActivationSpec] = Nil,
+    onSuccess: List[ActivationSpec] = Nil,
+    onFinish: List[ActivationSpec] = Nil
+):
+  def isEmpty: Boolean = onFailure.isEmpty && onSuccess.isEmpty && onFinish.isEmpty
+
+  /** The hooks that apply to a run outcome */
+  def hooksFor(failed: Boolean): List[ActivationSpec] =
+    (
+      if failed then
+        onFailure
+      else
+        onSuccess
+    ) ++ onFinish
+
+object FlowNotifyConfig:
+  def fromFlow(flow: FlowDef): FlowNotifyConfig =
+    flow
+      .config
+      .foldLeft(FlowNotifyConfig()) { (c, item) =>
+        def spec = ActivationSpec.fromExpression(item.value)
+        item.key.unquotedValue match
+          case "on_failure" =>
+            spec.fold(c)(s => c.copy(onFailure = c.onFailure :+ s))
+          case "on_success" =>
+            spec.fold(c)(s => c.copy(onSuccess = c.onSuccess :+ s))
+          case "on_finish" =>
+            spec.fold(c)(s => c.copy(onFinish = c.onFinish :+ s))
+          case _ =>
+            c
+      }
+
 object FlowLowering:
 
   /**

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -1309,4 +1309,79 @@ class FlowExecutorTest extends UniTest:
     id shouldBe 2L
   }
 
+  // --- Flow notification hooks ---
+
+  private class RecordingSink extends ActivationSink:
+    val requests              = ListBuffer.empty[(ActivationRequest, List[String])]
+    override def name: String = "test_notify"
+    override def activate(request: ActivationRequest): Unit =
+      val rows =
+        connector.runQuery(s"""select stage, state from "${request.table}" order by stage""") {
+          rs =>
+            val b = ListBuffer.empty[String]
+            while rs.next() do
+              b += s"${rs.getString(1)}:${rs.getString(2)}"
+            b.toList
+        }
+      requests += ((request, rows))
+
+  test("fire on_failure hooks with the run summary") {
+    val sink        = RecordingSink()
+    val (flow, ctx) = compileFlow(
+      """flow NotifyFailFlow with { on_failure: activate('test_notify', channel: 'ops') } = {
+        |  stage broken = from nonexistent_table_xyz
+        |  stage downstream = from broken | select *
+        |}""".stripMargin
+    )
+    val result =
+      FlowExecutor(connector, workEnv, activationSinks = List(sink)).execute(flow)(using ctx)
+    result.hasError shouldBe true
+    sink.requests.size shouldBe 1
+    val (req, rows) = sink.requests.head
+    req.params shouldBe Map("channel" -> "ops")
+    req.stageName shouldBe "NotifyFailFlow"
+    rows shouldBe List("broken:failed", "downstream:skipped")
+  }
+
+  test("fire on_success hooks only for successful runs") {
+    val sink        = RecordingSink()
+    val (flow, ctx) = compileFlow("""flow NotifyOkFlow with {
+        |  on_failure: activate('test_notify', kind: 'fail')
+        |  on_success: activate('test_notify', kind: 'ok')
+        |} = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin)
+    val result =
+      FlowExecutor(connector, workEnv, activationSinks = List(sink)).execute(flow)(using ctx)
+    result.isSuccess shouldBe true
+    sink.requests.map(_._1.params) shouldBe List(Map("kind" -> "ok"))
+  }
+
+  test("fire on_finish hooks for both outcomes") {
+    val sink        = RecordingSink()
+    val (flow, ctx) = compileFlow(
+      """flow NotifyFinishFlow with { on_finish: activate('test_notify') } = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin
+    )
+    FlowExecutor(connector, workEnv, activationSinks = List(sink)).execute(flow)(using ctx)
+    sink.requests.size shouldBe 1
+  }
+
+  test("keep the run result when a notification sink fails") {
+    val failingSink =
+      new ActivationSink:
+        override def name: String                               = "test_notify"
+        override def activate(request: ActivationRequest): Unit =
+          throw IllegalStateException("notification endpoint down")
+    val (flow, ctx) = compileFlow(
+      """flow NotifySinkDownFlow with { on_success: activate('test_notify') } = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin
+    )
+    val result =
+      FlowExecutor(connector, workEnv, activationSinks = List(failingSink)).execute(flow)(using ctx)
+    result.isSuccess shouldBe true
+  }
+
 end FlowExecutorTest


### PR DESCRIPTION
## Summary

Item 3 of #1845. The activation sink SPI delivers stage *data*, but nothing reported that a run failed — operators had to poll `wvlet flow session list`. Flows can now declare notification hooks in their config block:

```wvlet
flow nightly_etl with {
  schedule: cron('0 2 * * *')
  on_failure: activate('webhook', url: 'https://alerts.example.com/wvlet')
} = { ... }
```

- **Parser**: `configValue` accepts `activate('target', name: value, ...)` (ACTIVATE is a keyword with its own parse path), represented as a regular `FunctionApply` on the `activate` name so no new AST node is needed.
- **`FlowNotifyConfig`** extracts `on_failure` / `on_success` / `on_finish` hooks from the flow config (`ActivationSpec.fromExpression` mirrors the stage-level `activate` param extraction).
- **Executor**: after the terminal snapshot is persisted, the run summary (`flow`, `run_id`, `stage`, `state`, `attempts`, `error` — one row per stage) is materialized as a short-lived table and delivered through the **existing activation sinks** (file, webhook, ServiceLoader-registered), then dropped. A notification failure or unknown sink name is logged and never changes the run result. `on_failure` fires for failed runs, `on_success` for successful ones, `on_finish` for both.

## Tests

New `FlowExecutorTest` cases with a recording sink: `on_failure` delivers the per-stage summary rows (`broken:failed`, `downstream:skipped`) with hook params; `on_success` fires only on success (and not `on_failure`); `on_finish` fires unconditionally; a throwing sink leaves the run result untouched. Full suite: 67/67.

## Documentation

`website/docs/syntax/flow.md`: hook rows in the flow-level property table plus a new *Run Notifications* subsection with a runnable example.

Refs #1845

🤖 Generated with [Claude Code](https://claude.com/claude-code)