### PR TITLE
feature: Slack connector with queryable tables and flow tool delivery (#1861 Phase 3)

### DIFF
--- a/website/docs/usage/connectors.md
+++ b/website/docs/usage/connectors.md
@@ -45,10 +45,12 @@ Models, CTEs, and query aliases take precedence over connector names, and connec
 precedence over schema names of the default catalog. Since you choose connector names yourself,
 rename the connector if it collides with a schema you need to address.
 
-Queries currently execute on one engine at a time: referencing a connector other than the active
-engine reports an error suggesting `use <connector>`. Inside [flows](../syntax/flow.md),
-cross-connector references are staged automatically, and each stage can pick its engine with
-`stage <name> on <connector>`. Cross-connector joins in ad-hoc queries are planned as a
+Queries execute on one SQL engine at a time: referencing another *engine* connector reports an
+error suggesting `use <connector>`. Tables of *source* connectors (services without a SQL
+engine, like [Slack](slack.md)) are staged into the active engine automatically, so
+`from slack.channels` works from any engine. Inside [flows](../syntax/flow.md),
+cross-connector references are staged automatically too, and each stage can pick its engine
+with `stage <name> on <connector>`. Cross-engine joins in ad-hoc queries are planned as a
 follow-up.
 
 ## Switching connectors with `use`

--- a/website/docs/usage/slack.md
+++ b/website/docs/usage/slack.md
@@ -1,0 +1,68 @@
+# Connector - Slack
+
+The Slack connector exposes a Slack workspace as queryable tables and lets flows post messages
+back to channels. It is a *source* connector: it has no SQL engine of its own, so its tables are
+staged automatically into the active engine (e.g. DuckDB) when a query references them.
+
+## Configuration
+
+Create a [Slack app](https://api.slack.com/apps) with a bot token that has the
+`channels:read`, `channels:history`, `users:read`, and `chat:write` scopes, then add a
+connector to your profile:
+
+```jsonc title='~/.wvlet/profiles.json'
+{
+  "profiles": [
+    {
+      "name": "dev",
+      "connectors": [
+        { "name": "duckdb", "type": "duckdb", "default": true, "catalog": "memory", "schema": "main" },
+        { "name": "slack", "type": "slack", "properties": { "token": "${SLACK_TOKEN}" } }
+      ]
+    }
+  ]
+}
+```
+
+Optional properties:
+
+- **message_fetch_limit**: messages fetched per channel when scanning the `messages` table
+  (default 1000)
+
+## Tables
+
+| Table | Columns |
+|-------|---------|
+| `channels` | `id`, `name`, `is_private`, `num_members`, `topic` |
+| `users` | `id`, `name`, `real_name`, `is_bot` |
+| `messages` | `channel`, `user`, `text`, `ts`, `thread_ts` |
+
+```sql
+-- Channels with the most members
+from slack.channels
+| order by num_members desc
+| limit 10
+
+-- Message counts per channel
+from slack.messages
+| group by channel
+| agg count(*) as messages
+```
+
+Scanning `messages` reads the recent history of every channel the bot can access, so prefer
+filtering early and consider a lower `message_fetch_limit` for large workspaces.
+
+## Posting messages from flows
+
+Every profile connector with tools is an activation target under its instance name. The
+`post_message` tool posts a stage's output (or an explicit `text:`) to a channel:
+
+```sql
+flow daily_report = {
+  stage summary = from slack.messages | group by channel | agg count(*) as messages
+  stage notify = from summary
+    | activate('slack', tool: 'post_message', channel: '#reports')
+}
+```
+
+When `text:` is omitted, the first rows of the stage output are attached as JSON lines.

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
@@ -21,6 +21,7 @@ import wvlet.lang.compiler.Symbol
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.runner.QueryExecutor
 import wvlet.lang.connector.DBConnector
+import wvlet.lang.runner.connector.ConnectorCatalogs
 import wvlet.lang.runner.connector.ConnectorProvider
 import wvlet.uni.log.LogSupport
 
@@ -116,19 +117,23 @@ class WvletCompiler(
     currentProfile
       .connectors
       .foreach { c =>
-        c.catalog
-          .foreach { catalogName =>
-            val schema = c.schema.getOrElse("main")
-            compiler.addConnectorCatalog(
-              c.name,
-              LazyCatalog(
+        val schema      = c.schema.getOrElse("main")
+        val catalogName = c.catalog.getOrElse(c.name)
+        compiler.addConnectorCatalog(
+          c.name,
+          LazyCatalog(
+            catalogName,
+            c.dbType,
+            () =>
+              ConnectorCatalogs.catalogOf(
+                dbConnectorProvider.getConnector(c),
+                c,
                 catalogName,
-                c.dbType,
-                () => dbConnectorProvider.getDBConnector(c).getCatalog(catalogName, schema)
-              ),
-              schema
-            )
-          }
+                schema
+              )
+          ),
+          schema
+        )
       }
 
     compiler

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -41,6 +41,7 @@ import wvlet.lang.runner.FlowRunStore
 import wvlet.lang.runner.FlowScheduleConfig
 import wvlet.lang.runner.FlowScheduler
 import wvlet.lang.runner.ScheduledFlow
+import wvlet.lang.runner.ConnectorActivationSink
 import wvlet.lang.runner.connector.ConnectorProvider
 import wvlet.uni.log.LogSupport
 
@@ -125,14 +126,21 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
               profile
                 .connectors
                 .find(_.name == name)
-                .map(dbConnectorProvider.getDBConnector)
+                .map(dbConnectorProvider.getConnector)
                 .getOrElse(
                   throw StatusCode
                     .INVALID_ARGUMENT
                     .newException(s"Connector '${name}' is not defined in the profile")
                 )
             ),
-            defaultEngineName = profile.defaultEngine.name
+            defaultEngineName = profile.defaultEngine.name,
+            activationSinks =
+              FlowExecutor.defaultActivationSinks ++
+                profile
+                  .connectors
+                  .map(c =>
+                    ConnectorActivationSink(c.name, () => dbConnectorProvider.getConnector(c))
+                  )
           ).execute(flow, resumeFrom, args)
           println(result.toPrettyBox())
           failed = result.hasError
@@ -232,14 +240,21 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
                 profile
                   .connectors
                   .find(_.name == name)
-                  .map(dbConnectorProvider.getDBConnector)
+                  .map(dbConnectorProvider.getConnector)
                   .getOrElse(
                     throw StatusCode
                       .INVALID_ARGUMENT
                       .newException(s"Connector '${name}' is not defined in the profile")
                   )
               ),
-              defaultEngineName = profile.defaultEngine.name
+              defaultEngineName = profile.defaultEngine.name,
+              activationSinks =
+                FlowExecutor.defaultActivationSinks ++
+                  profile
+                    .connectors
+                    .map(c =>
+                      ConnectorActivationSink(c.name, () => dbConnectorProvider.getConnector(c))
+                    )
             )
             val it = runTimes.iterator
             while !failed && it.hasNext do
@@ -513,16 +528,27 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
                           profile
                             .connectors
                             .find(_.name == name)
-                            .map(dbConnectorProvider.getDBConnector)
+                            .map(dbConnectorProvider.getConnector)
                             .getOrElse(
                               throw StatusCode
                                 .INVALID_ARGUMENT
                                 .newException(s"Connector '${name}' is not defined in the profile")
                             )
                         ),
-                        defaultEngineName = profile.defaultEngine.name
+                        defaultEngineName = profile.defaultEngine.name,
+                        activationSinks =
+                          FlowExecutor.defaultActivationSinks ++
+                            profile
+                              .connectors
+                              .map(c =>
+                                ConnectorActivationSink(
+                                  c.name,
+                                  () => dbConnectorProvider.getConnector(c)
+                                )
+                              )
                       ).execute(flow, runTime = Some(fireTime))
                       println(runResult.toPrettyBox())
+                    end run
                 )
           )
           // Retention: the per-flow keep_runs: caps plus the daemon-wide --retention TTL.

--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/Connector.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/Connector.scala
@@ -53,12 +53,18 @@ trait Connector extends AutoCloseable:
 end Connector
 
 /**
-  * Table-exposure capability of a [[Connector]]. Phase-1 skeleton: `scan(table, filters)` for
-  * materializing source-connector tables into an engine lands with the first non-SQL connector
+  * Table-exposure capability of a [[Connector]]: the tables a source connector offers to queries,
+  * and a scan operation that materializes a table's rows for staging into an engine
   */
 trait CatalogProvider:
   def listTables: Seq[Catalog.TableName]
   def schemaOf(table: String): Option[RelationType]
