### PR TITLE
feature: Add LSP code completion for the Wvlet language server

### DIFF
--- a/sdks/typescript/lib/main.d.ts
+++ b/sdks/typescript/lib/main.d.ts
@@ -30,6 +30,15 @@ export interface WvletJSType {
    * @returns JSON array of symbols
    */
   getDocumentSymbols(content: string): string;
+
+  /**
+   * Compute code completion candidates for a Wvlet source at the given cursor position as JSON
+   * @param content The Wvlet source code
+   * @param line 1-based line number of the cursor
+   * @param column 1-based column number of the cursor
+   * @returns JSON array of completion items ({label, kind, detail})
+   */
+  getCompletionItems(content: string, line: number, column: number): string;
 }
 
 export const WvletJS: WvletJSType;

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -122,3 +122,13 @@ export interface LspSymbol {
   endLine: number;
   endColumn: number;
 }
+
+/**
+ * LSP completion item from the Wvlet compiler.
+ * `kind` is an LSP `CompletionItemKind` numeric value.
+ */
+export interface LspCompletionItem {
+  label: string;
+  kind: number;
+  detail: string;
+}

--- a/sdks/typescript/tests/completion.test.ts
+++ b/sdks/typescript/tests/completion.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+// The completion API is exposed directly on the Scala.js WvletJS module used by the LSP server.
+import { WvletJS } from '../lib/main.js';
+import type { LspCompletionItem } from '../src/types.js';
+
+function complete(
+  content: string,
+  line: number,
+  column: number
+): LspCompletionItem[] {
+  return JSON.parse(WvletJS.getCompletionItems(content, line, column));
+}
+
+describe('WvletJS.getCompletionItems', () => {
+  it('should always offer keyword candidates', () => {
+    const labels = complete('', 1, 1).map((i) => i.label);
+    expect(labels).toContain('from');
+    expect(labels).toContain('select');
+    expect(labels).toContain('where');
+  });
+
+  it('should complete column names of a well-formed query', () => {
+    const src = 'from [[1, "alice", 10]] as person(id, name, age)';
+    const items = complete(src, 1, src.length + 1);
+    const columns = items.filter((i) => i.kind === 5).map((i) => i.label);
+    expect(columns).toContain('id');
+    expect(columns).toContain('name');
+    expect(columns).toContain('age');
+  });
+
+  it('should complete in-file model names', () => {
+    const src = 'model m1 = {\n  from [[1]] as t(x)\n}\nfrom m1';
+    const items = complete(src, 4, 8);
+    const model = items.find((i) => i.label === 'm1');
+    expect(model).toBeDefined();
+    expect(model?.kind).toBe(7);
+  });
+
+  it('should not throw on incomplete input', () => {
+    const labels = complete('from ', 1, 6).map((i) => i.label);
+    expect(labels).toContain('select');
+  });
+});

--- a/vscode-wvlet/README.md
+++ b/vscode-wvlet/README.md
@@ -17,6 +17,11 @@ This extension provides syntax highlighting and language support for the Wvlet q
   - Comment toggling
   - Word pattern recognition
 
+- **Language Server**:
+  - Inline compilation diagnostics
+  - Document outline (models, types, vals, and flows)
+  - Code completion for keywords, in-file definitions, and column names
+
 ## Supported File Extensions
 
 - `.wv` - Wvlet query files

--- a/vscode-wvlet/src/server.ts
+++ b/vscode-wvlet/src/server.ts
@@ -11,12 +11,18 @@ import {
   SymbolKind,
   Range,
   Position,
+  CompletionItem,
+  CompletionItemKind,
 } from 'vscode-languageserver/node';
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 import type { WvletJSType } from '../../sdks/typescript/lib/main';
-import type { LspDiagnostic, LspSymbol } from '../../sdks/typescript/src/types';
+import type {
+  LspDiagnostic,
+  LspSymbol,
+  LspCompletionItem,
+} from '../../sdks/typescript/src/types';
 
 // The Scala.js module exports WvletJS as a named export
 interface WvletJSModule {
@@ -61,6 +67,9 @@ connection.onInitialize((_params: InitializeParams): InitializeResult => {
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       documentSymbolProvider: true,
+      completionProvider: {
+        triggerCharacters: ['.'],
+      },
     },
   };
 });
