### PR TITLE
feature: Persist bound arguments and run_time on flow run records

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -622,12 +622,17 @@ executing any stage.
 
 Runs are managed with `wvlet flow session` subcommands:
 
-- `wvlet flow session list` / `show <run_id>`: inspect recorded runs and per-stage states
+- `wvlet flow session list` / `show <run_id>`: inspect recorded runs and per-stage states.
+  `show` displays how the run was invoked — its flow call form with the resolved arguments
+  (e.g. `customer_pipeline(segment = 'premium')`) and its logical `run_time` — so backfilled
+  and parameterized runs stay auditable
 - `wvlet flow session cancel <run_id>`: request cancellation of a running flow, even from
   another process. The executor polls the registry and stops in-flight stage attempts
   (cancelling their SQL statements server-side)
 - `wvlet flow session resume <run_id>`: re-run a failed or cancelled run from its first
-  non-successful stage, reusing the materialized tables of stages that already succeeded
+  non-successful stage, reusing the materialized tables of stages that already succeeded.
+  The run's recorded arguments and `run_time`/`run_date` are re-bound automatically, so a
+  parameterized or backfilled run resumes with exactly the values of its original invocation
 - `wvlet flow session clean`: delete terminal run records and drop their run-scoped
   `__wv_flow_*` tables. With `--stale`, also remove running records whose liveness lease
   expired (crashed runs)

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -340,8 +340,9 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
         case "show" =>
           val r = recordOf(requireRunId("show <run_id>"))
           println(s"run:      ${r.runId}")
-          println(s"flow:     ${r.flowName}")
+          println(s"flow:     ${r.flowCallForm}")
           println(s"state:    ${r.state}")
+          r.runTimeMillis.foreach(t => println(s"run_time: ${fmtTime(t)}"))
           println(s"started:  ${fmtTime(r.startedAtMillis)}")
           r.finishedAtMillis.foreach(f => println(s"finished: ${fmtTime(f)}"))
           r.stages
@@ -497,8 +498,10 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
             sweepNow()
 
           if catchup then
+            // Compare against the logical run time when recorded: it equals the fire time of a
+            // scheduled run exactly, while startedAtMillis (older records) trails it slightly
             val fired = flowScheduler.catchUp(name =>
-              store.latestRunOf(name).map(_.startedAtMillis)
+              store.latestRunOf(name).map(r => r.runTimeMillis.getOrElse(r.startedAtMillis))
             )
             if fired.nonEmpty then
               println(s"Catch-up triggered ${fired.size} missed flow(s): ${fired.mkString(", ")}")

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletFlowCommandTest.scala
@@ -29,6 +29,11 @@ class WvletFlowCommandTest extends UniTest:
         |  stage src = from [[1, 'a'], [2, 'b'], [3, 'a']] as t(id, name)
         |  stage filtered = from src | where name = target_name and id >= min_id
         |}
