### PR TITLE
dep: Upgrade uni to 2026.1.16 and drop the Weaver[Any] workaround

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import scala.scalanative.build.NativeConfig
 import scala.language.implicitConversions
 import WvletBuildKeys.*
 
-val UNI_VERSION = "2026.1.15"
+val UNI_VERSION = "2026.1.16"
 
 val TRINO_VERSION          = "476"
 val AWS_SDK_VERSION        = "2.20.146"

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/Profile.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/Profile.scala
@@ -19,7 +19,6 @@ import wvlet.uni.json.JSON.JSONObject
 import wvlet.uni.json.JSON.JSONString
 import wvlet.uni.json.JSON.JSONValue
 import wvlet.uni.weaver.Weaver
-import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 import wvlet.lang.api.StatusCode
 import wvlet.lang.compiler.DBType
 import wvlet.uni.log.LogSupport
@@ -131,14 +130,6 @@ object Profile extends LogSupport:
   // Wraps the top-level shape of profiles.json: {"profiles": [Profile, ...]}.
   // Private to keep the on-disk schema an implementation detail.
   private case class ProfileConfig(profiles: Seq[Profile] = Seq.empty)
-
-  // Weaver's derivation falls back to Surface-driven weavers for field types with no given in
-  // scope, and that runtime path decodes `Any` with a lossy fallback — every value in a
-  // connector's `properties` map would silently become null. Declaring the case-class weavers as
-  // givens lets the derivation macro compose them with PrimitiveWeaver's map/seq/any givens
-  // (imported above), which preserve primitive JSON values.
-  private given connectorConfigWeaver: Weaver[ConnectorConfig] = Weaver.of[ConnectorConfig]
-  private given profileWeaver: Weaver[Profile]                 = Weaver.of[Profile]
 
   def defaultGenericProfile = Profile(
     name = "local",


### PR DESCRIPTION
## Summary

uni [v2026.1.16](https://github.com/wvlet/uni/releases/tag/v2026.1.16) fixes wvlet/uni#632: `Weaver`'s Surface-driven path now resolves `Any` through `AnyWeaver` instead of the lossy empty-object fallback.

- Bump `UNI_VERSION` to 2026.1.16
- Remove the explicit given chain in `object Profile` (and the now-unneeded `PrimitiveWeaver.given` import) that worked around JSON values in `ConnectorConfig.properties: Map[String, Any]` decoding to null

`ProfileTest`'s "should read connector properties on non-default connectors" (JSON `false` / `3` round-trip) passes against plain `Weaver.of` derivation, confirming the upstream fix. Full JVM test suites plus JS/Native compiles are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)