### PR TITLE
fix: Bind qualified stage references in join conditions to run-scoped tables

### DIFF
--- a/spec/basic/flow-run.wv
+++ b/spec/basic/flow-run.wv
@@ -97,3 +97,18 @@ run flow JourneyPipeline
 | where state = 'success'
 test _.size should be 4
 ;
+
+flow JoinPipeline = {
+  stage orders = from [[1, 101, 120.50], [2, 102, -5.00], [3, 101, 89.99], [4, 103, 300.00]] as t(order_id, customer_id, amount)
+  stage customers = from [[101, 'Alice'], [102, 'Bob'], [103, 'Carol']] as t(customer_id, name)
+  stage clean = from orders | where amount > 0
+  stage enriched = from clean | join customers on clean.customer_id = customers.customer_id
+  stage totals = from enriched | group by name | select name, sum(amount) as total_amount
+}
+
+-- An ingest -> clean -> join -> aggregate scenario: qualified stage references in join
+-- conditions bind to the run-scoped stage tables
+run flow JoinPipeline
+| where state = 'success'
+test _.size should be 5
+;

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -1149,19 +1149,28 @@ object FlowExecutor:
       routeFilters: Map[(String, String), Expression]
   ): Relation =
     // Reference a source stage's run-scoped table, filtered with the routing predicate when
-    // the reader stage is a route target of the source
+    // the reader stage is a route target of the source. The result is aliased back to the
+    // stage name so that qualified column references (e.g. `clean.customer_id` in a join
+    // condition) still bind after the table is renamed to its run-scoped form
     def stageTableRef(stageName: String, span: Span): Relation =
       val ref = TableRef(DoubleQuotedIdentifier(tableFor(stageName), span), span)
-      routeFilters.get((readerStage, stageName)) match
-        case Some(pred) =>
-          Filter(ref, pred, span)
-        case None =>
-          ref
+      val src =
+        routeFilters.get((readerStage, stageName)) match
+          case Some(pred) =>
+            Filter(ref, pred, span)
+          case None =>
+            ref
+      AliasedRelation(src, UnquotedIdentifier(stageName, span), None, span)
 
     body
       .transformUp {
         case t: TableRef if stageNames.contains(t.name.fullName) =>
           stageTableRef(t.name.fullName, t.span)
+        // A user-provided alias (`from clean as c`) supersedes the stage-name alias the
+        // rewrite adds around the run-scoped table: collapse to keep the user's alias only
+        case a @ AliasedRelation(inner: AliasedRelation, _, _, _)
+            if inner.columnNames.isEmpty && stageNames.contains(inner.alias.fullName) =>
+          a.copy(child = inner.child)
         case m: FlowMerge =>
           m.sources
             .map { src =>

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -116,6 +116,27 @@ class FlowExecutorTest extends UniTest:
     countStageRows(result, "output") shouldBe 2L
   }
 
+  test("bind qualified stage references in join conditions to run-scoped tables") {
+    val result = runFlow("""flow JoinFlow = {
+        |  stage orders = from [[1, 101, 120.50], [2, 102, -5.00], [3, 101, 89.99]] as t(order_id, customer_id, amount)
+        |  stage customers = from [[101, 'Alice'], [102, 'Bob']] as t(customer_id, name)
+        |  stage clean = from orders | where amount > 0
+        |  stage enriched = from clean | join customers on clean.customer_id = customers.customer_id
+        |}""".stripMargin)
+    result.isSuccess shouldBe true
+    countStageRows(result, "enriched") shouldBe 2L
+  }
+
+  test("keep a user-provided alias on a stage reference in a join") {
+    val result = runFlow("""flow AliasedJoinFlow = {
+        |  stage src = from [[1, 'a'], [2, 'b']] as t(id, name)
+        |  stage lookup = from [[1, 'x']] as t(id, tag)
+        |  stage joined = from src as s | join lookup as l on s.id = l.id | select s.id, l.tag
+        |}""".stripMargin)
+    result.isSuccess shouldBe true
+    countStageRows(result, "joined") shouldBe 1L
+  }
+
   test("skip downstream stages when an upstream stage fails") {
     val result = runFlow("""flow FailingFlow = {
         |  stage primary = from nonexistent_table_xyz


### PR DESCRIPTION
## Summary

Flow stages materialize into run-scoped tables (`__wv_flow_<run_id>_<stage>`), and the stage-source rewrite replaced the stage table name without preserving the original stage name. As a result, a join condition written in the natural form fails at execution time:

```wvlet
flow demo = {
  stage clean = from orders | where amount > 0
  stage enriched = from clean
    | join customers on clean.customer_id = customers.customer_id
}
```

```
Binder Error: Referenced table "clean" not found!
Candidate tables: "__wv_flow_01kwqnsz..._clean", ...
```

The only workaround was aliasing every stage reference by hand (`from clean as c | join customers as cu on c.customer_id = cu.customer_id`).

## Changes

- `FlowExecutor.rewriteStageRefs` now aliases each rewritten run-scoped table back to its stage name (`"__wv_flow_..._clean" as clean`), so qualified column references in join conditions (and anywhere else in the stage body) keep binding.
- When the user supplies their own alias (`from clean as c`), the added stage-name alias is collapsed so only the user's alias remains.
- Adds an end-to-end ingest → clean → join → aggregate scenario to `spec/basic/flow-run.wv` exercising the natural qualified-join form, plus `FlowExecutorTest` cases for both the unaliased and user-aliased join paths.

## Testing

- `runner/testOnly *FlowExecutorTest` — 75 tests pass (2 new; route/merge tests cover the same rewrite path)
- `runner/testOnly *RunnerSpecBasic` — 129 specs pass including the new scenario
- Verified end-to-end with the installed CLI (`wvlet flow run --profile duckdb`): a CSV ingest → filter → qualified join → group-by → `activate('file')` parquet export pipeline that previously failed now runs green with correct results
- `projectJS/Test/compile` passes (change is JVM-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)