### PR TITLE
fix: Route conditional cases with first-match semantics

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -307,8 +307,10 @@ Stage bodies can use flow operators in addition to regular query operators.
 ### Conditional Routing with route
 
 `route` sends rows to different target stages based on conditions. Each target stage reads
-the routing stage and receives only its matching rows. Targets may reference stages defined
-later in the flow:
+the routing stage and receives only its matching rows. Cases follow first-match semantics
+like a `case`/`when` expression: a row is routed to the first case whose condition holds,
+and `else` receives the rows matching no case — so overlapping conditions never send a row
+to more than one target. Targets may reference stages defined later in the flow:
 
 ```wvlet
 flow conditional_flow = {

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1604,7 +1604,12 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
       case i: IfExpr =>
         text("if") + paren(cl(expr(i.cond), expr(i.onTrue), expr(i.onFalse)))
       case n: Not =>
-        wl("not", expr(n.child))
+        // Parenthesize and/or children: `not a or b` binds as `(not a) or b` in SQL
+        n.child match
+          case c: LogicalConditionalExpression =>
+            wl("not", paren(expr(c)))
+          case other =>
+            wl("not", expr(other))
       case l: ListExpr =>
         cl(l.exprs.map(x => expr(x)))
       case d @ DotRef(qual: Expression, name: NameExpr, _, _) =>

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
@@ -242,9 +242,17 @@ object FlowLowering:
     val conditionCases  = r.cases.filter(_.condition.isDefined)
     val percentageCases = r.cases.filter(_.percentage.isDefined)
 
-    val fromConditions: List[(String, Expression)] = conditionCases.map { c =>
-      c.target.fullName -> resolveContextRefs(c.condition.get)
-    }
+    // Condition cases follow first-match semantics like a case/when expression: a row is
+    // routed to the first case whose condition holds, so each case predicate excludes the
+    // conditions of all preceding cases
+    val fromConditions: List[(String, Expression)] =
+      var matchedSoFar: Option[Expression] = None
+      conditionCases.map { c =>
+        val cond = resolveContextRefs(c.condition.get)
+        val pred = matchedSoFar.map(p => And(Not(p, NoSpan), cond, NoSpan)).getOrElse(cond)
+        matchedSoFar = Some(matchedSoFar.map(p => Or(p, cond, NoSpan)).getOrElse(cond))
+        c.target.fullName -> pred
+      }
 
     val fromPercentages: List[(String, Expression)] =
       if percentageCases.isEmpty then

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowLowering.scala
@@ -247,11 +247,14 @@ object FlowLowering:
     // conditions of all preceding cases
     val fromConditions: List[(String, Expression)] =
       var matchedSoFar: Option[Expression] = None
-      conditionCases.map { c =>
-        val cond = resolveContextRefs(c.condition.get)
-        val pred = matchedSoFar.map(p => And(Not(p, NoSpan), cond, NoSpan)).getOrElse(cond)
-        matchedSoFar = Some(matchedSoFar.map(p => Or(p, cond, NoSpan)).getOrElse(cond))
-        c.target.fullName -> pred
+      conditionCases.flatMap { c =>
+        c.condition
+          .map { rawCond =>
+            val cond = resolveContextRefs(rawCond)
+            val pred = matchedSoFar.map(p => And(Not(p, NoSpan), cond, NoSpan)).getOrElse(cond)
+            matchedSoFar = Some(matchedSoFar.map(p => Or(p, cond, NoSpan)).getOrElse(cond))
+            c.target.fullName -> pred
+          }
       }
 
     val fromPercentages: List[(String, Expression)] =

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -506,6 +506,25 @@ class FlowExecutorTest extends UniTest:
     countStageRows(result, "minor") shouldBe 1L
   }
 
+  test("route overlapping conditional cases with first-match semantics") {
+    val result = runFlow("""flow TieredRouteFlow = {
+        |  stage src = from [[1, 430], [2, 60], [3, 375], [4, 15], [5, 42]] as t(id, total)
+        |  stage gate = from src | route {
+        |    case _.total >= 300 -> vip
+        |    case _.total >= 50 -> regular
+        |    else -> occasional
+        |  }
+        |  stage vip = from gate | select id
+        |  stage regular = from gate | select id
+        |  stage occasional = from gate | select id
+        |}""".stripMargin)
+    result.isSuccess shouldBe true
+    // Each row lands in exactly one target: 430/375 -> vip, 60 -> regular, 15/42 -> occasional
+    countStageRows(result, "vip") shouldBe 2L
+    countStageRows(result, "regular") shouldBe 1L
+    countStageRows(result, "occasional") shouldBe 2L
+  }
+
   test("route rows deterministically with percentage buckets") {
     val values = (1 to 100).map(i => s"[${i}]").mkString(", ")
     val flowWv =


### PR DESCRIPTION
## Summary

Building an end-to-end flow demo surfaced two related correctness bugs in conditional routing. With a tiered route:

```wvlet
stage gate = from totals | route {
  case _.total_amount >= 300 -> vip
  case _.total_amount >= 50 -> regular
  else -> occasional
}
```

every customer landed in **multiple segments**: vip rows also appeared in `regular` (overlapping conditions are applied independently), and **every** row appeared in `occasional`.

## Root causes

1. **Route lowering** (`FlowLowering.routePredicatesOf`): each condition case used its raw condition as the target filter, without excluding the preceding cases. `case >= 300` / `case >= 50` therefore overlapped.
2. **SQL generation** (`SqlGenerator`): `Not` rendered its child without parentheses, so the else predicate `Not(Or(a, b))` generated `not a or b`, which SQL binds as `(not a) or b` — true for almost every row. This only affects synthetically constructed expression trees (parsed `not (...)` keeps a `ParenthesizedExpression` node), but any rewriter building `Not` over a logical expression would hit it.

## Changes

- Route condition cases now follow first-match semantics like a `case`/`when` expression: each case predicate excludes the conditions of all preceding cases, so a row is routed to exactly one target. Percentage buckets were already disjoint and are unchanged.
- The SQL generator parenthesizes and/or children of `not`.
- Docs: the route section now states first-match semantics explicitly.
- New `FlowExecutorTest` case with overlapping conditions + else asserting exact per-target row counts (this test fails without either fix; the existing single-case route tests could not catch these since a single comparison needs no parentheses and no exclusion).

## Testing

- `langJVM/test`: 851 tests pass (the `Not` change affects general SQL generation)
- `runner/test`: 229 tests pass, including the new first-match test
- `projectJS/Test/compile` passes
- Verified with the real CLI: the tiered-segment pipeline now assigns each customer to exactly one segment

🤖 Generated with [Claude Code](https://claude.com/claude-code)