+        |
+        |flow ParamFailPipeline(target_name: string) = {
+        |  stage src = from [[1, 'a'], [2, 'b']] as t(id, name) | where name = target_name
+        |  stage broken = from src cross join nonexistent_table_xyz
+        |}
         |""".stripMargin
     )
     dir.toAbsolutePath.toString
@@ -235,6 +240,23 @@ class WvletFlowCommandTest extends UniTest:
     // the same run record
     WvletMain.main(s"flow session resume ${failed.runId} -w ${flowDir}")
     registry.get(failed.runId).get.state shouldBe "failed"
+  }
+
+  test("resume a parameterized flow run re-binding its recorded arguments") {
+    import wvlet.lang.compiler.WorkEnv
+    import wvlet.lang.runner.FlowRunRegistry
+    WvletMain.main(Array("flow", "run", "ParamFailPipeline(target_name = 'a')", "-w", flowDir))
+    val registry = FlowRunRegistry.forWorkEnv(WorkEnv(flowDir))
+    val failed   =
+      registry.list().find(r => r.flowName == "ParamFailPipeline" && r.state == "failed").get
+    failed.args shouldBe Map("target_name" -> "'a'")
+    failed.flowCallForm shouldBe "ParamFailPipeline(target_name = 'a')"
+    // Resume passes no arguments: the recorded ones are re-bound instead of failing with
+    // a missing-parameter error. The broken stage fails again, which is fine here
+    WvletMain.main(s"flow session resume ${failed.runId} -w ${flowDir}")
+    val resumed = registry.get(failed.runId).get
+    resumed.state shouldBe "failed"
+    resumed.args shouldBe Map("target_name" -> "'a'")
   }
 
   test("reject resuming a run that never failed") {

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -17,9 +17,11 @@ import wvlet.lang.api.Span
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.api.v1.flow.StageState
+import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Context
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.compiler.codegen.GenSQL
+import wvlet.lang.compiler.parser.ParserPhase
 import wvlet.lang.compiler.transform.FlowParams
 import wvlet.lang.model.DataType
 import wvlet.lang.model.expr.*
@@ -294,7 +296,11 @@ class FlowExecutor(
     * `runTime` is the logical time of the run: the schedule fire time for scheduler-triggered and
     * backfill runs, and the current wall clock otherwise. Stage bodies can reference it through the
     * implicit `run_time` (timestamp) and `run_date` (`'yyyy-MM-dd'` string) bindings; a declared
-    * flow parameter of the same name takes precedence
+    * flow parameter of the same name takes precedence.
+    *
+    * The resolved bindings and the logical run time are persisted on the run record, so a resumed
+    * run re-binds the arguments and `run_time` of its original invocation when the caller passes
+    * neither explicitly
     */
   def execute(
       flow: FlowDef,
@@ -302,13 +308,32 @@ class FlowExecutor(
       args: List[FunctionArg] = Nil,
       runTime: Option[ZonedDateTime] = None
   )(using ctx: Context): FlowExecutionResult =
-    val bindings =
-      // A manual run evaluates "now" in the flow's configured timezone, so that run_date
-      // agrees with what the flow's schedule would produce
-      FlowExecutor.runTimeBindings(
-        runTime.getOrElse(ZonedDateTime.now(FlowScheduleConfig.fromFlow(flow).zoneId))
-      ) ++ FlowParams.bind(flow, args)
-    executeInternal(FlowParams.substitute(flow, bindings), resumeFrom, jumpDepth = 0)
+    val zoneId        = FlowScheduleConfig.fromFlow(flow).zoneId
+    val effectiveArgs =
+      if args.isEmpty then
+        resumeFrom.map(r => FlowExecutor.recordedArgsOf(flow, r)).getOrElse(Nil)
+      else
+        args
+    // A manual run evaluates "now" in the flow's configured timezone, so that run_date
+    // agrees with what the flow's schedule would produce
+    val resolvedRunTime = runTime
+      .orElse(
+        resumeFrom
+          .flatMap(_.runTimeMillis)
+          .map(millis => java.time.Instant.ofEpochMilli(millis).atZone(zoneId))
+      )
+      .getOrElse(ZonedDateTime.now(zoneId))
+    val paramBindings = FlowParams.bind(flow, effectiveArgs)
+    val bindings      = FlowExecutor.runTimeBindings(resolvedRunTime) ++ paramBindings
+    executeInternal(
+      FlowParams.substitute(flow, bindings),
+      resumeFrom,
+      jumpDepth = 0,
+      runArgs = FlowExecutor.renderBindings(paramBindings),
+      runTimeMillis = resolvedRunTime.toInstant.toEpochMilli
+    )
+
+  end execute
 
   /** Resolve a flow referenced by a `-> Flow` jump through the compilation context */
   private def resolveJumpTarget(name: String)(using ctx: Context): FlowDef =
@@ -320,9 +345,13 @@ class FlowExecutor(
           .FLOW_NOT_FOUND
           .newException(s"Flow '${name}' referenced by a -> jump is not found")
 
-  private def executeInternal(flow: FlowDef, resumeFrom: Option[FlowRunRecord], jumpDepth: Int)(
-      using ctx: Context
-  ): FlowExecutionResult =
+  private def executeInternal(
+      flow: FlowDef,
+      resumeFrom: Option[FlowRunRecord],
+      jumpDepth: Int,
+      runArgs: Map[String, String],
+      runTimeMillis: Long
+  )(using ctx: Context): FlowExecutionResult =
     val runId     = resumeFrom.map(_.runId).getOrElse(ULID.newULIDString)
     val startedAt = System.currentTimeMillis()
     workEnv.info(s"Executing flow ${flow.name.name} (run: ${runId})")
@@ -344,7 +373,9 @@ class FlowExecutor(
             FlowRunRecord.STATE_SKIPPED,
             startedAt,
             Some(System.currentTimeMillis()),
-            skipped.stageResults.map(r => StageRunRecord(r.name, r.state.stateName, r.attempts))
+            skipped.stageResults.map(r => StageRunRecord(r.name, r.state.stateName, r.attempts)),
+            args = runArgs,
+            runTimeMillis = Some(runTimeMillis)
           )
         )
       }
@@ -600,6 +631,9 @@ class FlowExecutor(
             None
           else
             Some(System.currentTimeMillis() + config.leaseTimeoutMillis)
+        ,
+        args = runArgs,
+        runTimeMillis = Some(runTimeMillis)
       )
     end currentRecord
 
@@ -919,15 +953,16 @@ class FlowExecutor(
             workEnv.info(s"Jumping from flow ${flow.name.name} to flow ${target}")
             // A jump carries no arguments, so the target flow runs with its parameter defaults
             // and the current wall clock as its run time
-            val targetFlow = jumpTargetFlows(target)
-            val bindings   =
-              FlowExecutor.runTimeBindings(
-                ZonedDateTime.now(FlowScheduleConfig.fromFlow(targetFlow).zoneId)
-              ) ++ FlowParams.bind(targetFlow, Nil)
+            val targetFlow    = jumpTargetFlows(target)
+            val jumpRunTime   = ZonedDateTime.now(FlowScheduleConfig.fromFlow(targetFlow).zoneId)
+            val paramBindings = FlowParams.bind(targetFlow, Nil)
+            val bindings      = FlowExecutor.runTimeBindings(jumpRunTime) ++ paramBindings
             executeInternal(
               FlowParams.substitute(targetFlow, bindings),
               resumeFrom = None,
-              jumpDepth = jumpDepth + 1
+              jumpDepth = jumpDepth + 1,
+              runArgs = FlowExecutor.renderBindings(paramBindings),
+              runTimeMillis = jumpRunTime.toInstant.toEpochMilli
             )
         }
 
@@ -1114,6 +1149,50 @@ object FlowExecutor:
       ),
     "run_date" -> SingleQuoteString(runTime.format(runDateFormat), Span.NoSpan)
   )
+
+  /**
+    * Render resolved parameter bindings as wvlet literals for persistence on the run record (e.g.
+    * `segment -> 'a'`), so that `session show` can display the flow call form and resume can
+    * re-bind the original values
+    */
+  def renderBindings(bindings: Map[String, Expression]): Map[String, String] = bindings.map(
+    (name, value) => name -> value.pp
+  )
+
+  /**
+    * Reconstruct the flow arguments persisted on a run record as named arguments, parsed with the
+    * regular flow-call grammar, so that resuming a parameterized run re-binds exactly the values
+    * its original invocation resolved. Recorded parameters that the flow no longer declares are
+    * dropped; parameters added since the run follow the regular default/missing-argument rules
+    */
+  def recordedArgsOf(flow: FlowDef, record: FlowRunRecord): List[FunctionArg] =
+    val recorded = flow
+      .params
+      .flatMap(p => record.args.get(p.name.name).map(v => s"${p.name.name} = ${v}"))
+    if recorded.isEmpty then
+      Nil
+    else
+      val call = s"${flow.name.name}(${recorded.mkString(", ")})"
+      try
+        val unit                    = CompilationUnit.fromWvletString(s"run flow ${call}")
+        val plan                    = ParserPhase.parseOnly(unit)
+        var args: List[FunctionArg] = Nil
+        plan.traverse { case q: Query =>
+          q.child match
+            case r: RunFlow =>
+              args = r.args
+            case _ =>
+        }
+        args
+      catch
+        case NonFatal(e) =>
+          throw StatusCode
+            .INVALID_ARGUMENT
+            .newException(
+              s"Cannot re-bind the recorded arguments of run ${record.runId} (${call}): ${e
+                  .getMessage}",
+              e
+            )
 
   /** The run-scoped table name holding the materialized result of a stage */
   def stageTableName(runId: String, stageName: String): String =

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
@@ -57,6 +57,14 @@ case class StageRunRecord(
   *   Liveness lease of a running record, refreshed periodically by the executor. A running record
   *   whose lease has expired belongs to a dead process (e.g. a crash mid-run) and is treated as
   *   failed by run-slot claims and cross-flow dependency evaluation
+  * @param args
+  *   The resolved flow arguments of the run (after defaults), each rendered as a wvlet literal
+  *   (e.g. `segment -> 'a'`). Resume re-binds these values, and `session show` displays the run's
+  *   flow call form
+  * @param runTimeMillis
+  *   The logical run time of the run (epoch millis): the schedule fire time for scheduler-triggered
+  *   and backfill runs, the wall clock at start otherwise. Absent in records written by older
+  *   versions
   */
 case class FlowRunRecord(
     runId: String,
@@ -65,7 +73,9 @@ case class FlowRunRecord(
     startedAtMillis: Long,
     finishedAtMillis: Option[Long] = None,
     stages: List[StageRunRecord] = Nil,
-    leaseExpiresAtMillis: Option[Long] = None
+    leaseExpiresAtMillis: Option[Long] = None,
+    args: Map[String, String] = Map.empty,
+    runTimeMillis: Option[Long] = None
 ):
   def isTerminal: Boolean = state != FlowRunRecord.STATE_RUNNING
 
@@ -79,6 +89,18 @@ case class FlowRunRecord(
       FlowRunRecord.STATE_FAILED
     else
       state
+
+  /**
+    * The flow call form of the run reconstructed from the recorded arguments, e.g. `F(segment =
+    * 'a')`. Arguments are listed in name order for a deterministic rendering
+    */
+  def flowCallForm: String =
+    if args.isEmpty then
+      flowName
+    else
+      s"${flowName}(${args.toList.sortBy(_._1).map((k, v) => s"${k} = ${v}").mkString(", ")})"
+
+end FlowRunRecord
 
 object FlowRunRecord:
   val STATE_RUNNING   = "running"

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowScheduler.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowScheduler.scala
@@ -211,14 +211,15 @@ class FlowScheduler(
   /**
     * Trigger the flows whose most recent scheduled fire time has no run recorded at or after it
     * (i.e. the fire was missed, e.g. while the scheduler daemon was down) and return their names.
-    * `lastRunStartedAt` supplies the start time of the latest recorded run of a flow
+    * `lastRunTimeOf` supplies the logical run time (or, for records without one, the start time) of
+    * the latest recorded run of a flow
     */
-  def catchUp(lastRunStartedAt: String => Option[Long]): List[String] = synchronized {
+  def catchUp(lastRunTimeOf: String => Option[Long]): List[String] = synchronized {
     val now    = clock()
     val missed = current.flatMap { sf =>
       try
         val prev = sf.cron.prevAtOrBefore(now.atZone(sf.zone))
-        if lastRunStartedAt(sf.name).forall(_ < prev.toInstant.toEpochMilli) then
+        if lastRunTimeOf(sf.name).forall(_ < prev.toInstant.toEpochMilli) then
           Some((sf, prev))
         else
           None

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/SQLiteFlowRunStore.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/SQLiteFlowRunStore.scala
@@ -14,6 +14,7 @@
 package wvlet.lang.runner
 
 import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -34,6 +35,11 @@ import scala.util.control.NonFatal
 class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
   Option(dbPath.getParent).foreach(Files.createDirectories(_))
 
+  import SQLiteFlowRunStore.RunArgs
+
+  // Bound flow arguments are stored as a single JSON object column
+  private val argsWeaver = Weaver.of[RunArgs]
+
   private val conn: Connection = DriverManager.getConnection(s"jdbc:sqlite:${dbPath}")
 
   Using.resource(conn.createStatement()) { stmt =>
@@ -46,18 +52,20 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
         |  started_at       integer not null,
         |  finished_at      integer,
         |  cancel_requested integer not null default 0,
-        |  lease_expires_at integer
+        |  lease_expires_at integer,
+        |  args             text,
+        |  run_time         integer
         |)""".stripMargin)
