### PR TITLE
feature: Switch NPM publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -76,13 +76,12 @@ jobs:
         run: |
           pnpm version ${{ inputs.version }} --no-git-tag-version
 
+      - name: Upgrade npm CLI for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to NPM
         working-directory: sdks/typescript
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          pnpm publish --no-git-checks --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
   publish-cli-node:
     name: Publish @wvlet/cli (Node.js) to NPM
@@ -133,13 +132,12 @@ jobs:
         run: |
           pnpm version ${{ inputs.version }} --no-git-tag-version
 
+      - name: Upgrade npm CLI for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to NPM
         working-directory: sdks/cli-node
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          pnpm publish --no-git-checks --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
   publish-prismjs:
     name: Publish Prism.js Wvlet extension to NPM
@@ -186,13 +184,12 @@ jobs:
         run: |
           pnpm version ${{ inputs.version }} --no-git-tag-version
 
+      - name: Upgrade npm CLI for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to NPM
         working-directory: prismjs-wvlet
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          pnpm publish --no-git-checks --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
   publish-highlightjs:
     name: Publish highlight.js extension to NPM
@@ -242,10 +239,9 @@ jobs:
         run: |
           pnpm version ${{ inputs.version }} --no-git-tag-version
 
+      - name: Upgrade npm CLI for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to NPM
         working-directory: highlightjs-wvlet
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          pnpm publish --no-git-checks --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

Move NPM publishing from `NPM_TOKEN` to [Trusted Publishing](https://docs.npmjs.com/trusted-publishers), using GitHub Actions OIDC. The workflow already declares `id-token: write` and passes `--provenance`, so publishes present an OIDC token that npmjs.com verifies against each package's trusted publisher config — no long-lived secret.

Motivation: v2026.2.0 could not publish (see #1873); the current `NPM_TOKEN` requires OTP for writes (`EOTP` in retries after rotation). Trusted publishing eliminates the token and its rotation/2FA class of failures entirely.

## Changes

- Drop `NODE_AUTH_TOKEN` env and the ad-hoc `.npmrc` write from every publish step.
- Use `npm publish` directly for the publish step (pnpm 10.7.1's publish path doesn't yet drive OIDC trusted publishing reliably). Install / build / test / version bump still run under pnpm.
- Add `npm install -g npm@latest` right before publish so npm CLI is 11.5.1+, which is required for trusted publishing.

## Required setup on npmjs.com (one-time per package)

For each of `@wvlet/prismjs-wvlet`, `@wvlet/highlightjs-wvlet`, `@wvlet/wvlet`, `@wvlet/cli`:

1. npmjs.com → package page → **Settings** → **Publishing access**.
2. **Require two-factor authentication and automation and publishing tokens** — pick whichever mode allows trusted publisher usage.
3. Add a Trusted Publisher:
   - Repository: `wvlet/wvlet`
   - Workflow filename: `npm-publish.yml`
   - Environment: (leave blank)

`@wvlet/cli` does not exist yet — trusted publishing can't be pre-configured for a non-existent package. Options:
- Publish `@wvlet/cli` once with a token (or via the automation token), then add the trusted publisher.
- Or accept that the first `@wvlet/cli` publish will require another token bootstrap.

After trusted publisher is configured, `NPM_TOKEN` secret can be removed from the repo.

## Test plan

- [ ] Configure trusted publishers on npmjs.com for the 3 existing packages.
- [ ] Merge PR.
- [ ] Trigger `workflow_dispatch` for `typescript-sdk`, `prismjs-wvlet`, `highlightjs-wvlet` with `version=2026.2.0`; confirm all three appear on npmjs.com.
- [ ] Decide whether to bootstrap `@wvlet/cli` first-publish with a token, or defer it to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)