### PR TITLE
feature: Support 4-part connector.catalog.schema.table names for multi-catalog engines

### DIFF
--- a/website/docs/usage/connectors.md
+++ b/website/docs/usage/connectors.md
@@ -39,6 +39,10 @@ from td.www_access
 
 -- <connector>.<schema>.<table>
 from td.sample_datasets.www_access
+
+-- <connector>.<catalog>.<schema>.<table>: addresses a catalog other than the
+-- configured one, for engines spanning multiple catalogs (e.g. Trino)
+from trino.tpch.tiny.nation
 ```
 
 Models, CTEs, and query aliases take precedence over connector names, and connector names take

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
@@ -117,22 +117,24 @@ class WvletCompiler(
     currentProfile
       .connectors
       .foreach { c =>
-        val schema      = c.schema.getOrElse("main")
-        val catalogName = c.catalog.getOrElse(c.name)
+        val schema                                   = c.schema.getOrElse("main")
+        val catalogName                              = c.catalog.getOrElse(c.name)
+        def lazyCatalogOf(name: String): LazyCatalog = LazyCatalog(
+          name,
+          c.dbType,
+          () => ConnectorCatalogs.catalogOf(dbConnectorProvider.getConnector(c), c, name, schema)
+        )
         compiler.addConnectorCatalog(
           c.name,
-          LazyCatalog(
-            catalogName,
-            c.dbType,
-            () =>
-              ConnectorCatalogs.catalogOf(
-                dbConnectorProvider.getConnector(c),
-                c,
-                catalogName,
-                schema
-              )
-          ),
-          schema
+          lazyCatalogOf(catalogName),
+          schema,
+          // Engines may span multiple catalogs (e.g. Trino), addressable with 4-part
+          // <connector>.<catalog>.<schema>.<table> names
+          catalogProvider =
+            if dbConnectorProvider.isEngineType(c.`type`) then
+              Some(lazyCatalogOf)
+            else
+              None
         )
       }
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
@@ -136,9 +136,23 @@ class Compiler(
   def setDefaultCatalog(catalog: Catalog): Unit = globalContext.defaultCatalog = catalog
   def setDefaultSchema(schema: String): Unit    = globalContext.defaultSchema = schema
 
-  /** Register a catalog under a connector name so queries can reference `<name>.<table>` */
-  def addConnectorCatalog(name: String, catalog: Catalog, defaultSchema: String): Unit =
-    globalContext.connectorCatalogs(name) = ConnectorCatalogEntry(catalog, defaultSchema)
+  /**
+    * Register a catalog under a connector name so queries can reference `<name>.<table>`. Engines
+    * spanning multiple catalogs pass a catalogProvider so 4-part
+    * `<name>.<catalog>.<schema>.<table>` references resolve against catalogs other than the
+    * configured one
+    */
+  def addConnectorCatalog(
+      name: String,
+      catalog: Catalog,
+      defaultSchema: String,
+      catalogProvider: Option[String => Catalog] = None
+  ): Unit =
+    globalContext.connectorCatalogs(name) = ConnectorCatalogEntry(
+      catalog,
+      defaultSchema,
+      catalogProvider
+    )
 
   def getDefaultCatalog: Catalog = globalContext.defaultCatalog
   def getDefaultSchema: String   = globalContext.defaultSchema

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -364,6 +364,10 @@ case class ConnectorCatalogEntry(
     defaultSchema: String,
     catalogProvider: Option[String => Catalog] = None
 ):
+  // Non-primary catalogs are cached per name so repeated 4-part resolutions reuse one Catalog
+  // instance (and its lazily fetched metadata) instead of rebuilding it on every reference
+  private val resolvedCatalogs = ConcurrentHashMap[String, Catalog]()
+
   /**
     * Resolve one of this connector's catalogs by name: the primary (configured) catalog, or another
     * catalog of the same connector when a multi-catalog provider is wired
@@ -372,4 +376,4 @@ case class ConnectorCatalogEntry(
     if name == catalog.catalogName then
       Some(catalog)
     else
-      catalogProvider.map(_(name))
+      catalogProvider.map(provider => resolvedCatalogs.computeIfAbsent(name, provider(_)))

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -354,6 +354,22 @@ object Context:
 
 /**
   * A catalog exposed under a connector name from the active profile, with the connector's
-  * configured default schema for resolving 2-part `<connector>.<table>` references
+  * configured default schema for resolving 2-part `<connector>.<table>` references. Engines that
+  * span multiple catalogs (e.g. Trino) additionally carry a catalogProvider so 4-part
+  * `<connector>.<catalog>.<schema>.<table>` references can address catalogs other than the
+  * configured one (#1867)
   */
-case class ConnectorCatalogEntry(catalog: Catalog, defaultSchema: String)
+case class ConnectorCatalogEntry(
+    catalog: Catalog,
+    defaultSchema: String,
+    catalogProvider: Option[String => Catalog] = None
+):
+  /**
+    * Resolve one of this connector's catalogs by name: the primary (configured) catalog, or another
+    * catalog of the same connector when a multi-catalog provider is wired
+    */
+  def catalogFor(name: String): Option[Catalog] =
+    if name == catalog.catalogName then
+      Some(catalog)
+    else
+      catalogProvider.map(_(name))

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -115,10 +115,12 @@ object RelationRefResolver extends ContextLogSupport:
   end resolveTableRef
 
   /**
-    * Resolve `from <connector>.<table>` / `from <connector>.<schema>.<table>` where the leading
-    * identifier names a connector activated by the current profile. Connector names are checked
-    * only after symbol lookup (models, CTEs, aliases) has failed, and shadow schema names of the
-    * default catalog.
+    * Resolve `from <connector>.<table>`, `from <connector>.<schema>.<table>`, or `from
+    * <connector>.<catalog>.<schema>.<table>` where the leading identifier names a connector
+    * activated by the current profile. Connector names are checked only after symbol lookup
+    * (models, CTEs, aliases) has failed, and shadow schema names of the default catalog. The 4-part
+    * form addresses engines spanning multiple catalogs (e.g. Trino) and resolves through the
+    * connector entry's catalog provider.
     */
   private def resolveConnectorQualifiedRef(ref: TableRef, context: Context): Option[Relation] =
     // Decompose the DotRef structurally (not by splitting fullName) so quoted identifiers
@@ -128,21 +130,22 @@ object RelationRefResolver extends ContextLogSupport:
         context
           .connectorCatalog(connectorName)
           .flatMap { entry =>
-            val schemaAndTable =
+            val target =
               rest match
                 case table :: Nil =>
-                  Some((entry.defaultSchema, table))
+                  Some((entry.catalog, entry.defaultSchema, table))
                 case schema :: table :: Nil =>
-                  Some((schema, table))
+                  Some((entry.catalog, schema, table))
+                case catalog :: schema :: table :: Nil =>
+                  // connector.catalog.schema.table (4-part, #1867)
+                  entry.catalogFor(catalog).map(cat => (cat, schema, table))
                 case _ =>
-                  // connector.catalog.schema.table (4-part) arrives with cross-connector staging
                   None
-            schemaAndTable.flatMap { (schema, table) =>
-              entry
-                .catalog
+            target.flatMap { (catalog, schema, table) =>
+              catalog
                 .findTable(schema, table)
                 .map { tbl =>
-                  val tableName = TableName(Some(entry.catalog.catalogName), Some(schema), table)
+                  val tableName = TableName(Some(catalog.catalogName), Some(schema), table)
                   TableScan(
                     tableName,
                     tbl.schemaType,
@@ -172,18 +175,24 @@ object RelationRefResolver extends ContextLogSupport:
         Nil
 
   private def resolveFromDefaultCatalog(ref: TableRef, context: Context): Relation =
-    val tableName = TableName.parse(ref.name.fullName)
-    context
-      .catalog
-      .findTable(tableName.schema.getOrElse(context.defaultSchema), tableName.name) match
-      case Some(tbl) =>
-        TableScan(tableName, tbl.schemaType, tbl.schemaType.fields, ref.span)
-      case None =>
-        context
-          .workEnv
-          .errorLogger
-          .debug(s"Unresolved table ref: ${ref.name.fullName}: ${context.scope.getAllEntries}")
-        ref
+    if nameParts(ref.name).length > 3 then
+      // A 4-part name resolves only through a connector (connector.catalog.schema.table); when
+      // that fails, leave the reference unresolved instead of failing TableName.parse, so the
+      // error reported downstream points at the reference itself
+      ref
+    else
+      val tableName = TableName.parse(ref.name.fullName)
+      context
+        .catalog
+        .findTable(tableName.schema.getOrElse(context.defaultSchema), tableName.name) match
+        case Some(tbl) =>
+          TableScan(tableName, tbl.schemaType, tbl.schemaType.fields, ref.span)
+        case None =>
+          context
+            .workEnv
+            .errorLogger
+            .debug(s"Unresolved table ref: ${ref.name.fullName}: ${context.scope.getAllEntries}")
+          ref
   end resolveFromDefaultCatalog
 
   /**

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/ConnectorCatalogEntryTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/ConnectorCatalogEntryTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler
+
+import wvlet.lang.catalog.InMemoryCatalog
+import wvlet.uni.test.UniTest
+
+class ConnectorCatalogEntryTest extends UniTest:
+
+  private def newEntry(providerCalls: scala.collection.mutable.ListBuffer[String]) =
+    ConnectorCatalogEntry(
+      catalog = InMemoryCatalog("primary", Nil),
+      defaultSchema = "main",
+      catalogProvider = Some { name =>
+        providerCalls += name
+        InMemoryCatalog(name, Nil)
+      }
+    )
+
+  test("should resolve the primary catalog without invoking the provider") {
+    val calls = scala.collection.mutable.ListBuffer.empty[String]
+    val entry = newEntry(calls)
+    entry.catalogFor("primary").map(_.catalogName) shouldBe Some("primary")
+    calls.toList shouldBe Nil
+  }
+
+  test("should build another catalog through the provider only once per name") {
+    val calls = scala.collection.mutable.ListBuffer.empty[String]
+    val entry = newEntry(calls)
+    entry.catalogFor("extra").map(_.catalogName) shouldBe Some("extra")
+    entry.catalogFor("extra").map(_.catalogName) shouldBe Some("extra")
+    calls.toList shouldBe List("extra")
+  }
+
+  test("should not resolve non-primary catalogs without a provider") {
+    val entry = ConnectorCatalogEntry(InMemoryCatalog("primary", Nil), "main")
+    entry.catalogFor("extra") shouldBe None
+    entry.catalogFor("primary").map(_.catalogName) shouldBe Some("primary")
+  }
+
+end ConnectorCatalogEntryTest

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -75,6 +75,11 @@ class QueryExecutor(
 
   def getConnector(config: ConnectorConfig): Connector = dbConnectorProvider.getConnector(config)
 
+  /** True when the config names a SQL-engine connector (as opposed to a source connector) */
+  def isEngineConnector(config: ConnectorConfig): Boolean = dbConnectorProvider.isEngineType(
+    config.`type`
+  )
+
   // The engine statements execute on: the profile's default engine until a `use <connector>`
   // statement switches it (#1861 Phase 2). Like the global default catalog/schema this is
   // session-level state: concurrent sessions should use separate QueryExecutor instances

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
@@ -104,22 +104,25 @@ class WvletScriptRunner(
       .profile
       .connectors
       .foreach { conn =>
-        val connSchema  = conn.schema.getOrElse("main")
-        val catalogName = conn.catalog.getOrElse(conn.name)
+        val connSchema                               = conn.schema.getOrElse("main")
+        val catalogName                              = conn.catalog.getOrElse(conn.name)
+        def lazyCatalogOf(name: String): LazyCatalog = LazyCatalog(
+          name,
+          conn.dbType,
+          () =>
+            ConnectorCatalogs.catalogOf(queryExecutor.getConnector(conn), conn, name, connSchema)
+        )
         c.addConnectorCatalog(
           conn.name,
-          LazyCatalog(
-            catalogName,
-            conn.dbType,
-            () =>
-              ConnectorCatalogs.catalogOf(
-                queryExecutor.getConnector(conn),
-                conn,
-                catalogName,
-                connSchema
-              )
-          ),
-          connSchema
+          lazyCatalogOf(catalogName),
+          connSchema,
+          // Engines may span multiple catalogs (e.g. Trino), addressable with 4-part
+          // <connector>.<catalog>.<schema>.<table> names
+          catalogProvider =
+            if queryExecutor.isEngineConnector(conn) then
+              Some(lazyCatalogOf)
+            else
+              None
         )
       }
 

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/ConnectorNamespaceTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/ConnectorNamespaceTest.scala
@@ -60,16 +60,17 @@ class ConnectorNamespaceTest extends UniTest:
   profile
     .connectors
     .foreach { c =>
-      val schema      = c.schema.getOrElse("main")
-      val catalogName = c.catalog.get
+      val schema                                   = c.schema.getOrElse("main")
+      def lazyCatalogOf(name: String): LazyCatalog = LazyCatalog(
+        name,
+        c.dbType,
+        () => provider.getDBConnector(c).getCatalog(name, schema)
+      )
       compiler.addConnectorCatalog(
         c.name,
-        LazyCatalog(
-          catalogName,
-          c.dbType,
-          () => provider.getDBConnector(c).getCatalog(catalogName, schema)
-        ),
-        schema
+        lazyCatalogOf(c.catalog.get),
+        schema,
+        catalogProvider = Some(lazyCatalogOf)
       )
     }
 
@@ -78,6 +79,9 @@ class ConnectorNamespaceTest extends UniTest:
 
   // A table that only exists on the second connector's in-memory database
   provider.getDBConnector(second).execute("create table events as select 42 as id")
+  // A second catalog attached to the second connector, for 4-part name resolution
+  provider.getDBConnector(second).execute("attach ':memory:' as extra")
+  provider.getDBConnector(second).execute("create table extra.main.remote_events as select 7 as id")
 
   override def afterAll: Unit =
     executor.close()
@@ -123,6 +127,25 @@ class ConnectorNamespaceTest extends UniTest:
     }
     exception.statusCode shouldBe StatusCode.INVALID_ARGUMENT
     exception.message shouldContain "not defined in profile"
+  }
+
+  test("should resolve a 4-part reference to the connector's configured catalog") {
+    run("use second") shouldBe QueryResult.empty
+    run("from second.memory.main.events").toTSV shouldContain "42"
+  }
+
+  test("should resolve a 4-part reference to another catalog of the same connector") {
+    // `extra` is a second catalog attached to the second connector's database
+    run("from second.extra.main.remote_events").toTSV shouldContain "7"
+  }
+
+  test("should reject a 4-part cross-connector reference while another engine is active") {
+    run("use first") shouldBe QueryResult.empty
+    val exception = intercept[WvletLangException] {
+      run("from second.extra.main.remote_events")
+    }
+    exception.statusCode shouldBe StatusCode.NOT_IMPLEMENTED
+    exception.message shouldContain "use second"
   }
 
 end ConnectorNamespaceTest

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowConnectorStagingTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/FlowConnectorStagingTest.scala
@@ -57,16 +57,17 @@ class FlowConnectorStagingTest extends UniTest:
   profile
     .connectors
     .foreach { c =>
-      val schema      = c.schema.getOrElse("main")
-      val catalogName = c.catalog.get
+      val schema                                   = c.schema.getOrElse("main")
+      def lazyCatalogOf(name: String): LazyCatalog = LazyCatalog(
+        name,
+        c.dbType,
+        () => provider.getDBConnector(c).getCatalog(name, schema)
+      )
       compiler.addConnectorCatalog(
         c.name,
-        LazyCatalog(
-          catalogName,
-          c.dbType,
-          () => provider.getDBConnector(c).getCatalog(catalogName, schema)
-        ),
-        schema
+        lazyCatalogOf(c.catalog.get),
+        schema,
+        catalogProvider = Some(lazyCatalogOf)
       )
     }
 
@@ -77,6 +78,12 @@ class FlowConnectorStagingTest extends UniTest:
   provider
     .getDBConnector(second)
     .execute("create table remote_events as select * from (values (1, 'a'), (2, 'b')) t(id, tag)")
+
+  // A second catalog attached to the second connector, for 4-part staged references
+  provider.getDBConnector(second).execute("attach ':memory:' as extra")
+  provider
+    .getDBConnector(second)
+    .execute("create table extra.main.extra_events as select * from (values (9, 'x')) t(id, tag)")
 
   override def afterAll: Unit =
     executor.close()
@@ -94,6 +101,16 @@ class FlowConnectorStagingTest extends UniTest:
         |}
         |
         |run flow staging_flow""".stripMargin)
+    result.isSuccess shouldBe true
+  }
+
+  test("should stage a 4-part cross-connector table into the stage's engine") {
+    val result = run("""flow four_part_flow = {
+        |  stage copied = from second.extra.main.extra_events
+        |  stage checked = from copied | select count(*) as cnt
+        |}
+        |
+        |run flow four_part_flow""".stripMargin)
     result.isSuccess shouldBe true
   }
 


### PR DESCRIPTION
## Summary

Adds 4-part `connector.catalog.schema.table` name resolution, deferred in #1864 and tracked in #1867. Engines spanning multiple catalogs (e.g. Trino) can now be addressed beyond their configured catalog:

```sql
use trino
from trino.tpch.tiny.nation          -- catalog other than the configured one
from trino.hive.web.access_logs
```

## Design

- **`TableName` stays 3-part; the connector stays out-of-band.** The resolver keeps the connector name in `TableScan.connectorName` (the #1864 design), so SQL generation is untouched — the engine receives plain `catalog.schema.table` — and flow staging (`FlowExecutor.materializeForeignTable`) already reconstructs the qualified name from `TableName.catalog`.
- **`ConnectorCatalogEntry` gains an optional `catalogProvider: String => Catalog`** so one connector can expose multiple catalogs. The provider builds a `LazyCatalog` per requested catalog name (connections still deferred to first use), and is wired only for engine-type connectors — source connectors (Slack) have no catalog concept.
- **Resolver**: `resolveConnectorQualifiedRef` handles the `catalog :: schema :: table` decomposition through `entry.catalogFor(name)`; the primary catalog resolves without the provider.
- **Fallback hardening**: a 4-part name that fails connector resolution previously died in `TableName.parse` with a misleading `SYNTAX_ERROR`; it now stays unresolved so the downstream error points at the reference.
- Cross-connector semantics are unchanged: a 4-part reference to a non-active engine still reports `NOT_IMPLEMENTED` suggesting `use <connector>`, and flows stage 4-part sources automatically.

## Changes

- `Context.scala`: `ConnectorCatalogEntry.catalogProvider` + `catalogFor`
- `Compiler.addConnectorCatalog`: optional `catalogProvider` parameter
- `RelationRefResolver.scala`: 4-part branch + fallback guard
- Wiring: `WvletCompiler` (CLI), `WvletScriptRunner` (REPL/server), with a new `QueryExecutor.isEngineConnector` accessor
- Docs: 4-part form documented in `usage/connectors.md`

## Testing

- `ConnectorNamespaceTest`: 4-part resolution against the configured catalog, against a second attached catalog, and cross-connector rejection while another engine is active
- `FlowConnectorStagingTest`: staging a 4-part cross-connector source into a flow stage's engine
- Full `langJVM/test` and `runner/test` suites green; Scala.js and CLI compilation verified

Part of #1867 (follow-up to #1861/#1864).

🤖 Generated with [Claude Code](https://claude.com/claude-code)