### PR TITLE
internal: Harden retention parsing and sweep internals from review feedback

### DIFF
--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -531,23 +531,34 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
 
   /** Parse a --retention argument like 7d, 12h, 30m, or 45s into milliseconds */
   private def parseRetentionMillis(s: String): Long =
+    def fail(): Nothing =
+      throw StatusCode
+        .INVALID_ARGUMENT
+        .newException(s"Cannot parse retention '${s}'. Use a number with d/h/m/s, e.g. 7d")
+
     val m = "^(\\d+)([dhms])$".r
     s.trim match
       case m(n, unit) =>
-        val base = n.toLong
-        unit match
-          case "d" =>
-            base * 24L * 3600_000L
-          case "h" =>
-            base * 3600_000L
-          case "m" =>
-            base * 60_000L
-          case _ =>
-            base * 1000L
+        try
+          val base       = n.toLong
+          val unitMillis =
+            unit match
+              case "d" =>
+                24L * 3600_000L
+              case "h" =>
+                3600_000L
+              case "m" =>
+                60_000L
+              case _ =>
+                1000L
+          // An absurdly large value would overflow into a negative TTL, which would make
+          // every finished run look expired
+          Math.multiplyExact(base, unitMillis)
+        catch
+          case _: NumberFormatException | _: ArithmeticException =>
+            fail()
       case _ =>
-        throw StatusCode
-          .INVALID_ARGUMENT
-          .newException(s"Cannot parse retention '${s}'. Use a number with d/h/m/s, e.g. 7d")
+        fail()
 
   /** Start a daemon thread running the retention sweep periodically (every 5 minutes) */
   private def startSweeper(sweep: () => Unit): Unit =

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRetention.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRetention.scala
@@ -55,30 +55,27 @@ object FlowRunRetention extends LogSupport:
   ): SweepSummary =
     val all = store.list()
 
-    val stale = all.filter(_.isStaleAt(nowMillis))
-    stale.foreach { r =>
-      warn(s"Finalizing stale run ${r.runId} of flow ${r.flowName} as failed (lease expired)")
-      store.save(
-        r.copy(
-          state = FlowRunRecord.STATE_FAILED,
-          finishedAtMillis = Some(nowMillis),
-          leaseExpiresAtMillis = None
-        )
-      )
-    }
+    val finalized =
+      all
+        .filter(_.isStaleAt(nowMillis))
+        .map { r =>
+          warn(s"Finalizing stale run ${r.runId} of flow ${r.flowName} as failed (lease expired)")
+          val failed = r.copy(
+            state = FlowRunRecord.STATE_FAILED,
+            finishedAtMillis = Some(nowMillis),
+            leaseExpiresAtMillis = None
+          )
+          store.save(failed)
+          r.runId -> failed
+        }
+        .toMap
 
-    val terminal =
-      (
-        if stale.isEmpty then
-          all
-        else
-          store.list()
-      ).filter(_.isTerminal)
-    var deleted = 0
+    val terminal = all.map(r => finalized.getOrElse(r.runId, r)).filter(_.isTerminal)
+    var deleted  = 0
     terminal
       .groupBy(_.flowName)
       .foreach { (flowName, runs) =>
-        val newestFirst = runs.sortBy(-_.startedAtMillis)
+        val newestFirst = runs.sortBy(_.startedAtMillis)(using Ordering[Long].reverse)
         val keep        = keepRunsOf(flowName)
         // Rank 1 (the latest terminal run) is never deleted
         newestFirst
@@ -101,9 +98,11 @@ object FlowRunRetention extends LogSupport:
           }
       }
 
-    if stale.nonEmpty || deleted > 0 then
-      info(s"Retention sweep: finalized ${stale.size} stale run(s), deleted ${deleted} old run(s)")
-    SweepSummary(stale.size, deleted)
+    if finalized.nonEmpty || deleted > 0 then
+      info(
+        s"Retention sweep: finalized ${finalized.size} stale run(s), deleted ${deleted} old run(s)"
+      )
+    SweepSummary(finalized.size, deleted)
 
   end sweep
 

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowRunRetentionTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowRunRetentionTest.scala
@@ -105,8 +105,8 @@ class FlowRunRetentionTest extends UniTest:
     val summary = FlowRunRetention.sweep(store, connector, nowMillis = now)
     summary.finalizedStale shouldBe 1
     summary.deletedRuns shouldBe 0
-    store.get("stalerun").get.state shouldBe FlowRunRecord.STATE_FAILED
-    store.get("liverun").get.state shouldBe FlowRunRecord.STATE_RUNNING
+    store.get("stalerun").map(_.state) shouldBe Some(FlowRunRecord.STATE_FAILED)
+    store.get("liverun").map(_.state) shouldBe Some(FlowRunRecord.STATE_RUNNING)
   }
 
   test("retention applies to runs finalized in the same sweep") {


### PR DESCRIPTION
## Summary

Follow-up to the Gemini review of #1851:

- **Overflow-safe `--retention`**: `Math.multiplyExact` with a clear `INVALID_ARGUMENT` on overflow — an absurdly large value (e.g. `99999999999d`) previously wrapped into a negative TTL that would have expired every finished run.
- **Sweep internals**: finalized stale records are patched into the in-memory list instead of re-reading the whole store (redundant disk I/O for the file store), and newest-first ordering uses `Ordering[Long].reverse` instead of sort-by-negation.
- **Test style**: `Option` assertions in `FlowRunRetentionTest` use `.map(...) shouldBe Some(...)` instead of `.get`.

`FlowRunRetentionTest` (4/4) and cli compilation pass locally.

Refs #1845, #1851

🤖 Generated with [Claude Code](https://claude.com/claude-code)