### PR TITLE
feature: Run flows on Trino with engine-aware DDL and HTTP statement cancellation

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -352,7 +352,9 @@ stage delayed = from entry | wait('7 days')
 external target. Two sinks are built in:
 
 - `activate('file', path: 'out.csv')` exports to a local file. The format comes from the
-  path extension or a `format:` parameter (csv, parquet, or json)
+  path extension or a `format:` parameter (csv, parquet, or json). File export uses the
+  engine's `COPY TO` statement and is available on DuckDB only; on other engines the stage
+  fails with a clear error
 - `activate('webhook', url: 'https://...')` posts the rows to an HTTP endpoint as a JSON
   array, or as newline-delimited JSON with `format: 'ndjson'`. At most `max_rows:` rows
   (1000 by default) are sent
@@ -504,6 +506,15 @@ flow hourly_metrics with {
 
 Flow definitions are declarations: running a file that contains flows does not execute them.
 Flows are triggered explicitly with the `run flow` statement or the `wvlet flow` CLI.
+
+### Engine Support
+
+Flows run on DuckDB (the default) and on Trino, selected with `--profile` like regular
+queries. Stage materialization adapts to the engine automatically (e.g. Trino catalogs
+without `create or replace table` get an explicit drop-and-create), and stage timeouts and
+cancellation stop the running query server-side on both engines. Run-scoped
+`__wv_flow_*` tables are created in the profile's `catalog`/`schema`, which must exist and
+be writable (for example a `memory` catalog schema on Trino).
 
 ### run flow Statement
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/ActivationSink.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/ActivationSink.scala
@@ -14,18 +14,14 @@
 package wvlet.lang.runner
 
 import wvlet.lang.api.StatusCode
-import wvlet.lang.runner.codec.JDBCCodec
 import wvlet.lang.runner.connector.DBConnector
 import wvlet.uni.log.LogSupport
-import wvlet.uni.weaver.Weaver
-import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
-import scala.collection.immutable.ListMap
 import scala.util.Using
 
 /**
@@ -72,6 +68,15 @@ class FileActivationSink extends ActivationSink with LogSupport:
   override def name: String = "file"
 
   override def activate(request: ActivationRequest): Unit =
+    // COPY TO is DuckDB-specific: fail with a clear, non-retryable error on other engines
+    if !request.connector.dbType.supportSaveAsFile then
+      throw StatusCode
+        .NOT_IMPLEMENTED
+        .newException(
+          s"activate('file') of stage ${request.stageName} is not supported on ${request
+              .connector
+              .dbType}: local file export requires an engine with COPY TO support (e.g. DuckDB)"
+        )
     val path = request
       .params
       .getOrElse(
@@ -192,25 +197,14 @@ class WebhookActivationSink(httpClient: => HttpClient = WebhookActivationSink.de
 
   /** Read up to maxRows rows of the stage table as JSON objects, reporting truncation */
   private def readRows(request: ActivationRequest, maxRows: Int): (List[String], Boolean) =
-    val rowCodec = summon[Weaver[ListMap[String, Any]]]
-    request
+    // Read one extra row to detect truncation; queryJsonRows is engine-independent (JDBC or HTTP)
+    val rows = request
       .connector
-      .withSession { conn =>
-        Using.resource(conn.createStatement()) { stmt =>
-          Using.resource(
-            // Read one extra row to detect truncation
-            stmt.executeQuery(s"""select * from "${request.table}" limit ${maxRows + 1}""")
-          ) { rs =>
-            val codec = JDBCCodec(rs)
-            val it = codec.mapMsgPackMapRows(msgpack => rowCodec.toJson(rowCodec.unweave(msgpack)))
-            val rows = it.take(maxRows + 1).toList
-            if rows.size > maxRows then
-              (rows.take(maxRows), true)
-            else
-              (rows, false)
-          }
-        }
-      }
+      .queryJsonRows(s"""select * from "${request.table}" limit ${maxRows + 1}""")
+    if rows.size > maxRows then
+      (rows.take(maxRows), true)
+    else
+      (rows, false)
 
 end WebhookActivationSink
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -26,6 +26,7 @@ import wvlet.lang.compiler.transform.FlowParams
 import wvlet.lang.model.DataType
 import wvlet.lang.model.expr.*
 import wvlet.lang.model.plan.*
+import wvlet.lang.runner.connector.CancellableStatement
 import wvlet.lang.runner.connector.DBConnector
 import wvlet.uni.log.LogSupport
 import wvlet.uni.util.ULID
@@ -38,7 +39,6 @@ import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.util.Using
 import scala.util.control.NonFatal
 
 /**
@@ -402,7 +402,7 @@ class FlowExecutor(
     // In-flight attempt tracking, keyed by (stage, attempt). Worker threads register their
     // active SQL statement while it executes; the scheduler thread cancels statements and
     // interrupts workers on timeout or flow cancellation
-    val activeStatements = ConcurrentHashMap[(String, Int), java.sql.Statement]()
+    val activeStatements = ConcurrentHashMap[(String, Int), CancellableStatement]()
     val activeFutures    = ConcurrentHashMap[(String, Int), java.util.concurrent.Future[?]]()
     // Liveness of in-flight attempts: last heartbeat per attempt, plus the periodic stall
     // checks scheduled for stages with a heartbeat: config
@@ -982,25 +982,25 @@ class FlowExecutor(
       val summaryTable              = s"__wv_flow_notify_${result.runId.toLowerCase}"
       def sqlLit(s: String): String = s"'${s.replaceAll("'", "''")}'"
       try
-        connector.withSession { conn =>
-          Using.resource(conn.createStatement()) { stmt =>
-            stmt.execute(
-              s"""create or replace table "${summaryTable}" ("flow" varchar, "run_id" varchar, "stage" varchar, "state" varchar, "attempts" bigint, "error" varchar)"""
-            )
-            if result.stageResults.nonEmpty then
-              val rows = result
-                .stageResults
-                .map { s =>
-                  // Exceptions like NullPointerException may carry a null message
-                  val err = s.error.flatMap(e => Option(e.getMessage)).map(sqlLit).getOrElse("null")
-                  s"(${sqlLit(result.flowName)}, ${sqlLit(result.runId)}, ${sqlLit(
-                      s.name
-                    )}, ${sqlLit(s.state.stateName)}, ${s.attempts}, ${err})"
-                }
-                .mkString(", ")
-              stmt.execute(s"""insert into "${summaryTable}" values ${rows}""")
-          }
-        }
+        val summaryColumns =
+          """("flow" varchar, "run_id" varchar, "stage" varchar, "state" varchar, "attempts" bigint, "error" varchar)"""
+        if connector.dbType.supportCreateOrReplace then
+          connector.execute(s"""create or replace table "${summaryTable}" ${summaryColumns}""")
+        else
+          connector.execute(s"""drop table if exists "${summaryTable}"""")
+          connector.execute(s"""create table "${summaryTable}" ${summaryColumns}""")
+        if result.stageResults.nonEmpty then
+          val rows = result
+            .stageResults
+            .map { s =>
+              // Exceptions like NullPointerException may carry a null message
+              val err = s.error.flatMap(e => Option(e.getMessage)).map(sqlLit).getOrElse("null")
+              s"(${sqlLit(result.flowName)}, ${sqlLit(result.runId)}, ${sqlLit(s.name)}, ${sqlLit(
+                  s.state.stateName
+                )}, ${s.attempts}, ${err})"
+            }
+            .mkString(", ")
+          connector.execute(s"""insert into "${summaryTable}" values ${rows}""")
         hooks.foreach { spec =>
           try
             activationSinks.find(_.name == spec.target) match
@@ -1037,11 +1037,7 @@ class FlowExecutor(
           )
       finally
         try
-          connector.withSession { conn =>
-            Using.resource(conn.createStatement()) { stmt =>
-              stmt.execute(s"""drop table if exists "${summaryTable}"""")
-            }
-          }
+          connector.execute(s"""drop table if exists "${summaryTable}"""")
         catch
           case NonFatal(_) =>
         end try
@@ -1061,7 +1057,7 @@ class FlowExecutor(
       stageNames: Set[String],
       tableFor: String => String,
       routeFilters: Map[(String, String), Expression],
-      registerStatement: java.sql.Statement => Unit,
+      registerStatement: CancellableStatement => Unit,
       deregisterStatement: () => Unit
   )(using ctx: Context): Unit =
     val body = ls
@@ -1105,18 +1101,20 @@ class FlowExecutor(
 
     // Quote the table name: it contains a ULID and stage names may collide with SQL keywords.
     // The table is a regular (non-temp) table because parallel stages materialize on separate
-    // sessions, and temp tables are session-scoped
-    val ddl = s"""create or replace table "${tableFor(ls.name)}" as\n${sql}"""
+    // sessions, and temp tables are session-scoped. Engines without `create or replace table`
+    // (e.g. Trino) get an explicit drop first: the run-scoped name is unique per run, so the
+    // drop only matters for re-executed attempts of this stage
+    val target = s""""${tableFor(ls.name)}""""
+    val ddl    =
+      if connector.dbType.supportCreateOrReplace then
+        s"""create or replace table ${target} as\n${sql}"""
+      else
+        connector.execute(s"drop table if exists ${target}")
+        s"""create table ${target} as\n${sql}"""
     debug(s"Materializing stage ${ls.name}:\n${ddl}")
-    connector.withSession { conn =>
-      Using.resource(conn.createStatement()) { stmt =>
-        // Expose the statement to the scheduler so that a timeout or cancellation can stop
-        // it server-side while it is executing
-        registerStatement(stmt)
-        try stmt.execute(ddl)
-        finally deregisterStatement()
-      }
-    }
+    // The registered handle lets the scheduler stop the statement server-side on a timeout
+    // or cancellation while it is executing
+    connector.executeCancellable(ddl, registerStatement, deregisterStatement)
 
   end materializeStage
 
@@ -1200,16 +1198,12 @@ object FlowExecutor:
 
   /** Drop the run-scoped tables of the given stages (best-effort cleanup) */
   def dropRunTables(connector: DBConnector, runId: String, stageNames: Seq[String]): Unit =
-    connector.withSession { conn =>
-      Using.resource(conn.createStatement()) { stmt =>
-        stageNames.foreach { name =>
-          try
-            stmt.execute(s"""drop table if exists "${stageTableName(runId, name)}"""")
-          catch
-            case NonFatal(e) =>
-          // best-effort cleanup
-        }
-      }
+    stageNames.foreach { name =>
+      try
+        connector.execute(s"""drop table if exists "${stageTableName(runId, name)}"""")
+      catch
+        case NonFatal(e) =>
+      // best-effort cleanup
     }
 
   private enum FlowEvent:

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/SQLiteFlowRunStore.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/SQLiteFlowRunStore.scala
@@ -59,7 +59,7 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
     // Migrate databases created before these columns were introduced
     val existingColumns =
       Using.resource(stmt.executeQuery("pragma table_info(runs)")) { rs =>
-        Iterator.continually(rs).takeWhile(_.next()).map(_.getString("name")).toSet
+        Iterator.continually(rs).takeWhile(_.next()).map(_.getString("name").toLowerCase).toSet
       }
     List("lease_expires_at" -> "integer", "args" -> "text", "run_time" -> "integer").foreach {
       (column, sqlType) =>

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/DBConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/DBConnector.scala
@@ -31,9 +31,13 @@ import wvlet.lang.model.RelationType
 import wvlet.lang.model.plan.LogicalPlan
 import wvlet.lang.model.plan.*
 import wvlet.lang.api.StatusCode
+import wvlet.lang.runner.codec.JDBCCodec
 import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import java.sql.Connection
+import scala.collection.immutable.ListMap
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.SQLWarning
@@ -61,6 +65,13 @@ case class DBConnection(jdbcConnection: Connection) extends AutoCloseable:
   def createStatement(): Statement             = jdbcConnection.createStatement()
   def getMetaData(): java.sql.DatabaseMetaData = jdbcConnection.getMetaData()
   def close(): Unit                            = jdbcConnection.close()
+
+/**
+  * A best-effort handle for cancelling an in-flight statement server-side (JDBC `Statement.cancel`
+  * or an HTTP query abort, depending on the connector)
+  */
+trait CancellableStatement:
+  def cancel(): Unit
 
 trait DBConnector(val dbType: DBType, workEnv: WorkEnv) extends AutoCloseable with LogSupport:
   private var queryScope: QueryScope = QueryScope.Global
@@ -102,6 +113,41 @@ trait DBConnector(val dbType: DBType, workEnv: WorkEnv) extends AutoCloseable wi
     val conn = newSession
     try body(conn)
     finally conn.close()
+
+  /**
+    * Execute a DDL/DML statement on a dedicated session, exposing a cancellation handle while the
+    * statement is in flight. The flow executor registers the handle so that stage timeouts and
+    * cross-process cancellation can stop the statement server-side; `deregister` runs when the
+    * statement finishes (successfully or not). Connectors without JDBC sessions (e.g. Trino over
+    * HTTP) override this with their own execution and cancellation mechanism
+    */
+  private[runner] def executeCancellable(
+      sql: String,
+      register: CancellableStatement => Unit,
+      deregister: () => Unit
+  ): Unit = withSession { conn =>
+    withResource(conn.createStatement()) { stmt =>
+      register(() => stmt.cancel())
+      try stmt.execute(sql)
+      finally deregister()
+    }
+  }
+
+  /**
+    * Run a query on a dedicated session and serialize each row as a JSON object string. Provides
+    * engine-independent row access for activation sinks and notification hooks; connectors without
+    * JDBC result sets (e.g. Trino over HTTP) override this
+    */
+  private[runner] def queryJsonRows(sql: String): List[String] = withSession { conn =>
+    withResource(conn.createStatement()) { stmt =>
+      withResource(stmt.executeQuery(sql)) { rs =>
+        val rowWeaver = summon[Weaver[ListMap[String, Any]]]
+        JDBCCodec(rs)
+          .mapMsgPackMapRows(msgpack => rowWeaver.toJson(rowWeaver.unweave(msgpack)))
+          .toList
+      }
+    }
+  }
 
   protected def withStatement[U](
       body: Statement => U

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/trino/TrinoConnector.scala
@@ -29,8 +29,11 @@ import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.model.DataType
 import wvlet.lang.runner.connector.*
 import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import java.sql.Statement
+import scala.collection.immutable.ListMap
 
 case class TrinoConfig(
     catalog: String,
@@ -146,6 +149,33 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
     monitor.newQuery(sql)
     try http(sql).columnCount > 0
     finally monitor.close()
+
+  /**
+    * Flow statements run through the HTTP query handle, whose `cancel()` issues a DELETE on the
+    * query so that stage timeouts and cancellations stop the query server-side, mirroring what JDBC
+    * `Statement.cancel` provides on other engines
+    */
+  override private[runner] def executeCancellable(
+      sql: String,
+      register: CancellableStatement => Unit,
+      deregister: () => Unit
+  ): Unit =
+    val handle = asSqlConnector.submit(sql)
+    try
+      register(() => handle.cancel())
+      val _ = handle.await()
+    finally
+      deregister()
+      handle.close()
+
+  override private[runner] def queryJsonRows(sql: String): List[String] =
+    val result    = http(sql)
+    val names     = result.columns.map(_.name.name)
+    val rowWeaver = summon[Weaver[ListMap[String, Any]]]
+    result
+      .rows
+      .map(row => rowWeaver.toJson(ListMap.from(names.zip(row.values.map(v => v.orNull: Any)))))
+      .toList
 
   override def createSchema(catalog: String, schema: String): TableSchema =
     http(s"create schema if not exists ${catalog}.${schema}")

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TrinoFlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/trino/TrinoFlowExecutorTest.scala
@@ -1,0 +1,139 @@
+package wvlet.lang.runner.connector.trino
+
+import wvlet.lang.api.v1.flow.StageState
+import wvlet.lang.catalog.Profile
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.Symbol
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.model.plan.FlowDef
+import wvlet.lang.runner.ActivationRequest
+import wvlet.lang.runner.ActivationSink
+import wvlet.lang.runner.FlowExecutor
+import wvlet.lang.runner.connector.DBConnectorProvider
+import wvlet.uni.control.Control
+import wvlet.uni.test.UniTest
+
+import scala.collection.mutable.ListBuffer
+
+/**
+  * Flow execution against an embedded Trino server: stage materialization uses engine-aware DDL (no
+  * `create or replace table`), all statements run over the HTTP query path, and notification hooks
+  * build their run-summary table with the same mechanism
+  */
+class TrinoFlowExecutorTest extends UniTest:
+  private val server  = TestTrinoServer().withCustomMemoryPlugin
+  private val workEnv = WorkEnv(".")
+  private val profile = Profile(
+    name = s"local-trino@${server.address}",
+    `type` = "trino",
+    user = Some("test"),
+    password = Some(""),
+    host = Some(server.address),
+    catalog = Some("memory"),
+    schema = Some("main"),
+    properties = Map("useSSL" -> false)
+  )
+
+  private val dbConnectorProvider = DBConnectorProvider(workEnv)
+  private val connector           = dbConnectorProvider.getConnector(profile)
+
+  // Run-scoped flow tables land in the profile's catalog/schema, which must exist and be writable
+  connector.createSchema("memory", "main")
+
+  override def afterAll: Unit = Control.closeResources(dbConnectorProvider, server)
+
+  private def compileFlow(wv: String): (FlowDef, Context) =
+    val compiler = Compiler(
+      CompilerOptions(workEnv = workEnv, catalog = Some("memory"), schema = Some("main"))
+    )
+    // Generate Trino SQL for the stage bodies
+    compiler.setDefaultCatalog(connector.getCatalog("memory", "main"))
+    val unit                  = CompilationUnit.fromWvletString(wv)
+    val result                = compiler.compileSingleUnit(unit)
+    val ctx                   = result.context.withCompilationUnit(unit).newContext(Symbol.NoSymbol)
+    var flow: Option[FlowDef] = None
+    unit
+      .resolvedPlan
+      .traverse { case f: FlowDef =>
+        if flow.isEmpty then
+          flow = Some(f)
+      }
+    (flow.getOrElse(fail("No FlowDef found in the compiled plan")), ctx)
+
+  private def countRows(table: String): Long =
+    val rows = connector.queryJsonRows(s"""select count(*) as cnt from "${table}"""")
+    rows.size shouldBe 1
+    "\\d+".r.findFirstIn(rows.head).map(_.toLong).getOrElse(fail(s"No count in ${rows.head}"))
+
+  test("materialize flow stages on Trino with engine-aware DDL") {
+    val (flow, ctx) = compileFlow("""flow TrinoFlow = {
+        |  stage src = from [[1, 'a'], [2, 'b'], [3, 'a']] as t(id, name)
+        |  stage filtered = from src | where name = 'a'
+        |  stage output = from filtered | select id
+        |}""".stripMargin)
+    val result = FlowExecutor(connector, workEnv).execute(flow)(using ctx)
+    result.isSuccess shouldBe true
+    countRows(result.stageResult("filtered").flatMap(_.table).get) shouldBe 2L
+    countRows(result.stageResult("output").flatMap(_.table).get) shouldBe 2L
+
+    // Retrying a stage of the same run re-creates its table (drop + create table path)
+    val again = FlowExecutor(connector, workEnv).execute(flow)(using ctx)
+    again.isSuccess shouldBe true
+
+    // Run-scoped tables are dropped over the same HTTP path
+    FlowExecutor.dropRunTables(connector, result.runId, result.stageResults.map(_.name))
+    val remaining = connector
+      .listTables("memory", "main")
+      .map(_.name)
+      .filter(_.contains(result.runId.toLowerCase))
+    remaining shouldBe Nil
+    FlowExecutor.dropRunTables(connector, again.runId, again.stageResults.map(_.name))
+  }
+
+  test("deliver run notification summaries on Trino") {
+    val recorded = ListBuffer.empty[List[String]]
+    val sink     =
+      new ActivationSink:
+        override def name: String                               = "test_notify"
+        override def activate(request: ActivationRequest): Unit =
+          recorded +=
+            request
+              .connector
+              .queryJsonRows(
+                s"""select "stage", "state" from "${request.table}" order by "stage""""
+              )
+
+    val (flow, ctx) = compileFlow(
+      """flow TrinoNotifyFlow with { on_finish: activate('test_notify') } = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin
+    )
+    val result =
+      FlowExecutor(connector, workEnv, activationSinks = List(sink)).execute(flow)(using ctx)
+    result.isSuccess shouldBe true
+    recorded.size shouldBe 1
+    recorded.head.size shouldBe 1
+    recorded.head.head shouldContain "src"
+    recorded.head.head shouldContain "success"
+    FlowExecutor.dropRunTables(connector, result.runId, result.stageResults.map(_.name))
+  }
+
+  test("fail activate('file') on Trino with a clear non-retryable error") {
+    val (flow, ctx) = compileFlow("""flow TrinoFileFlow = {
+        |  stage src = from [[1]] as t(id)
+        |  stage export = from src | activate('file', path: 'target/trino-export.csv')
+        |}""".stripMargin)
+    val result = FlowExecutor(connector, workEnv).execute(flow)(using ctx)
+    result.isSuccess shouldBe false
+    val exportStage = result.stageResult("export").get
+    exportStage.state shouldBe StageState.Failed
+    // NOT_IMPLEMENTED is non-retryable: the stage fails on the first attempt
+    exportStage.attempts shouldBe 1
+    exportStage.error.get.getMessage shouldContain "not supported"
+    FlowExecutor.dropRunTables(connector, result.runId, result.stageResults.map(_.name))
+  }
+
+end TrinoFlowExecutorTest


### PR DESCRIPTION
## Summary

Item 2 of #1853. Flow execution assumed DuckDB end-to-end and was fully broken on Trino: `TrinoConnector` provides no JDBC sessions anymore (every SQL statement goes over the HTTP query path), and the flow paths hard-coded DuckDB-only SQL.

## Changes

- **Connector-level execution hooks** (`DBConnector`):
  - `CancellableStatement` + `executeCancellable(sql, register, deregister)`: executes a statement on a dedicated session and exposes a best-effort server-side cancel handle. Default implementation wraps JDBC `Statement.cancel`; `TrinoConnector` overrides it with `asSqlConnector.submit` and the HTTP `QueryHandle.cancel()` (a DELETE on the query), so stage `timeout:`/cancellation still stop the query server-side on Trino
  - `queryJsonRows(sql)`: engine-independent row access serializing rows as JSON objects (JDBC + `JDBCCodec` by default, `QueryResult` over HTTP on Trino)
- **Engine-aware materialization DDL** (`FlowExecutor.materializeStage`): engines with `supportCreateOrReplace` keep `create or replace table`; others (Trino) get `drop table if exists` + `create table ... as`
- **Notification hooks on Trino** (`notifyRunResult`): the run-summary table is built with the same engine-aware create and plain `connector.execute` statements instead of a JDBC session; `dropRunTables` likewise
- **Activation sinks**: `activate('file')` is gated on `supportSaveAsFile` and fails with a clear NOT_IMPLEMENTED (non-retryable) error on engines without `COPY TO`; the webhook sink reads rows through `queryJsonRows`
- **Run-scoped table placement**: `__wv_flow_*` tables resolve against the profile's `catalog`/`schema` (the Trino session defaults), documented in `website/docs/syntax/flow.md`

## Tests

- New `TrinoFlowExecutorTest` against an embedded `TestTrinoServer` (memory catalog): multi-stage materialization with the drop-and-create path (including re-running the same flow), run-table cleanup over HTTP, notification summary delivery reading rows over HTTP, and the `activate('file')` error path failing non-retryably on the first attempt
- Full `runner` and `cli` suites pass (DuckDB behavior unchanged)

Also carries a one-line follow-up from #1854's review (lowercasing `pragma table_info` column names) that missed the auto-merge window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)