### PR TITLE
feature: Add call statement for ad-hoc connector tool invocation

### DIFF
--- a/website/docs/usage/connectors.md
+++ b/website/docs/usage/connectors.md
@@ -68,3 +68,24 @@ use td.sample_datasets  -- switch connector and schema in one statement
 Bare names are resolved connector-first: `use analytics` switches to a connector named
 `analytics` when the profile defines one, and otherwise behaves like `use schema analytics`
 (see [CLI reference](cli-reference.md) for the schema forms).
+
+## Calling connector tools
+
+Connectors can expose callable tools (MCP-shaped methods) beyond tables and SQL execution. The
+`call` statement invokes a tool ad hoc, outside of a flow:
+
+```sql
+call slack.post_message(channel: '#reports', text: 'daily report done')
+```
+
+Arguments are named and take literal values, following the tool's input schema. The statement
+returns a single-row summary (`connector`, `tool`, `status`, `content`) that composes with query
+operators and `test` statements like any query:
+
+```sql
+call slack.post_message(channel: '#reports', text: 'ping')
+test _.columns should contain 'status'
+```
+
+Inside flows, use `activate('<connector>', tool: ...)` instead to deliver a stage's output
+through a tool (see [Flows](../syntax/flow.md)).

--- a/website/docs/usage/slack.md
+++ b/website/docs/usage/slack.md
@@ -66,3 +66,14 @@ flow daily_report = {
 ```
 
 When `text:` is omitted, the first rows of the stage output are attached as JSON lines.
+
+## Posting messages ad hoc
+
+Outside of a flow, the `call` statement invokes a tool directly:
+
+```sql
+call slack.post_message(channel: '#reports', text: 'hello from wvlet')
+```
+
+See [Working with Multiple Connectors](connectors.md#calling-connector-tools) for details on
+`call`.

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -461,6 +461,11 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
               expr(r.flowName) + paren(cl(r.args.map(a => expr(a))))
           wl("run", "flow", call)
         }
+      case c: CallTool =>
+        code(c) {
+          val target = expr(c.connectorName) + text(".") + expr(c.toolName)
+          wl("call", target + paren(cl(c.args.map(a => expr(a)))))
+        }
       // Flow-related relations
       case s: StageDef =>
         // Note: inputRefs are tracked for dependency analysis but the body already contains

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -464,7 +464,15 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
       case c: CallTool =>
         code(c) {
           val target = expr(c.connectorName) + text(".") + expr(c.toolName)
-          wl("call", target + paren(cl(c.args.map(a => expr(a)))))
+          val args   = c
+            .args
+            .map {
+              case f: FunctionArg if f.name.isDefined =>
+                wl(text(s"${f.name.get.name}:"), expr(f.value))
+              case a =>
+                expr(a)
+            }
+          wl("call", target + paren(cl(args)))
         }
       // Flow-related relations
       case s: StageDef =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -390,6 +390,30 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
   }
 
   /**
+    * Parse a tool-call statement: `call <connector>.<tool>(name: value, ...)`
+    *
+    * The statement produces a single-row invocation summary relation (connector, tool, status,
+    * content), so it can be followed by query operators or test statements like a regular query
+    */
+  def callToolStatement(): LogicalPlan = node {
+    val t             = consume(WvletToken.CALL)
+    val connectorName = identifier()
+    consume(WvletToken.DOT)
+    val toolName = identifier()
+    consume(WvletToken.L_PAREN)
+    val args =
+      scanner.lookAhead().token match
+        case WvletToken.R_PAREN =>
+          Nil
+        case _ =>
+          activateParams()
+    consume(WvletToken.R_PAREN)
+    val c = CallTool(connectorName, toolName, args, spanFrom(t))
+    val q = queryBlock(c)
+    Query(q, spanFrom(t))
+  }
+
+  /**
     * Parse a flow definition: `flow Name(params) = { stage ... }`
     *
     * Supports:
@@ -909,6 +933,8 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         flowDef()
       case WvletToken.RUN =>
         runFlowStatement()
+      case WvletToken.CALL =>
+        callToolStatement()
       case WvletToken.VAL =>
         valDef()
       case WvletToken.SHOW =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
@@ -281,6 +281,9 @@ enum WvletToken(val tokenType: TokenType, val str: String):
   case ACTIVATE extends WvletToken(Keyword, "activate")
   case END      extends WvletToken(Keyword, "end")
 
+  // Connector tool invocation
+  case CALL extends WvletToken(Keyword, "call")
+
 end WvletToken
 
 object WvletToken:
@@ -307,7 +310,8 @@ object WvletToken:
     WvletToken.MERGE,
     WvletToken.FLOW,
     WvletToken.STAGE,
-    WvletToken.DEPENDS
+    WvletToken.DEPENDS,
+    WvletToken.CALL
   )
 
   val stringStartToken = List(

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/relation.scala
@@ -1161,6 +1161,49 @@ case class IncrementalAppend(
 ) extends UnaryRelation:
   override def relationType: RelationType = child.relationType
 
+/**
+  * CallTool invokes an MCP-shaped tool of a profile connector ad hoc:
+  * {{{
+  * call slack.post_message(channel: '#reports', text: 'daily report done')
+  * }}}
+  *
+  * It is a leaf relation whose output is a single-row invocation summary (connector, tool, status,
+  * content), so the result can be piped through query operators or verified with test statements
+  *
+  * @param connectorName
+  *   The profile connector instance exposing the tool
+  * @param toolName
+  *   The tool to invoke
+  * @param args
+  *   Named arguments bound to the tool's input schema
+  * @param span
+  *   Source location
+  */
+case class CallTool(
+    connectorName: NameExpr,
+    toolName: NameExpr,
+    args: List[FunctionArg],
+    span: Span
+) extends Relation
+    with LeafPlan:
+  override def children: List[LogicalPlan] = Nil
+  override def relationType: RelationType  = CallTool.resultType
+
+object CallTool:
+  /**
+    * The relation type of a tool-call result: one row describing the invocation outcome
+    */
+  val resultType: SchemaType = SchemaType(
+    None,
+    Name.typeName("tool_call"),
+    List(
+      NamedType(Name.termName("connector"), DataType.StringType),
+      NamedType(Name.termName("tool"), DataType.StringType),
+      NamedType(Name.termName("status"), DataType.StringType),
+      NamedType(Name.termName("content"), DataType.StringType)
+    )
+  )
+
 enum ShowType:
   case models
   case tables

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -47,4 +47,12 @@ class WvletGeneratorTest extends UniTest:
     printed.contains("F()") shouldBe false
   }
 
+  test("should print call statement arguments in name: value form") {
+    val printed = print("call slack.post_message(channel: '#reports', text: 'hello')")
+    printed shouldContain "call slack.post_message(channel: '#reports', text: 'hello')"
+
+    // The printed statement should parse back to the same tool call
+    print(printed) shouldContain "call slack.post_message(channel: '#reports', text: 'hello')"
+  }
+
 end WvletGeneratorTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/ParserTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/ParserTest.scala
@@ -14,6 +14,7 @@
 package wvlet.lang.compiler.parser
 
 import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.model.plan.CallTool
 import wvlet.lang.model.plan.PackageDef
 import wvlet.lang.model.plan.TableRef
 import wvlet.lang.model.plan.Query
@@ -39,3 +40,35 @@ class ParserTest extends UniTest:
     val plan = p.parse()
     debug(plan)
   }
+
+  test("should parse a call statement with named tool arguments") {
+    val p = WvletParser(
+      CompilationUnit.fromWvletString(
+        """call slack.post_message(channel: '#reports', text: 'hello')"""
+      )
+    )
+    val plan = p.parse()
+    debug(plan)
+    plan shouldMatch { case p: PackageDef =>
+      p.statements shouldMatch { case List(Query(c: CallTool, _)) =>
+        c.connectorName.fullName shouldBe "slack"
+        c.toolName.fullName shouldBe "post_message"
+        c.args.flatMap(_.name.map(_.name)) shouldBe List("channel", "text")
+      }
+    }
+  }
+
+  test("should parse a call statement with no arguments followed by query operators") {
+    val p = WvletParser(CompilationUnit.fromWvletString("""call slack.refresh()
+        |select status""".stripMargin))
+    val plan = p.parse()
+    debug(plan)
+    var found = false
+    plan.traverse { case c: CallTool =>
+      found = true
+      c.args shouldBe Nil
+    }
+    found shouldBe true
+  }
+
+end ParserTest

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -40,6 +40,7 @@ import wvlet.lang.connector.DBConnector
 import wvlet.lang.connector.Connector
 import wvlet.lang.runner.connector.ConnectorProvider
 import wvlet.lang.runner.connector.SourceTableStaging
+import wvlet.uni.json.JSON
 import wvlet.uni.log.LogLevel
 import wvlet.uni.log.LogSupport
 import wvlet.uni.weaver.Weaver
@@ -638,6 +639,106 @@ class QueryExecutor(
 
   end runEmbeddedFlows
 
+  /**
+    * Execute ad-hoc connector tool calls (`call <connector>.<tool>(...)`) embedded in a query plan
+    * and replace each CallTool node with a reference to a materialized single-row invocation
+    * summary table (connector, tool, status, content), so that downstream query operators and test
+    * statements work on the result via regular SQL
+    */
+  private def runEmbeddedToolCalls(q: Relation)(using context: Context): Relation =
+    def sqlLit(s: String): String = s"'${s.replaceAll("'", "''")}'"
+
+    def jsonArgValue(toolName: String, e: Expression): JSON.JSONValue =
+      e match
+        case s: StringLiteral =>
+          JSON.JSONString(s.unquotedValue)
+        case l: LongLiteral =>
+          JSON.JSONLong(l.value)
+        case d: DoubleLiteral =>
+          JSON.JSONDouble(d.value)
+        case _: TrueLiteral =>
+          JSON.JSONBoolean(true)
+        case _: FalseLiteral =>
+          JSON.JSONBoolean(false)
+        case _: NullLiteral =>
+          JSON.JSONNull()
+        case l: Literal =>
+          JSON.JSONString(l.stringValue)
+        case other =>
+          throw StatusCode
+            .INVALID_ARGUMENT
+            .newException(s"Tool '${toolName}' arguments must be literal values, found: ${other}")
+
+    q.transformUp { case ct: CallTool =>
+        val connectorName = ct.connectorName.fullName
+        val toolName      = ct.toolName.fullName
+        val config        = defaultProfile
+          .connectors
+          .find(_.name == connectorName)
+          .getOrElse(
+            throw StatusCode
+              .INVALID_ARGUMENT
+              .newException(
+                s"Connector '${connectorName}' is not found in profile '${defaultProfile.name}'",
+                ct.sourceLocation(using context)
+              )
+          )
+        val target = dbConnectorProvider.getConnector(config)
+        if !target.tools.exists(_.name == toolName) then
+          throw StatusCode
+            .INVALID_ARGUMENT
+            .newException(
+              s"Connector '${connectorName}' has no tool '${toolName}' (available: ${target
+                  .tools
+                  .map(_.name)
+                  .mkString(", ")})",
+              ct.sourceLocation(using context)
+            )
+        val args = ct
+          .args
+          .map { arg =>
+            val name = arg
+              .name
+              .getOrElse(
+                throw StatusCode
+                  .INVALID_ARGUMENT
+                  .newException(
+                    s"Tool arguments must be named, e.g. ${toolName}(channel: '#general')",
+                    ct.sourceLocation(using context)
+                  )
+              )
+            name.name -> jsonArgValue(toolName, arg.value)
+          }
+        val result = target.invoke(toolName, JSON.JSONObject(args))
+        val status =
+          if result.isError then
+            "error"
+          else
+            "ok"
+        val content =
+          result.content match
+            case s: JSON.JSONString =>
+              s.v
+            case other =>
+              other.toJSON
+
+        given monitor: QueryProgressMonitor = context.queryProgressMonitor
+
+        val summaryTable = s"__wv_call_${wvlet.uni.util.ULID.newULIDString.toLowerCase}"
+        activeDBConnector.execute(
+          s"""create or replace temp table "${summaryTable}" ("connector" varchar, "tool" varchar, "status" varchar, "content" varchar)"""
+        )
+        activeDBConnector.execute(
+          s"""insert into "${summaryTable}" values (${sqlLit(connectorName)}, ${sqlLit(
+              toolName
+            )}, ${sqlLit(status)}, ${sqlLit(content)})"""
+        )
+        TableRef(DoubleQuotedIdentifier(summaryTable, ct.span), ct.span)
+      }
+      .asInstanceOf[Relation]
+
+  end runEmbeddedToolCalls
+
   private def executeQuery(plan0: LogicalPlan)(using context: Context): QueryResult =
     // Tables resolved through a profile connector name must live on the engine active when
     // this query runs (an in-file `use <connector>` earlier in the unit has already switched
@@ -686,8 +787,9 @@ class QueryExecutor(
     workEnv.trace(s"Executing plan: ${plan.pp}")
     plan match
       case q0: Relation =>
-        // Execute any embedded flow runs first, replacing them with their summary tables
-        val q = runEmbeddedFlows(q0)
+        // Execute any embedded flow runs and ad-hoc tool calls first, replacing them with their
+        // summary tables
+        val q = runEmbeddedToolCalls(runEmbeddedFlows(q0))
         // Decide whether to auto-switch to DuckDB for simple local file reads
         def isRemotePath(p: String): Boolean = p.startsWith("s3://") || p.startsWith("https://")
         def prefersDuckDBForLocalRead(r: Relation): Boolean =

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -656,12 +656,35 @@ class QueryExecutor(
           JSON.JSONLong(l.value)
         case d: DoubleLiteral =>
           JSON.JSONDouble(d.value)
+        case d: DecimalLiteral =>
+          JSON.JSONDouble(d.value.toDouble)
         case _: TrueLiteral =>
           JSON.JSONBoolean(true)
         case _: FalseLiteral =>
           JSON.JSONBoolean(false)
         case _: NullLiteral =>
           JSON.JSONNull()
+        // Negative (or explicitly signed) numbers parse as a unary expression over the literal
+        case a: ArithmeticUnaryExpr =>
+          jsonArgValue(toolName, a.child) match
+            case JSON.JSONLong(v) =>
+              JSON.JSONLong(
+                if a.sign == Sign.Negative then
+                  -v
+                else
+                  v
+              )
+            case JSON.JSONDouble(v) =>
+              JSON.JSONDouble(
+                if a.sign == Sign.Negative then
+                  -v
+                else
+                  v
+              )
+            case _ =>
+              throw StatusCode
+                .INVALID_ARGUMENT
+                .newException(s"Tool '${toolName}' arguments must be literal values, found: ${e}")
         case l: Literal =>
           JSON.JSONString(l.stringValue)
         case other =>

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/SlackSourceQueryTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/SlackSourceQueryTest.scala
@@ -167,6 +167,15 @@ class SlackSourceQueryTest extends UniTest:
     result.isSuccess shouldBe true
   }
 
+  test("should accept negative numeric literal arguments in a call statement") {
+    fakeSlack.posted.clear()
+    val result = run(
+      "call slack.post_message(channel: '#general', text: 'with numbers', priority: -5, score: -1.5)"
+    )
+    result.isSuccess shouldBe true
+    fakeSlack.posted.toList shouldBe List("#general" -> "with numbers")
+  }
+
   test("should report an unknown tool in a call statement") {
     val e = intercept[Exception] {
       run("call slack.no_such_tool(text: 'x')")

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/SlackSourceQueryTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/SlackSourceQueryTest.scala
@@ -143,4 +143,50 @@ class SlackSourceQueryTest extends UniTest:
     fakeSlack.posted.head._2 shouldContain "channels"
   }
 
+  test("should invoke a connector tool ad hoc with a call statement") {
+    fakeSlack.posted.clear()
+    val result = run("call slack.post_message(channel: '#general', text: 'hello from wvlet')")
+    result.isSuccess shouldBe true
+    fakeSlack.posted.toList shouldBe List("#general" -> "hello from wvlet")
+    val tsv = result.toTSV
+    tsv shouldContain "post_message"
+    tsv shouldContain "ok"
+  }
+
+  test("should pipe a call statement result through query operators") {
+    val result = run("""call slack.post_message(channel: '#general', text: 'piped')
+        |select connector, tool, status
+        |""".stripMargin)
+    result.toTSV shouldContain "slack\tpost_message\tok"
+  }
+
+  test("should verify a call statement result with a test statement") {
+    val result = run("""call slack.post_message(channel: '#general', text: 'tested')
+        |test _.columns should contain 'status'
+        |""".stripMargin)
+    result.isSuccess shouldBe true
+  }
+
+  test("should report an unknown tool in a call statement") {
+    val e = intercept[Exception] {
+      run("call slack.no_such_tool(text: 'x')")
+    }
+    e.getMessage shouldContain "no tool 'no_such_tool'"
+    e.getMessage shouldContain "post_message"
+  }
+
+  test("should report an unknown connector in a call statement") {
+    val e = intercept[Exception] {
+      run("call nowhere.post_message(text: 'x')")
+    }
+    e.getMessage shouldContain "'nowhere' is not found"
+  }
+
+  test("should reject positional arguments in a call statement") {
+    val e = intercept[Exception] {
+      run("call slack.post_message('#general')")
+    }
+    e.getMessage shouldContain "must be named"
+  }
+
 end SlackSourceQueryTest


### PR DESCRIPTION
## Summary

Adds a first-class `call <connector>.<tool>(...)` statement for invoking connector tools ad hoc, a follow-up of #1867 (from the #1861 multi-connector design, where this was left as an open question).

Previously, MCP-shaped connector tools (e.g. Slack's `post_message`) were only reachable through `activate('<connector>', tool: ...)` inside a flow, so a one-off tool invocation required defining and running a whole flow:

```sql
call slack.post_message(channel: '#reports', text: 'daily report done')
```

## Design

- **Row-returning, not a side-effect command**: the statement produces a single-row invocation summary relation (`connector`, `tool`, `status`, `content`), following the `run flow` summary-relation pattern, so the result composes with query operators and `test` statements:
  ```sql
  call slack.post_message(channel: '#reports', text: 'ping')
  test _.columns should contain 'status'
  ```
- **Execution** mirrors `runEmbeddedFlows`: `CallTool` leaf nodes are materialized into temp summary tables before SQL generation, keeping the SQL pipeline untouched.
- **Arguments must be named literals** (`name: value` or `name = value`), matching the tool's JSON-schema input; positional or non-literal arguments report a clear `INVALID_ARGUMENT` error. Literal types are preserved in the JSON payload (string/long/double/boolean/null).
- `call` is a non-reserved keyword, so existing identifiers named `call` keep working.

## Changes

- `WvletToken` / `WvletParser`: new `CALL` keyword (non-reserved) and `callToolStatement()` parse rule modeled on `runFlowStatement()` / `activateParams()`
- `relation.scala`: `CallTool` leaf relation with static `tool_call` result type
- `WvletGenerator`: pretty-printing for the new node
- `QueryExecutor.runEmbeddedToolCalls`: resolves the profile connector, validates the tool, invokes it via `Connector.invoke`, and materializes the `ToolResult` (previously discarded by the activation path) as a queryable row
- Docs: new "Calling connector tools" section in `usage/connectors.md`, ad-hoc posting example in `usage/slack.md`

## Testing

- Parser tests for named-arg and zero-arg forms (`ParserTest`)
- End-to-end tests on the fake-Slack harness (`SlackSourceQueryTest`): ad-hoc invocation, piping through operators, `test` statement verification, and error cases (unknown tool, unknown connector, positional args)
- Full `langJVM/test` (866 passed) and `runner/test` (247 passed) suites green; Scala.js compilation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)