### PR TITLE
feature: Isolate the active engine and catalog per client session on the server

### DIFF
--- a/website/docs/usage/connectors.md
+++ b/website/docs/usage/connectors.md
@@ -73,6 +73,9 @@ Bare names are resolved connector-first: `use analytics` switches to a connector
 `analytics` when the profile defines one, and otherwise behaves like `use schema analytics`
 (see [CLI reference](cli-reference.md) for the schema forms).
 
+The switch is scoped to your session: in the web UI each browser page is its own session, so
+`use` statements of one client never change the engine, catalog, or schema of another.
+
 ## Calling connector tools
 
 Connectors can expose callable tools (MCP-shaped methods) beyond tables and SQL execution. The

--- a/wvlet-api/src/main/scala/wvlet/lang/api/v1/query/QueryRequest.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/v1/query/QueryRequest.scala
@@ -14,6 +14,9 @@ case class QueryRequest(
     isDebugRun: Boolean = true,
     // Limit the max output rows for debug run
     maxRows: Option[Int] = None,
+    // Identifies the client session so `use` statements (active engine, catalog, schema) affect
+    // only this session on the server; requests without a session id share a default session
+    sessionId: Option[String] = None,
     requestId: ULID = ULID.newULID
 ):
   def queryLine: String =

--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/duckdb/DuckDBConnector.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/duckdb/DuckDBConnector.scala
@@ -106,7 +106,14 @@ class DuckDBConnector(workEnv: WorkEnv, prepareTPCH: Boolean = false, prepareTPC
 
   override def withConnection[U](body: DBConnection => U): U =
     try
-      body(getConnection)
+      val c = getConnection
+      // A DuckDB JDBC connection is not safe for concurrent statement execution: parallel use
+      // fails with "Attempting to execute an unsuccessful or closed pending query result".
+      // Serialize access to the shared primary connection; concurrent workloads (parallel flow
+      // stages, per-session server queries) use dedicated sessions via newSession instead
+      c.synchronized {
+        body(c)
+      }
     catch
       case e: SQLException if e.getMessage.contains("403") =>
         throw StatusCode.PERMISSION_DENIED.newException(e.getMessage, e)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Compiler.scala
@@ -16,7 +16,6 @@ package wvlet.lang.compiler
 import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.catalog.Catalog
-import wvlet.lang.compiler.Compiler.presetLibraries
 import wvlet.lang.compiler.analyzer.EmptyTypeResolver
 import wvlet.lang.compiler.analyzer.ModelDependencyAnalyzer
 import wvlet.lang.compiler.analyzer.RemoveUnusedQueries
@@ -89,8 +88,6 @@ object Compiler extends LogSupport:
     List(ParserPhase, RemoveUnusedQueries(), EmptyTypeResolver)
   )
 
