### PR TITLE
feature: Add wait until event sensors for condition-based stage gating

### DIFF
--- a/spec/basic/flow-syntax.wv
+++ b/spec/basic/flow-syntax.wv
@@ -51,6 +51,14 @@ flow JourneyFlow = {
 }
 ;
 
+-- Flow with an event sensor: the stage proceeds once a row satisfies the condition
+flow SensorFlow = {
+  stage landing = from source
+  stage gate with { poll_interval: 30s, timeout: 1h } = from landing | wait until _.value = 'ready'
+  stage output = from gate | select id
+}
+;
+
 -- Flow with merge (fan-in)
 flow MergeFlow = {
   stage source_a = from users | where region = 'US'

--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -346,6 +346,34 @@ flow notification_flow = {
 stage delayed = from entry | wait('7 days')
 ```
 
+### Event Sensors with wait until
+
+`wait until <condition>` waits for an *event* instead of a fixed time: the stage polls its
+input and proceeds once **at least one row satisfies the condition**. `_.column` in the
+condition refers to a row of the input (the same convention as `route` cases). The sensor
+only gates execution — it does not filter the rows the stage materializes.
+
+```wvlet
+flow load_orders = {
+  stage landing = from landing_files | where table_name = 'orders'
+  stage gate with {
+    poll_interval: 30s     -- how often the condition is re-checked (default: 10s)
+    timeout: 2h            -- give up like any other stage timeout
+  } = from landing | wait until _.status = 'ready'
+  stage load = from gate | save to orders
+}
+```
+
+To wait on an aggregate condition, aggregate in the pipeline before the sensor:
+
+```wvlet
+stage gate = from new_events | select count(*) as cnt | wait until _.cnt > 1000
+```
+
+Polling respects the stage's `heartbeat:` config (a polling sensor is never mistaken for a
+stalled attempt), and a `timeout:` expiry follows the stage's regular retry and failure
+policy.
+
 ### Delivering Results with activate
 
 `activate('<target>', param: value, ...)` delivers the materialized stage output to an

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -524,6 +524,12 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
           code(w) {
             group(wl("wait", paren(expr(w.duration))))
           }
+      case w: FlowWaitUntil =>
+        val prev = relation(w.child)
+        prev /
+          code(w) {
+            group(wl("wait until", expr(w.condition)))
+          }
       case a: FlowActivate =>
         val prev    = relation(a.child)
         val allArgs =

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -791,14 +791,28 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
   }
 
   /**
-    * Parse flow wait expression: `wait('7 days')`
+    * Parse a flow wait expression: a time-based delay `wait('7 days')` or an event sensor `wait
+    * until <condition>` (`until` is a soft keyword)
     */
-  def flowWaitExpr(input: Relation): FlowWait = node {
+  def flowWaitExpr(input: Relation): UnaryFlowOp = node {
     val t = consume(WvletToken.WAIT)
-    consume(WvletToken.L_PAREN)
-    val duration = expression()
-    consume(WvletToken.R_PAREN)
-    FlowWait(input, duration, spanFrom(t))
+    scanner.lookAhead().token match
+      case WvletToken.L_PAREN =>
+        consume(WvletToken.L_PAREN)
+        val duration = expression()
+        consume(WvletToken.R_PAREN)
+        FlowWait(input, duration, spanFrom(t))
+      case _ =>
+        val id = identifier()
+        if id.leafName != "until" then
+          throw StatusCode
+            .SYNTAX_ERROR
+            .newException(
+              s"Expected wait('<duration>') or wait until <condition>, but found: ${id.leafName}",
+              id.sourceLocationOfCompilationUnit
+            )
+        val condition = expression()
+        FlowWaitUntil(input, condition, spanFrom(t))
   }
 
   /**

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/flow.scala
@@ -313,6 +313,14 @@ object RunFlow:
 case class FlowWait(child: Relation, duration: Expression, span: Span) extends UnaryFlowOp
 
 /**
+  * FlowWaitUntil is an event sensor: it polls its input until at least one row satisfies the
+  * condition, then lets the stage proceed. `_.column` in the condition refers to the input row.
+  *
+  * Example: `from landing_files | wait until _.status = 'ready'`
+  */
+case class FlowWaitUntil(child: Relation, condition: Expression, span: Span) extends UnaryFlowOp
+
+/**
   * FlowActivate represents sending data to an external system.
   *
   * Example: `activate('email', template: 'promo_v1')`

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -1095,7 +1095,13 @@ class FlowExecutor(
         throw StatusCode.NOT_IMPLEMENTED.newException(s"Stage ${ls.name} has no executable body")
       )
 
-    val executable = FlowExecutor.rewriteStageRefs(body, ls.name, stageNames, tableFor, routeFilters)
+    val executable = FlowExecutor.rewriteStageRefs(
+      body,
+      ls.name,
+      stageNames,
+      tableFor,
+      routeFilters
+    )
 
     val sql = GenSQL.generateSQLFromRelation(executable, addHeader = false).sql
 
@@ -1186,9 +1192,16 @@ object FlowExecutor:
       readerStage: String
   )(using ctx: Context): String =
     val input = rewriteStageRefs(sensor.input, readerStage, stageNames, tableFor, routeFilters)
-    val sql   = GenSQL
-      .generateSQLFromRelation(Filter(input, sensor.condition, Span.NoSpan), addHeader = false)
-      .sql
+    // The braced input forces a subquery boundary, so a condition over an aggregated input
+    // (e.g. `select count(*) as cnt | wait until _.cnt > 0`) filters the aggregate's result
+    // instead of being merged into its where clause
+    val sql =
+      GenSQL
+        .generateSQLFromRelation(
+          Filter(BracedRelation(input, Span.NoSpan), sensor.condition, Span.NoSpan),
+          addHeader = false
+        )
+        .sql
     s"""select 1 from (\n${sql}\n) as "__wv_sensor" limit 1"""
 
   private val runTimeFormat = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -50,9 +50,12 @@ case class StageExecutionConfig(
     backoff: String = StageExecutionConfig.BACKOFF_EXPONENTIAL,
     maxRetryDelayMillis: Option[Long] = None,
     timeoutMillis: Option[Long] = None,
-    heartbeatMillis: Option[Long] = None
+    heartbeatMillis: Option[Long] = None,
+    pollIntervalMillis: Long = StageExecutionConfig.DEFAULT_POLL_INTERVAL_MILLIS
 ):
   def withHeartbeatMillis(millis: Long): StageExecutionConfig = copy(heartbeatMillis = Some(millis))
+
+  def withPollIntervalMillis(millis: Long): StageExecutionConfig = copy(pollIntervalMillis = millis)
 
   def noHeartbeat(): StageExecutionConfig                           = copy(heartbeatMillis = None)
   def withRetries(retries: Int): StageExecutionConfig               = copy(retries = retries)
@@ -92,6 +95,9 @@ object StageExecutionConfig:
   val BACKOFF_LINEAR      = "linear"
   val BACKOFF_EXPONENTIAL = "exponential"
 
+  /** Default polling interval of `wait until` event sensors */
+  val DEFAULT_POLL_INTERVAL_MILLIS = 10_000L
+
   def fromConfigItems(items: List[ConfigItem]): StageExecutionConfig =
     items.foldLeft(StageExecutionConfig()) { (config, item) =>
       def durationMillis: Option[Long] =
@@ -121,6 +127,8 @@ object StageExecutionConfig:
           durationMillis.fold(config)(config.withTimeoutMillis)
         case "heartbeat" =>
           durationMillis.fold(config)(config.withHeartbeatMillis)
+        case "poll_interval" =>
+          durationMillis.fold(config)(config.withPollIntervalMillis)
         case _ =>
           // Unknown or not-yet-supported properties are ignored by this executor
           config
@@ -440,22 +448,43 @@ class FlowExecutor(
           (ls, table, attemptKey) => r.runWithHeartbeat(ls.stage, table, () => beat(attemptKey))
         case None =>
           (ls, table, attemptKey) =>
-            // A wait operator delays the materialization of this stage. The sleep runs on a
-            // worker thread in bounded slices (heartbeating each slice) and is interruptible
-            // for cancellation
+            // Sleep in slices no longer than half the heartbeat interval so that an
+            // intentional wait or sensor poll is never mistaken for a stalled attempt.
+            // Slices run on the worker thread and stay interruptible for cancellation
+            def maxSlice = stageConfigs(ls.name)
+              .heartbeatMillis
+              .map(h => (h / 2).max(1L))
+              .getOrElse(1000L)
+              .min(1000L)
+            def sleepWithHeartbeat(delay: Long): Unit =
+              val deadline = System.currentTimeMillis() + delay
+              while System.currentTimeMillis() < deadline do
+                Thread.sleep((deadline - System.currentTimeMillis()).max(1L).min(maxSlice))
+                beat(attemptKey)
+
+            // A wait operator delays the materialization of this stage
             ls.waitMillis
               .foreach { delay =>
                 workEnv.info(s"Stage ${ls.name} waits for ${delay}ms")
-                // Sleep in slices no longer than half the heartbeat interval so that an
-                // intentional wait is never mistaken for a stalled attempt
-                val maxSlice = stageConfigs(ls.name)
-                  .heartbeatMillis
-                  .map(h => (h / 2).max(1L))
-                  .getOrElse(1000L)
-                  .min(1000L)
-                val deadline = System.currentTimeMillis() + delay
-                while System.currentTimeMillis() < deadline do
-                  Thread.sleep((deadline - System.currentTimeMillis()).max(1L).min(maxSlice))
+                sleepWithHeartbeat(delay)
+              }
+            // Event sensors poll their condition until it holds. The stage's timeout: (and the
+            // regular retry/failure policy) bounds the polling like any other attempt work
+            ls.waitUntil
+              .foreach { sensor =>
+                val pollSql = FlowExecutor.sensorPollSql(
+                  sensor,
+                  stageNames,
+                  tableFor,
+                  routeFilters,
+                  ls.name
+                )
+                val interval = stageConfigs(ls.name).pollIntervalMillis.max(1L)
+                workEnv.info(s"Stage ${ls.name} waits until its sensor condition holds")
+                debug(s"Sensor poll of stage ${ls.name}:\n${pollSql}")
+                beat(attemptKey)
+                while connector.queryJsonRows(pollSql).isEmpty do
+                  sleepWithHeartbeat(interval)
                   beat(attemptKey)
               }
             materializeStage(
@@ -1066,36 +1095,7 @@ class FlowExecutor(
         throw StatusCode.NOT_IMPLEMENTED.newException(s"Stage ${ls.name} has no executable body")
       )
 
-    // Reference a source stage's run-scoped table, filtered with the routing predicate when
-    // this stage is a route target of the source
-    def stageTableRef(stageName: String, span: Span): Relation =
-      val ref = TableRef(DoubleQuotedIdentifier(tableFor(stageName), span), span)
-      routeFilters.get((ls.name, stageName)) match
-        case Some(pred) =>
-          Filter(ref, pred, span)
-        case None =>
-          ref
-
-    // Rewrite stage references to their run-scoped tables, and merge (fan-in) into union all
-    val executable = body
-      .transformUp {
-        case t: TableRef if stageNames.contains(t.name.fullName) =>
-          stageTableRef(t.name.fullName, t.span)
-        case m: FlowMerge =>
-          m.sources
-            .map { src =>
-              // Only stage references map to run-scoped tables; other sources are regular
-              // tables and are read as-is, consistent with `from` inside a stage body
-              if stageNames.contains(src.fullName) then
-                stageTableRef(src.fullName, src.span)
-              else
-                TableRef(UnquotedIdentifier(src.fullName, src.span), src.span)
-            }
-            .reduceLeft[Relation] { (l, r) =>
-              Union(l, r, isDistinct = false, m.span)
-            }
-      }
-      .asInstanceOf[Relation]
+    val executable = FlowExecutor.rewriteStageRefs(body, ls.name, stageNames, tableFor, routeFilters)
 
     val sql = GenSQL.generateSQLFromRelation(executable, addHeader = false).sql
 
@@ -1130,6 +1130,66 @@ object FlowExecutor:
   def defaultActivationSinks: List[ActivationSink] =
     val loaded = java.util.ServiceLoader.load(classOf[ActivationSink]).iterator().asScala.toList
     loaded ++ List(FileActivationSink(), WebhookActivationSink())
+
+  /**
+    * Rewrite stage references inside a stage's relation to their run-scoped tables (applying route
+    * predicates when the reading stage is a route target), and lower merge (fan-in) into union all
+    */
+  private[runner] def rewriteStageRefs(
+      body: Relation,
+      readerStage: String,
+      stageNames: Set[String],
+      tableFor: String => String,
+      routeFilters: Map[(String, String), Expression]
+  ): Relation =
+    // Reference a source stage's run-scoped table, filtered with the routing predicate when
+    // the reader stage is a route target of the source
+    def stageTableRef(stageName: String, span: Span): Relation =
+      val ref = TableRef(DoubleQuotedIdentifier(tableFor(stageName), span), span)
+      routeFilters.get((readerStage, stageName)) match
+        case Some(pred) =>
+          Filter(ref, pred, span)
+        case None =>
+          ref
+
+    body
+      .transformUp {
+        case t: TableRef if stageNames.contains(t.name.fullName) =>
+          stageTableRef(t.name.fullName, t.span)
+        case m: FlowMerge =>
+          m.sources
+            .map { src =>
+              // Only stage references map to run-scoped tables; other sources are regular
+              // tables and are read as-is, consistent with `from` inside a stage body
+              if stageNames.contains(src.fullName) then
+                stageTableRef(src.fullName, src.span)
+              else
+                TableRef(UnquotedIdentifier(src.fullName, src.span), src.span)
+            }
+            .reduceLeft[Relation] { (l, r) =>
+              Union(l, r, isDistinct = false, m.span)
+            }
+      }
+      .asInstanceOf[Relation]
+
+  end rewriteStageRefs
+
+  /**
+    * The polling query of a `wait until` sensor: selects one row from the sensor's input filtered
+    * by the condition, so a non-empty result means the condition holds for at least one row
+    */
+  private[runner] def sensorPollSql(
+      sensor: FlowLowering.SensorSpec,
+      stageNames: Set[String],
+      tableFor: String => String,
+      routeFilters: Map[(String, String), Expression],
+      readerStage: String
+  )(using ctx: Context): String =
+    val input = rewriteStageRefs(sensor.input, readerStage, stageNames, tableFor, routeFilters)
+    val sql   = GenSQL
+      .generateSQLFromRelation(Filter(input, sensor.condition, Span.NoSpan), addHeader = false)
+      .sql
+    s"""select 1 from (\n${sql}\n) as "__wv_sensor" limit 1"""
 
   private val runTimeFormat = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
   private val runDateFormat = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd")

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
@@ -130,6 +130,13 @@ object FlowNotifyConfig:
 object FlowLowering:
 
   /**
+    * An event sensor extracted from a `wait until <condition>` operator: the stage proceeds once
+    * at least one row of `input` satisfies `condition` (with `_.column` references resolved to
+    * plain columns)
+    */
+  case class SensorSpec(input: Relation, condition: Expression)
+
+  /**
     * A stage with flow operators stripped from its body
     *
     * @param stage
@@ -138,6 +145,8 @@ object FlowLowering:
     *   The SQL-expressible stage body (pass-through where flow operators were removed)
     * @param waitMillis
     *   Delay to apply before materializing the stage
+    * @param waitUntil
+    *   Event sensors to poll (in pipeline order) before materializing the stage
     * @param activateTargets
     *   External activation targets (with named parameters) to deliver the materialized output to
     * @param jumpTargets
@@ -147,6 +156,7 @@ object FlowLowering:
       stage: StageDef,
       body: Option[Relation],
       waitMillis: Option[Long] = None,
+      waitUntil: List[SensorSpec] = Nil,
       activateTargets: List[ActivationSpec] = Nil,
       jumpTargets: List[String] = Nil
   ):
@@ -189,6 +199,7 @@ object FlowLowering:
 
     val lowered = flatStages.map { s =>
       var waitMillis: Option[Long] = None
+      val sensors                  = List.newBuilder[SensorSpec]
       val activations              = List.newBuilder[ActivationSpec]
       val jumps                    = List.newBuilder[String]
       val newBody                  = s
@@ -205,6 +216,10 @@ object FlowLowering:
               case w: FlowWait =>
                 waitMillis = Some(waitMillis.getOrElse(0L) + waitDurationMillis(w))
                 w.child
+              case w: FlowWaitUntil =>
+                // transformUp visits children first, so sensors accumulate in pipeline order
+                sensors += SensorSpec(w.child, resolveContextRefs(w.condition))
+                w.child
               case a: FlowActivate =>
                 activations += activationSpecOf(a)
                 a.child
@@ -216,7 +231,7 @@ object FlowLowering:
             }
             .asInstanceOf[Relation]
         }
-      LoweredStage(s, newBody, waitMillis, activations.result(), jumps.result())
+      LoweredStage(s, newBody, waitMillis, sensors.result(), activations.result(), jumps.result())
     }
     LoweredFlow(flow, lowered, routeFilters.result())
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
@@ -130,9 +130,9 @@ object FlowNotifyConfig:
 object FlowLowering:
 
   /**
-    * An event sensor extracted from a `wait until <condition>` operator: the stage proceeds once
-    * at least one row of `input` satisfies `condition` (with `_.column` references resolved to
-    * plain columns)
+    * An event sensor extracted from a `wait until <condition>` operator: the stage proceeds once at
+    * least one row of `input` satisfies `condition` (with `_.column` references resolved to plain
+    * columns)
     */
   case class SensorSpec(input: Relation, condition: Expression)
 

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -1323,6 +1323,77 @@ class FlowExecutorTest extends UniTest:
     countStageRows(result, "minor") shouldBe 1L
   }
 
+  // --- Event sensors (wait until) ---
+
+  test("wait until the sensor condition holds before materializing the stage") {
+    connector.execute("drop table if exists __wv_sensor_dep")
+    connector.execute("create table __wv_sensor_dep as select 1 as x limit 0")
+    try
+      // Satisfy the sensor condition from another thread while the flow is polling
+      val feeder = Thread(
+        new Runnable:
+          override def run(): Unit =
+            Thread.sleep(300)
+            connector.execute("insert into __wv_sensor_dep values (10), (0)")
+      )
+      feeder.setDaemon(true)
+      feeder.start()
+
+      val startedAt = System.currentTimeMillis()
+      val result    = runFlow("""flow SensorFlow = {
+          |  stage gate with { poll_interval: 20ms } = from __wv_sensor_dep | wait until _.x > 5
+          |  stage out = from gate | select x
+          |}""".stripMargin)
+      result.isSuccess shouldBe true
+      // The sensor really waited for the feeder instead of proceeding immediately
+      (System.currentTimeMillis() - startedAt) >= 300 shouldBe true
+      // The gate materialized all input rows; the sensor only gates, it does not filter
+      countStageRows(result, "gate") shouldBe 2L
+      countStageRows(result, "out") shouldBe 2L
+    finally
+      connector.execute("drop table if exists __wv_sensor_dep")
+  }
+
+  test("fail a sensor stage when its timeout expires before the condition holds") {
+    connector.execute("drop table if exists __wv_sensor_empty")
+    connector.execute("create table __wv_sensor_empty as select 1 as x limit 0")
+    try
+      val result = runFlow("""flow SensorTimeoutFlow = {
+          |  stage gate with {
+          |    poll_interval: 10ms
+          |    timeout: 150ms
+          |  } = from __wv_sensor_empty | wait until _.x > 0
+          |  stage out = from gate | select x
+          |}""".stripMargin)
+      result.isSuccess shouldBe false
+      // The timed-out sensor follows the stage's regular failure policy (no retries here)
+      result.stageResult("gate").get.state shouldBe StageState.Failed
+      result.stageResult("out").get.state shouldBe StageState.Skipped
+    finally
+      connector.execute("drop table if exists __wv_sensor_empty")
+  }
+
+  test("wait until an aggregate sensor condition holds") {
+    // Aggregate conditions are phrased by aggregating in the pipeline before the sensor
+    val result = runFlow("""flow AggSensorFlow = {
+        |  stage src = from [[1], [2], [3]] as t(id)
+        |  stage gate = from src | select count(*) as cnt | wait until _.cnt > 2
+        |}""".stripMargin)
+    result.isSuccess shouldBe true
+    countStageRows(result, "gate") shouldBe 1L
+  }
+
+  test("poll a sensor over an upstream stage") {
+    // The sensor input references a stage, which resolves to its run-scoped table; the
+    // condition holds immediately, so the flow completes without external help
+    val result = runFlow("""flow StageSensorFlow = {
+        |  stage src = from [[1, 'ready'], [2, 'ready']] as t(id, status)
+        |  stage gate = from src | wait until _.status = 'ready'
+        |}""".stripMargin)
+    result.isSuccess shouldBe true
+    countStageRows(result, "gate") shouldBe 2L
+  }
+
   // --- Implicit run_time / run_date bindings ---
 
   private val utcRunTime = java


### PR DESCRIPTION
## Summary

Item 4 of #1853 (the final item). `wait('10m')` delays by time only; this adds **event sensors**: `wait until <condition>` polls the stage's input and lets the stage proceed once at least one row satisfies the condition. The sensor only gates execution — it does not filter the rows the stage materializes.

```wvlet
flow load_orders = {
  stage landing = from landing_files | where table_name = 'orders'
  stage gate with {
    poll_interval: 30s
    timeout: 2h
  } = from landing | wait until _.status = 'ready'
  stage load = from gate | save to orders
}
```

## Changes

- **Syntax**: `wait until <condition>` with `until` as a soft keyword (no new reserved word); `_.column` refers to an input row, the same convention as `route` cases. A malformed `wait` reports a clear syntax error. `FlowWaitUntil` AST node + `WvletGenerator` printing for round-trips
- **Lowering**: `FlowLowering` extracts `SensorSpec(input, condition)` per stage (in pipeline order), resolving `_.column` context refs like route predicates
- **Execution**: the worker polls `select 1 from (<input>) where <condition> limit 1` through the engine-independent `queryJsonRows` path (so sensors work on Trino too), sleeping `poll_interval:` (default 10s) between polls in heartbeat-bounded slices — a polling sensor is never mistaken for a stalled attempt, and `timeout:` expiry follows the stage's regular retry/failure policy. The input is wrapped in a subquery boundary so aggregate conditions (`select count(*) as cnt | wait until _.cnt > 1000`) filter the aggregate's result
- **Config**: `poll_interval:` duration on stage `with {}` blocks (`StageExecutionConfig.pollIntervalMillis`)
- Docs: new "Event Sensors with wait until" section in `website/docs/syntax/flow.md`; `spec/basic/flow-syntax.wv` gains a sensor sample

## Tests

- Sensor blocks until a feeder thread satisfies the condition, then materializes all input rows (elapsed-time asserted)
- `timeout:` expiry fails the sensor stage and skips downstream stages
- Aggregate condition over a pre-aggregated pipeline
- Sensor over an upstream stage reference (run-scoped table rewrite)
- Parser/typer coverage via `spec/basic/flow-syntax.wv` (TyperCoverageCheck ratchet passes); full `langJVM`, `runner`, `cli` suites and `langJS` compilation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)