+
+  /**
+    * Read every row of the table as a JSON object string (one per row, matching the shape of
+    * `DBConnector.queryJsonRows`). Filter/projection pushdown is a future extension
+    */
+  def scan(table: String): Seq[String]
 
 /**
   * MCP-compatible tool description: `inputSchema` is a JSON Schema object for the tool arguments

--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/ConnectorCatalogAdapter.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/ConnectorCatalogAdapter.scala
@@ -40,10 +40,12 @@ class ConnectorCatalogAdapter(override val catalogName: String, provider: Catalo
     Catalog.TableSchema(Some(catalogName), "main")
   )
 
-  override def getSchema(schemaName: String): Catalog.TableSchema = Catalog.TableSchema(
-    Some(catalogName),
-    schemaName
-  )
+  override def getSchema(schemaName: String): Catalog.TableSchema =
+    if !schemaExists(schemaName) then
+      throw StatusCode
+        .INVALID_ARGUMENT
+        .newException(s"Catalog '${catalogName}' has no schema '${schemaName}' (only 'main')")
+    Catalog.TableSchema(Some(catalogName), schemaName)
 
   override def schemaExists(schemaName: String): Boolean = schemaName == "main"
   override def createSchema(schema: Catalog.TableSchema, createMode: Catalog.CreateMode): Unit =
@@ -54,14 +56,17 @@ class ConnectorCatalogAdapter(override val catalogName: String, provider: Catalo
     .listTables
     .flatMap(t => findTable(schemaName, t.name))
 
-  override def findTable(schemaName: String, tableName: String): Option[Catalog.TableDef] = provider
-    .schemaOf(tableName)
-    .collect { case s: SchemaType =>
-      Catalog.TableDef(
-        TableName(Some(catalogName), Some("main"), tableName),
-        columns = s.fields.map(f => Catalog.TableColumn(f.name.name, f.dataType))
-      )
-    }
+  override def findTable(schemaName: String, tableName: String): Option[Catalog.TableDef] =
+    if schemaName != "main" then
+      return None
+    provider
+      .schemaOf(tableName)
+      .collect { case s: SchemaType =>
+        Catalog.TableDef(
+          TableName(Some(catalogName), Some("main"), tableName),
+          columns = s.fields.map(f => Catalog.TableColumn(f.name.name, f.dataType))
+        )
+      }
 
   override def getTable(schemaName: String, tableName: String): Catalog.TableDef = findTable(
     schemaName,

--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/ConnectorCatalogAdapter.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/ConnectorCatalogAdapter.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.connector
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.catalog.Catalog
+import wvlet.lang.catalog.Catalog.TableName
+import wvlet.lang.catalog.SQLFunction
+import wvlet.lang.compiler.DBType
+import wvlet.lang.model.DataType.SchemaType
+
+/**
+  * Exposes a source connector's [[CatalogProvider]] as a read-only [[Catalog]] so that the compiler
+  * can resolve `from <connector>.<table>` references against it. Source connectors have a single
+  * flat namespace: every table lives in the synthetic `main` schema
+  */
+class ConnectorCatalogAdapter(override val catalogName: String, provider: CatalogProvider)
+    extends Catalog:
+
+  override def dbType: DBType = DBType.Generic
+
+  private def readOnly: Nothing =
+    throw StatusCode
+      .NOT_IMPLEMENTED
+      .newException(s"Catalog '${catalogName}' is a read-only data source")
+
+  override def listSchemaNames: Seq[String]          = Seq("main")
+  override def listSchemas: Seq[Catalog.TableSchema] = Seq(
+    Catalog.TableSchema(Some(catalogName), "main")
+  )
+
+  override def getSchema(schemaName: String): Catalog.TableSchema = Catalog.TableSchema(
+    Some(catalogName),
+    schemaName
+  )
+
+  override def schemaExists(schemaName: String): Boolean = schemaName == "main"
+  override def createSchema(schema: Catalog.TableSchema, createMode: Catalog.CreateMode): Unit =
+    readOnly
+
+  override def listTableNames(schemaName: String): Seq[String] = provider.listTables.map(_.name)
+  override def listTables(schemaName: String): Seq[Catalog.TableDef] = provider
+    .listTables
+    .flatMap(t => findTable(schemaName, t.name))
+
+  override def findTable(schemaName: String, tableName: String): Option[Catalog.TableDef] = provider
+    .schemaOf(tableName)
+    .collect { case s: SchemaType =>
+      Catalog.TableDef(
+        TableName(Some(catalogName), Some("main"), tableName),
+        columns = s.fields.map(f => Catalog.TableColumn(f.name.name, f.dataType))
+      )
+    }
+
+  override def getTable(schemaName: String, tableName: String): Catalog.TableDef = findTable(
+    schemaName,
+    tableName
+  ).getOrElse(
+    throw StatusCode
+      .TABLE_NOT_FOUND
+      .newException(s"Table '${tableName}' is not found in ${catalogName}")
+  )
+
+  override def tableExists(schemaName: String, tableName: String): Boolean =
+    findTable(schemaName, tableName).isDefined
+
+  override def createTable(table: Catalog.TableDef, createMode: Catalog.CreateMode): Unit = readOnly
+
+  override def listFunctions: Seq[SQLFunction] = Nil
+
+  override def updateColumns(
+      schemaName: String,
+      tableName: String,
+      columns: Seq[Catalog.TableColumn]
+  ): Unit = readOnly
+
+  override def updateTableProperties(
+      schemaName: String,
+      tableName: String,
+      properties: Map[String, Any]
+  ): Unit = readOnly
+
+  override def updateDatabaseProperties(schemaName: String, properties: Map[String, Any]): Unit =
+    readOnly
+
+end ConnectorCatalogAdapter

--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/ConnectorFactory.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/ConnectorFactory.scala
@@ -25,4 +25,10 @@ trait ConnectorFactory:
   /** The `type` value in the connector config this factory handles, e.g. "duckdb" */
   def connectorType: String
 
+  /**
+    * Whether the created connectors are SQL engines. Lets callers classify connectors from their
+    * config type without instantiating them (which may open a connection)
+    */
+  def isEngine: Boolean = true
+
   def create(config: ConnectorConfig, workEnv: WorkEnv): Connector

--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/slack/SlackApiClient.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/slack/SlackApiClient.scala
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.connector.slack
+
+import wvlet.lang.api.StatusCode
+import wvlet.uni.http.Http
+import wvlet.uni.http.HttpMethod
+import wvlet.uni.http.HttpSyncClient
+import wvlet.uni.http.Request
+import wvlet.uni.json.JSON
+import wvlet.uni.json.JSON.JSONArray
+import wvlet.uni.json.JSON.JSONBoolean
+import wvlet.uni.json.JSON.JSONObject
+import wvlet.uni.json.JSON.JSONString
+import wvlet.uni.log.LogSupport
+
+case class SlackChannel(
+    id: String,
+    name: String,
+    isPrivate: Boolean,
+    numMembers: Long,
+    topic: String
+)
+
+case class SlackUser(id: String, name: String, realName: String, isBot: Boolean)
+
+case class SlackMessage(
+    channel: String,
+    user: String,
+    text: String,
+    ts: String,
+    threadTs: Option[String]
+)
+
+/**
+  * The subset of the Slack Web API the connector consumes. Injectable so tests can run against an
+  * in-memory workspace instead of HTTP
+  */
+trait SlackApiClient:
+  def listChannels(): List[SlackChannel]
+  def listUsers(): List[SlackUser]
+
+  /** Latest messages of a channel, newest first, up to `limit` */
+  def channelHistory(channelId: String, limit: Int): List[SlackMessage]
+
+  def postMessage(channel: String, text: String): Unit
+
+/**
+  * Slack Web API client over uni's HTTP client. Handles cursor-based pagination for the list
+  * endpoints and surfaces Slack's `ok: false` responses as errors
+  */
+class HttpSlackApiClient(token: String, baseUrl: String = "https://slack.com/api")
+    extends SlackApiClient
+    with LogSupport:
+
+  private lazy val client: HttpSyncClient = Http.client.withBaseUri(baseUrl).newSyncClient
+
+  private def call(method: String, params: Map[String, String]): JSONObject =
+    val query = params
+      .map { case (k, v) =>
+        s"${k}=${java.net.URLEncoder.encode(v, "UTF-8")}"
+      }
+      .mkString("&")
+    val path =
+      if query.isEmpty then
+        s"/${method}"
+      else
+        s"/${method}?${query}"
+    val request = Request(method = HttpMethod.POST, uri = path).setHeader(
+      "Authorization",
+      s"Bearer ${token}"
+    )
+    val response = client.send(request)
+    val body     = response.contentAsString.getOrElse("{}")
+    JSON.parse(body) match
+      case o: JSONObject if o.get("ok").contains(JSONBoolean(true)) =>
+        o
+      case o: JSONObject =>
+        val error = o
+          .get("error")
+          .collect { case JSONString(s) =>
+            s
+          }
+          .getOrElse("unknown error")
+        throw StatusCode.INVALID_ARGUMENT.newException(s"Slack API ${method} failed: ${error}")
+      case other =>
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(s"Slack API ${method} returned unexpected response")
+
+  end call
+
+  // Iterate a cursor-paginated list endpoint, collecting `field` arrays until the cursor runs out
+  private def paginate(
+      method: String,
+      params: Map[String, String],
+      field: String
+  ): List[JSONObject] =
+    val results = List.newBuilder[JSONObject]
+    var cursor  = ""
+    var more    = true
+    while more do
+      val pageParams =
+        if cursor.isEmpty then
+          params
+        else
+          params + ("cursor" -> cursor)
+      val page = call(method, pageParams)
+      page.get(field) match
+        case Some(JSONArray(items)) =>
+          items.foreach {
+            case o: JSONObject =>
+              results += o
+            case _ =>
+          }
+        case _ =>
+      cursor = page
+        .get("response_metadata")
+        .collect { case m: JSONObject =>
+          m
+        }
+        .flatMap(_.get("next_cursor"))
+        .collect { case JSONString(s) =>
+          s
+        }
+        .getOrElse("")
+      more = cursor.nonEmpty
+    results.result()
+
+  end paginate
+
+  private def str(o: JSONObject, key: String): String = o
+    .get(key)
+    .collect { case JSONString(s) =>
+      s
+    }
+    .getOrElse("")
+
+  private def bool(o: JSONObject, key: String): Boolean = o.get(key).contains(JSONBoolean(true))
+
+  override def listChannels(): List[SlackChannel] = paginate(
+    "conversations.list",
+    Map("limit" -> "200", "types" -> "public_channel,private_channel"),
+    "channels"
+  ).map { c =>
+    SlackChannel(
+      id = str(c, "id"),
+      name = str(c, "name"),
+      isPrivate = bool(c, "is_private"),
+      numMembers = c
+        .get("num_members")
+        .collect {
+          case n: JSON.JSONLong =>
+            n.v
+          case n: JSON.JSONDouble =>
+            n.v.toLong
+        }
+        .getOrElse(0L),
+      topic = c
+        .get("topic")
+        .collect { case t: JSONObject =>
+          str(t, "value")
+        }
+        .getOrElse("")
+    )
+  }
+
+  override def listUsers(): List[SlackUser] = paginate(
+    "users.list",
+    Map("limit" -> "200"),
+    "members"
+  ).map { u =>
+    SlackUser(
+      id = str(u, "id"),
+      name = str(u, "name"),
+      realName = u
+        .get("profile")
+        .collect { case p: JSONObject =>
+          str(p, "real_name")
+        }
+        .getOrElse(""),
+      isBot = bool(u, "is_bot")
+    )
+  }
+
+  override def channelHistory(channelId: String, limit: Int): List[SlackMessage] = paginate(
+    "conversations.history",
+    Map("channel" -> channelId, "limit" -> limit.min(200).toString),
+    "messages"
+  ).take(limit)
+    .map { m =>
+      SlackMessage(
+        channel = channelId,
+        user = str(m, "user"),
+        text = str(m, "text"),
+        ts = str(m, "ts"),
+        threadTs = m
+          .get("thread_ts")
+          .collect { case JSONString(s) =>
+            s
+          }
+      )
+    }
+
+  override def postMessage(channel: String, text: String): Unit = call(
+    "chat.postMessage",
+    Map("channel" -> channel, "text" -> text)
+  )
+
+end HttpSlackApiClient

