### PR TITLE
dep: Upgrade uni to 2026.1.20

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import scala.scalanative.build.NativeConfig
 import scala.language.implicitConversions
 import WvletBuildKeys.*
 
-val UNI_VERSION = "2026.1.18"
+val UNI_VERSION = "2026.1.20"
 
 val TRINO_VERSION          = "476"
 val AWS_SDK_VERSION        = "2.20.146"

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,6 +1,6 @@
 // ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-val UNI_VERSION = "2026.1.18"
+val UNI_VERSION = "2026.1.20"
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.6.1")
 addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo" % "0.13.1")


### PR DESCRIPTION
**Description**

Bumps uni from 2026.1.18 to 2026.1.20.

**Note:** wvlet's `Native` workflow on `main` is **already green** — Scala Steward's earlier bump to 2026.1.18 (#1876) picked up the actual fix (wvlet/uni#640, `uni_curl_shim.c` building on Windows) and both Windows native jobs now pass on `main`. So this is a version-currency bump, not an unblock.

What 2026.1.19 → 2026.1.20 adds on top:

- **wvlet/uni#641** (v2026.1.19) — `NativeServer` links and runs on Windows (`WSAStartup` / `WSAPoll` / `closesocket` shim). Gives uni a real `Scala Native (Windows)` CI job, so this class of break now fails in uni's own CI rather than surfacing downstream here.
- **wvlet/uni#643** (v2026.1.20) — remaining Windows-only native test gaps closed; uni's Windows Native job runs the full `projectNative/test` (1441 tests green).

The value here is that wvlet builds against the uni version whose Windows Scala Native support is actually exercised by upstream CI, so a future regression is caught in uni rather than here.

`langJVM/Test/compile` is clean against the new version — no wvlet code changes.

**Note on CI coverage:** wvlet's own Windows native jobs are gated to `push` on `main` (they're expensive), so they don't run on this PR — they'll run post-merge on `main`. The identical uni shims are already validated by uni's own green `Scala Native (Windows)` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)