@@ -165,6 +174,43 @@ connection.onDocumentSymbol(async (params) => {
   } catch (e) {
     connection.console.error(
       `Document symbol error: ${e instanceof Error ? e.message : String(e)}`
+    );
+    return [];
+  }
+});
+
+connection.onCompletion(async (params): Promise<CompletionItem[]> => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) {
+    return [];
+  }
+
+  const module = await getWvletJS();
+  if (!module) {
+    return [];
+  }
+
+  try {
+    // Convert from 0-based (LSP) to 1-based (Wvlet)
+    const line = params.position.line + 1;
+    const column = params.position.character + 1;
+    const resultJson = module.WvletJS.getCompletionItems(
+      document.getText(),
+      line,
+      column
+    );
+    const items: LspCompletionItem[] = JSON.parse(resultJson);
+
+    return items.map(
+      (item): CompletionItem => ({
+        label: item.label,
+        kind: item.kind as CompletionItemKind,
+        detail: item.detail,
+      })
+    );
+  } catch (e) {
+    connection.console.error(
+      `Completion error: ${e instanceof Error ? e.message : String(e)}`
     );
     return [];
   }

--- a/website/docs/usage/vscode.md
+++ b/website/docs/usage/vscode.md
@@ -18,6 +18,23 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Comment Support**: Single-line (`--`) and multi-line (`---`) comments
 - **String Interpolation**: Highlighting for `${...}` expressions
 - **Auto-closing**: Brackets and quotes automatically close when typed
+- **Diagnostics**: Compilation errors are reported inline as you edit
+- **Document Outline**: Models, types, vals, and flows appear in the outline view
+- **Code Completion**: Context-aware suggestions as you type
+
+## Code Completion
+
+The extension suggests candidates while you write a query. Completion is triggered
+automatically as you type or on demand with `Ctrl+Space`, and offers:
+
+- **Keywords**: Wvlet language keywords such as `from`, `select`, and `where`
+- **Model & definition names**: Models, types, vals, and flows defined in the current file
+- **Column names**: Columns available at the cursor, resolved from the query's input relation
+  (for example, after `from` and inside `select` or `where`)
+
+Column suggestions rely on type resolution, so they appear once the surrounding query
+is complete enough to be analyzed. Keyword and definition suggestions are always available,
+including while a query is still being written.
 
 ## Example
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/CompletionProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/CompletionProvider.scala
@@ -85,8 +85,13 @@ object CompletionProvider:
     plan.collectAllNodes.filter(_.span.containsInclusive(offset)).sortBy(_.span.size).headOption
 
   /**
-    * Extract completion items for the definitions (models, types, vals, flows, ...) declared in the
-    * given plan.
+    * Extract completion items for the definitions (models, types, vals, flows, ...) declared at the
+    * top level of the given plan.
+    *
+    * This intentionally recurses only into `PackageDef` containers instead of walking the whole
+    * tree with `collectAllNodes`: definitions nested inside model/type bodies are not referenceable
+    * from other top-level statements, so surfacing them would only add noise (and a full-tree walk
+    * would also visit every expression node of the parse-only plan).
     */
   def definitionItems(plan: LogicalPlan): List[CompletionItem] =
     val buf                        = List.newBuilder[CompletionItem]
@@ -115,14 +120,16 @@ object CompletionProvider:
   /**
     * Extract column completion items visible at the given cursor offset. The columns come from the
     * input and output schema of the query relation that most tightly encloses the cursor; when no
-    * relation encloses the cursor (e.g. an incomplete pipeline), the widest relation in the plan is
-    * used as a fallback.
+    * relation encloses the cursor (e.g. a trailing space or newline at the end of the file), the
+    * relation nearest to the cursor is used as a fallback so that suggestions come from the query
+    * being edited rather than an unrelated definition elsewhere in the file.
     */
   def columnItems(plan: LogicalPlan, offset: Int): List[CompletionItem] =
     val relations = plan
       .collectAllNodes