--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/slack/SlackApiClient.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/slack/SlackApiClient.scala
@@ -101,31 +101,38 @@ class HttpSlackApiClient(token: String, baseUrl: String = "https://slack.com/api
 
   end call
 
-  // Iterate a cursor-paginated list endpoint, collecting `field` arrays until the cursor runs out
+  // Iterate a cursor-paginated list endpoint, collecting `field` arrays until the cursor runs
+  // out, `maxItems` rows are collected, or the page cap is hit (a repeated or never-ending
+  // cursor from a misbehaving endpoint must not spin forever)
   private def paginate(
       method: String,
       params: Map[String, String],
-      field: String
+      field: String,
+      maxItems: Int = Int.MaxValue
   ): List[JSONObject] =
-    val results = List.newBuilder[JSONObject]
-    var cursor  = ""
-    var more    = true
-    while more do
+    val results   = List.newBuilder[JSONObject]
+    var collected = 0
+    var cursor    = ""
+    var pages     = 0
+    var more      = true
+    while more && collected < maxItems && pages < HttpSlackApiClient.MaxPages do
       val pageParams =
         if cursor.isEmpty then
           params
         else
           params + ("cursor" -> cursor)
       val page = call(method, pageParams)
+      pages += 1
       page.get(field) match
         case Some(JSONArray(items)) =>
           items.foreach {
             case o: JSONObject =>
               results += o
+              collected += 1
             case _ =>
           }
         case _ =>
-      cursor = page
+      val nextCursor = page
         .get("response_metadata")
         .collect { case m: JSONObject =>
           m
@@ -135,7 +142,8 @@ class HttpSlackApiClient(token: String, baseUrl: String = "https://slack.com/api
           s
         }
         .getOrElse("")
-      more = cursor.nonEmpty
+      more = nextCursor.nonEmpty && nextCursor != cursor
+      cursor = nextCursor
     results.result()
 
   end paginate
@@ -197,7 +205,8 @@ class HttpSlackApiClient(token: String, baseUrl: String = "https://slack.com/api
   override def channelHistory(channelId: String, limit: Int): List[SlackMessage] = paginate(
     "conversations.history",
     Map("channel" -> channelId, "limit" -> limit.min(200).toString),
-    "messages"
+    "messages",
+    maxItems = limit
   ).take(limit)
     .map { m =>
       SlackMessage(
@@ -219,3 +228,7 @@ class HttpSlackApiClient(token: String, baseUrl: String = "https://slack.com/api
   )
 
 end HttpSlackApiClient
+
+object HttpSlackApiClient:
+  /** Hard cap on pages per paginated call, guarding against never-ending cursors */
+  val MaxPages = 1000

--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/slack/SlackConnector.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/slack/SlackConnector.scala
@@ -138,17 +138,24 @@ class SlackConnector(
           client
             .listChannels()
             .flatMap { channel =>
-              client
-                .channelHistory(channel.id, messageFetchLimit)
-                .map { m =>
-                  row(
-                    "channel"   -> JSONString(channel.name),
-                    "user"      -> JSONString(m.user),
-                    "text"      -> JSONString(m.text),
-                    "ts"        -> JSONString(m.ts),
-                    "thread_ts" -> m.threadTs.map[JSONValue](JSONString(_)).getOrElse(JSONNull())
-                  )
-                }
+              // conversations.list returns channels the bot is not a member of; their history
+              // is not readable (not_in_channel), so skip them instead of failing the scan
+              val history =
+                try
+                  client.channelHistory(channel.id, messageFetchLimit)
+                catch
+                  case scala.util.control.NonFatal(e) =>
+                    warn(s"Skipping channel #${channel.name}: ${e.getMessage}")
+                    Nil
+              history.map { m =>
+                row(
+                  "channel"   -> JSONString(channel.name),
+                  "user"      -> JSONString(m.user),
+                  "text"      -> JSONString(m.text),
+                  "ts"        -> JSONString(m.ts),
+                  "thread_ts" -> m.threadTs.map[JSONValue](JSONString(_)).getOrElse(JSONNull())
+                )
+              }
             }
         case other =>
           throw StatusCode.TABLE_NOT_FOUND.newException(s"Slack connector has no table '${other}'")
@@ -206,6 +213,7 @@ end SlackConnector
 
 object SlackConnectorFactory extends ConnectorFactory:
   override def connectorType: String = "slack"
+  override def isEngine: Boolean     = false
 
   override def create(config: ConnectorConfig, workEnv: WorkEnv): Connector =
     val token = config

--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/slack/SlackConnector.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/slack/SlackConnector.scala
@@ -1,0 +1,229 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.connector.slack
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.catalog.Catalog.TableName
+import wvlet.lang.catalog.ConnectorConfig
+import wvlet.lang.compiler.Name
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.connector.CatalogProvider
+import wvlet.lang.connector.Connector
+import wvlet.lang.connector.ConnectorFactory
+import wvlet.lang.connector.ToolResult
+import wvlet.lang.connector.ToolSpec
+import wvlet.lang.model.DataType
+import wvlet.lang.model.DataType.NamedType
+import wvlet.lang.model.DataType.SchemaType
+import wvlet.lang.model.RelationType
+import wvlet.uni.json.JSON.JSONBoolean
+import wvlet.uni.json.JSON.JSONLong
+import wvlet.uni.json.JSON.JSONNull
+import wvlet.uni.json.JSON.JSONObject
+import wvlet.uni.json.JSON.JSONString
+import wvlet.uni.json.JSON.JSONValue
+import wvlet.uni.log.LogSupport
+
+/**
+  * Slack as a wvlet connector (#1861 Phase 3): exposes the workspace as tables (`channels`,
+  * `users`, `messages`) through the [[CatalogProvider]] capability, and MCP-shaped tools
+  * (`post_message`) through [[Connector.tools]]
+  */
+class SlackConnector(
+    override val name: String,
+    client: SlackApiClient,
+    messageFetchLimit: Int = SlackConnector.DefaultMessageFetchLimit
+) extends Connector
+    with LogSupport:
+
+  override def connectorType: String = "slack"
+
+  override def close(): Unit = ()
+
+  override def catalog: Option[CatalogProvider] = Some(SlackCatalogProvider)
+
+  override val tools: Seq[ToolSpec] = Seq(
+    ToolSpec(
+      name = "post_message",
+      description = "Post a message to a Slack channel",
+      inputSchema = JSONObject(
+        Seq(
+          "type"       -> JSONString("object"),
+          "properties" ->
+            JSONObject(
+              Seq(
+                "channel" ->
+                  JSONObject(
+                    Seq(
+                      "type"        -> JSONString("string"),
+                      "description" -> JSONString("Channel name or ID to post to")
+                    )
+                  ),
+                "text" ->
+                  JSONObject(
+                    Seq("type" -> JSONString("string"), "description" -> JSONString("Message text"))
+                  )
+              )
+            ),
+          "required" ->
+            wvlet.uni.json.JSON.JSONArray(IndexedSeq(JSONString("channel"), JSONString("text")))
+        )
+      )
+    )
+  )
+
+  override def invoke(tool: String, args: JSONObject): ToolResult =
+    tool match
+      case "post_message" =>
+        def arg(key: String): String = args
+          .get(key)
+          .collect { case JSONString(s) =>
+            s
+          }
+          .getOrElse(
+            throw StatusCode
+              .INVALID_ARGUMENT
+              .newException(s"post_message requires a '${key}' argument")
+          )
+        client.postMessage(arg("channel"), arg("text"))
+        ToolResult(JSONString("ok"))
+      case other =>
+        super.invoke(other, args)
+
+  private object SlackCatalogProvider extends CatalogProvider:
+    override def listTables: Seq[TableName] =
+      SlackConnector.tableSchemas.keys.map(t => TableName(Some(name), Some("main"), t)).toSeq
+
+    override def schemaOf(table: String): Option[RelationType] = SlackConnector
+      .tableSchemas
+      .get(table)
+
+    override def scan(table: String): Seq[String] =
+      table match
+        case "channels" =>
+          client
+            .listChannels()
+            .map { c =>
+              row(
+                "id"          -> JSONString(c.id),
+                "name"        -> JSONString(c.name),
+                "is_private"  -> JSONBoolean(c.isPrivate),
+                "num_members" -> JSONLong(c.numMembers),
+                "topic"       -> JSONString(c.topic)
+              )
+            }
+        case "users" =>
+          client
+            .listUsers()
+            .map { u =>
+              row(
+                "id"        -> JSONString(u.id),
+                "name"      -> JSONString(u.name),
+                "real_name" -> JSONString(u.realName),
+                "is_bot"    -> JSONBoolean(u.isBot)
+              )
+            }
+        case "messages" =>
+          client
+            .listChannels()
+            .flatMap { channel =>
+              client
+                .channelHistory(channel.id, messageFetchLimit)
+                .map { m =>
+                  row(
+                    "channel"   -> JSONString(channel.name),
+                    "user"      -> JSONString(m.user),
+                    "text"      -> JSONString(m.text),
+                    "ts"        -> JSONString(m.ts),
+                    "thread_ts" -> m.threadTs.map[JSONValue](JSONString(_)).getOrElse(JSONNull())
+                  )
+                }
+            }
+        case other =>
+          throw StatusCode.TABLE_NOT_FOUND.newException(s"Slack connector has no table '${other}'")
+
+    private def row(fields: (String, JSONValue)*): String = JSONObject(fields.toSeq).toJSON
+
+  end SlackCatalogProvider
+
+end SlackConnector
+
+object SlackConnector:
+  /** Messages fetched per channel when scanning the `messages` table */
+  val DefaultMessageFetchLimit = 1000
+
+  private def schema(table: String, fields: (String, DataType)*): SchemaType = SchemaType(
+    None,
+    Name.typeName(table),
+    fields
+      .map { case (n, t) =>
+        NamedType(Name.termName(n), t)
+      }
+      .toList
+  )
+
+  private[slack] val tableSchemas: Map[String, SchemaType] = Map(
+    "channels" ->
+      schema(
+        "channels",
+        "id"          -> DataType.StringType,
+        "name"        -> DataType.StringType,
+        "is_private"  -> DataType.BooleanType,
+        "num_members" -> DataType.LongType,
+        "topic"       -> DataType.StringType
+      ),
+    "users" ->
+      schema(
+        "users",
+        "id"        -> DataType.StringType,
+        "name"      -> DataType.StringType,
+        "real_name" -> DataType.StringType,
+        "is_bot"    -> DataType.BooleanType
+      ),
+    "messages" ->
+      schema(
+        "messages",
+        "channel"   -> DataType.StringType,
+        "user"      -> DataType.StringType,
+        "text"      -> DataType.StringType,
+        "ts"        -> DataType.StringType,
+        "thread_ts" -> DataType.StringType
+      )
+  )
+
+end SlackConnector
+
+object SlackConnectorFactory extends ConnectorFactory:
+  override def connectorType: String = "slack"
+
+  override def create(config: ConnectorConfig, workEnv: WorkEnv): Connector =
+    val token = config
+      .properties
+      .get("token")
+      .map(_.toString)
+      .orElse(config.password)
+      .getOrElse(
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(
+            s"Slack connector '${config
+                .name}' requires a 'token' property (e.g. \"properties\": {\"token\": \"${'$'}{SLACK_TOKEN}\"})"
+          )
+      )
+    val fetchLimit = config
+      .properties
+      .get("message_fetch_limit")
+      .map(_.toString.toInt)
+      .getOrElse(SlackConnector.DefaultMessageFetchLimit)
+    SlackConnector(config.name, HttpSlackApiClient(token), fetchLimit)

--- a/wvlet-connector/src/test/scala/wvlet/lang/connector/slack/SlackConnectorTest.scala
+++ b/wvlet-connector/src/test/scala/wvlet/lang/connector/slack/SlackConnectorTest.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.connector.slack
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
+import wvlet.lang.catalog.ConnectorConfig
+import wvlet.lang.compiler.WorkEnv
+import wvlet.uni.json.JSON.JSONObject
+import wvlet.uni.json.JSON.JSONString
+import wvlet.uni.test.UniTest
+import wvlet.uni.test.defined
+
+/** An in-memory Slack workspace for tests */
+class FakeSlackApiClient extends SlackApiClient:
+  val posted = scala.collection.mutable.ListBuffer.empty[(String, String)]
+
+  override def listChannels(): List[SlackChannel] = List(
+    SlackChannel("C1", "general", isPrivate = false, numMembers = 12, topic = "Announcements"),
+    SlackChannel("C2", "dev", isPrivate = false, numMembers = 5, topic = "")
+  )
+
+  override def listUsers(): List[SlackUser] = List(
+    SlackUser("U1", "alice", "Alice A", isBot = false),
+    SlackUser("U2", "wvlet-bot", "Wvlet Bot", isBot = true)
+  )
+
+  override def channelHistory(channelId: String, limit: Int): List[SlackMessage] =
+    channelId match
+      case "C1" =>
+        List(
+          SlackMessage("C1", "U1", "hello wvlet", "1751692800.000100", None),
+          SlackMessage(
+            "C1",
+            "U2",
+            "flow daily completed",
+            "1751692900.000200",
+            Some("1751692800.000100")
+          )
+        )
+      case _ =>
+        List(SlackMessage("C2", "U1", "deploy done", "1751693000.000300", None))
+
+  override def postMessage(channel: String, text: String): Unit = posted += (channel -> text)
+
+end FakeSlackApiClient
+
+class SlackConnectorTest extends UniTest:
+
+  private def newConnector(client: FakeSlackApiClient = FakeSlackApiClient()): SlackConnector =
+    SlackConnector("slack", client)
+
+  test("should list the workspace tables") {
+    val catalog = newConnector().catalog.get
+    catalog.listTables.map(_.name).toSet shouldBe Set("channels", "users", "messages")
+  }
+
+  test("should describe table schemas") {
+    val catalog = newConnector().catalog.get
+    val schema  = catalog.schemaOf("channels")
+    schema shouldBe defined
+    schema.get.fields.map(_.name.name) shouldBe
+      List("id", "name", "is_private", "num_members", "topic")
+    catalog.schemaOf("no_such_table") shouldBe None
+  }
+
+  test("should scan channels as JSON rows") {
+    val rows = newConnector().catalog.get.scan("channels")
+    rows.size shouldBe 2
+    rows.head shouldContain "\"name\":\"general\""
+    rows.head shouldContain "\"num_members\":12"
+  }
+
+  test("should scan messages across channels") {
+    val rows = newConnector().catalog.get.scan("messages")
+    rows.size shouldBe 3
+    rows.head shouldContain "\"channel\":\"general\""
+    rows.head shouldContain "hello wvlet"
+  }
+
+  test("should reject scans of unknown tables") {
+    val exception = intercept[WvletLangException] {
+      newConnector().catalog.get.scan("nope")
+    }
+    exception.statusCode shouldBe StatusCode.TABLE_NOT_FOUND
+  }
+
+  test("should expose post_message as an MCP-shaped tool and invoke it") {
+    val client    = FakeSlackApiClient()
+    val connector = newConnector(client)
+    connector.tools.map(_.name) shouldBe Seq("post_message")
+    connector.tools.head.inputSchema.toJSON shouldContain "\"channel\""
+
+    connector.invoke(
+      "post_message",
+      JSONObject(Seq("channel" -> JSONString("#general"), "text" -> JSONString("hi")))
+    )
+    client.posted.toList shouldBe List("#general" -> "hi")
+  }
+
+  test("should fail with a clear error for unknown tools and missing arguments") {
+    val connector = newConnector()
+    intercept[WvletLangException] {
+      connector.invoke("no_such_tool", JSONObject(Seq.empty))
+    }.statusCode shouldBe StatusCode.NOT_IMPLEMENTED
+    intercept[WvletLangException] {
+      connector.invoke("post_message", JSONObject(Seq("channel" -> JSONString("#g"))))
+    }.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+  }
+
+  test("should require a token in the factory") {
+    val exception = intercept[WvletLangException] {
+      SlackConnectorFactory.create(ConnectorConfig(name = "slack", `type` = "slack"), WorkEnv())
+    }
+    exception.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+    exception.message shouldContain "token"
+  }
+
+end SlackConnectorTest

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/ConnectorActivationSink.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/ConnectorActivationSink.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.connector.Connector
+import wvlet.uni.json.JSON.JSONObject
+import wvlet.uni.json.JSON.JSONString
+import wvlet.uni.log.LogSupport
+
+/**
+  * Delivers stage outputs to a connector tool (#1861 Phase 3): a profile connector exposing
+  * MCP-shaped tools becomes an activation target under its instance name, e.g.
+  *
+  * {{{
+  *   activate('slack', tool: 'post_message', channel: '#reports', text: 'daily flow done')
+  * }}}
+  *
+  * When the tool takes a `text` argument and none is given, the first rows of the materialized
+  * stage output are attached as JSON lines
+  */
+class ConnectorActivationSink(connectorName: String, connector: () => Connector)
+    extends ActivationSink
+    with LogSupport:
+
+  override def name: String = connectorName
+
+  override def activate(request: ActivationRequest): Unit =
+    val toolName = request
+      .params
+      .get("tool")
+      .getOrElse(
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(
+            s"activate('${connectorName}') of stage ${request.stageName} requires a tool: parameter"
+          )
+      )
+    val target   = connector()
+    val toolSpec = target
+      .tools
+      .find(_.name == toolName)
+      .getOrElse(
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(
+            s"Connector '${connectorName}' has no tool '${toolName}' " +
+              s"(available: ${target.tools.map(_.name).mkString(", ")})"
+          )
+      )
+    val explicitArgs: Seq[(String, JSONString)] = request
+      .params
+      .removed("tool")
+      .toSeq
+      .map { case (k, v) =>
+        k -> JSONString(v)
+      }
+    // Attach the stage output as JSON lines when the tool accepts `text` and none was given
+    val args =
+      if request.params.contains("text") || !toolSpec.inputSchema.toJSON.contains("\"text\"") then
+        explicitArgs
+      else
+        val rows = request
+          .connector
+          .queryJsonRows(
+            s"""select * from "${request.table}" limit ${ConnectorActivationSink.MaxAttachedRows}"""
+          )
+        explicitArgs :+ ("text" -> JSONString(rows.mkString("\n")))
+    target.invoke(toolName, JSONObject(args))
+    logDelivered(request)
+
+  end activate
+
+  private def logDelivered(request: ActivationRequest): Unit = info(
+    s"Delivered stage ${request.stageName} output of run to '${connectorName}' via tool"
+  )
+
+end ConnectorActivationSink
+
+object ConnectorActivationSink:
+  /** Rows of the stage output attached to a tool's text argument */
+  val MaxAttachedRows = 20

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/ConnectorActivationSink.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/ConnectorActivationSink.scala
@@ -66,9 +66,17 @@ class ConnectorActivationSink(connectorName: String, connector: () => Connector)
       .map { case (k, v) =>
         k -> JSONString(v)
       }
-    // Attach the stage output as JSON lines when the tool accepts `text` and none was given
+    // Attach the stage output as JSON lines when the tool declares a top-level `text`
+    // property and none was given
+    val acceptsText = toolSpec
+      .inputSchema
+      .get("properties")
+      .collect { case o: JSONObject =>
+        o
+      }
+      .exists(_.get("text").isDefined)
     val args =
-      if request.params.contains("text") || !toolSpec.inputSchema.toJSON.contains("\"text\"") then
+      if request.params.contains("text") || !acceptsText then
         explicitArgs
       else
         val rows = request

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -28,7 +28,9 @@ import wvlet.lang.model.DataType
 import wvlet.lang.model.expr.*
 import wvlet.lang.model.plan.*
 import wvlet.lang.connector.CancellableStatement
+import wvlet.lang.connector.Connector
 import wvlet.lang.connector.DBConnector
+import wvlet.lang.runner.connector.SourceTableStaging
 import wvlet.uni.log.LogSupport
 import wvlet.uni.util.ULID
 
@@ -242,15 +244,15 @@ class FlowExecutor(
     retryScheduler: Option[(Long, () => Unit) => Unit] = None,
     registry: Option[FlowRunStore] = None,
     activationSinks: List[ActivationSink] = FlowExecutor.defaultActivationSinks,
-    // Resolve a profile connector name to a live engine, for `stage <name> on <connector>`
-    // and for reading connector-qualified tables of other engines (#1861 Phase 2)
-    engineResolver: Option[String => DBConnector] = None,
+    // Resolve a profile connector name to a live connector, for `stage <name> on <connector>`
+    // and for reading connector-qualified tables of other connectors (#1861 Phase 2/3)
+    engineResolver: Option[String => Connector] = None,
     // The profile connector name of `connector`, used to decide which table references are
     // foreign and need staging
     defaultEngineName: String = "default"
 ) extends LogSupport:
 
-  private def resolveEngine(name: String): DBConnector =
+  private def resolveConnector(name: String): Connector =
     if name == defaultEngineName then
       connector
     else
@@ -260,9 +262,21 @@ class FlowExecutor(
           throw StatusCode
             .INVALID_ARGUMENT
             .newException(
-              s"Stage engine '${name}' cannot be resolved: run the flow with a profile that defines it"
+              s"Connector '${name}' cannot be resolved: run the flow with a profile that defines it"
             )
         )
+
+  private def resolveEngine(name: String): DBConnector =
+    resolveConnector(name) match
+      case db: DBConnector =>
+        db
+      case other =>
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(
+            s"Connector '${name}' (${other
+                .connectorType}) is not a SQL engine and cannot run a stage"
+          )
 
   /** The engine a stage runs on: its `on <connector>` selection, or the flow's engine */
   private def connectorFor(ls: FlowLowering.LoweredStage): DBConnector = ls
@@ -1250,10 +1264,10 @@ class FlowExecutor(
               )
           val stagingTable = stagedTables.getOrElseUpdate(
             (sourceName, t.name.fullName), {
-              val source = resolveEngine(sourceName)
+              val source = resolveConnector(sourceName)
               stagedCount += 1
               val staging = tableFor(s"${stageName}__src${stagedCount}")
-              materializeForeignTable(source, t, staging, engine)
+              materializeForeignTable(source, t, staging, engine, engineName)
               staging
             }
           )
@@ -1272,77 +1286,25 @@ class FlowExecutor(
 
   // Copy a foreign connector's table into a staging table on the target engine via JSON lines
   private def materializeForeignTable(
-      source: DBConnector,
+      source: Connector,
       table: TableScan,
       stagingTable: String,
-      engine: DBConnector
+      engine: DBConnector,
+      engineName: String
   ): Unit =
-    // Quote each identifier part: source engines have their own casing/keyword rules
-    val qualifiedSource = (table.name.catalog.toList ++ table.name.schema.toList :+ table.name.name)
-      .map(part => s"\"${part}\"")
-      .mkString(".")
-    val rows = source.queryJsonRows(s"select * from ${qualifiedSource}")
+    val qualifiedName = table.name.catalog.toList ++ table.name.schema.toList :+ table.name.name
+    val rows          = SourceTableStaging.readTableAsJsonRows(source, qualifiedName)
     workEnv.info(
       s"Staging ${table.connectorName.getOrElse("")}.${table.name.name} (${rows
           .size} rows) as ${stagingTable}"
     )
-    val file = java.nio.file.Files.createTempFile(s"wv_flow_staging_", ".jsonl")
-    // DuckDB accepts forward slashes on every platform; backslashes would need escaping in
-    // the SQL literal
-    val filePath = file.toAbsolutePath.toString.replace('\\', '/')
-    try
-      val writer = java
-        .nio
-        .file
-        .Files
-        .newBufferedWriter(file, java.nio.charset.StandardCharsets.UTF_8)
-      try rows.foreach { row =>
-          writer.write(row)
-          writer.newLine()
-        }
-      finally writer.close()
-      if rows.nonEmpty then
-        engine.execute(
-          s"""create or replace table "${stagingTable}" as select * from read_json_auto('${filePath}')"""
-        )
-      else
-        // read_json_auto cannot infer a schema from an empty file: create the empty staging
-        // table from the resolved column types instead
-        val columns = table
-          .schema
-          .fields
-          .map(f => s""""${f.name.name}" ${FlowExecutor.duckdbTypeOf(f.dataType)}""")
-          .mkString(", ")
-        engine.execute(s"""create or replace table "${stagingTable}" (${columns})""")
-    finally
-      java.nio.file.Files.deleteIfExists(file)
+    SourceTableStaging.loadJsonRows(engine, engineName, stagingTable, rows, table.schema.fields)
 
   end materializeForeignTable
 
 end FlowExecutor
 
 object FlowExecutor:
-
-  // Best-effort mapping of resolved wvlet types to DuckDB column types for empty staging
-  // tables; anything uncommon degrades to VARCHAR (the staging table is empty anyway)
-  private[runner] def duckdbTypeOf(dataType: DataType): String =
-    dataType match
-      case DataType.IntType =>
-        "INTEGER"
-      case DataType.LongType =>
-        "BIGINT"
-      case DataType.FloatType =>
-        "FLOAT"
-      case DataType.DoubleType =>
-        "DOUBLE"
-      case DataType.BooleanType =>
-        "BOOLEAN"
-      case DataType.DateType =>
-        "DATE"
-      case _: DataType.TimestampType =>
-        "TIMESTAMP"
-      case _ =>
-        "VARCHAR"
 
   /**
     * The activation sinks available by default: sinks registered via the Java ServiceLoader

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -165,15 +165,23 @@ class QueryExecutor(
     * Materialize tables of source connectors (non-engine connectors like Slack) referenced by the
     * plan into session tables on the active engine, and point the plan at them
     */
-  private def stageSourceTables(plan: LogicalPlan): LogicalPlan =
-    val staged = scala.collection.mutable.Map.empty[(String, String), String]
-    plan.transformUp {
+  private def stageSourceTables(plan: LogicalPlan): (LogicalPlan, List[String]) =
+    val staged    = scala.collection.mutable.Map.empty[(String, String), String]
+    val rewritten = plan.transformUp {
       case t @ TableScan(_, _, _, _, Some(sourceName)) if sourceName != activeEngine.name =>
         val stagingTable = staged.getOrElseUpdate(
           (sourceName, t.name.name), {
-            val source  = profileEngineResolver(sourceName)
-            val rows    = SourceTableStaging.readTableAsJsonRows(source, List(t.name.name))
-            val staging = s"__wv_src_${sourceName}_${t.name.name}"
+            val source = profileEngineResolver(sourceName)
+            val rows   = SourceTableStaging.readTableAsJsonRows(source, List(t.name.name))
+            // ULID-suffixed so concurrent queries staging the same source never collide;
+            // the table is dropped when this query finishes
+            val staging =
+              s"__wv_src_${sourceName}_${t.name.name}_${wvlet
+                  .uni
+                  .util
+                  .ULID
+                  .newULIDString
+                  .toLowerCase}"
             workEnv.info(s"Staging ${sourceName}.${t.name.name} (${rows.size} rows) as ${staging}")
             SourceTableStaging.loadJsonRows(
               activeDBConnector,
@@ -192,6 +200,7 @@ class QueryExecutor(
           t.span
         )
     }
+    (rewritten, staged.values.toList)
 
   end stageSourceTables
 
@@ -638,7 +647,14 @@ class QueryExecutor(
     plan0.traverse { case t: TableScan =>
       t.connectorName
         .filter(_ != activeEngine.name)
-        .filter(name => profileEngineResolver(name).engine.isDefined)
+        // Classified from the config type: instantiating the connector here would open a
+        // connection just to reject the query
+        .filter(name =>
+          defaultProfile
+            .connectors
+            .find(_.name == name)
+            .forall(c => dbConnectorProvider.isEngineType(c.`type`))
+        )
         .foreach(foreignEngines += _)
     }
     if foreignEngines.nonEmpty then
@@ -651,7 +667,21 @@ class QueryExecutor(
               .name}'. Cross-connector queries are not supported yet; run `use ${foreignEngines
               .head}` first to execute on that connector"
         )
-    val plan = stageSourceTables(plan0)
+    val (plan, stagedTables) = stageSourceTables(plan0)
+    try executeQueryPlan(plan)
+    finally
+      // Staged source tables are per-query scratch space; drop them so persistent engine
+      // databases do not accumulate them
+      stagedTables.foreach { staging =>
+        try
+          activeDBConnector.execute(s"""drop table if exists "${staging}"""")
+        catch
+          case scala.util.control.NonFatal(e) =>
+            debug(s"Failed to drop staging table ${staging}: ${e.getMessage}")
+      }
+  end executeQuery
+
+  private def executeQueryPlan(plan: LogicalPlan)(using context: Context): QueryResult =
     trace(s"Executing query: ${plan.pp}")
     workEnv.trace(s"Executing plan: ${plan.pp}")
     plan match
@@ -743,7 +773,7 @@ class QueryExecutor(
         QueryResult.empty
     end match
 
-  end executeQuery
+  end executeQueryPlan
 
   /**
     * Adapt a cross-platform `XPQueryResult` (from `SqlConnector.execute`) into the runner's

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -37,7 +37,9 @@ import wvlet.lang.model.expr.*
 import wvlet.lang.model.plan.*
 import wvlet.lang.compiler.connector.QueryResult as XPQueryResult
 import wvlet.lang.connector.DBConnector
+import wvlet.lang.connector.Connector
 import wvlet.lang.runner.connector.ConnectorProvider
+import wvlet.lang.runner.connector.SourceTableStaging
 import wvlet.uni.log.LogLevel
 import wvlet.uni.log.LogSupport
 import wvlet.uni.weaver.Weaver
@@ -71,6 +73,8 @@ class QueryExecutor(
     config
   )
 
+  def getConnector(config: ConnectorConfig): Connector = dbConnectorProvider.getConnector(config)
+
   // The engine statements execute on: the profile's default engine until a `use <connector>`
   // statement switches it (#1861 Phase 2). Like the global default catalog/schema this is
   // session-level state: concurrent sessions should use separate QueryExecutor instances
@@ -78,12 +82,12 @@ class QueryExecutor(
 
   private def activeDBConnector: DBConnector = dbConnectorProvider.getDBConnector(activeEngine)
 
-  // Resolve a profile connector name to a live engine, for per-stage `on <connector>` in flows
-  // and cross-connector staging
-  private def profileEngineResolver(name: String): DBConnector = defaultProfile
+  // Resolve a profile connector name to a live connector, for per-stage `on <connector>` in
+  // flows and cross-connector staging
+  private def profileEngineResolver(name: String): Connector = defaultProfile
     .connectors
     .find(_.name == name)
-    .map(dbConnectorProvider.getDBConnector)
+    .map(dbConnectorProvider.getConnector)
     .getOrElse(
       throw StatusCode
         .INVALID_ARGUMENT
@@ -148,6 +152,48 @@ class QueryExecutor(
     QueryResult.empty
 
   end switchConnector
+
+  // Every profile connector becomes an activation target under its instance name, delivering
+  // stage outputs through its MCP-shaped tools (e.g. activate('slack', tool: 'post_message'))
+  private def profileActivationSinks: List[ActivationSink] =
+    FlowExecutor.defaultActivationSinks ++
+      defaultProfile
+        .connectors
+        .map(c => ConnectorActivationSink(c.name, () => dbConnectorProvider.getConnector(c)))
+
+  /**
+    * Materialize tables of source connectors (non-engine connectors like Slack) referenced by the
+    * plan into session tables on the active engine, and point the plan at them
+    */
+  private def stageSourceTables(plan: LogicalPlan): LogicalPlan =
+    val staged = scala.collection.mutable.Map.empty[(String, String), String]
+    plan.transformUp {
+      case t @ TableScan(_, _, _, _, Some(sourceName)) if sourceName != activeEngine.name =>
+        val stagingTable = staged.getOrElseUpdate(
+          (sourceName, t.name.name), {
+            val source  = profileEngineResolver(sourceName)
+            val rows    = SourceTableStaging.readTableAsJsonRows(source, List(t.name.name))
+            val staging = s"__wv_src_${sourceName}_${t.name.name}"
+            workEnv.info(s"Staging ${sourceName}.${t.name.name} (${rows.size} rows) as ${staging}")
+            SourceTableStaging.loadJsonRows(
+              activeDBConnector,
+              activeEngine.name,
+              staging,
+              rows,
+              t.schema.fields
+            )
+            staging
+          }
+        )
+        AliasedRelation(
+          TableRef(DoubleQuotedIdentifier(stagingTable, t.span), t.span),
+          UnquotedIdentifier(t.name.name, t.span),
+          None,
+          t.span
+        )
+    }
+
+  end stageSourceTables
 
   def executeSingleSpec(sourceFolder: String, file: String): QueryResult =
     val compiler = Compiler(
@@ -256,7 +302,8 @@ class QueryExecutor(
                 workEnv,
                 registry = Some(store),
                 engineResolver = Some(profileEngineResolver),
-                defaultEngineName = activeEngine.name
+                defaultEngineName = activeEngine.name,
+                activationSinks = profileActivationSinks
               )
               report(flowExecutor.execute(flow))
             }
@@ -556,7 +603,8 @@ class QueryExecutor(
                 workEnv,
                 registry = Some(store),
                 engineResolver = Some(profileEngineResolver),
-                defaultEngineName = activeEngine.name
+                defaultEngineName = activeEngine.name,
+                activationSinks = profileActivationSinks
               ).execute(flow, args = rf.args)
             }
 
@@ -581,24 +629,29 @@ class QueryExecutor(
 
   end runEmbeddedFlows
 
-  private def executeQuery(plan: LogicalPlan)(using context: Context): QueryResult =
-    // Cross-connector staging is not implemented yet: every table resolved through a profile
-    // connector name must live on the engine that is active when this query runs (an in-file
-    // `use <connector>` earlier in the unit has already switched activeEngine by now)
-    val foreignConnectors = scala.collection.mutable.Set.empty[String]
-    plan.traverse { case t: TableScan =>
-      t.connectorName.filter(_ != activeEngine.name).foreach(foreignConnectors += _)
+  private def executeQuery(plan0: LogicalPlan)(using context: Context): QueryResult =
+    // Tables resolved through a profile connector name must live on the engine active when
+    // this query runs (an in-file `use <connector>` earlier in the unit has already switched
+    // activeEngine by now) — except source connectors (Slack etc.), whose tables are staged
+    // into the active engine below
+    val foreignEngines = scala.collection.mutable.Set.empty[String]
+    plan0.traverse { case t: TableScan =>
+      t.connectorName
+        .filter(_ != activeEngine.name)
+        .filter(name => profileEngineResolver(name).engine.isDefined)
+        .foreach(foreignEngines += _)
     }
-    if foreignConnectors.nonEmpty then
+    if foreignEngines.nonEmpty then
       throw StatusCode
         .NOT_IMPLEMENTED
         .newException(
-          s"Query references connector(s) ${foreignConnectors.mkString(
+          s"Query references connector(s) ${foreignEngines.mkString(
               ", "
             )} but the active engine is '${activeEngine
-              .name}'. Cross-connector queries are not supported yet; run `use ${foreignConnectors
+              .name}'. Cross-connector queries are not supported yet; run `use ${foreignEngines
               .head}` first to execute on that connector"
         )
+    val plan = stageSourceTables(plan0)
     trace(s"Executing query: ${plan.pp}")
     workEnv.trace(s"Executing plan: ${plan.pp}")
     plan match

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
@@ -18,6 +18,7 @@ import wvlet.lang.api.WvletLangException
 import wvlet.lang.api.v1.query.QueryRequest
 import wvlet.lang.api.v1.query.QuerySelection
 import wvlet.lang.catalog.LazyCatalog
+import wvlet.lang.runner.connector.ConnectorCatalogs
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.*
 import wvlet.lang.compiler.query.QueryProgressMonitor
@@ -103,20 +104,23 @@ class WvletScriptRunner(
       .profile
       .connectors
       .foreach { conn =>
-        conn
-          .catalog
-          .foreach { catalogName =>
-            val connSchema = conn.schema.getOrElse("main")
-            c.addConnectorCatalog(
-              conn.name,
-              LazyCatalog(
+        val connSchema  = conn.schema.getOrElse("main")
+        val catalogName = conn.catalog.getOrElse(conn.name)
+        c.addConnectorCatalog(
+          conn.name,
+          LazyCatalog(
+            catalogName,
+            conn.dbType,
+            () =>
+              ConnectorCatalogs.catalogOf(
+                queryExecutor.getConnector(conn),
+                conn,
                 catalogName,
-                conn.dbType,
-                () => queryExecutor.getDBConnector(conn).getCatalog(catalogName, connSchema)
-              ),
-              connSchema
-            )
-          }
+                connSchema
+              )
+          ),
+          connSchema
+        )
       }
 
     // Pre-compile files in the source paths

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorCatalogs.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorCatalogs.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner.connector
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.catalog.Catalog
+import wvlet.lang.catalog.ConnectorConfig
+import wvlet.lang.connector.Connector
+import wvlet.lang.connector.ConnectorCatalogAdapter
+import wvlet.lang.connector.DBConnector
+
+object ConnectorCatalogs:
+
+  /**
+    * The compiler-facing [[Catalog]] of a connector: SQL engines expose their database catalog;
+    * source connectors expose their [[wvlet.lang.connector.CatalogProvider]] tables through a
+    * read-only adapter
+    */
+  def catalogOf(
+      connector: Connector,
+      config: ConnectorConfig,
+      catalogName: String,
+      schema: String
+  ): Catalog =
+    connector match
+      case db: DBConnector =>
+        db.getCatalog(catalogName, schema)
+      case other =>
+        other
+          .catalog
+          .map(provider => ConnectorCatalogAdapter(catalogName, provider))
+          .getOrElse(
+            throw StatusCode
+              .INVALID_ARGUMENT
+              .newException(
+                s"Connector '${config.name}' (${other.connectorType}) exposes no tables"
+              )
+          )

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorProvider.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorProvider.scala
@@ -23,6 +23,7 @@ import wvlet.lang.connector.ConnectorFactory
 import wvlet.lang.connector.DBConnector
 import wvlet.lang.connector.duckdb.DuckDBConnectorFactory
 import wvlet.lang.connector.duckdb.GenericConnectorFactory
+import wvlet.lang.connector.slack.SlackConnectorFactory
 import wvlet.lang.connector.snowflake.SnowflakeConnectorFactory
 import wvlet.lang.connector.trino.TrinoConnectorFactory
 import wvlet.uni.log.LogSupport
@@ -107,5 +108,6 @@ object ConnectorProvider:
     DuckDBConnectorFactory,
     GenericConnectorFactory,
     TrinoConnectorFactory,
-    SnowflakeConnectorFactory
+    SnowflakeConnectorFactory,
+    SlackConnectorFactory
   )

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorProvider.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/ConnectorProvider.scala
@@ -53,6 +53,11 @@ class ConnectorProvider(
 
   // computeIfAbsent (not the Scala wrapper's getOrElseUpdate) so a race on first use cannot
   // create two live connectors and silently leak the losing one
+  /** Whether configs of this type create SQL engines, decided without instantiating one */
+  def isEngineType(connectorType: String): Boolean = factoryMap
+    .get(connectorType.toLowerCase)
+    .forall(_.isEngine)
+
   def getConnector(config: ConnectorConfig): Connector = connectorCache.computeIfAbsent(
     config,
     c => createConnector(c)

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/SourceTableStaging.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/SourceTableStaging.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner.connector
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.compiler.DBType
+import wvlet.lang.connector.CatalogProvider
+import wvlet.lang.connector.Connector
+import wvlet.lang.connector.DBConnector
+import wvlet.lang.model.DataType
+import wvlet.lang.model.DataType.NamedType
+import wvlet.uni.log.LogSupport
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+/**
+  * Moves rows between connectors for cross-connector staging: reads a table engine-independently as
+  * JSON lines and lands them in a staging table on the target engine (#1861 Phase 2/3)
+  */
+object SourceTableStaging extends LogSupport:
+
+  /** Read every row of a connector's table as JSON object strings */
+  def readTableAsJsonRows(source: Connector, qualifiedName: List[String]): Seq[String] =
+    source match
+      case db: DBConnector =>
+        // Quote each identifier part: source engines have their own casing/keyword rules
+        val qualified = qualifiedName.map(part => s"\"${part}\"").mkString(".")
+        db.queryJsonRows(s"select * from ${qualified}")
+      case other =>
+        other
+          .catalog
+          .map(_.scan(qualifiedName.last))
+          .getOrElse(
+            throw StatusCode
+              .INVALID_ARGUMENT
+              .newException(
+                s"Connector '${other.name}' (${other.connectorType}) exposes no tables to read"
+              )
+          )
+
+  /**
+    * Land JSON rows in `stagingTable` on the target engine. `schemaFields` builds the empty table
+    * when there are no rows (read_json_auto cannot infer a schema from an empty file)
+    */
+  def loadJsonRows(
+      engine: DBConnector,
+      engineName: String,
+      stagingTable: String,
+      rows: Seq[String],
+      schemaFields: Seq[NamedType]
+  ): Unit =
+    if engine.dbType != DBType.DuckDB then
+      throw StatusCode
+        .NOT_IMPLEMENTED
+        .newException(
+          s"Staging into '${engineName}' (${engine.dbType}) is not supported yet; " +
+            "use a DuckDB engine as the staging target"
+        )
+    val file = Files.createTempFile(s"wv_staging_", ".jsonl")
+    // DuckDB accepts forward slashes on every platform; backslashes would need escaping in
+    // the SQL literal
+    val filePath = file.toAbsolutePath.toString.replace('\\', '/')
+    try
+      val writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)
+      try rows.foreach { row =>
+          writer.write(row)
+          writer.newLine()
+        }
+      finally writer.close()
+      if rows.nonEmpty then
+        engine.execute(
+          s"""create or replace table "${stagingTable}" as select * from read_json_auto('${filePath}')"""
+        )
+      else
+        val columns = schemaFields
+          .map(f => s""""${f.name.name}" ${duckdbTypeOf(f.dataType)}""")
+          .mkString(", ")
+        engine.execute(s"""create or replace table "${stagingTable}" (${columns})""")
+    finally
+      Files.deleteIfExists(file)
+
+  end loadJsonRows
+
+  // Best-effort mapping of resolved wvlet types to DuckDB column types for empty staging
+  // tables; anything uncommon degrades to VARCHAR (the staging table is empty anyway)
+  def duckdbTypeOf(dataType: DataType): String =
+    dataType match
+      case DataType.IntType =>
+        "INTEGER"
+      case DataType.LongType =>
+        "BIGINT"
+      case DataType.FloatType =>
+        "FLOAT"
+      case DataType.DoubleType =>
+        "DOUBLE"
+      case DataType.BooleanType =>
+        "BOOLEAN"
+      case DataType.DateType =>
+        "DATE"
+      case _: DataType.TimestampType =>
+        "TIMESTAMP"
+      case _ =>
+        "VARCHAR"
+
+end SourceTableStaging

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/SourceTableStaging.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/SourceTableStaging.scala
@@ -73,12 +73,15 @@ object SourceTableStaging extends LogSupport:
     // the SQL literal
     val filePath = file.toAbsolutePath.toString.replace('\\', '/')
     try
-      val writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)
-      try rows.foreach { row =>
-          writer.write(row)
-          writer.newLine()
+      scala
+        .util
+        .Using
+        .resource(Files.newBufferedWriter(file, StandardCharsets.UTF_8)) { writer =>
+          rows.foreach { row =>
+            writer.write(row)
+            writer.newLine()
+          }
         }
-      finally writer.close()
       if rows.nonEmpty then
         engine.execute(
           s"""create or replace table "${stagingTable}" as select * from read_json_auto('${filePath}')"""

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/SlackSourceQueryTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/SlackSourceQueryTest.scala
@@ -60,6 +60,7 @@ class SlackSourceQueryTest extends UniTest:
   // A factory returning the fake-backed connector, replacing the HTTP-based default
   private object FakeSlackFactory extends ConnectorFactory:
     override def connectorType: String                                        = "slack"
+    override def isEngine: Boolean                                            = false
     override def create(config: ConnectorConfig, workEnv: WorkEnv): Connector = SlackConnector(
       config.name,
       fakeSlack

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/SlackSourceQueryTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/SlackSourceQueryTest.scala
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.catalog.ConnectorConfig
+import wvlet.lang.catalog.LazyCatalog
+import wvlet.lang.catalog.Profile
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.connector.Connector
+import wvlet.lang.connector.ConnectorFactory
+import wvlet.lang.connector.slack.SlackChannel
+import wvlet.lang.connector.slack.SlackConnector
+import wvlet.lang.connector.slack.SlackMessage
+import wvlet.lang.connector.slack.SlackApiClient
+import wvlet.lang.connector.slack.SlackUser
+import wvlet.lang.runner.connector.ConnectorCatalogs
+import wvlet.lang.runner.connector.ConnectorProvider
+import wvlet.uni.test.UniTest
+
+/**
+  * End-to-end: a Slack source connector queried from a DuckDB engine (#1861 Phase 3). Slack tables
+  * are staged into the active engine transparently; flows deliver stage outputs through the
+  * connector's post_message tool
+  */
+class SlackSourceQueryTest extends UniTest:
+
+  private class RecordingSlackClient extends SlackApiClient:
+    val posted = scala.collection.mutable.ListBuffer.empty[(String, String)]
+    override def listChannels(): List[SlackChannel] = List(
+      SlackChannel("C1", "general", isPrivate = false, numMembers = 12, topic = ""),
+      SlackChannel("C2", "dev", isPrivate = false, numMembers = 5, topic = "")
+    )
+
+    override def listUsers(): List[SlackUser] = List(
+      SlackUser("U1", "alice", "Alice A", isBot = false)
+    )
+
+    override def channelHistory(channelId: String, limit: Int): List[SlackMessage] = List(
+      SlackMessage(channelId, "U1", s"message in ${channelId}", "1751692800.000100", None)
+    )
+
+    override def postMessage(channel: String, text: String): Unit = posted += (channel -> text)
+
+  private val fakeSlack = RecordingSlackClient()
+
+  // A factory returning the fake-backed connector, replacing the HTTP-based default
+  private object FakeSlackFactory extends ConnectorFactory:
+    override def connectorType: String                                        = "slack"
+    override def create(config: ConnectorConfig, workEnv: WorkEnv): Connector = SlackConnector(
+      config.name,
+      fakeSlack
+    )
+
+  private val workEnv = WorkEnv()
+  private val duckdb  = ConnectorConfig(
+    name = "duckdb",
+    `type` = "duckdb",
+    default = true,
+    catalog = Some("memory"),
+    schema = Some("main")
+  )
+
+  private val slack   = ConnectorConfig(name = "slack", `type` = "slack")
+  private val profile = Profile(name = "dev", connectors = Seq(duckdb, slack))
+
+  private val provider = ConnectorProvider(
+    workEnv,
+    factories =
+      ConnectorProvider.defaultFactories.filterNot(_.connectorType == "slack") :+ FakeSlackFactory
+  )
+
+  private val executor = QueryExecutor(provider, profile, workEnv)
+
+  private val compiler = Compiler(
+    CompilerOptions(sourceFolders = List("."), workEnv = workEnv, catalog = Some("memory"))
+  )
+
+  profile
+    .connectors
+    .foreach { c =>
+      val schema      = c.schema.getOrElse("main")
+      val catalogName = c.catalog.getOrElse(c.name)
+      compiler.addConnectorCatalog(
+        c.name,
+        LazyCatalog(
+          catalogName,
+          c.dbType,
+          () => ConnectorCatalogs.catalogOf(provider.getConnector(c), c, catalogName, schema)
+        ),
+        schema
+      )
+    }
+
+  compiler.setDefaultCatalog(provider.getDBConnector(duckdb).getCatalog("memory", "main"))
+  compiler.setDefaultSchema("main")
+
+  override def afterAll: Unit =
+    executor.close()
+    provider.close()
+
+  private def run(statement: String): QueryResult =
+    val unit   = CompilationUnit.fromWvletString(statement)
+    val result = compiler.compileSingleUnit(unit)
+    executor.executeSingle(unit, result.context)
+
+  test("should query a Slack table from the DuckDB engine via automatic staging") {
+    val result = run("from slack.channels | where is_private = false | select name")
+    val tsv    = result.toTSV
+    tsv shouldContain "general"
+    tsv shouldContain "dev"
+  }
+
+  test("should aggregate over staged Slack messages") {
+    val result = run("from slack.messages | select count(*) as cnt")
+    result.toTSV shouldContain "2"
+  }
+
+  test("should deliver a flow stage output through the post_message tool") {
+    val result = run("""flow notify_flow = {
+        |  stage summary = from slack.channels | select count(*) as channels
+        |  stage send = from summary | activate('slack', tool: 'post_message', channel: '#reports')
+        |}
+        |
+        |run flow notify_flow""".stripMargin)
+    result.isSuccess shouldBe true
+    fakeSlack.posted.size shouldBe 1
+    fakeSlack.posted.head._1 shouldBe "#reports"
+    fakeSlack.posted.head._2 shouldContain "channels"
+  }
+
+end SlackSourceQueryTest


### PR DESCRIPTION
## Summary

Phase 3 of #1861: the first non-SQL connector. Slack workspaces become queryable tables, and flows can post results back to channels through the connector's MCP-shaped tools. This exercises both capability surfaces the `Connector` trait was designed for — `catalog` (scan/materialize) and `tools` (invocation via flows).

```sql
-- Slack tables staged automatically into the active engine
from slack.messages | group by channel | agg count(*) as messages

flow daily_report = {
  stage summary = from slack.messages | group by channel | agg count(*) as messages
  stage notify = from summary | activate('slack', tool: 'post_message', channel: '#reports')
}
```

### Slack connector (`wvlet.lang.connector.slack`)

- `SlackConnector` implements `catalog` (tables `channels`, `users`, `messages` with static schemas) and `tools` (`post_message`, MCP-shaped input schema). The Slack Web API client is a small injectable trait (`SlackApiClient`) with an HTTP implementation over uni's client (cursor pagination, `ok: false` error surfacing) — tests run against an in-memory workspace, no HTTP.
- Config: `{ "name": "slack", "type": "slack", "properties": { "token": "${SLACK_TOKEN}" } }`; optional `message_fetch_limit` bounds per-channel history scans.
- `CatalogProvider` gains the `scan(table): Seq[String]` operation promised in Phase 1 (JSON object per row, matching `DBConnector.queryJsonRows`).

### Source-connector infrastructure

- **Ad-hoc query staging**: `QueryExecutor` now stages tables of *source* connectors (non-engine) into the active engine transparently — the cross-connector guard only rejects foreign *engine* references. Shared movement logic lives in `SourceTableStaging` (JSON lines → `read_json_auto`, typed empty-table DDL), also used by the flow staging from #1865.
- **Compiler registration**: source connectors surface their tables through a read-only `ConnectorCatalogAdapter`, registered lazily like engine catalogs, so `from slack.channels` type-checks with real column types.
- **Flow tool delivery**: every profile connector becomes an activation target under its instance name (`ConnectorActivationSink`); `activate('<connector>', tool: '<name>', ...)` invokes the tool, attaching the stage output as JSON lines when the tool takes `text` and none is given.
- `FlowExecutor`'s engine resolver generalizes from `DBConnector` to `Connector`, so per-stage `on <engine>` still requires a SQL engine (clear error otherwise) while foreign reads accept sources.

### Tests

- `SlackConnectorTest` (8 tests): tables, schemas, scans, tool exposure/invocation, factory validation — all against the fake client.
- `SlackSourceQueryTest` (3 tests, end-to-end): Slack tables queried and aggregated from DuckDB via automatic staging; a flow delivering its stage output through `post_message`.

### Docs

- New `usage/slack.md` (setup, tables, flow delivery); `usage/connectors.md` explains the engine/source distinction.

This completes the in-scope phases of #1861 (Phase 4 `connector-mcp` is deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