-    // Migrate databases created before the lease column was introduced
-    val hasLeaseColumn =
+    // Migrate databases created before these columns were introduced
+    val existingColumns =
       Using.resource(stmt.executeQuery("pragma table_info(runs)")) { rs =>
-        Iterator
-          .continually(rs)
-          .takeWhile(_.next())
-          .exists(_.getString("name") == "lease_expires_at")
+        Iterator.continually(rs).takeWhile(_.next()).map(_.getString("name")).toSet
       }
-    if !hasLeaseColumn then
-      stmt.execute("alter table runs add column lease_expires_at integer")
+    List("lease_expires_at" -> "integer", "args" -> "text", "run_time" -> "integer").foreach {
+      (column, sqlType) =>
+        if !existingColumns.contains(column) then
+          stmt.execute(s"alter table runs add column ${column} ${sqlType}")
+    }
     stmt.execute("""create table if not exists stages(
         |  run_id     text not null,
         |  ordinal    integer not null,
@@ -75,14 +83,16 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
     try
       Using.resource(
         conn.prepareStatement(
-          """insert into runs(run_id, flow_name, state, started_at, finished_at, lease_expires_at)
-            |values(?, ?, ?, ?, ?, ?)
+          """insert into runs(run_id, flow_name, state, started_at, finished_at, lease_expires_at, args, run_time)
+            |values(?, ?, ?, ?, ?, ?, ?, ?)
             |on conflict(run_id) do update set
             |  flow_name = excluded.flow_name,
             |  state = excluded.state,
             |  started_at = excluded.started_at,
             |  finished_at = excluded.finished_at,
-            |  lease_expires_at = excluded.lease_expires_at""".stripMargin
+            |  lease_expires_at = excluded.lease_expires_at,
+            |  args = excluded.args,
+            |  run_time = excluded.run_time""".stripMargin
         )
       ) { ps =>
         bindRunColumns(ps, record)
@@ -113,6 +123,15 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
         ps.setLong(6, l)
       case None =>
         ps.setNull(6, java.sql.Types.BIGINT)
+    if record.args.isEmpty then
+      ps.setNull(7, java.sql.Types.VARCHAR)
+    else
+      ps.setString(7, argsWeaver.toJson(RunArgs(record.args)))
+    record.runTimeMillis match
+      case Some(t) =>
+        ps.setLong(8, t)
+      case None =>
+        ps.setNull(8, java.sql.Types.BIGINT)
 
   private def saveStages(record: FlowRunRecord): Unit =
     Using.resource(conn.prepareStatement("delete from stages where run_id = ?")) { ps =>
@@ -155,18 +174,18 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
     val claimed =
       Using.resource(
         conn.prepareStatement(
-          """insert into runs(run_id, flow_name, state, started_at, finished_at, lease_expires_at)
-            |select ?, ?, ?, ?, ?, ?
+          """insert into runs(run_id, flow_name, state, started_at, finished_at, lease_expires_at, args, run_time)
+            |select ?, ?, ?, ?, ?, ?, ?, ?
             |where (select count(*) from runs
             |       where flow_name = ? and state = ?
             |         and (lease_expires_at is null or lease_expires_at >= ?)) < ?""".stripMargin
         )
       ) { ps =>
         bindRunColumns(ps, record)
-        ps.setString(7, record.flowName)
-        ps.setString(8, FlowRunRecord.STATE_RUNNING)
-        ps.setLong(9, System.currentTimeMillis())
-        ps.setInt(10, concurrencyLimit)
+        ps.setString(9, record.flowName)
+        ps.setString(10, FlowRunRecord.STATE_RUNNING)
+        ps.setLong(11, System.currentTimeMillis())
+        ps.setInt(12, concurrencyLimit)
         ps.executeUpdate() == 1
       }
     if claimed then
