### PR TITLE
fix: Write .npmrc explicitly before pnpm publish to fix NPM auth

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -78,7 +78,9 @@ jobs:
 
       - name: Publish to NPM
         working-directory: sdks/typescript
-        run: pnpm publish --no-git-checks --provenance --access public
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
+          pnpm publish --no-git-checks --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -133,7 +135,9 @@ jobs:
 
       - name: Publish to NPM
         working-directory: sdks/cli-node
-        run: pnpm publish --no-git-checks --provenance --access public
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
+          pnpm publish --no-git-checks --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -184,7 +188,9 @@ jobs:
 
       - name: Publish to NPM
         working-directory: prismjs-wvlet
-        run: pnpm publish --no-git-checks --provenance --access public
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
+          pnpm publish --no-git-checks --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -238,6 +244,8 @@ jobs:
 
       - name: Publish to NPM
         working-directory: highlightjs-wvlet
-        run: pnpm publish --no-git-checks --provenance --access public
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
+          pnpm publish --no-git-checks --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Diagnose why the v2026.2.0 release could not publish four NPM packages
  (`@wvlet/prismjs-wvlet`, `@wvlet/highlightjs-wvlet`, `@wvlet/wvlet`,
  `@wvlet/cli`). Each hit `npm error 404 Not Found - PUT
  https://registry.npmjs.org/@wvlet/...` **after** the provenance
  statement was accepted by Sigstore.
- NPM masks unauthenticated publishes as 404, so the failure points at
  the auth token not reaching the registry PUT — even for packages
  already published at 2026.1.1.
- This is the first release since the npm→pnpm migration (#1668). Under
  pnpm 10.7.1 the auth token set by `setup-node` into
  `NPM_CONFIG_USERCONFIG` as `${NODE_AUTH_TOKEN}` is not substituted at
  publish time reliably. This PR writes the token directly into a
  `.npmrc` in each package's working directory before `pnpm publish`,
  which is the pattern most pnpm-based release workflows use.

Failed run: https://github.com/wvlet/wvlet/actions/runs/28809039852

## Test plan

- [ ] Manually re-trigger each `NPM Publish` job for tag v2026.2.0 via
      `workflow_dispatch` (or push the next release tag) and confirm
      all four packages appear at 2026.2.0 on npmjs.com.
- [ ] If publishes still 404 after this fix, rotate `NPM_TOKEN`
      (or migrate to NPM Trusted Publishing / OIDC) — the token was
      last updated 2025-06-22 and may be expired or lack scope access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)