### PR TITLE
feature: Connector-qualified table names and use <connector> engine switching (#1861 Phase 2, part 1)

### DIFF
--- a/plans/2026-07-05-connector-namespace-phase2.md
+++ b/plans/2026-07-05-connector-namespace-phase2.md
@@ -1,0 +1,41 @@
+# Phase 2 of #1861 — Connector namespaces, `use` statement, staging
+
+Builds on Phase 1 (#1863, merged): multi-connector `Profile`, `Connector` capability trait, `ConnectorProvider`.
+
+Split into two PRs:
+
+- **PR-A (this branch): connector namespaces in the compiler + extended `use`.** Queries can reference `from <connector>.<table>` and switch the active engine with `use <connector>`. Cross-connector references inside one query are type-checked but rejected at execution with a clear "staging lands in a follow-up" error unless the referenced connector is the active engine.
+- **PR-B: runtime staging + per-stage `on <connector>` in flows.** Materialize connector B's tables into engine A (JSONL → CTAS, reusing the QueryExecutor.executeSaveToLocalFileViaDuckDB pattern), per-stage engine selection in FlowExecutor.
+
+## Exploration facts (file:line verified)
+
+- `from a.b.c` parses to `TableRef(QualifiedName)` (WvletParser.scala:2431-2442); resolution in `RelationRefResolver.resolveTableRef` (RelationRefResolver.scala:60): symbol `lookup` returns None for any DotRef (":54 TODO"), then catalog fallback `context.catalog.findTable(schema, table)` (:108-112) via `TableName.parse` (2-part = schema.table, 3-part = catalog.schema.table, catalog part dropped at this call site). Unresolved refs pass through.
+- `Context.catalog` = single `global.defaultCatalog` var (Context.scala:78, ":178 TODO support multiple catalogs"); **`Context.dbType = catalog.dbType`** (:180) — the SQL dialect follows the active catalog, so switching the active connector's catalog switches dialect for free.
+- `use` parses to `UseSchema` (WvletParser.scala:924, optional soft keyword "schema"); no compiler-phase handling; runtime handler QueryExecutor.scala:265-284 mutates `context.global.defaultSchema` (2-part catalog ignored, 3-part rejected).
+- CLI registers only the default engine's catalog: WvletCompiler.scala:102 `setDefaultCatalog(getDBConnector.getCatalog(...))`; same in WvletScriptRunner.scala:87-96.
+- `ConnectorCatalog` construction triggers an async `init()` that queries the DB → registering all profile connectors eagerly would open connections to every engine at startup. Needs a lazy wrapper.
+- Flow seams for PR-B: `FlowExecutor` single `connector` field (:236); `materializeStage` (:1084, engine-aware DDL :1114); `rewriteStageRefs` (:1144) is where staging-table rewrites inject; `StageDef` (flow.scala:132) gains `engine: Option[NameExpr]`; parser slot in `stageDef()` between config block (:473) and `=` (:475); `FlowLowering.LoweredStage` waitUntil-extraction (FlowLowering.scala:155-234) is the pattern for the new per-stage directive; `ConnectorProvider` needs `getConnector(profile, name)`.
+
+## PR-A design
+
+1. **Registry**: `GlobalContext` gets `connectorCatalogs: mutable.Map[String, Catalog]` + `Compiler.addConnectorCatalog(name, catalog)`. New `LazyCatalog(name, () => Catalog)` in wvlet-lang catalog package delegating all `Catalog` methods to a lazily-built target (so non-default engines connect only on first reference).
+2. **CLI/runner wiring**: WvletCompiler.createCompiler + WvletScriptRunner register every profile connector that has `catalog`+`schema` config: default engine eagerly (as today), others as `LazyCatalog` via `ConnectorProvider.getConnector(config).getCatalog(...)`.
+3. **Resolution**: in `RelationRefResolver.resolveTableRef`, after symbol lookup fails and the name is a DotRef whose leading identifier matches a registered connector name (connector names shadow schema names; CTEs/aliases/models still win via the earlier symbol path): resolve the remaining 1-2 parts against that connector's catalog (2-part `td.orders` → td's default schema; 3-part `td.s.t` → schema s). 4-part deferred to PR-B. Record the connector name in `CompilationUnit` (e.g. `referencedConnectors`) so the executor can enforce single-engine execution; the emitted `TableScan.name` is the fully-qualified `catalog.schema.table` on that engine.
+4. **`use` extension**: parser accepts `use connector <name>` (soft keyword, like `schema`); bare `use <name>` resolution at runtime checks the active profile's connector names first, then falls back to today's schema behavior. Switching connector = set `global.defaultCatalog` to that connector's catalog (dialect follows), `defaultSchema` to its config schema, and the executor's active engine config (new `private var activeEngine: ConnectorConfig` in QueryExecutor; `getDBConnector` uses it). `use prod.td` across profiles: not supported (profile stays a CLI boundary).
+5. **Execution guard**: QueryExecutor errors with NOT_IMPLEMENTED "cross-connector query staging arrives in a follow-up; run `use <name>` to execute on that connector" when a compiled unit references a connector other than the active engine.
+6. **Specs/tests**: ProfileTest-style unit tests for LazyCatalog; RelationRefResolver test with a registered fake connector catalog; runner spec: multi-connector profile (duckdb + second duckdb alias), `use <name>` switch, `from <name>.tbl` resolution; `use connector` parse test in spec/basic; TyperCoverageCheck must not regress.
+7. **Docs**: website/docs — connector namespace + `use` section in the profiles doc.
+
+## PR-B design (follow-up branch)
+
+1. `StageDef.engine: Option[NameExpr]`; parse `on <name>` in stageDef() (lookahead to disambiguate from `depends on`); thread per-stage connector through FlowExecutor (resolve via `ConnectorProvider` + `Profile.connectorByName`); engine-aware DDL already per-connector.
+2. `CatalogProvider.scan` + JSONL→CTAS staging: materialize non-local `TableRef`s in `rewriteStageRefs`/`materializeStage` into run-scoped `__wv_flow_*_stg_*` tables on the stage's engine.
+3. Lift the PR-A execution guard for the staged paths.
+4. Trino flow test with a DuckDB-sourced staged input; docs update (flow.md `on <connector>`).
+
+## Verification (each PR)
+
+- `./sbt "projectJVM/Test/compile" "projectJS/Test/compile" "projectNative/Test/compile"`
+- `./sbt "langJVM/test"` (TyperCoverageCheck ratchet), `./sbt runner/test`, `./sbt cli/test`
+- Smoke: packInstall; multi-connector profiles.json with two duckdb connectors; `wv -c 'use second; from second.t'`
+- `./sbt scalafmtAll`

--- a/spec/basic/use-schema.wv
+++ b/spec/basic/use-schema.wv
@@ -15,3 +15,12 @@ use main
 
 -- Test another schema switch with explicit syntax
 use schema production
+-- Test explicit connector switch syntax (the default DuckDB profile defines
+-- a connector named 'duckdb')
+use connector duckdb
+
+-- A bare name matching a profile connector switches the connector
+use duckdb
+
+-- connector.schema form selects a schema on that connector
+use duckdb.main

--- a/website/docs/usage/connectors.md
+++ b/website/docs/usage/connectors.md
@@ -1,0 +1,66 @@
+# Working with Multiple Connectors
+
+A profile in `~/.wvlet/profiles.json` describes a working environment and can activate several
+connectors at once — for example a production Trino cluster next to a local DuckDB database:
+
+```jsonc title='~/.wvlet/profiles.json'
+{
+  "profiles": [
+    {
+      "name": "dev",
+      "connectors": [
+        {
+          "name": "td",
+          "type": "trino",
+          "default": true,
+          "host": "api-presto.treasuredata.com",
+          "user": "${TD_API_KEY}",
+          "catalog": "td",
+          "schema": "sample_datasets"
+        },
+        { "name": "local", "type": "duckdb", "catalog": "memory", "schema": "main" }
+      ]
+    }
+  ]
+}
+```
+
+The connector marked `"default": true` (or the first one) is the engine your queries run on when
+the session starts.
+
+## Referencing tables through a connector name
+
+Table references can name a connector explicitly. The first identifier is checked against the
+connector names of the active profile:
+
+```sql
+-- <connector>.<table>: uses the connector's configured schema
+from td.www_access
+
+-- <connector>.<schema>.<table>
+from td.sample_datasets.www_access
+```
+
+Models, CTEs, and query aliases take precedence over connector names, and connector names take
+precedence over schema names of the default catalog. Since you choose connector names yourself,
+rename the connector if it collides with a schema you need to address.
+
+Queries currently execute on one engine at a time: referencing a connector other than the active
+engine reports an error suggesting `use <connector>`. Combining tables from different connectors
+in a single query (cross-connector staging) is planned as a follow-up.
+
+## Switching connectors with `use`
+
+The `use` statement switches the active connector for subsequent statements. Its catalog then
+drives table resolution and the SQL dialect:
+
+```sql
+use td                  -- switch to the td connector
+use local               -- switch to the local DuckDB connector
+use connector td        -- explicit form, for when a name collides with a schema
+use td.sample_datasets  -- switch connector and schema in one statement
+```
+
+Bare names are resolved connector-first: `use analytics` switches to a connector named
+`analytics` when the profile defines one, and otherwise behaves like `use schema analytics`
+(see [CLI reference](cli-reference.md) for the schema forms).

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
@@ -5,6 +5,7 @@ import wvlet.uni.cli.launcher.option
 import wvlet.uni.control.Control
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.v1.query.QuerySelection
+import wvlet.lang.catalog.LazyCatalog
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.codegen.CodeFormatterConfig
 import wvlet.lang.compiler.codegen.GenSQL
@@ -107,6 +108,27 @@ class WvletCompiler(
       .schema
       .foreach { schema =>
         compiler.setDefaultSchema(schema)
+      }
+
+    // Register every profile connector under its name so queries can reference
+    // `from <connector>.<table>` and switch engines with `use <connector>` (#1861 Phase 2).
+    // Non-default connectors get a LazyCatalog so they only connect on first reference.
+    currentProfile
+      .connectors
+      .foreach { c =>
+        c.catalog
+          .foreach { catalogName =>
+            val schema = c.schema.getOrElse("main")
+            compiler.addConnectorCatalog(
+              c.name,
+              LazyCatalog(
+                catalogName,
+                c.dbType,
+                () => dbConnectorProvider.getDBConnector(c).getCatalog(catalogName, schema)
+              ),
+              schema
+            )
+          }
       }
 
     compiler

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/catalog/LazyCatalogTest.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/catalog/LazyCatalogTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.catalog
+
+import wvlet.lang.compiler.DBType
+import wvlet.uni.test.UniTest
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class LazyCatalogTest extends UniTest:
+
+  test("should not build the backing catalog until a metadata lookup") {
+    val buildCount = AtomicInteger(0)
+    val catalog    = LazyCatalog(
+      "memory",
+      DBType.DuckDB,
+      () =>
+        buildCount.incrementAndGet()
+        InMemoryCatalog("memory", Nil)
+    )
+
+    // Name and dialect are available without materialization
+    catalog.catalogName shouldBe "memory"
+    catalog.dbType shouldBe DBType.DuckDB
+    buildCount.get() shouldBe 0
+
+    // First lookup materializes; further lookups reuse the same instance
+    catalog.findTable("main", "t") shouldBe None
+    catalog.listSchemaNames
+    buildCount.get() shouldBe 1
+  }
+
+end LazyCatalogTest

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/LazyCatalog.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/LazyCatalog.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.catalog
+
+import wvlet.lang.compiler.DBType
+
+/**
+  * A [[Catalog]] that defers building its backing catalog (and thus opening any database
+  * connection) until the first metadata lookup. Profiles can activate many connectors at once; only
+  * the ones a query actually references should connect.
+  *
+  * `catalogName` and `dbType` come from the connector config so that name resolution and SQL
+  * dialect selection never force materialization on their own.
+  */
+class LazyCatalog(
+    override val catalogName: String,
+    override val dbType: DBType,
+    build: () => Catalog
+) extends Catalog:
+
+  private lazy val underlying: Catalog = build()
+
+  override def listSchemaNames: Seq[String]                       = underlying.listSchemaNames
+  override def listSchemas: Seq[Catalog.TableSchema]              = underlying.listSchemas
+  override def getSchema(schemaName: String): Catalog.TableSchema = underlying.getSchema(schemaName)
+  override def schemaExists(schemaName: String): Boolean = underlying.schemaExists(schemaName)
+  override def createSchema(schema: Catalog.TableSchema, createMode: Catalog.CreateMode): Unit =
+    underlying.createSchema(schema, createMode)
+
+  override def listTableNames(schemaName: String): Seq[String] = underlying.listTableNames(
+    schemaName
+  )
+
+  override def listTables(schemaName: String): Seq[Catalog.TableDef] = underlying.listTables(
+    schemaName
+  )
+
+  override def findTable(schemaName: String, tableName: String): Option[Catalog.TableDef] =
+    underlying.findTable(schemaName, tableName)
+
+  override def getTable(schemaName: String, tableName: String): Catalog.TableDef = underlying
+    .getTable(schemaName, tableName)
+
+  override def tableExists(schemaName: String, tableName: String): Boolean = underlying.tableExists(
+    schemaName,
+    tableName
+  )
+
+  override def createTable(table: Catalog.TableDef, createMode: Catalog.CreateMode): Unit =
+    underlying.createTable(table, createMode)
+
+  override def listFunctions: Seq[SQLFunction] = underlying.listFunctions
+
+  override def updateColumns(
+      schemaName: String,
+      tableName: String,
+      columns: Seq[Catalog.TableColumn]
+  ): Unit = underlying.updateColumns(schemaName, tableName, columns)
+
+  override def updateTableProperties(
+      schemaName: String,
+      tableName: String,
+      properties: Map[String, Any]
+  ): Unit = underlying.updateTableProperties(schemaName, tableName, properties)
+
+  override def updateDatabaseProperties(schemaName: String, properties: Map[String, Any]): Unit =
+    underlying.updateDatabaseProperties(schemaName, properties)
+
+end LazyCatalog

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
@@ -45,12 +45,6 @@ case class CompilationUnit(sourceFile: SourceFile, isPreset: Boolean = false)
   // Untyped plan tree
   var unresolvedPlan: LogicalPlan = LogicalPlan.empty
 
-  // Connector names referenced via `from <connector>.<table>` in this unit, recorded during
-  // name resolution so the executor can enforce single-engine execution until cross-connector
-  // staging lands (#1861 Phase 2)
-  val referencedConnectors: scala.collection.mutable.Set[String] =
-    scala.collection.mutable.Set.empty
-
   // Cached after parsing; symbol lookup reads this on a hot path
   private var cachedPackageName: String = null
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/CompilationUnit.scala
@@ -45,6 +45,12 @@ case class CompilationUnit(sourceFile: SourceFile, isPreset: Boolean = false)
   // Untyped plan tree
   var unresolvedPlan: LogicalPlan = LogicalPlan.empty
 
+  // Connector names referenced via `from <connector>.<table>` in this unit, recorded during
+  // name resolution so the executor can enforce single-engine execution until cross-connector
+  // staging lands (#1861 Phase 2)
+  val referencedConnectors: scala.collection.mutable.Set[String] =
+    scala.collection.mutable.Set.empty
+
   // Cached after parsing; symbol lookup reads this on a hot path
   private var cachedPackageName: String = null
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
@@ -136,6 +136,10 @@ class Compiler(
   def setDefaultCatalog(catalog: Catalog): Unit = globalContext.defaultCatalog = catalog
   def setDefaultSchema(schema: String): Unit    = globalContext.defaultSchema = schema
 
+  /** Register a catalog under a connector name so queries can reference `<name>.<table>` */
+  def addConnectorCatalog(name: String, catalog: Catalog, defaultSchema: String): Unit =
+    globalContext.connectorCatalogs(name) = ConnectorCatalogEntry(catalog, defaultSchema)
+
   def getDefaultCatalog: Catalog = globalContext.defaultCatalog
   def getDefaultSchema: String   = globalContext.defaultSchema
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -78,6 +78,10 @@ case class GlobalContext(compilerOptions: CompilerOptions):
   var defaultCatalog: Catalog = loadCatalog(compilerOptions)
   var defaultSchema: String   = compilerOptions.schema.getOrElse("main")
 
+  // Connector-name -> catalog registry for resolving `from <connector>.<table>` references
+  // against the connectors activated by the current profile (#1861 Phase 2)
+  val connectorCatalogs = scala.collection.mutable.Map.empty[String, ConnectorCatalogEntry]
+
   var workEnv: WorkEnv = compilerOptions.workEnv
 
   def init(using rootContext: Context): Unit =
@@ -174,10 +178,14 @@ case class Context(
     .sourceFile
     .sourceLocationAt(span.start)
 
-  // Get the context catalog
-  // TODO support multiple catalogs
+  // Get the context catalog (the active engine's catalog)
   def catalog: Catalog = global.defaultCatalog
   def dbType: DBType   = catalog.dbType
+
+  /** Find a catalog registered under a connector name from the active profile */
+  def connectorCatalog(connectorName: String): Option[ConnectorCatalogEntry] = global
+    .connectorCatalogs
+    .get(connectorName)
 
   def defaultSchema: String = global.defaultSchema
 
@@ -343,3 +351,9 @@ object Context:
     // Need to initialize the global context before running the analysis phases
     global.init(using rootContext)
     global
+
+/**
+  * A catalog exposed under a connector name from the active profile, with the connector's
+  * configured default schema for resolving 2-part `<connector>.<table>` references
+  */
+case class ConnectorCatalogEntry(catalog: Catalog, defaultSchema: String)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -121,7 +121,9 @@ object RelationRefResolver extends ContextLogSupport:
     * default catalog.
     */
   private def resolveConnectorQualifiedRef(ref: TableRef, context: Context): Option[Relation] =
-    ref.name.fullName.split("\\.").toList match
+    // Decompose the DotRef structurally (not by splitting fullName) so quoted identifiers
+    // containing dots keep their boundaries
+    nameParts(ref.name) match
       case connectorName :: rest if rest.nonEmpty =>
         context
           .connectorCatalog(connectorName)
@@ -140,14 +142,34 @@ object RelationRefResolver extends ContextLogSupport:
                 .catalog
                 .findTable(schema, table)
                 .map { tbl =>
-                  context.compilationUnit.referencedConnectors += connectorName
                   val tableName = TableName(Some(entry.catalog.catalogName), Some(schema), table)
-                  TableScan(tableName, tbl.schemaType, tbl.schemaType.fields, ref.span)
+                  TableScan(
+                    tableName,
+                    tbl.schemaType,
+                    tbl.schemaType.fields,
+                    ref.span,
+                    connectorName = Some(connectorName)
+                  )
                 }
             }
           }
       case _ =>
         None
+
+  // The individual identifier parts of a qualified name, or Nil when the expression contains
+  // anything other than a plain identifier chain
+  private def nameParts(e: Expression): List[String] =
+    e match
+      case i: Identifier =>
+        List(i.leafName)
+      case DotRef(qualifier, name: Identifier, _, _) =>
+        nameParts(qualifier) match
+          case Nil =>
+            Nil
+          case parts =>
+            parts :+ name.leafName
+      case _ =>
+        Nil
 
   private def resolveFromDefaultCatalog(ref: TableRef, context: Context): Relation =
     val tableName = TableName.parse(ref.name.fullName)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -106,22 +106,63 @@ object RelationRefResolver extends ContextLogSupport:
             val tableName = TableName.parse(tblType.toTermName.name)
             TableScan(tableName, tpe, tpe.fields, ref.span)
           case _ =>
-            val tableName = TableName.parse(ref.name.fullName)
-            context
-              .catalog
-              .findTable(tableName.schema.getOrElse(context.defaultSchema), tableName.name) match
-              case Some(tbl) =>
-                TableScan(tableName, tbl.schemaType, tbl.schemaType.fields, ref.span)
+            resolveConnectorQualifiedRef(ref, context) match
+              case Some(resolved) =>
+                resolved
               case None =>
-                context
-                  .workEnv
-                  .errorLogger
-                  .debug(
-                    s"Unresolved table ref: ${ref.name.fullName}: ${context.scope.getAllEntries}"
-                  )
-                ref
+                resolveFromDefaultCatalog(ref, context)
     end match
   end resolveTableRef
+
+  /**
+    * Resolve `from <connector>.<table>` / `from <connector>.<schema>.<table>` where the leading
+    * identifier names a connector activated by the current profile. Connector names are checked
+    * only after symbol lookup (models, CTEs, aliases) has failed, and shadow schema names of the
+    * default catalog.
+    */
+  private def resolveConnectorQualifiedRef(ref: TableRef, context: Context): Option[Relation] =
+    ref.name.fullName.split("\\.").toList match
+      case connectorName :: rest if rest.nonEmpty =>
+        context
+          .connectorCatalog(connectorName)
+          .flatMap { entry =>
+            val schemaAndTable =
+              rest match
+                case table :: Nil =>
+                  Some((entry.defaultSchema, table))
+                case schema :: table :: Nil =>
+                  Some((schema, table))
+                case _ =>
+                  // connector.catalog.schema.table (4-part) arrives with cross-connector staging
+                  None
+            schemaAndTable.flatMap { (schema, table) =>
+              entry
+                .catalog
+                .findTable(schema, table)
+                .map { tbl =>
+                  context.compilationUnit.referencedConnectors += connectorName
+                  val tableName = TableName(Some(entry.catalog.catalogName), Some(schema), table)
+                  TableScan(tableName, tbl.schemaType, tbl.schemaType.fields, ref.span)
+                }
+            }
+          }
+      case _ =>
+        None
+
+  private def resolveFromDefaultCatalog(ref: TableRef, context: Context): Relation =
+    val tableName = TableName.parse(ref.name.fullName)
+    context
+      .catalog
+      .findTable(tableName.schema.getOrElse(context.defaultSchema), tableName.name) match
+      case Some(tbl) =>
+        TableScan(tableName, tbl.schemaType, tbl.schemaType.fields, ref.span)
+      case None =>
+        context
+          .workEnv
+          .errorLogger
+          .debug(s"Unresolved table ref: ${ref.name.fullName}: ${context.scope.getAllEntries}")
+        ref
+  end resolveFromDefaultCatalog
 
   /**
     * Fill in unresolved column types of a table-value-constant schema from the literal values of

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -665,6 +665,8 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
           group(wl("show", "query", expr(t.name)))
         case u: UseSchema =>
           group(wl("use", expr(u.schema)))
+        case u: UseConnector =>
+          group(wl("use", "connector", expr(u.connector)))
         case e: ExplainPlan =>
           group(wl("explain", render(e.child)))
         case other =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -921,16 +921,24 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
   }
   end statement
 
-  def use(): UseSchema = node {
+  def use(): Command = node {
     val t = consume(WvletToken.USE)
-    // Support both:
-    // - use <schema_name> (common case)
-    // - use schema <schema_name> (explicit form)
+    // Support:
+    // - use <name>                  (a connector name from the profile, or a schema)
+    // - use schema <schema_name>    (explicit schema form)
+    // - use connector <name>        (explicit connector form)
+    // Bare names are disambiguated at execution time: connector names of the active profile
+    // shadow schema names.
     val nextToken = scanner.lookAhead()
-    if nextToken.token == WvletToken.IDENTIFIER && nextToken.str == "schema" then
-      consume(WvletToken.IDENTIFIER) // consume optional "schema" keyword
-    val schema = qualifiedId()
-    UseSchema(schema, spanFrom(t))
+    if nextToken.token == WvletToken.IDENTIFIER && nextToken.str == "connector" then
+      consume(WvletToken.IDENTIFIER) // consume the "connector" soft keyword
+      val connector = qualifiedId()
+      UseConnector(connector, spanFrom(t))
+    else
+      if nextToken.token == WvletToken.IDENTIFIER && nextToken.str == "schema" then
+        consume(WvletToken.IDENTIFIER) // consume optional "schema" keyword
+      val schema = qualifiedId()
+      UseSchema(schema, spanFrom(t))
   }
 
   def showExpr(): LogicalPlan = node {

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -294,6 +294,14 @@ object Typer extends Phase("typer") with LogSupport:
             copied
         TyperRules.typeStatement(typedValDef)
         typedValDef
+      case u: UseSchema =>
+        // The name in `use <schema>` is a namespace reference, not a value expression: mark it
+        // typed so it doesn't surface as an unresolved expression
+        markNamespaceRef(u.schema)
+        typeNode(u)
+      case u: UseConnector =>
+        markNamespaceRef(u.connector)
+        typeNode(u)
       // Default: bottom-up typing for other nodes
       case other =>
         val withTypedChildren = other.mapChildren(typePlan)
@@ -658,6 +666,12 @@ object Typer extends Phase("typer") with LogSupport:
       }
 
   end structuralResolutionRule
+
+  // Namespace references (schema/connector names in `use`) carry no value type; NullType marks
+  // them resolved for typing-coverage purposes
+  private def markNamespaceRef(name: Expression): Unit =
+    name.tpe = DataType.NullType
+    name.children.foreach(markNamespaceRef)
 
   /**
     * Returns true if the relation tree may contain function applications, method or native function

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/commands.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/commands.scala
@@ -28,5 +28,11 @@ case class ExplainPlan(
 ) extends Command
 
 case class UseSchema(schema: QualifiedName, span: Span) extends Command
-case class DescribeInput(name: NameExpr, span: Span)    extends Command
-case class DescribeOutput(name: NameExpr, span: Span)   extends Command
+
+/**
+  * Explicit `use connector <name>` form: switch the active connector (execution engine and default
+  * namespace) to a connector defined in the current profile
+  */
+case class UseConnector(connector: QualifiedName, span: Span) extends Command
+case class DescribeInput(name: NameExpr, span: Span)          extends Command
+case class DescribeOutput(name: NameExpr, span: Span)         extends Command

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
@@ -1073,8 +1073,15 @@ case class LateralView(
   * @param columns
   *   projected columns
   */
-case class TableScan(name: TableName, schema: RelationType, columns: List[NamedType], span: Span)
-    extends TableInput
+case class TableScan(
+    name: TableName,
+    schema: RelationType,
+    columns: List[NamedType],
+    span: Span,
+    // Set when the reference was resolved through a profile connector name
+    // (`from <connector>.<table>`), so the executor can verify the query runs on that engine
+    connectorName: Option[String] = None
+) extends TableInput
     with HasTableName:
 
   override def sqlExpr: Expression = NameExpr.fromString(name.fullName, span)

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -18,6 +18,7 @@ import wvlet.lang.connector.codec.JDBCCodec
 import wvlet.lang.api.LinePosition
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
+import wvlet.lang.catalog.ConnectorConfig
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.*
 import wvlet.lang.compiler.codegen.CodeFormatterConfig
@@ -66,6 +67,60 @@ class QueryExecutor(
 
   def getDBConnector(profile: Profile): DBConnector = dbConnectorProvider.getConnector(profile)
 
+  def getDBConnector(config: ConnectorConfig): DBConnector = dbConnectorProvider.getDBConnector(
+    config
+  )
+
+  // The engine statements execute on: the profile's default engine until a `use <connector>`
+  // statement switches it (#1861 Phase 2)
+  private var activeEngine: ConnectorConfig = defaultProfile.defaultEngine
+
+  private def activeDBConnector: DBConnector = dbConnectorProvider.getDBConnector(activeEngine)
+
+  /**
+    * Switch the active connector: `use <connector>[.<catalog>].<schema>`. Subsequent statements
+    * plan and execute on the selected connector, and its catalog drives name resolution and the SQL
+    * dialect
+    */
+  private def switchConnector(parts: List[String])(using context: Context): QueryResult =
+    val connectorName = parts.head
+    val config        = defaultProfile
+      .connectors
+      .find(_.name == connectorName)
+      .getOrElse(
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(
+            s"Connector '${connectorName}' is not defined in profile '${defaultProfile.name}' " +
+              s"(available: ${defaultProfile.connectors.map(_.name).mkString(", ")})"
+          )
+      )
+    val (catalogName, schemaName) =
+      parts.tail match
+        case Nil =>
+          (config.catalog, config.schema)
+        case schema :: Nil =>
+          (config.catalog, Some(schema))
+        case catalog :: schema :: Nil =>
+          (Some(catalog), Some(schema))
+        case _ =>
+          throw StatusCode
+            .SYNTAX_ERROR
+            .newException(
+              s"Invalid connector reference: ${parts.mkString(".")}. " +
+                "Expected format: <connector>, <connector>.<schema>, or <connector>.<catalog>.<schema>"
+            )
+    activeEngine = config
+    val schema = schemaName.getOrElse("main")
+    catalogName.foreach { catalog =>
+      context.global.defaultCatalog = activeDBConnector.getCatalog(catalog, schema)
+    }
+    context.global.defaultSchema = schema
+    workEnv.info(s"Switched to connector: ${connectorName}")
+    QueryResult.empty
+
+  end switchConnector
+
   def executeSingleSpec(sourceFolder: String, file: String): QueryResult =
     val compiler = Compiler(
       CompilerOptions(sourceFolders = List(sourceFolder), workEnv = WorkEnv(sourceFolder))
@@ -98,6 +153,19 @@ class QueryExecutor(
 
   def executeSingle(u: CompilationUnit, rootContext: Context): QueryResult =
     workEnv.info(s"Executing ${u.sourceFile.fileName}")
+    // Cross-connector staging is not implemented yet: every table referenced through a
+    // connector name must live on the active engine
+    val foreignConnectors = u.referencedConnectors.toSet - activeEngine.name
+    if foreignConnectors.nonEmpty then
+      throw StatusCode
+        .NOT_IMPLEMENTED
+        .newException(
+          s"Query references connector(s) ${foreignConnectors.mkString(
+              ", "
+            )} but the active engine is '${activeEngine
+              .name}'. Cross-connector queries are not supported yet; switch with `use ${foreignConnectors
+              .head}` to run on that connector"
+        )
     val ctx = rootContext.withCompilationUnit(u).newContext(Symbol.NoSymbol)
 
     // val executionPlan = u.executionPlan // ExecutionPlanner.plan(u, ctx)
@@ -168,11 +236,7 @@ class QueryExecutor(
             .util
             .Using
             .resource(FlowRunStore.forWorkEnv(workEnv)) { store =>
-              val flowExecutor = FlowExecutor(
-                getDBConnector(defaultProfile),
-                workEnv,
-                registry = Some(store)
-              )
+              val flowExecutor = FlowExecutor(activeDBConnector, workEnv, registry = Some(store))
               report(flowExecutor.execute(flow))
             }
         case ExecuteValDef(v) =>
@@ -208,7 +272,7 @@ class QueryExecutor(
       debug(s"Executing SQL:\n${sql}")
       given monitor: QueryProgressMonitor = context.queryProgressMonitor
       try
-        getDBConnector(defaultProfile).execute(sql)
+        activeDBConnector.execute(sql)
       catch
         case e: SQLException =>
           throw StatusCode.SYNTAX_ERROR.newException(s"${e.getMessage}\n[sql]\n${sql}", e)
@@ -262,21 +326,24 @@ class QueryExecutor(
             QueryResult.empty
           case None =>
             WarningResult(s"${s.name} is not found", s.sourceLocation(using context))
+      case u: UseConnector =>
+        switchConnector(u.connector.fullName.split("\\.").toList)(using context)
       case u: UseSchema =>
-        // Update the global context with the new schema/catalog
+        // Update the global context with the new schema/catalog. Connector names of the active
+        // profile shadow schema names, so `use td` switches the connector when `td` is one.
         val schemaName = u.schema
         val fullName   = schemaName.fullName
-        val parts      = fullName.split("\\.")
-        parts.length match
-          case 1 =>
+        val parts      = fullName.split("\\.").toList
+        parts match
+          case name :: rest if defaultProfile.connectors.exists(_.name == name) =>
+            switchConnector(parts)(using context)
+          case schema :: Nil =>
             // use schema <schema_name>
-            context.global.defaultSchema = fullName
-            workEnv.info(s"Switched to schema: ${fullName}")
+            context.global.defaultSchema = schema
+            workEnv.info(s"Switched to schema: ${schema}")
             QueryResult.empty
-          case 2 =>
+          case catalogName :: schema :: Nil =>
             // use schema <catalog_name>.<schema_name>
-            val catalogName = parts(0)
-            val schema      = parts(1)
             // For now, we only update the schema since catalog switching requires more complex handling
             context.global.defaultSchema = schema
             workEnv.info(s"Switched to schema: ${schema}")
@@ -390,7 +457,7 @@ class QueryExecutor(
     // 1) Execute on Trino (or current engine) and dump to JSONL
     val baseSQL = GenSQL.generateSQLFromRelation(save.child, addHeader = false)
     given monitor: QueryProgressMonitor = context.queryProgressMonitor
-    val sourceConn                      = getDBConnector(defaultProfile)
+    val sourceConn                      = activeDBConnector
     val n                               =
       sourceConn.sqlConnector match
         case Some(sc) =>
@@ -457,7 +524,7 @@ class QueryExecutor(
 
     q.transformUp { case rf: RunFlow =>
         val flow       = resolveFlow(rf)
-        val connector  = getDBConnector(defaultProfile)
+        val connector  = activeDBConnector
         val flowResult =
           scala
             .util
@@ -523,7 +590,7 @@ class QueryExecutor(
             if useDuck then
               dbConnectorProvider.getConnector(DBType.DuckDB, None)
             else
-              getDBConnector(defaultProfile)
+              activeDBConnector
 
           val result =
             connector.sqlConnector match

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -72,7 +72,8 @@ class QueryExecutor(
   )
 
   // The engine statements execute on: the profile's default engine until a `use <connector>`
-  // statement switches it (#1861 Phase 2)
+  // statement switches it (#1861 Phase 2). Like the global default catalog/schema this is
+  // session-level state: concurrent sessions should use separate QueryExecutor instances
   private var activeEngine: ConnectorConfig = defaultProfile.defaultEngine
 
   private def activeDBConnector: DBConnector = dbConnectorProvider.getDBConnector(activeEngine)
@@ -110,11 +111,23 @@ class QueryExecutor(
               s"Invalid connector reference: ${parts.mkString(".")}. " +
                 "Expected format: <connector>, <connector>.<schema>, or <connector>.<catalog>.<schema>"
             )
+    val schema  = schemaName.getOrElse("main")
+    val catalog = catalogName.getOrElse(
+      // Without a catalog the switched engine could not drive name resolution or dialect
+      // selection, silently leaving the previous engine's catalog active
+      throw StatusCode
+        .INVALID_ARGUMENT
+        .newException(
+          s"Connector '${connectorName}' has no catalog configured. Add \"catalog\" to its " +
+            s"profile entry or switch with `use ${connectorName}.<catalog>.<schema>`"
+        )
+    )
+    // Resolve the connector and its catalog BEFORE committing any state, so a connection
+    // failure leaves the previous engine fully active
+    val connector  = dbConnectorProvider.getDBConnector(config)
+    val newCatalog = connector.getCatalog(catalog, schema)
     activeEngine = config
-    val schema = schemaName.getOrElse("main")
-    catalogName.foreach { catalog =>
-      context.global.defaultCatalog = activeDBConnector.getCatalog(catalog, schema)
-    }
+    context.global.defaultCatalog = newCatalog
     context.global.defaultSchema = schema
     workEnv.info(s"Switched to connector: ${connectorName}")
     QueryResult.empty
@@ -153,19 +166,6 @@ class QueryExecutor(
 
   def executeSingle(u: CompilationUnit, rootContext: Context): QueryResult =
     workEnv.info(s"Executing ${u.sourceFile.fileName}")
-    // Cross-connector staging is not implemented yet: every table referenced through a
-    // connector name must live on the active engine
-    val foreignConnectors = u.referencedConnectors.toSet - activeEngine.name
-    if foreignConnectors.nonEmpty then
-      throw StatusCode
-        .NOT_IMPLEMENTED
-        .newException(
-          s"Query references connector(s) ${foreignConnectors.mkString(
-              ", "
-            )} but the active engine is '${activeEngine
-              .name}'. Cross-connector queries are not supported yet; switch with `use ${foreignConnectors
-              .head}` to run on that connector"
-        )
     val ctx = rootContext.withCompilationUnit(u).newContext(Symbol.NoSymbol)
 
     // val executionPlan = u.executionPlan // ExecutionPlanner.plan(u, ctx)
@@ -555,6 +555,23 @@ class QueryExecutor(
   end runEmbeddedFlows
 
   private def executeQuery(plan: LogicalPlan)(using context: Context): QueryResult =
+    // Cross-connector staging is not implemented yet: every table resolved through a profile
+    // connector name must live on the engine that is active when this query runs (an in-file
+    // `use <connector>` earlier in the unit has already switched activeEngine by now)
+    val foreignConnectors = scala.collection.mutable.Set.empty[String]
+    plan.traverse { case t: TableScan =>
+      t.connectorName.filter(_ != activeEngine.name).foreach(foreignConnectors += _)
+    }
+    if foreignConnectors.nonEmpty then
+      throw StatusCode
+        .NOT_IMPLEMENTED
+        .newException(
+          s"Query references connector(s) ${foreignConnectors.mkString(
+              ", "
+            )} but the active engine is '${activeEngine
+              .name}'. Cross-connector queries are not supported yet; run `use ${foreignConnectors
+              .head}` first to execute on that connector"
+        )
     trace(s"Executing query: ${plan.pp}")
     workEnv.trace(s"Executing plan: ${plan.pp}")
     plan match

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
@@ -17,6 +17,7 @@ import org.jline.terminal.Terminal
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.api.v1.query.QueryRequest
 import wvlet.lang.api.v1.query.QuerySelection
+import wvlet.lang.catalog.LazyCatalog
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.*
 import wvlet.lang.compiler.query.QueryProgressMonitor
@@ -94,6 +95,28 @@ class WvletScriptRunner(
       .schema
       .foreach { schema =>
         c.setDefaultSchema(schema)
+      }
+
+    // Register every profile connector by name for `from <connector>.<table>` and
+    // `use <connector>` (#1861 Phase 2); LazyCatalog defers connections to first use
+    config
+      .profile
+      .connectors
+      .foreach { conn =>
+        conn
+          .catalog
+          .foreach { catalogName =>
+            val connSchema = conn.schema.getOrElse("main")
+            c.addConnectorCatalog(
+              conn.name,
+              LazyCatalog(
+                catalogName,
+                conn.dbType,
+                () => queryExecutor.getDBConnector(conn).getCatalog(catalogName, connSchema)
+              ),
+              connSchema
+            )
+          }
       }
 
     // Pre-compile files in the source paths

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorProvider.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorProvider.scala
@@ -81,8 +81,11 @@ class ConnectorProvider(
           )
 
   /** Resolve the profile's default engine as a SQL engine connector */
-  def getConnector(profile: Profile): DBConnector =
-    getConnector(profile.defaultEngine) match
+  def getConnector(profile: Profile): DBConnector = getDBConnector(profile.defaultEngine)
+
+  /** Resolve a connector config as a SQL engine connector */
+  def getDBConnector(config: ConnectorConfig): DBConnector =
+    getConnector(config) match
       case db: DBConnector =>
         db
       case other =>

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/ConnectorNamespaceTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/ConnectorNamespaceTest.scala
@@ -107,6 +107,16 @@ class ConnectorNamespaceTest extends UniTest:
     result.toTSV shouldContain "42"
   }
 
+  test("should run use and a connector-qualified query within a single unit") {
+    // The guard must evaluate against the engine active when the query runs, not when the
+    // unit starts — otherwise the documented `use x` + `from x.t` batch pattern breaks
+    run("use first") shouldBe QueryResult.empty
+    val result = run("""use second
+        |from second.events""".stripMargin)
+    result.toTSV shouldContain "42"
+    run("use first") shouldBe QueryResult.empty
+  }
+
   test("should fail with a clear error for an unknown connector in use") {
     val exception = intercept[WvletLangException] {
       run("use connector no_such_connector")

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/ConnectorNamespaceTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/ConnectorNamespaceTest.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
+import wvlet.lang.catalog.ConnectorConfig
+import wvlet.lang.catalog.LazyCatalog
+import wvlet.lang.catalog.Profile
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.runner.connector.ConnectorProvider
+import wvlet.uni.test.UniTest
+
+/**
+  * End-to-end tests for `from <connector>.<table>` resolution and `use <connector>` switching with
+  * a profile that activates two DuckDB connectors (#1861 Phase 2)
+  */
+class ConnectorNamespaceTest extends UniTest:
+
+  private val workEnv = WorkEnv()
+  private val first   = ConnectorConfig(
+    name = "first",
+    `type` = "duckdb",
+    default = true,
+    catalog = Some("memory"),
+    schema = Some("main")
+  )
+
+  private val second = ConnectorConfig(
+    name = "second",
+    `type` = "duckdb",
+    catalog = Some("memory"),
+    schema = Some("main")
+  )
+
+  private val profile = Profile(name = "multi", connectors = Seq(first, second))
+
+  private val provider = ConnectorProvider(workEnv)
+  private val executor = QueryExecutor(provider, profile, workEnv)
+
+  private val compiler = Compiler(
+    CompilerOptions(sourceFolders = List("."), workEnv = workEnv, catalog = Some("memory"))
+  )
+
+  // Register both connectors by name, as WvletCompiler/WvletScriptRunner do from a profile
+  profile
+    .connectors
+    .foreach { c =>
+      val schema      = c.schema.getOrElse("main")
+      val catalogName = c.catalog.get
+      compiler.addConnectorCatalog(
+        c.name,
+        LazyCatalog(
+          catalogName,
+          c.dbType,
+          () => provider.getDBConnector(c).getCatalog(catalogName, schema)
+        ),
+        schema
+      )
+    }
+
+  compiler.setDefaultCatalog(provider.getDBConnector(first).getCatalog("memory", "main"))
+  compiler.setDefaultSchema("main")
+
+  // A table that only exists on the second connector's in-memory database
+  provider.getDBConnector(second).execute("create table events as select 42 as id")
+
+  override def afterAll: Unit =
+    executor.close()
+    provider.close()
+
+  private def run(statement: String): QueryResult =
+    val unit   = CompilationUnit.fromWvletString(statement)
+    val result = compiler.compileSingleUnit(unit)
+    executor.executeSingle(unit, result.context)
+
+  test("should reject a cross-connector reference while another engine is active") {
+    val exception = intercept[WvletLangException] {
+      run("from second.events")
+    }
+    exception.statusCode shouldBe StatusCode.NOT_IMPLEMENTED
+    exception.message shouldContain "use second"
+  }
+
+  test("should run a connector-qualified query after switching with use <connector>") {
+    run("use second") shouldBe QueryResult.empty
+    val result = run("from second.events")
+    result.toTSV shouldContain "42"
+  }
+
+  test("should resolve connector-qualified schema.table references") {
+    val result = run("from second.main.events")
+    result.toTSV shouldContain "42"
+  }
+
+  test("should fail with a clear error for an unknown connector in use") {
+    val exception = intercept[WvletLangException] {
+      run("use connector no_such_connector")
+    }
+    exception.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    exception.message shouldContain "not defined in profile"
+  }
+
+end ConnectorNamespaceTest


### PR DESCRIPTION
## Summary

Phase 2 (part 1) of #1861: queries can now reference tables through connector names and switch the active engine with `use <connector>`. Builds on the multi-connector profiles from #1863.

```sql
from td.www_access                 -- <connector>.<table>, using td's configured schema
from td.sample_datasets.www_access -- <connector>.<schema>.<table>

use td                             -- switch the active engine to the td connector
use connector td                   -- explicit form for name collisions
use td.sample_datasets             -- switch connector and schema together
```

### Connector namespaces in the compiler

- `GlobalContext` gains a connector-name → catalog registry (`Compiler.addConnectorCatalog`); `WvletCompiler` and `WvletScriptRunner` register every connector of the active profile.
- New `LazyCatalog` wraps non-default connectors so activating a profile with many connectors opens **no** connections — a connector connects only when a query first references it (`catalogName`/`dbType` come from the config, so name resolution and dialect selection don't force materialization).
- `RelationRefResolver` resolves connector-qualified references after symbol lookup (models, CTEs, and aliases keep precedence) and before the default-catalog fallback, so connector names shadow schema names. Resolved units record their referenced connectors.

### `use` statement

- Parser accepts `use connector <name>` (soft keyword, mirroring `use schema`); bare `use <name>` is disambiguated at execution: connector names of the active profile win, otherwise today's schema behavior applies unchanged.
- Switching a connector updates the active engine in `QueryExecutor`, the default catalog (which drives the SQL dialect — `Context.dbType` follows the active catalog), and the default schema. Supported forms: `use <connector>`, `use <connector>.<schema>`, `use <connector>.<catalog>.<schema>`.
- `use` name expressions are now typed as namespace references in the Typer (they previously counted as unresolved expressions; expression typing coverage improves from 87.0% → 87.2% over spec/basic).

### Single-engine execution guard

Queries still execute on exactly one engine. Referencing a connector other than the active engine fails with a clear NOT_IMPLEMENTED error suggesting `use <name>`. Cross-connector staging (materializing connector B's tables into engine A) and per-stage `on <connector>` in flows follow in part 2.

### Tests / docs

- `ConnectorNamespaceTest`: end-to-end two-DuckDB-connector profile — cross-connector guard, `use` switching, 2-part and 3-part qualified references, unknown-connector error.
- `LazyCatalogTest`: no materialization before first metadata lookup.
- `spec/basic/use-schema.wv` exercises the new `use connector` / bare-connector / `connector.schema` forms; TyperCoverageCheck ratchet passes with improved coverage.
- New user doc `website/docs/usage/connectors.md` (multi-connector profiles, namespaces, `use`).

Phases: #1861 — this is the first half of the Phase 2 checkbox; the staging/flows half follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