@@ -237,7 +256,7 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
     val runs =
       Using.resource(
         conn.prepareStatement(
-          s"select run_id, flow_name, state, started_at, finished_at, lease_expires_at from runs ${clause}"
+          s"select run_id, flow_name, state, started_at, finished_at, lease_expires_at, args, run_time from runs ${clause}"
         )
       ) { ps =>
         bind(ps)
@@ -253,6 +272,8 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
           while rs.next() do
             val finishedAtOpt = nullableLong(5)
             val leaseOpt      = nullableLong(6)
+            val argsOpt       = Option(rs.getString(7))
+            val runTimeOpt    = nullableLong(8)
             b +=
               FlowRunRecord(
                 runId = rs.getString(1),
@@ -260,7 +281,9 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
                 state = rs.getString(3),
                 startedAtMillis = rs.getLong(4),
                 finishedAtMillis = finishedAtOpt,
-                leaseExpiresAtMillis = leaseOpt
+                leaseExpiresAtMillis = leaseOpt,
+                args = argsOpt.map(json => argsWeaver.fromJson(json).args).getOrElse(Map.empty),
+                runTimeMillis = runTimeOpt
               )
           b.result()
         }
@@ -292,3 +315,7 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
     }
 
 end SQLiteFlowRunStore
+
+object SQLiteFlowRunStore:
+  /** JSON envelope of the bound flow arguments stored in the `args` column */
+  private case class RunArgs(args: Map[String, String] = Map.empty)

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -1233,6 +1233,76 @@ class FlowExecutorTest extends UniTest:
     e.getMessage shouldContain "expects string"
   }
 
