### PR TITLE
feature: Sweep old flow runs with keep_runs retention and a scheduler TTL

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -188,6 +188,7 @@ flow daily_etl with {
 | `on_failure` | Activation | Notification hook fired when a run fails |
 | `on_success` | Activation | Notification hook fired when a run succeeds |
 | `on_finish` | Activation | Notification hook fired for both outcomes |
+| `keep_runs` | Int | Retention cap: only the N most recent finished runs are kept |
 
 ### Run Notifications
 
@@ -475,6 +476,29 @@ Two flags cover scripting and missed windows:
 `run flow`): a run atomically claims one of the flow's N slots and is recorded as `skipped`
 when all slots are taken by running runs. With the `sqlite` run store the claim is
 transactional across processes.
+
+### Run Retention
+
+Run records and their run-scoped `__wv_flow_*` tables accumulate until cleaned. Besides the
+manual `wvlet flow session clean`, the scheduler sweeps them automatically — at startup and
+every few minutes while the daemon runs — when a retention policy is set:
+
+- `keep_runs: N` in a flow's config block keeps only the N most recent finished runs of that
+  flow
+- `wvlet flow scheduler --retention 7d` (also `12h`, `30m`) deletes finished runs older than
+  the given age, across all flows
+
+The sweep first marks crashed runs (running records whose liveness lease expired) as failed,
+then deletes finished runs beyond the policy together with their tables. The most recent
+finished run of each flow is always kept, because cross-flow dependencies (`depends on X`,
+`if X.failed`) are evaluated against it.
+
+```wvlet
+flow hourly_metrics with {
+  schedule: cron('0 * * * *')
+  keep_runs: 24
+} = { ... }
+```
 
 ## Running Flows
 

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -36,6 +36,7 @@ import wvlet.lang.model.plan.RunFlow
 import wvlet.lang.runner.CronSchedule
 import wvlet.lang.runner.FlowExecutor
 import wvlet.lang.runner.FlowRunRecord
+import wvlet.lang.runner.FlowRunRetention
 import wvlet.lang.runner.FlowRunStore
 import wvlet.lang.runner.FlowScheduleConfig
 import wvlet.lang.runner.FlowScheduler
@@ -423,8 +424,16 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
         prefix = "--reload-interval",
         description = "Interval (seconds) for polling .wv file changes; 0 disables reloading"
       )
-      reloadInterval: Int = 5
+      reloadInterval: Int = 5,
+      @option(
+        prefix = "--retention",
+        description =
+          "Delete terminal run records (and their run tables) older than this age, e.g. 7d, 12h, 30m"
+      )
+      retention: Option[String] = None
   ): Unit =
+    // Validate the retention argument up front, before any flow is loaded or triggered
+    val ttlMillis                       = retention.map(parseRetentionMillis)
     val (flows, compileResult, workEnv) = loadFlows(flowOption)
     val scheduled                       = scheduledFlowsOf(flows)
     if scheduled.isEmpty then
@@ -472,6 +481,21 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
                       println(runResult.toPrettyBox())
                 )
           )