-      .collect { case r: Relation =>
-        r
+      .collect {
+        case r: Relation if r.span.exists =>
+          r
       }
     if relations.isEmpty then
       Nil
@@ -131,7 +138,17 @@ object CompletionProvider:
         .filter(_.span.containsInclusive(offset))
         .sortBy(_.span.size)
         .headOption
-        .getOrElse(relations.maxBy(_.span.size))
+        .getOrElse {
+          // Nearest relation by span distance to the cursor
+          relations.minBy { r =>
+            if offset < r.span.start then
+              r.span.start - offset
+            else if offset > r.span.end then
+              offset - r.span.end
+            else
+              0
+          }
+        }
       val fields =
         try
           enclosing.inputRelationType.fields ++ enclosing.relationType.fields
@@ -142,6 +159,8 @@ object CompletionProvider:
         .filter(f => !f.name.isEmpty && f.name.name != "<NoName>")
         .map(f => CompletionItem(f.name.name, CompletionItemKind.Field, f.dataType.typeName.name))
         .distinct
+
+  end columnItems
 
   /**
     * Compute completion candidates for the given source at the given character offset.

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/CompletionProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/CompletionProvider.scala
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.lsp
+
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.compiler.parser.WvletToken
+import wvlet.lang.model.SyntaxTreeNode
+import wvlet.lang.model.plan.*
+
+/**
+  * A single completion candidate returned to an editor / language server client.
+  *
+  * @param label
+  *   The text inserted when the item is selected (e.g. a keyword, model name, or column name)
+  * @param kind
+  *   The LSP `CompletionItemKind` numeric value (see [[CompletionItemKind]])
+  * @param detail
+  *   A short human-readable description shown next to the label (e.g. a data type or "model")
+  */
+case class CompletionItem(label: String, kind: Int, detail: String)
+
+/**
+  * LSP `CompletionItemKind` numeric values used by Wvlet completions. Only the subset relevant to
+  * Wvlet is defined here. See the LSP specification for the full enumeration.
+  */
+object CompletionItemKind:
+  val Field: Int    = 5
+  val Variable: Int = 6
+  val Class: Int    = 7
+  val Function: Int = 3
+  val Keyword: Int  = 14
+  val Struct: Int   = 22
+
+/**
+  * Provides code completion candidates for the Wvlet language.
+  *
+  * The provider is deliberately platform independent (it lives in the cross-built `wvlet-lang`
+  * module) so it can run on both the JVM and Scala.js, and be unit tested on the JVM. It never
+  * throws for malformed or incomplete input: each completion tier is attempted independently and
+  * degrades gracefully so that at least keyword candidates are always returned.
+  *
+  * The candidates are produced in three tiers:
+  *   1. Keywords — always available.
+  *   1. In-file definitions (model / type / val / flow / partial-query names) — extracted with a
+  *      parse-only pass that tolerates parse errors.
+  *   1. Column names of the query relation enclosing the cursor — extracted after best-effort full
+  *      typing.
+  */
+object CompletionProvider:
+
+  /**
+    * Keyword candidates. These are always available regardless of the cursor position.
+    */
+  def keywordItems: List[CompletionItem] =
+    WvletToken
+      .keywords
+      .map(k => CompletionItem(k.str, CompletionItemKind.Keyword, "keyword"))
+      .toList
+
+  /**
+    * Find the innermost syntax tree node whose span contains the given character offset.
+    *
+    * The innermost node is the one with the smallest containing span. Returns None if no node
+    * covers the offset (e.g. the offset points into trailing whitespace of an incomplete input).
+    *
+    * @param plan
+    *   The (unresolved or resolved) plan to search
+    * @param offset
+    *   0-based character offset into the source
+    */
+  def nodeAt(plan: LogicalPlan, offset: Int): Option[SyntaxTreeNode] =
+    plan.collectAllNodes.filter(_.span.containsInclusive(offset)).sortBy(_.span.size).headOption
+
+  /**
+    * Extract completion items for the definitions (models, types, vals, flows, ...) declared in the
+    * given plan.
+    */
+  def definitionItems(plan: LogicalPlan): List[CompletionItem] =
+    val buf                        = List.newBuilder[CompletionItem]
+    def loop(p: LogicalPlan): Unit =
+      p match
+        case pkg: PackageDef =>
+          pkg.statements.foreach(loop)
+        case m: ModelDef =>
+          buf += CompletionItem(m.name.fullName, CompletionItemKind.Class, "model")
+        case t: TypeDef =>
+          buf += CompletionItem(t.name.name, CompletionItemKind.Struct, "type")
+        case f: TopLevelFunctionDef =>
+          buf += CompletionItem(f.functionDef.name.name, CompletionItemKind.Function, "function")
+        case v: ValDef =>
+          buf += CompletionItem(v.name.name, CompletionItemKind.Variable, "val")
+        case p: PartialQueryDef =>
+          buf += CompletionItem(p.name.name, CompletionItemKind.Function, "query")
+        case fl: FlowDef =>
+          buf += CompletionItem(fl.name.name, CompletionItemKind.Function, "flow")
+        case _ =>
+    loop(plan)
+    buf.result()
+
+  end definitionItems
+
+  /**
+    * Extract column completion items visible at the given cursor offset. The columns come from the
+    * input and output schema of the query relation that most tightly encloses the cursor; when no
+    * relation encloses the cursor (e.g. an incomplete pipeline), the widest relation in the plan is
+    * used as a fallback.
+    */
+  def columnItems(plan: LogicalPlan, offset: Int): List[CompletionItem] =
+    val relations = plan
+      .collectAllNodes
+      .collect { case r: Relation =>
+        r
+      }
+    if relations.isEmpty then
+      Nil
+    else
+      val enclosing = relations
+        .filter(_.span.containsInclusive(offset))
+        .sortBy(_.span.size)
+        .headOption
+        .getOrElse(relations.maxBy(_.span.size))
+      val fields =
+        try
+          enclosing.inputRelationType.fields ++ enclosing.relationType.fields
+        catch
+          case _: Throwable =>
+            Nil
+      fields
+        .filter(f => !f.name.isEmpty && f.name.name != "<NoName>")
+        .map(f => CompletionItem(f.name.name, CompletionItemKind.Field, f.dataType.typeName.name))
+        .distinct
+
+  /**
+    * Compute completion candidates for the given source at the given character offset.
+    *
+    * This is the main entry point. It never throws: parsing and typing are attempted defensively so
+    * that partially written queries (e.g. a trailing `from ` or `select foo.`) still yield useful
+    * results.
+    *
+    * @param content
+    *   The full Wvlet source text
+    * @param offset
+    *   0-based character offset of the cursor
+    * @param compiler
+    *   A compiler used for the best-effort full typing pass that resolves column names
+    */
+  def complete(content: String, offset: Int, compiler: Compiler): List[CompletionItem] =
+    val items = List.newBuilder[CompletionItem]
+
+    // Tier 1: keywords (always)
+    items ++= keywordItems
+
+    // Tier 2: in-file definitions via a parse-only pass (resilient to parse errors)
+    val parseUnit = CompilationUnit.fromWvletString(content)
+    try
+      parseUnit.unresolvedPlan = ParserPhase.parseOnly(parseUnit)
+      items ++= definitionItems(parseUnit.unresolvedPlan)
+    catch
+      case _: Throwable =>
+      // Ignore parse errors — offer whatever we could extract
+
+    // Tier 3: column names via a best-effort full typing pass
+    try
+      val typedUnit = CompilationUnit.fromWvletString(content)
+      compiler.compileSingleUnit(typedUnit)
+      val plan = typedUnit.resolvedPlan
+      if plan.nonEmpty then
+        items ++= columnItems(plan, offset)
+    catch
+      case _: Throwable =>
+      // Ignore typing errors — column completion is opportunistic
+
+    dedup(items.result())
+
+  end complete
+
+  /**
+    * Remove duplicate candidates, keeping the first occurrence of each label. Column and definition
+    * candidates (added later) therefore never shadow one another, and keyword duplicates are
+    * dropped.
+    */
+  private def dedup(items: List[CompletionItem]): List[CompletionItem] =
+    val seen   = scala.collection.mutable.HashSet.empty[String]
+    val result = List.newBuilder[CompletionItem]
+    items.foreach { item =>
+      if seen.add(item.label) then
+        result += item
+    }
+    result.result()
+
+end CompletionProvider

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/CompletionProviderTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/CompletionProviderTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.lsp
+
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.WorkEnv
+import wvlet.uni.test.UniTest
+
+class CompletionProviderTest extends UniTest:
+
+  private def newCompiler: Compiler = Compiler(CompilerOptions(workEnv = WorkEnv(path = ".")))
+
+  private def complete(content: String, offset: Int): List[CompletionItem] = CompletionProvider
+    .complete(content, offset, newCompiler)
+
+  test("should always offer keyword candidates"):
+    val items  = complete("", 0)
+    val labels = items.map(_.label).toSet
+    labels shouldContain "from"
+    labels shouldContain "select"
+    labels shouldContain "where"
+    // Keywords carry the Keyword kind
+    items.find(_.label == "from").map(_.kind) shouldBe Some(CompletionItemKind.Keyword)
+
+  test("should complete in-file model names"):
+    val src =
+      """model my_model = {
+        |  from [[1, "alice", 10]] as person(id, name, age)
+        |}
+        |from my_model""".stripMargin
+    val items     = complete(src, src.length)
+    val modelItem = items.find(_.label == "my_model")
+    modelItem.map(_.kind) shouldBe Some(CompletionItemKind.Class)
+    modelItem.map(_.detail) shouldBe Some("model")
+
+  test("should complete column names from an inline values relation"):
+    val src    = """from [[1, "alice", 10], [2, "bob", 20]] as person(id, name, age)"""
+    val items  = complete(src, src.length)
+    val labels = items.map(_.label).toSet
+    labels shouldContain "id"
+    labels shouldContain "name"
+    labels shouldContain "age"
+    items.find(_.label == "id").map(_.kind) shouldBe Some(CompletionItemKind.Field)
+
+  test("should complete columns of the input relation inside a select"):
+    val src = "from [[1, \"alice\", 10]] as person(id, name, age)\nselect id"
+    // Place the cursor inside the select projection
+    val offset = src.length
+    val labels = complete(src, offset).map(_.label).toSet
+    labels shouldContain "id"
+    labels shouldContain "name"
+    labels shouldContain "age"
+
+  test("should not throw on incomplete input with a trailing from"):
+    val src = "from "
+    // Must return at least keyword candidates without throwing
+    val items = complete(src, src.length)
+    items.map(_.label).toSet shouldContain "select"
+
+  test("should not throw on an incomplete select projection"):
+    val src   = "from [[1, \"alice\", 10]] as person(id, name, age)\nselect "
+    val items = complete(src, src.length)
+    // Keywords must still be present even if typing of the incomplete query fails
+    items.map(_.label).toSet shouldContain "where"
+
+  test("nodeAt should return None when the offset is outside every span"):
+    // An empty source has no nodes covering a positive offset
+    val emptyPlan = wvlet.lang.model.plan.LogicalPlan.empty
+    CompletionProvider.nodeAt(emptyPlan, 5) shouldBe None
+
+end CompletionProviderTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/CompletionProviderTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/CompletionProviderTest.scala
@@ -75,6 +75,21 @@ class CompletionProviderTest extends UniTest:
     // Keywords must still be present even if typing of the incomplete query fails
     items.map(_.label).toSet shouldContain "where"
 
+  test("should suggest columns from the nearest query when the cursor is past the end of file"):
+    // A large model at the top of the file plus a small query at the bottom. With a trailing
+    // newline the cursor is outside every relation's span, so the fallback must pick the
+    // nearest (bottom) query, not the widest relation inside the unrelated model
+    val src =
+      """model big_model = {
+        |  from [[1, "x", 2.0, true, "y"]] as wide(model_c1, model_c2, model_c3, model_c4, model_c5)
+        |}
+        |from [[1, "alice"]] as person(id, name)
+        |""".stripMargin
+    val labels = complete(src, src.length).map(_.label).toSet
+    labels shouldContain "id"
+    labels shouldContain "name"
+    labels shouldNotContain "model_c1"
+
   test("nodeAt should return None when the offset is outside every span"):
     // An empty source has no nodes covering a positive offset
     val emptyPlan = wvlet.lang.model.plan.LogicalPlan.empty

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -17,6 +17,8 @@ import wvlet.lang.api.v1.compile.CompileError
 import wvlet.lang.api.v1.compile.ErrorLocation
 import wvlet.lang.BuildInfo
 import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.compiler.lsp.CompletionItem
+import wvlet.lang.compiler.lsp.CompletionProvider
 import wvlet.lang.model.plan.*
 import wvlet.uni.weaver.Weaver
 import wvlet.uni.weaver.codec.PrimitiveWeaver.given
@@ -249,6 +251,41 @@ object WvletJS:
     summon[Weaver[List[LspSymbol]]].toJson(symbols.toList)
 
   end getDocumentSymbols
+
+  // Cached compiler instance for completion (avoids repeated initialization and filesystem scans)
+  private lazy val completionCompiler = Compiler(CompilerOptions(workEnv = WorkEnv(path = ".")))
+
+  /**
+    * Compute code completion candidates for the given source at the given cursor position.
+    *
+    * @param content
+    *   The Wvlet source code
+    * @param line
+    *   1-based line number of the cursor
+    * @param column
+    *   1-based column number of the cursor
+    * @return
+    *   JSON array of completion items: [{label, kind, detail}]. `kind` is an LSP
+    *   `CompletionItemKind` numeric value. Returns at least keyword candidates even for invalid or
+    *   incomplete input.
+    */
+  @JSExport
+  def getCompletionItems(content: String, line: Int, column: Int): String =
+    val items =
+      try
+        val sourceFile = CompilationUnit.fromWvletString(content).sourceFile
+        sourceFile.ensureLoaded
+        val offset = sourceFile.offsetAt(wvlet.lang.api.LinePosition(line, column))
+        CompletionProvider.complete(content, offset, completionCompiler)
+      catch
+        case _: Throwable =>
+          // Fall back to keyword candidates if the position cannot be resolved
+          CompletionProvider.keywordItems
+
+    given Weaver[CompletionItem] = Weaver.of[CompletionItem]
+    summon[Weaver[List[CompletionItem]]].toJson(items)
+
+  end getCompletionItems
 
 end WvletJS
 


### PR DESCRIPTION
## Summary

Adds LSP **code completion** to the Wvlet language server. The editor already
provided diagnostics and a document outline; this fills in the remaining
completion capability so authors get suggestions while writing `.wv` queries.

Completion is produced in three tiers, each attempted independently so the
result degrades gracefully on incomplete/invalid input:

1. **Keywords** — always available (`from`, `select`, `where`, ...).
2. **In-file definitions** — model / type / val / flow / partial-query names,
   extracted with a parse-only pass that tolerates parse errors.
3. **Column names** — columns visible at the cursor, resolved from the enclosing
   query relation's input/output schema after a best-effort full typing pass.

## Changes

- **`wvlet-lang`**: new platform-independent `CompletionProvider` (+ `CompletionItem`,
  `CompletionItemKind`, and a `nodeAt(offset)` utility) in a new
  `wvlet.lang.compiler.lsp` package. Pure and cross-built, so it runs on JVM and
  Scala.js and is unit-testable on the JVM.
- **`wvlet-sdk-js`**: `WvletJS.getCompletionItems(content, line, column)` returns a
  JSON array of `{label, kind, detail}` (1-based line/column, LSP
  `CompletionItemKind` numeric values), using the same Weaver JSON pattern as the
  existing diagnostics/symbols APIs.
- **TypeScript SDK**: `LspCompletionItem` type, `getCompletionItems` in the
  `WvletJSType` declaration.
- **VS Code server** (`vscode-wvlet/src/server.ts`): advertises
  `completionProvider` (trigger character `.`) and implements `onCompletion`,
  converting LSP 0-based positions to Wvlet 1-based.
- **Docs**: VS Code extension docs and README updated to describe the language
  server features, including completion.

## Testing

- `langJVM/testOnly *CompletionProviderTest` — **7/7 passed** (keywords, model
  names, column completion from an inline relation, columns inside `select`,
  graceful handling of incomplete `from `/`select `, `nodeAt` bounds).
- `projectJVM/Test/compile` and `projectJS/Test/compile` — **success** (verifies
  the completion core compiles for both platforms).
- TypeScript SDK vitest (`pnpm test:ci`) — **11/11 passed**, including 4 new
  completion tests exercising the linked Scala.js bundle end-to-end.
- VS Code extension `pnpm run compile` (esbuild) — **success**.

## Known limitations

- Column completion requires the surrounding query to be complete enough to type;
  a fully empty projection (`select ` with nothing after it) yields only keyword
  and definition candidates. Keyword/definition tiers are always available.
- Dot-completion (`foo.`) is scoped to the same union of candidates and left to
  the client's prefix filtering; deeper member resolution is out of scope here.
- Table-name completion comes from source-defined models only; the JS catalog is
  empty by default, so live catalog tables are not suggested.

Related to #1612 (completion checkbox — not closed; other items remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)