-  lazy val presetLibraries: List[CompilationUnit] = CompilationUnit.stdLib
-
 end Compiler
 
 case class CompilerOptions(
@@ -120,6 +117,11 @@ class Compiler(
 
   // A cache for skipping parsing the same file multiple times
   private val compilationUnitCache = CompilationUnitCache()
+
+  // Standard-library units are built per compiler: compilation units carry mutable state
+  // (symbols, resolved trees) tied to this compiler's global context, so sharing them between
+  // concurrently running compilers (e.g. per-session compilers on the server) is not safe
+  private lazy val presetLibraries: List[CompilationUnit] = CompilationUnit.stdLib
 
   // Compilation units in the given source folders (except preset-libraries)
   def localCompilationUnits = listLocalCompilationUnits(compilerOptions.sourceFolders)

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -83,7 +83,8 @@ class QueryExecutor(
 
   // The engine statements execute on: the profile's default engine until a `use <connector>`
   // statement switches it (#1861 Phase 2). Like the global default catalog/schema this is
-  // session-level state: concurrent sessions should use separate QueryExecutor instances
+  // session-level state: concurrent sessions must use separate QueryExecutor instances, as the
+  // server does by building one script runner per client session (ScriptRunnerSessions, #1867)
   private var activeEngine: ConnectorConfig = defaultProfile.defaultEngine
 
   private def activeDBConnector: DBConnector = dbConnectorProvider.getDBConnector(activeEngine)

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
@@ -39,7 +39,11 @@ case class WvletScriptRunnerConfig(
     maxColWidth: Int = 150,
     profile: Profile,
     catalog: Option[String],
-    schema: Option[String]
+    schema: Option[String],
+    // Pre-compile the source folders in the background at startup. Disable for runners created
+    // on demand (per-session runners on the server): the background compilation would race the
+    // very statement that triggered the runner's creation within one compiler
+    precompileSourcePaths: Boolean = true
 )
 
 case class LastOutput(
@@ -127,12 +131,13 @@ class WvletScriptRunner(
       }
 
     // Pre-compile files in the source paths
-    threadManager.runBackgroundTask { () =>
-      val result = c.compileSourcePaths(contextFile = None)
-      // Report compilation errors in the initialization phases
-      if result.hasFailures then
-        workEnv.logError(result.failureException)
-    }
+    if config.precompileSourcePaths then
+      threadManager.runBackgroundTask { () =>
+        val result = c.compileSourcePaths(contextFile = None)
+        // Report compilation errors in the initialization phases
+        if result.hasFailures then
+          workEnv.logError(result.failureException)
+      }
     c
 
   end compiler

--- a/wvlet-server/src/main/scala/wvlet/lang/server/QueryService.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/QueryService.scala
@@ -13,9 +13,6 @@ import wvlet.lang.api.v1.query.QueryStatus
 import wvlet.lang.api.v1.query.QueryStatus.QUEUED
 import wvlet.lang.api.v1.query.QueryStatus.RUNNING
 import wvlet.lang.compiler.query.QueryProgressMonitor
-import wvlet.lang.runner.QueryExecutor
-import wvlet.lang.runner.WvletScriptRunner
-import wvlet.lang.connector.DBConnector
 import wvlet.uni.log.LogSupport
 import wvlet.uni.util.ThreadUtil
 import wvlet.uni.util.ULID
@@ -25,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import scala.jdk.CollectionConverters.*
 
-class QueryService(scriptRunner: WvletScriptRunner) extends LogSupport with AutoCloseable:
+class QueryService(sessions: ScriptRunnerSessions) extends LogSupport with AutoCloseable:
 
   private val threadManager = Executors.newCachedThreadPool(
     ThreadUtil.newDaemonThreadFactory("wvlet-query-service")
@@ -74,7 +71,9 @@ class QueryService(scriptRunner: WvletScriptRunner) extends LogSupport with Auto
     )
     queryMap += queryId -> lastInfo
 
-    val queryResult = scriptRunner.runStatement(request)
+    // Route the query to the runner owning the client's session, so `use` statements switch
+    // the engine/catalog only for that session
+    val queryResult = sessions.runnerFor(request.sessionId).runStatement(request)
     if queryResult.isSuccess then
       // TODO Support pagination
       // TODO Return the query result

--- a/wvlet-server/src/main/scala/wvlet/lang/server/ScriptRunnerSessions.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/ScriptRunnerSessions.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.server
+
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.runner.QueryExecutor
+import wvlet.lang.runner.ThreadManager
+import wvlet.lang.runner.WvletScriptRunner
+import wvlet.lang.runner.WvletScriptRunnerConfig
+import wvlet.lang.runner.connector.ConnectorProvider
+import wvlet.uni.log.LogSupport
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.concurrent.duration.Duration
+import scala.jdk.CollectionConverters.*
+
+/**
+  * One [[WvletScriptRunner]] (compiler + query executor) per client session, so `use` statements —
+  * which switch the session's active engine and mutate the compiler's default catalog/schema — do
+  * not leak between concurrent clients (#1867). Heavy resources (database connections through the
+  * shared [[ConnectorProvider]], the background thread pool) stay shared; only the per-session
+  * compilation and engine-selection state is isolated.
+  *
+  * Requests without a session id share one default session, preserving the previous single-runner
+  * behavior. Sessions idle longer than the timeout are evicted on access; growth is bounded by the
+  * timeout since every live client keeps touching its own session.
+  */
+class ScriptRunnerSessions(
+    workEnv: WorkEnv,
+    config: WvletScriptRunnerConfig,
+    connectorProvider: ConnectorProvider,
+    threadManager: ThreadManager,
+    idleTimeout: Duration
+) extends AutoCloseable
+    with LogSupport:
+
+  private class Entry(val runner: WvletScriptRunner):
+    @volatile
+    var lastAccessMillis: Long = System.currentTimeMillis()
+
+    def touch(): Unit = lastAccessMillis = System.currentTimeMillis()
+
+  private val sessions = ConcurrentHashMap[String, Entry]()
+
+  override def close(): Unit =
+    sessions.values().asScala.foreach(e => e.runner.close())
+    sessions.clear()
+
+  /**
+    * The runner of the given session, creating it on first use. Requests without a session id share
+    * the default session
+    */
+  def runnerFor(sessionId: Option[String]): WvletScriptRunner =
+    evictIdleSessions()
+    val key   = sessionId.getOrElse(ScriptRunnerSessions.DefaultSessionKey)
+    val entry = sessions.computeIfAbsent(
+      key,
+      _ =>
+        debug(s"Creating a new script-runner session: ${key}")
+        Entry(newRunner())
+    )
+    entry.touch()
+    entry.runner
+
+  /** The number of live sessions (for monitoring and tests) */
+  def sessionCount: Int = sessions.size()
+
+  private def newRunner(): WvletScriptRunner = WvletScriptRunner(
+    workEnv,
+    // Session runners are created on demand by the first request, so a background source
+    // pre-compilation would race that request's own compilation within one compiler
+    config.copy(precompileSourcePaths = false),
+    QueryExecutor(connectorProvider, config.profile, workEnv),
+    threadManager
+  )
+
+  private def evictIdleSessions(): Unit =
+    val cutoff = System.currentTimeMillis() - idleTimeout.toMillis
+    sessions
+      .entrySet()
+      .asScala
+      .foreach { e =>
+        val key   = e.getKey
+        val entry = e.getValue
+        // The default session stays: it is the compatibility path for id-less clients
+        if key != ScriptRunnerSessions.DefaultSessionKey && entry.lastAccessMillis < cutoff then
+          if sessions.remove(key, entry) then
+            debug(s"Evicting idle script-runner session: ${key}")
+            // Closing the runner is safe for in-flight queries: the underlying database
+            // connections belong to the shared ConnectorProvider and stay open
+            entry.runner.close()
+      }
+
+end ScriptRunnerSessions
+
+object ScriptRunnerSessions:
+  /** Session key of requests that carry no session id */
+  val DefaultSessionKey = "__default"
+
+  /** Sessions idle longer than this are evicted */
+  val DefaultIdleTimeout: Duration = Duration(1, java.util.concurrent.TimeUnit.HOURS)

--- a/wvlet-server/src/main/scala/wvlet/lang/server/ScriptRunnerSessions.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/ScriptRunnerSessions.scala
@@ -63,14 +63,19 @@ class ScriptRunnerSessions(
     */
   def runnerFor(sessionId: Option[String]): WvletScriptRunner =
     evictIdleSessions()
-    val key   = sessionId.getOrElse(ScriptRunnerSessions.DefaultSessionKey)
-    val entry = sessions.computeIfAbsent(
+    val key = sessionId.getOrElse(ScriptRunnerSessions.DefaultSessionKey)
+    // Create-or-touch atomically: compute and the eviction's computeIfPresent serialize on the
+    // same key, so an entry can never be touched after eviction closed it
+    val entry = sessions.compute(
       key,
-      _ =>
-        debug(s"Creating a new script-runner session: ${key}")
-        Entry(newRunner())
+      (k, existing) =>
+        if existing == null then
+          debug(s"Creating a new script-runner session: ${k}")
+          Entry(newRunner())
+        else
+          existing.touch()
+          existing
     )
-    entry.touch()
     entry.runner
 
   /** The number of live sessions (for monitoring and tests) */
@@ -88,18 +93,25 @@ class ScriptRunnerSessions(
   private def evictIdleSessions(): Unit =
     val cutoff = System.currentTimeMillis() - idleTimeout.toMillis
     sessions
-      .entrySet()
+      .keySet()
       .asScala
-      .foreach { e =>
-        val key   = e.getKey
-        val entry = e.getValue
+      .foreach { key =>
         // The default session stays: it is the compatibility path for id-less clients
-        if key != ScriptRunnerSessions.DefaultSessionKey && entry.lastAccessMillis < cutoff then
-          if sessions.remove(key, entry) then
-            debug(s"Evicting idle script-runner session: ${key}")
-            // Closing the runner is safe for in-flight queries: the underlying database
-            // connections belong to the shared ConnectorProvider and stay open
-            entry.runner.close()
+        if key != ScriptRunnerSessions.DefaultSessionKey then
+          // Re-check the idle time inside computeIfPresent: it serializes with runnerFor's
+          // compute on the same key, so a session touched concurrently is not evicted
+          sessions.computeIfPresent(
+            key,
+            (k, entry) =>
+              if entry.lastAccessMillis < cutoff then
+                debug(s"Evicting idle script-runner session: ${k}")
+                // Closing the runner is safe for in-flight queries: the underlying database
+                // connections belong to the shared ConnectorProvider and stay open
+                entry.runner.close()
+                null
+              else
+                entry
+          )
       }
 
 end ScriptRunnerSessions

--- a/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
@@ -7,7 +7,7 @@ import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.OS
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.runner.connector.ConnectorProvider
-import wvlet.lang.runner.{QueryExecutor, WvletScriptRunnerConfig}
+import wvlet.lang.runner.{ThreadManager, WvletScriptRunnerConfig}
 import wvlet.uni.cli.launcher.option
 import wvlet.uni.control.Control.withResource
 import wvlet.uni.io.IO
@@ -188,7 +188,24 @@ object WvletServer extends LogSupport:
       .bindProvider[WorkEnv, ConnectorProvider] { (workEnv: WorkEnv) =>
         ConnectorProvider(workEnv)
       }
-      .bindSingleton[QueryExecutor]
+      // One script runner (compiler + executor) per client session, so concurrent sessions
+      // racing `use` statements cannot corrupt each other's active engine (#1867). Explicit
+      // provider: the idle-timeout parameter should not be DI-resolved
+      .bindProvider {
+        (
+            workEnv: WorkEnv,
+            config: WvletScriptRunnerConfig,
+            connectorProvider: ConnectorProvider,
+            threadManager: ThreadManager
+        ) =>
+          ScriptRunnerSessions(
+            workEnv,
+            config,
+            connectorProvider,
+            threadManager,
+            ScriptRunnerSessions.DefaultIdleTimeout
+          )
+      }
       .bindImpl[FrontendApi, FrontendApiImpl]
       .bindImpl[FileApi, FileApiImpl]
       .bindImpl[FlowApi, FlowApiImpl]

--- a/wvlet-server/src/test/scala/wvlet/lang/server/ScriptRunnerSessionsTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/ScriptRunnerSessionsTest.scala
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.server
+
+import wvlet.lang.api.v1.query.QueryRequest
+import wvlet.lang.api.v1.query.QuerySelection
+import wvlet.lang.catalog.ConnectorConfig
+import wvlet.lang.catalog.Profile
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.compiler.query.QueryProgressMonitor
+import wvlet.lang.runner.ThreadManager
+import wvlet.lang.runner.WvletScriptRunner
+import wvlet.lang.runner.WvletScriptRunnerConfig
+import wvlet.lang.runner.connector.ConnectorProvider
+import wvlet.uni.test.UniTest
+
+import scala.concurrent.duration.Duration
+
+/**
+  * Per-session isolation of the active engine and default catalog/schema (#1867): `use` statements
+  * of one session must not affect queries of another
+  */
+class ScriptRunnerSessionsTest extends UniTest:
+
+  // An isolated working folder so each session's background source pre-compilation has no
+  // repository files to chew through
+  private val workDir = new java.io.File("target/script-runner-sessions-test")
+  workDir.mkdirs()
+  private val workEnv = WorkEnv(path = workDir.getPath)
+
+  private val first = ConnectorConfig(
+    name = "first",
+    `type` = "duckdb",
+    default = true,
+    catalog = Some("memory"),
+    schema = Some("main")
+  )
+
+  private val second = ConnectorConfig(
+    name = "second",
+    `type` = "duckdb",
+    catalog = Some("memory"),
+    schema = Some("main")
+  )
+
+  private val profile = Profile(name = "multi", connectors = Seq(first, second))
+
+  private val provider      = ConnectorProvider(workEnv)
+  private val threadManager = ThreadManager()
+  private val config        = WvletScriptRunnerConfig(
+    interactive = false,
+    profile = profile,
+    catalog = first.catalog,
+    schema = first.schema
+  )
+
+  private val sessions = ScriptRunnerSessions(
+    workEnv,
+    config,
+    provider,
+    threadManager,
+    ScriptRunnerSessions.DefaultIdleTimeout
+  )
+
+  // A table that only exists on the second connector's in-memory database
+  provider.getDBConnector(second).execute("create table events as select 42 as id")
+
+  override def afterAll: Unit =
+    sessions.close()
+    threadManager.close()
+    provider.close()
+
+  private given QueryProgressMonitor = QueryProgressMonitor.noOp
+
+  private def run(runner: WvletScriptRunner, query: String) = runner.runStatement(
+    QueryRequest(query = query, querySelection = QuerySelection.All)
+  )
+
+  test("should return the same runner for the same session id") {
+    sessions.runnerFor(Some("a")) shouldBeTheSameInstanceAs sessions.runnerFor(Some("a"))
+  }
+
+  test("should share the default session for requests without a session id") {
+    sessions.runnerFor(None) shouldBeTheSameInstanceAs sessions.runnerFor(None)
+  }
+
+  test("should isolate use statements between sessions") {
+    val a = sessions.runnerFor(Some("session-a"))
+    val b = sessions.runnerFor(Some("session-b"))
+
+    run(a, "use second").isSuccess shouldBe true
+    // session-a now targets the second engine
+    run(a, "from second.events").toTSV shouldContain "42"
+
+    // session-b still targets the first engine, so the cross-connector guard rejects the
+    // reference — proving session-a's `use` did not leak
+    val result = run(b, "from second.events")
+    result.isSuccess shouldBe false
+    result.getError.map(_.getMessage).getOrElse("") shouldContain "use second"
+
+    // session-a keeps its switched engine after session-b's failed attempt
+    run(a, "from second.events").toTSV shouldContain "42"
+  }
+
+  test("should compile and run concurrently in separate sessions") {
+    // Sessions must not share mutable compiler state (e.g. standard-library units): concurrent
+    // first compilations in separate sessions used to race symbol completion
+    val pool = java.util.concurrent.Executors.newFixedThreadPool(4)
+    try
+      val futures = (0 until 4).map { i =>
+        pool.submit(
+          new java.util.concurrent.Callable[Boolean]:
+            override def call(): Boolean =
+              run(sessions.runnerFor(Some(s"concurrent-${i}")), "select 1 as x").isSuccess
+        )
+      }
+      futures.foreach(f => f.get() shouldBe true)
+    finally
+      pool.shutdownNow()
+  }
+
+  test("should evict idle sessions but keep the default session") {
+    val shortLived = ScriptRunnerSessions(workEnv, config, provider, threadManager, Duration.Zero)
+    try
+      val defaultRunner = shortLived.runnerFor(None)
+      val r1            = shortLived.runnerFor(Some("ephemeral"))
+      shortLived.sessionCount shouldBe 2
+      // Let the zero idle timeout elapse, then access again: the ephemeral session is rebuilt
+      // while the default session survives
+      Thread.sleep(10)
+      val r2 = shortLived.runnerFor(Some("ephemeral"))
+      (r1 eq r2) shouldBe false
+      shortLived.runnerFor(None) shouldBeTheSameInstanceAs defaultRunner
+    finally
+      shortLived.close()
+  }
+
+end ScriptRunnerSessionsTest

--- a/wvlet-server/src/test/scala/wvlet/lang/server/ScriptRunnerSessionsTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/ScriptRunnerSessionsTest.scala
@@ -19,6 +19,7 @@ import wvlet.lang.catalog.ConnectorConfig
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.compiler.query.QueryProgressMonitor
+import wvlet.lang.runner.QueryResult
 import wvlet.lang.runner.ThreadManager
 import wvlet.lang.runner.WvletScriptRunner
 import wvlet.lang.runner.WvletScriptRunnerConfig
@@ -120,12 +121,18 @@ class ScriptRunnerSessionsTest extends UniTest:
     try
       val futures = (0 until 4).map { i =>
         pool.submit(
-          new java.util.concurrent.Callable[Boolean]:
-            override def call(): Boolean =
-              run(sessions.runnerFor(Some(s"concurrent-${i}")), "select 1 as x").isSuccess
+          new java.util.concurrent.Callable[QueryResult]:
+            override def call(): QueryResult = run(
+              sessions.runnerFor(Some(s"concurrent-${i}")),
+              "select 1 as x"
+            )
         )
       }
-      futures.foreach(f => f.get() shouldBe true)
+      futures.foreach { f =>
+        val result = f.get()
+        result.getError.map(_.getMessage).getOrElse("") shouldBe ""
+        result.isSuccess shouldBe true
+      }
     finally
       pool.shutdownNow()
   }

--- a/wvlet-ui-main/src/main/scala/wvlet/lang/ui/component/UISession.scala
+++ b/wvlet-ui-main/src/main/scala/wvlet/lang/ui/component/UISession.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.ui.component
+
+import wvlet.uni.util.ULID
+
+object UISession:
+  /**
+    * Identifies this browser page load. Sent with query requests so server-side `use` statements
+    * (active engine, catalog, schema) affect only this session
+    */
+  val sessionId: String = ULID.newULIDString

--- a/wvlet-ui-main/src/main/scala/wvlet/lang/ui/component/editor/WvletEditor.scala
+++ b/wvlet-ui-main/src/main/scala/wvlet/lang/ui/component/editor/WvletEditor.scala
@@ -12,6 +12,7 @@ import wvlet.lang.api.v1.query.QuerySelection
 import wvlet.lang.api.v1.query.QuerySelection.Describe
 import wvlet.lang.ui.component.monaco.EditorBase
 import wvlet.lang.ui.component.MainFrame
+import wvlet.lang.ui.component.UISession
 import wvlet.lang.ui.component.WindowSize
 
 object WvletEditor:
@@ -74,7 +75,8 @@ class WvletMonacoEditor(
 
   private def processRequest(request: QueryRequest): Unit =
     ConsoleLog.write(s"Processing query with mode:${request.querySelection}\n${request.query}")
-    queryResultReader.submitQuery(request)
+    // Stamp this page load's session id so server-side `use` state stays scoped to this client
+    queryResultReader.submitQuery(request.copy(sessionId = Some(UISession.sessionId)))
 
   private var errorMonitor: Cancelable = Cancelable.empty
 


### PR DESCRIPTION
## Summary

Fixes the server-side session-state hazard tracked in #1867: `QueryExecutor.activeEngine` and the compiler's global default catalog/schema were session-level state living on a process-wide singleton, so two concurrent clients racing `use` statements could switch each other's target engine and SQL dialect mid-query.

## Design

- **One script runner per client session.** `ScriptRunnerSessions` (new, in `wvlet-server`) builds a `WvletScriptRunner` — which owns the pair that must be isolated together: one `Compiler` (global default catalog/schema) and one `QueryExecutor` (`activeEngine`) — per session id. Heavy resources stay shared: database connections live in the shared `ConnectorProvider`, and the background thread pool is common.
- **Session identity**: `QueryRequest` gains `sessionId: Option[String]`. The web UI mints a ULID per page load (`UISession`) and stamps it on every query. Requests without an id share a stable default session, preserving the previous single-client behavior (and old clients keep working).
- **Lifecycle**: sessions idle longer than 1 hour are evicted on access and their runners closed — safe for in-flight work since connections belong to the shared provider. The default session is never evicted.
- **CLI/REPL** are already isolated by construction (one runner per process) and are unchanged.

Two latent concurrency bugs surfaced by per-session compilers, fixed here:

- **Standard-library units are now per-compiler** (`Compiler.presetLibraries` moved from the companion object to the instance): compilation units carry mutable symbol state tied to one compiler's global context, and concurrent compilers racing lazy symbol completion on the shared trees produced spurious "Cyclic reference detected" errors.
- **On-demand runners skip the startup background pre-compilation** (`WvletScriptRunnerConfig.precompileSourcePaths = false` for session runners): a session runner is created by the first request, so the background compile raced that request's own compilation within one compiler. The REPL keeps pre-compiling as before.

## Testing

- `ScriptRunnerSessionsTest`: session identity (same id → same runner; no id → default), **`use` isolation** (session A switches to a second engine and queries it while session B is still rejected with the `use second` guard), concurrent first-compilations across four sessions (regression for the shared-stdlib race), and idle eviction semantics (default session survives).
- Full `langJVM`, `runner`, and `server` suites green; Scala.js and CLI compilation verified.

Completes the three prioritized multi-connector follow-ups from #1867 (after #1868, #1869).

🤖 Generated with [Claude Code](https://claude.com/claude-code)