+  test("record the resolved arguments and logical run time on the run record") {
+    val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val runTime  = java.time.ZonedDateTime.of(2026, 7, 1, 2, 30, 0, 0, java.time.ZoneId.of("UTC"))
+    val result   = runFlow(
+      paramFlow,
+      registry = Some(registry),
+      args = List(namedArg("target_name", str("a"))),
+      runTime = Some(runTime)
+    )
+    result.isSuccess shouldBe true
+    val record = registry.get(result.runId).get
+    // The record captures the resolved bindings after defaults, rendered as wvlet literals
+    record.args shouldBe Map("target_name" -> "'a'", "min_id" -> "1")
+    record.runTimeMillis shouldBe Some(runTime.toInstant.toEpochMilli)
+    record.flowCallForm shouldBe "ParamFlow(min_id = 1, target_name = 'a')"
+  }
+
+  test("resume a parameterized flow re-binding its recorded arguments and run time") {
+    val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-reg"))
+    val wv       =
+      """flow ResumeParamFlow(target_name: string) with {
+        |  timezone: 'UTC'
+        |} = {
+        |  stage src = from [[1, 'a'], [2, 'b'], [3, 'a']] as t(id, name)
+        |  stage out = from src cross join __wv_resume_param_dep as d
+        |    | where name = target_name
+        |    | select id, run_date as rd
+        |}""".stripMargin
+    connector.execute("drop table if exists __wv_resume_param_dep")
+    val originalRunTime = java
+      .time
+      .ZonedDateTime
+      .of(2020, 6, 15, 0, 0, 0, 0, java.time.ZoneId.of("UTC"))
+    val first = runFlow(
+      wv,
+      registry = Some(registry),
+      args = List(namedArg("target_name", str("a"))),
+      runTime = Some(originalRunTime)
+    )
+    first.isSuccess shouldBe false
+    first.stageResult("out").get.state shouldBe StageState.Failed
+
+    try
+      connector.execute("create or replace table __wv_resume_param_dep as select 10 as x")
+      val record = registry.get(first.runId).get
+      record.args shouldBe Map("target_name" -> "'a'")
+
+      // Resume passes no arguments and no run time: both are re-bound from the record
+      val (flow, ctx) = compileFlow(wv)
+      val resumed     =
+        FlowExecutor(connector, workEnv, registry = Some(registry)).execute(
+          flow,
+          resumeFrom = Some(record)
+        )(using ctx)
+      resumed.runId shouldBe first.runId
+      resumed.isSuccess shouldBe true
+      // The original argument filtered the rows, and the original run_date was substituted
+      // instead of today's wall clock
+      val table = resumed.stageResult("out").flatMap(_.table).get
+      val rows  =
+        connector.runQuery(s"""select count(*), min(cast(rd as varchar)) from "${table}"""") { rs =>
+          rs.next()
+          (rs.getLong(1), rs.getString(2))
+        }
+      rows._1 shouldBe 2L
+      rows._2 shouldBe "2020-06-15"
+    finally
+      connector.execute("drop table if exists __wv_resume_param_dep")
+  }
+
   test("substitute parameters into route predicates") {
     // Note: the parameter is written on the left of the comparison because a route condition
     // ending with a bare identifier would parse `<identifier> -> <target>` as a lambda

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowRunStoreTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowRunStoreTest.scala
@@ -190,6 +190,77 @@ class FlowRunStoreTest extends UniTest:
     }
   }
 