+          // Retention: the per-flow keep_runs: caps plus the daemon-wide --retention TTL.
+          // The sweep runs at startup (finalizing stale records frees concurrency slots
+          // before any schedule fires) and periodically in daemon mode
+          val keepRunsOf: Map[String, Option[Int]] =
+            flows.map((_, f) => f.name.name -> FlowScheduleConfig.fromFlow(f).keepRuns).toMap
+          val retentionActive  = ttlMillis.isDefined || keepRunsOf.values.exists(_.isDefined)
+          def sweepNow(): Unit = FlowRunRetention.sweep(
+            store,
+            connector,
+            name => keepRunsOf.getOrElse(name, None),
+            ttlMillis
+          )
+          if retentionActive then
+            sweepNow()
+
           if catchup then
             val fired = flowScheduler.catchUp(name =>
               store.latestRunOf(name).map(_.startedAtMillis)
@@ -487,6 +511,8 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
           else
             if reloadInterval > 0 then
               startReloader(flowOption, flowScheduler, compiled, reloadInterval)
+            if retentionActive then
+              startSweeper(sweepNow)
             Runtime
               .getRuntime
               .addShutdownHook(
@@ -502,6 +528,43 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
     end if
 
   end scheduler
+
+  /** Parse a --retention argument like 7d, 12h, 30m, or 45s into milliseconds */
+  private def parseRetentionMillis(s: String): Long =
+    val m = "^(\\d+)([dhms])$".r
+    s.trim match
+      case m(n, unit) =>
+        val base = n.toLong
+        unit match
+          case "d" =>
+            base * 24L * 3600_000L
+          case "h" =>
+            base * 3600_000L
+          case "m" =>
+            base * 60_000L
+          case _ =>
+            base * 1000L
+      case _ =>
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(s"Cannot parse retention '${s}'. Use a number with d/h/m/s, e.g. 7d")
+
+  /** Start a daemon thread running the retention sweep periodically (every 5 minutes) */
+  private def startSweeper(sweep: () => Unit): Unit =
+    val sweeper = Thread(
+      () =>
+        while true do
+          Thread.sleep(5 * 60 * 1000L)
+          try
+            sweep()
+          catch
+            case scala.util.control.NonFatal(e) =>
+              warn(s"Retention sweep failed: ${e.getMessage}")
+      ,
+      "wvlet-flow-retention-sweep"
+    )
+    sweeper.setDaemon(true)
+    sweeper.start()
 
   /**
     * Start a daemon thread that polls the .wv sources of the working folder and reloads the

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -124,6 +124,52 @@ class WvletFlowCommandTest extends UniTest:
     FlowRunRegistry.forWorkEnv(WorkEnv(dir.toString)).list().size shouldBe 1
   }
 
+  test("sweep runs beyond keep_runs at scheduler startup") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRecord
+    import wvlet.lang.runner.FlowRunRegistry
+    import wvlet.lang.runner.StageRunRecord
+    val dir = Files.createTempDirectory("wvlet-flow-retention")
+    Files.writeString(
+      dir.resolve("scheduled.wv"),
+      """flow RetainedPipeline with {
+        |  schedule: cron('* * * * *')
+        |  keep_runs: 1
+        |} = {
+        |  stage src = from [[1]] as t(id)
+        |}
+        |""".stripMargin
+    )
+    val registry = FlowRunRegistry.forWorkEnv(WorkEnv(dir.toString))
+    List(("old1", 1000L), ("old2", 2000L)).foreach { (id, at) =>
+      registry.save(
+        FlowRunRecord(
+          id,
+          "RetainedPipeline",
+          FlowRunRecord.STATE_SUCCESS,
+          at,
+          Some(at),
+          stages = List(StageRunRecord("src", "success", 1))
+        )
+      )
+    }
+
+    WvletMain.main(s"flow scheduler --once -w ${dir}")
+
+    // The startup sweep kept only the latest seeded run; --once then recorded one new run
+    val runs = registry.list().map(_.runId)
+    runs.contains("old1") shouldBe false
+    runs.contains("old2") shouldBe true
+    runs.size shouldBe 2
+  }
+
+  test("reject an unparseable --retention argument") {
+    val e = intercept[WvletLangException] {
+      WvletMain.main(s"flow scheduler --once --retention forever -w ${flowDir}")
+    }
+    e.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+  }
+
   test("reject backfill of a flow without a schedule") {
     val e = intercept[WvletLangException] {
       WvletMain.main(

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -956,7 +956,8 @@ class FlowExecutor(
               val rows = result
                 .stageResults
                 .map { s =>
-                  val err = s.error.map(e => sqlLit(e.getMessage)).getOrElse("null")
+                  // Exceptions like NullPointerException may carry a null message
+                  val err = s.error.flatMap(e => Option(e.getMessage)).map(sqlLit).getOrElse("null")
                   s"(${sqlLit(result.flowName)}, ${sqlLit(result.runId)}, ${sqlLit(
                       s.name
                     )}, ${sqlLit(s.state.stateName)}, ${s.attempts}, ${err})"

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
@@ -65,17 +65,20 @@ object ActivationSpec:
         if isActivate then
           val params =
             f.args
-              .collect {
-                case arg: FunctionArg if arg.name.isDefined =>
-                  val value =
-                    arg.value match
-                      case s: StringLiteral =>
-                        s.unquotedValue
-                      case l: Literal =>
-                        l.stringValue
-                      case other =>
-                        other.toString
-                  arg.name.get.name -> value
+              .flatMap { arg =>
+                arg
+                  .name
+                  .map { name =>
+                    val value =
+                      arg.value match
+                        case s: StringLiteral =>
+                          s.unquotedValue
+                        case l: Literal =>
+                          l.stringValue
+                        case other =>
+                          other.toString
+                    name.name -> value
+                  }
               }
               .toMap
           target.map(ActivationSpec(_, params))
@@ -342,17 +345,23 @@ object FlowLowering:
           other.toString
     val params =
       a.params
-        .collect {
-          case arg: FunctionArg if arg.name.isDefined =>
-            val value =
-              arg.value match
-                case s: StringLiteral =>
-                  s.unquotedValue
-                case l: Literal =>
-                  l.stringValue
-                case other =>
-                  other.toString
-            arg.name.get.name -> value
+        .flatMap {
+          case arg: FunctionArg =>
+            arg
+              .name
+              .map { name =>
+                val value =
+                  arg.value match
+                    case s: StringLiteral =>
+                      s.unquotedValue
+                    case l: Literal =>
+                      l.stringValue
+                    case other =>
+                      other.toString
+                name.name -> value
+              }
+          case _ =>
+            None
         }
         .toMap
     ActivationSpec(target, params)

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRetention.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRetention.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.runner.connector.DBConnector
+import wvlet.uni.log.LogSupport
+
+import scala.util.control.NonFatal
+
+/**
+  * Retention sweep over recorded flow runs, used by the scheduler daemon (and `--once` runs) to
+  * keep the run store and the run-scoped `__wv_flow_*` tables from growing without bound.
+  *
+  * A sweep performs two steps:
+  *
+  *   1. *Finalize* stale running records: a record still in the `running` state whose liveness
+  *      lease has expired belongs to a dead process and is marked as failed, so it becomes subject
+  *      to retention like any other terminal run.
+  *   1. *Delete* terminal records beyond the retention policy — a per-flow `keep_runs: N` cap (the
+  *      N most recent terminal runs are kept) and/or an age TTL — dropping their run-scoped tables.
+  *      The most recent terminal run of each flow is always kept, because cross-flow dependencies
+  *      (`depends on X`, `if X.failed`) read it through `latestRunOf`.
+  */
+object FlowRunRetention extends LogSupport:
+
+  /** The outcome of a retention sweep */
+  case class SweepSummary(finalizedStale: Int, deletedRuns: Int)
+
+  /**
+    * Run one retention sweep.
+    *
+    * @param keepRunsOf
+    *   Per-flow `keep_runs:` cap (None keeps an unlimited number of runs)
+    * @param ttlMillis
+    *   Age limit of terminal records, measured against their finish time (falling back to the start
+    *   time)
+    */
+  def sweep(
+      store: FlowRunStore,
+      connector: DBConnector,
+      keepRunsOf: String => Option[Int] = _ => None,
+      ttlMillis: Option[Long] = None,
+      nowMillis: Long = System.currentTimeMillis()
+  ): SweepSummary =
+    val all = store.list()
+
+    val stale = all.filter(_.isStaleAt(nowMillis))
+    stale.foreach { r =>
+      warn(s"Finalizing stale run ${r.runId} of flow ${r.flowName} as failed (lease expired)")
+      store.save(
+        r.copy(
+          state = FlowRunRecord.STATE_FAILED,
+          finishedAtMillis = Some(nowMillis),
+          leaseExpiresAtMillis = None
+        )
+      )
+    }
+
+    val terminal =
+      (
+        if stale.isEmpty then
+          all
+        else
+          store.list()
+      ).filter(_.isTerminal)
+    var deleted = 0
+    terminal
+      .groupBy(_.flowName)
+      .foreach { (flowName, runs) =>
+        val newestFirst = runs.sortBy(-_.startedAtMillis)
+        val keep        = keepRunsOf(flowName)
+        // Rank 1 (the latest terminal run) is never deleted
+        newestFirst
+          .zipWithIndex
+          .drop(1)
+          .foreach { (r, idx) =>
+            val rank    = idx + 1
+            val overCap = keep.exists(rank > _)
+            val expired = ttlMillis.exists(ttl =>
+              r.finishedAtMillis.getOrElse(r.startedAtMillis) < nowMillis - ttl
+            )
+            if overCap || expired then
+              try
+                FlowExecutor.dropRunTables(connector, r.runId, r.stages.map(_.name))
+                store.delete(r.runId)
+                deleted += 1
+              catch
+                case NonFatal(e) =>
+                  warn(s"Failed to remove run ${r.runId} of flow ${flowName}: ${e.getMessage}")
+          }
+      }
+
+    if stale.nonEmpty || deleted > 0 then
+      info(s"Retention sweep: finalized ${stale.size} stale run(s), deleted ${deleted} old run(s)")
+    SweepSummary(stale.size, deleted)
+
+  end sweep
+
+end FlowRunRetention

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowScheduler.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowScheduler.scala
@@ -37,7 +37,8 @@ import scala.util.control.NonFatal
 case class FlowScheduleConfig(
     cron: Option[String] = None,
     timezone: Option[String] = None,
-    concurrency: Option[Int] = None
+    concurrency: Option[Int] = None,
+    keepRuns: Option[Int] = None
 ):
   def withCron(cron: String): FlowScheduleConfig      = copy(cron = Some(cron))
   def noCron(): FlowScheduleConfig                    = copy(cron = None)
@@ -45,11 +46,13 @@ case class FlowScheduleConfig(
   def noTimezone(): FlowScheduleConfig                = copy(timezone = None)
   def withConcurrency(limit: Int): FlowScheduleConfig = copy(concurrency = Some(limit))
   def noConcurrency(): FlowScheduleConfig             = copy(concurrency = None)
+  def withKeepRuns(n: Int): FlowScheduleConfig        = copy(keepRuns = Some(n))
+  def noKeepRuns(): FlowScheduleConfig                = copy(keepRuns = None)
 
   def zoneId: ZoneId = timezone.map(ZoneId.of).getOrElse(ZoneId.systemDefault())
 
 object FlowScheduleConfig:
-  /** Extract schedule, timezone, and concurrency from the flow's config items */
+  /** Extract schedule, timezone, concurrency, and keep_runs from the flow's config items */
   def fromFlow(flow: FlowDef): FlowScheduleConfig =
     flow
       .config
@@ -85,6 +88,12 @@ object FlowScheduleConfig:
             item.value match
               case l: LongLiteral =>
                 config.withConcurrency(l.value.toInt)
+              case _ =>
+                config
+          case "keep_runs" =>
+            item.value match
+              case l: LongLiteral =>
+                config.withKeepRuns(l.value.toInt)
               case _ =>
                 config
           case _ =>

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowRunRetentionTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowRunRetentionTest.scala
@@ -1,0 +1,139 @@
+package wvlet.lang.runner
+
+import wvlet.lang.catalog.Profile
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.runner.connector.DBConnectorProvider
+import wvlet.uni.test.UniTest
+
+import java.nio.file.Files
+
+class FlowRunRetentionTest extends UniTest:
+  private val workEnv             = WorkEnv(".")
+  private val dbConnectorProvider = DBConnectorProvider(workEnv)
+  private val connector           = dbConnectorProvider.getConnector(Profile.defaultDuckDBProfile)
+
+  override def afterAll: Unit = dbConnectorProvider.close()
+
+  // Note: an explicit registry path — WorkEnv.targetFolder of a folder without .wv files
+  // falls back to the shared ~/.cache/wvlet/target, which would leak records across tests
+  private def newStore(): FlowRunStore = FlowRunRegistry(
+    Files.createTempDirectory("wvlet-retention-test")
+  )
+
+  private def terminalRun(
+      runId: String,
+      flow: String,
+      startedAt: Long,
+      finishedAt: Long,
+      stage: String = "src"
+  ): FlowRunRecord = FlowRunRecord(
+    runId,
+    flow,
+    FlowRunRecord.STATE_SUCCESS,
+    startedAt,
+    Some(finishedAt),
+    stages = List(StageRunRecord(stage, "success", 1))
+  )
+
+  private def createStageTable(runId: String, stage: String): String =
+    val table = FlowExecutor.stageTableName(runId, stage)
+    connector.execute(s"""create or replace table "${table}" as select 1 as id""")
+    table
+
+  private def tableExists(table: String): Boolean =
+    connector.runQuery(
+      s"select count(*) cnt from information_schema.tables where table_name = '${table}'"
+    ) { rs =>
+      rs.next()
+      rs.getLong(1) > 0
+    }
+
+  test("keep the latest terminal run and delete runs beyond keep_runs") {
+    val store  = newStore()
+    val tables = (1 to 3).map { i =>
+      store.save(terminalRun(s"keeprun${i}", "F", startedAt = i * 1000L, finishedAt = i * 1000L))
+      createStageTable(s"keeprun${i}", "src")
+    }
+
+    val summary = FlowRunRetention.sweep(store, connector, keepRunsOf = _ => Some(1))
+    summary.deletedRuns shouldBe 2
+    store.list().map(_.runId) shouldBe List("keeprun3")
+    tableExists(tables(2)) shouldBe true
+    tableExists(tables(0)) shouldBe false
+    tableExists(tables(1)) shouldBe false
+  }
+
+  test("delete terminal runs older than the ttl but never the latest") {
+    val store = newStore()
+    store.save(terminalRun("ttlrun1", "F", startedAt = 1000L, finishedAt = 1000L))
+    store.save(terminalRun("ttlrun2", "F", startedAt = 2000L, finishedAt = 2000L))
+
+    // Both runs are far older than the ttl, but the latest terminal run survives because
+    // cross-flow dependencies read it via latestRunOf
+    val summary = FlowRunRetention.sweep(
+      store,
+      connector,
+      ttlMillis = Some(1000L),
+      nowMillis = 1_000_000L
+    )
+    summary.deletedRuns shouldBe 1
+    store.list().map(_.runId) shouldBe List("ttlrun2")
+  }
+
+  test("finalize stale running records and keep live ones") {
+    val store = newStore()
+    val now   = 100_000L
+    store.save(
+      FlowRunRecord(
+        "stalerun",
+        "F",
+        FlowRunRecord.STATE_RUNNING,
+        startedAtMillis = now - 60_000,
+        leaseExpiresAtMillis = Some(now - 30_000)
+      )
+    )
+    store.save(
+      FlowRunRecord(
+        "liverun",
+        "F",
+        FlowRunRecord.STATE_RUNNING,
+        startedAtMillis = now,
+        leaseExpiresAtMillis = Some(now + 60_000)
+      )
+    )
+
+    val summary = FlowRunRetention.sweep(store, connector, nowMillis = now)
+    summary.finalizedStale shouldBe 1
+    summary.deletedRuns shouldBe 0
+    store.get("stalerun").get.state shouldBe FlowRunRecord.STATE_FAILED
+    store.get("liverun").get.state shouldBe FlowRunRecord.STATE_RUNNING
+  }
+
+  test("retention applies to runs finalized in the same sweep") {
+    val store = newStore()
+    val now   = 100_000L
+    store.save(terminalRun("newterm", "F", startedAt = now - 1000, finishedAt = now - 1000))
+    store.save(
+      FlowRunRecord(
+        "oldstale",
+        "F",
+        FlowRunRecord.STATE_RUNNING,
+        startedAtMillis = now - 60_000,
+        leaseExpiresAtMillis = Some(now - 30_000)
+      )
+    )
+
+    // The stale run is finalized as failed, ranks below the newer terminal run, and is
+    // deleted by the keep_runs cap in the same sweep
+    val summary = FlowRunRetention.sweep(
+      store,
+      connector,
+      keepRunsOf = _ => Some(1),
+      nowMillis = now
+    )
+    summary.finalizedStale shouldBe 1
+    summary.deletedRuns shouldBe 1
+    store.list().map(_.runId) shouldBe List("newterm")
+  }
+
+end FlowRunRetentionTest


### PR DESCRIPTION
## Summary

Item 4 of #1845 (the last item of the round). Run-scoped `__wv_flow_*` tables and run records accumulated until someone manually ran `wvlet flow session clean`. The scheduler daemon is now the automatic sweeper:

- **`keep_runs: N`** in a flow's config block keeps only the N most recent finished runs of that flow (`FlowScheduleConfig` gains the field).
- **`wvlet flow scheduler --retention 7d`** (`12h`, `30m`, `45s`) deletes finished runs older than the given age across all flows; an unparseable value is rejected up front.
- **`FlowRunRetention.sweep`** runs at scheduler startup (both daemon and `--once` modes) and every 5 minutes in daemon mode, when any retention policy is active. It first *finalizes* crashed runs — running records whose liveness lease expired are marked failed, freeing their `concurrency:` slots before any schedule fires — then *deletes* finished runs beyond the policy together with their run tables.
- **The most recent finished run of each flow is always kept**, because cross-flow dependencies (`depends on X`, `if X.failed`) are evaluated against it via `latestRunOf`.

Also addresses the Gemini review of #1850: a null exception message (e.g. `NullPointerException`) no longer breaks run-summary preparation in `notifyRunResult`, and the `Option.get`-guarded-by-`isDefined` patterns in activation param extraction are rewritten with `flatMap`/`map`.

## Tests

- `FlowRunRetentionTest` (new): `keep_runs` cap deletes older runs and drops their tables (verified via `information_schema`), TTL never deletes the latest terminal run, stale running records are finalized while live-lease runs are untouched, and a run finalized in a sweep is subject to retention in the same sweep. The suite constructs its registry with an explicit path since `WorkEnv.targetFolder` of a `.wv`-less folder falls back to the shared `~/.cache/wvlet/target`.
- `WvletFlowCommandTest`: seeded old runs are swept at `scheduler --once` startup under `keep_runs: 1`; `--retention forever` is rejected with `INVALID_ARGUMENT`.
- Full runner + cli suites pass locally (108 cli tests).

## Documentation

`website/docs/syntax/flow.md`: `keep_runs` in the flow-level property table and a new *Run Retention* subsection under Flow Scheduling.

Refs #1845, #1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)