+  test("persist bound arguments and the logical run time") {
+    withStores { (kind, store) =>
+      val invoked = record("run1", "FlowA", FlowRunRecord.STATE_SUCCESS, 100L).copy(
+        args = Map("segment" -> "'a'", "min_id" -> "3"),
+        runTimeMillis = Some(1234L)
+      )
+      store.save(invoked)
+      val r = store.get("run1").getOrElse(fail(s"run1 not found in ${kind} store"))
+      r.args shouldBe Map("segment" -> "'a'", "min_id" -> "3")
+      r.runTimeMillis shouldBe Some(1234L)
+      r.flowCallForm shouldBe "FlowA(min_id = 3, segment = 'a')"
+
+      // Records without arguments keep an empty map and no run time
+      store.save(record("run2", "FlowB", FlowRunRecord.STATE_SUCCESS, 200L))
+      val plain = store.get("run2").get
+      plain.args shouldBe Map.empty
+      plain.runTimeMillis shouldBe None
+      plain.flowCallForm shouldBe "FlowB"
+
+      // claimRunSlot persists the invocation like save
+      val claimed = record("run3", "FlowC", FlowRunRecord.STATE_RUNNING, 300L).copy(
+        args = Map("segment" -> "'b'"),
+        runTimeMillis = Some(5678L)
+      )
+      store.claimRunSlot(claimed, concurrencyLimit = 1) shouldBe true
+      store.get("run3").get.args shouldBe Map("segment" -> "'b'")
+      store.get("run3").get.runTimeMillis shouldBe Some(5678L)
+    }
+  }
+
+  test("migrate a SQLite database created before the args and run_time columns") {
+    val dir    = Files.createTempDirectory("wv-flow-store-migrate")
+    val dbPath = dir.resolve("registry.db")
+    // Create a database with the pre-args schema and one row
+    val conn = java.sql.DriverManager.getConnection(s"jdbc:sqlite:${dbPath}")
+    try
+      val stmt = conn.createStatement()
+      stmt.execute("""create table runs(
+          |  run_id           text primary key,
+          |  flow_name        text not null,
+          |  state            text not null,
+          |  started_at       integer not null,
+          |  finished_at      integer,
+          |  cancel_requested integer not null default 0,
+          |  lease_expires_at integer
+          |)""".stripMargin)
+      stmt.execute(
+        "insert into runs(run_id, flow_name, state, started_at) values('old1', 'FlowA', 'success', 100)"
+      )
+      stmt.close()
+    finally
+      conn.close()
+
+    val store = SQLiteFlowRunStore(dbPath)
+    try
+      val old = store.get("old1").getOrElse(fail("old1 not found after migration"))
+      old.args shouldBe Map.empty
+      old.runTimeMillis shouldBe None
+      // New records persist the added columns
+      store.save(
+        record("new1", "FlowA", FlowRunRecord.STATE_SUCCESS, 200L).copy(
+          args = Map("segment" -> "'a'"),
+          runTimeMillis = Some(999L)
+        )
+      )
+      store.get("new1").get.args shouldBe Map("segment" -> "'a'")
+      store.get("new1").get.runTimeMillis shouldBe Some(999L)
+    finally
+      store.close()
+  }
+
   test("share state between store instances on the same path") {
     // Simulates cross-process observation: a second store instance sees runs and cancellation
     // requests written by the first one


### PR DESCRIPTION
## Summary

Item 1 of #1853. Flow run records did not store how a run was invoked, which caused concrete problems:

- `wvlet flow session resume <run_id>` of a parameterized flow failed: resume passed no arguments, so a required parameter hit `Missing argument for parameter ...` instead of re-binding the original values
- `session show` could not display which arguments or schedule window a run computed, so backfills were not auditable
- scheduler catch-up compared `startedAtMillis` against fire times; the logical `run_time` is more precise

## Changes

- `FlowRunRecord` gains `args: Map[String, String]` (the resolved bindings after defaults, each rendered as a wvlet literal) and `runTimeMillis: Option[Long]`, plus a `flowCallForm` helper rendering `F(segment = 'a')`
- The SQLite store adds `args` (JSON) and `run_time` columns with a `pragma table_info` migration following the `lease_expires_at` pattern; the file store picks the fields up via JSON
- `FlowExecutor.execute` records the resolved bindings and the logical run time on every snapshot (including skipped runs and `->` jump runs)
- Resume re-binds the stored arguments (parsed back with the regular flow-call grammar) and the stored `run_time` when the caller passes neither, so a parameterized or backfilled run resumes with exactly its original invocation; parameters the flow no longer declares are dropped
- `session show` prints the flow call form and the `run_time` of the run window
- `scheduler --catchup` compares fire times against the recorded `run_time`, falling back to `startedAtMillis` for older records
- Docs: `website/docs/syntax/flow.md` session subcommand section updated

## Tests

- `FlowRunStoreTest`: args/run_time round-trip on both stores (save and `claimRunSlot`), plus a SQLite migration test from the pre-args schema
- `FlowExecutorTest`: records capture resolved args (with defaults) and run time; resuming a parameterized flow re-binds the recorded arguments and the original `run_date` instead of the wall clock
- `WvletFlowCommandTest`: end-to-end CLI resume of a parameterized flow that previously failed with a missing-parameter error

🤖 Generated with [Claude Code](https://claude.com/claude-code)