### PR TITLE
feature: Add LSP hover for models, columns, and types

### DIFF
--- a/sdks/typescript/lib/main.d.ts
+++ b/sdks/typescript/lib/main.d.ts
@@ -39,6 +39,15 @@ export interface WvletJSType {
    * @returns JSON array of completion items ({label, kind, detail})
    */
   getCompletionItems(content: string, line: number, column: number): string;
+
+  /**
+   * Compute hover information (type / model signature) for a Wvlet source at the given cursor position as JSON
+   * @param content The Wvlet source code
+   * @param line 1-based line number of the cursor
+   * @param column 1-based column number of the cursor
+   * @returns JSON object ({content, startLine, startColumn, endLine, endColumn}) or the literal `null` when there is nothing to show
+   */
+  getHover(content: string, line: number, column: number): string;
 }
 
 export const WvletJS: WvletJSType;

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -132,3 +132,16 @@ export interface LspCompletionItem {
   kind: number;
   detail: string;
 }
+
+/**
+ * LSP hover information from the Wvlet compiler.
+ * `content` is markdown text; the line/column fields are the 1-based source
+ * range of the hovered node.
+ */
+export interface LspHover {
+  content: string;
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}

--- a/sdks/typescript/tests/hover.test.ts
+++ b/sdks/typescript/tests/hover.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+// The hover API is exposed directly on the Scala.js WvletJS module used by the LSP server.
+import { WvletJS } from '../lib/main.js';
+import type { LspHover } from '../src/types.js';
+
+function hover(
+  content: string,
+  line: number,
+  column: number
+): LspHover | null {
+  return JSON.parse(WvletJS.getHover(content, line, column));
+}
+
+describe('WvletJS.getHover', () => {
+  it('should show the model schema for a model reference', () => {
+    const src =
+      'model my_model = {\n  from [[1, "alice", 10]] as person(id, name, age)\n}\nfrom my_model';
+    // Cursor on `my_model` in the last line (1-based line 4, column ~7)
+    const result = hover(src, 4, 7);
+    expect(result).not.toBeNull();
+    expect(result?.content).toContain('model my_model');
+    expect(result?.content).toContain('name: string');
+  });
+
+  it('should show name and type for a column reference', () => {
+    const src = 'from [[1, "alice", 10]] as person(id, name, age)\nselect name';
+    // Cursor on `name` in the select (line 2, column 8)
+    const result = hover(src, 2, 8);
+    expect(result).not.toBeNull();
+    expect(result?.content).toContain('name: string');
+  });
+
+  it('should return null when hovering an empty position', () => {
+    expect(hover('', 1, 1)).toBeNull();
+  });
+
+  it('should not throw on incomplete input', () => {
+    expect(hover('from ', 1, 6)).toBeNull();
+  });
+});

--- a/vscode-wvlet/src/server.ts
+++ b/vscode-wvlet/src/server.ts
@@ -13,6 +13,8 @@ import {
   Position,
   CompletionItem,
   CompletionItemKind,
+  Hover,
+  MarkupKind,
 } from 'vscode-languageserver/node';
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -22,6 +24,7 @@ import type {
   LspDiagnostic,
   LspSymbol,
   LspCompletionItem,
+  LspHover,
 } from '../../sdks/typescript/src/types';
 
 // The Scala.js module exports WvletJS as a named export
@@ -70,6 +73,7 @@ connection.onInitialize((_params: InitializeParams): InitializeResult => {
       completionProvider: {
         triggerCharacters: ['.'],
       },
+      hoverProvider: true,
     },
   };
 });
@@ -213,6 +217,50 @@ connection.onCompletion(async (params): Promise<CompletionItem[]> => {
       `Completion error: ${e instanceof Error ? e.message : String(e)}`
     );
     return [];
+  }
+});
+
+connection.onHover(async (params): Promise<Hover | null> => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) {
+    return null;
+  }
+
+  const module = await getWvletJS();
+  if (!module) {
+    return null;
+  }
+
+  try {
+    // Convert from 0-based (LSP) to 1-based (Wvlet)
+    const line = params.position.line + 1;
+    const column = params.position.character + 1;
+    const resultJson = module.WvletJS.getHover(
+      document.getText(),
+      line,
+      column
+    );
+    const hover: LspHover | null = JSON.parse(resultJson);
+    if (!hover) {
+      return null;
+    }
+
+    return {
+      contents: {
+        kind: MarkupKind.Markdown,
+        value: hover.content,
+      },
+      range: {
+        // Convert from 1-based (Wvlet) to 0-based (LSP)
+        start: Position.create(hover.startLine - 1, hover.startColumn - 1),
+        end: Position.create(hover.endLine - 1, hover.endColumn - 1),
+      },
+    };
+  } catch (e) {
+    connection.console.error(
+      `Hover error: ${e instanceof Error ? e.message : String(e)}`
+    );
+    return null;
   }
 });
 

--- a/website/docs/usage/vscode.md
+++ b/website/docs/usage/vscode.md
@@ -21,6 +21,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Diagnostics**: Compilation errors are reported inline as you edit
 - **Document Outline**: Models, types, vals, and flows appear in the outline view
 - **Code Completion**: Context-aware suggestions as you type
+- **Hover Information**: Type and schema details when you hover over models and columns
 
 ## Code Completion
 
@@ -35,6 +36,18 @@ automatically as you type or on demand with `Ctrl+Space`, and offers:
 Column suggestions rely on type resolution, so they appear once the surrounding query
 is complete enough to be analyzed. Keyword and definition suggestions are always available,
 including while a query is still being written.
+
+## Hover Information
+
+Hover over a symbol to see its type information in a tooltip:
+
+- **Models**: The model signature — its name, parameters, and output schema (each column with its type)
+- **Columns**: The column name and its resolved data type, for example `name: string`
+- **Type definitions**: The declared fields of a type
+
+Hover relies on type resolution, so it appears once the surrounding query is complete
+enough to be analyzed. When the cursor is not on a symbol with a resolved type, no tooltip
+is shown.
 
 ## Example
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/HoverProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/HoverProvider.scala
@@ -99,7 +99,15 @@ object HoverProvider:
           .sortBy(_.span.size)
         candidates
           .iterator
-          .flatMap(n => markdownFor(n).map(md => toResult(md, n, sourceFile)))
+          .flatMap { n =>
+            // Rendering a single candidate may fail while resolving its type on an
+            // incomplete/malformed AST; skip it so an enclosing candidate can still hover
+            try
+              markdownFor(n).map(md => toResult(md, n, sourceFile))
+            catch
+              case _: Throwable =>
+                None
+          }
           .nextOption()
     catch
       case _: Throwable =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/HoverProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/HoverProvider.scala
@@ -1,0 +1,242 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.lsp
+
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.ModelSymbolInfo
+import wvlet.lang.model.DataType
+import wvlet.lang.model.DataType.NamedType
+import wvlet.lang.model.RelationType
+import wvlet.lang.model.SyntaxTreeNode
+import wvlet.lang.model.expr.NameExpr
+import wvlet.lang.model.plan.*
+
+/**
+  * The result of a hover request: markdown text to render plus the 1-based source range of the
+  * hovered node, so the editor can underline exactly the token the information describes.
+  *
+  * @param content
+  *   Markdown text (typically a fenced ```wvlet code block) describing the hovered node
+  * @param startLine
+  *   1-based line of the range start
+  * @param startColumn
+  *   1-based column of the range start
+  * @param endLine
+  *   1-based line of the range end
+  * @param endColumn
+  *   1-based column of the range end
+  */
+case class HoverResult(
+    content: String,
+    startLine: Int,
+    startColumn: Int,
+    endLine: Int,
+    endColumn: Int
+)
+
+/**
+  * Provides hover (type information / model signature) tooltips for the Wvlet language.
+  *
+  * Like [[CompletionProvider]], this lives in the cross-built `wvlet-lang` module so it runs on
+  * both the JVM and Scala.js and can be unit tested on the JVM. Hover requests fire on possibly
+  * incomplete source, so the best-effort compile is wrapped defensively: any failure yields `None`
+  * rather than throwing.
+  *
+  * The information shown depends on the innermost typed node under the cursor:
+  *   - A reference to (or definition of) a model shows the model signature: its name, parameters,
+  *     and output schema.
+  *   - A resolved column/attribute reference shows `name: type`.
+  *   - A relation step (from / where / select) shows its output schema.
+  *   - A type definition shows its declared fields.
+  *
+  * When no node under the cursor carries resolved type information, `None` is returned so the
+  * editor shows no noisy fallback tooltip.
+  */
+object HoverProvider:
+
+  /** Maximum number of schema columns shown before the list is truncated. */
+  private val MaxSchemaColumns: Int = 30
+
+  /**
+    * Compute the hover result for the given source at the given character offset.
+    *
+    * This never throws: parsing and typing are attempted defensively so that a partially written
+    * query does not surface an error to the editor.
+    *
+    * @param content
+    *   The full Wvlet source text
+    * @param offset
+    *   0-based character offset of the cursor
+    * @param compiler
+    *   A compiler used for the best-effort full typing pass that resolves types and symbols
+    */
+  def hover(content: String, offset: Int, compiler: Compiler): Option[HoverResult] =
+    try
+      val unit = CompilationUnit.fromWvletString(content)
+      compiler.compileSingleUnit(unit)
+      val plan = unit.resolvedPlan
+      if plan.isEmpty then
+        None
+      else
+        val sourceFile = unit.sourceFile
+        sourceFile.ensureLoaded
+        // Candidate nodes covering the cursor, innermost (smallest span) first
+        val candidates = plan
+          .collectAllNodes
+          .filter(n => n.span.exists && n.span.containsInclusive(offset))
+          .sortBy(_.span.size)
+        candidates
+          .iterator
+          .flatMap(n => markdownFor(n).map(md => toResult(md, n, sourceFile)))
+          .nextOption()
+    catch
+      case _: Throwable =>
+        // Hover is opportunistic: never surface a compile error to the editor
+        None
+
+  end hover
+
+  /**
+    * Build the markdown description for a single node, or `None` if the node carries no useful type
+    * information. Node kinds are tried from the most specific (model / type definitions) to the
+    * most general (any typed name or relation).
+    */
+  private def markdownFor(node: SyntaxTreeNode): Option[String] =
+    node match
+      case m: ModelScan =>
+        Some(modelMarkdown(m.name.name, Nil, m.relationType))
+      case m: ModelDef =>
+        Some(modelMarkdown(m.name.name, m.params, m.relationType))
+      case t: TypeDef =>
+        Some(typeMarkdown(t))
+      case e: NameExpr =>
+        modelReferenceMarkdown(e).orElse(columnMarkdown(e))
+      case r: Relation =>
+        schemaMarkdown(r.relationType).map(body => codeBlock(body))
+      case _ =>
+        None
+
+  /**
+    * If the given name expression resolves to a model symbol, render the model signature. Otherwise
+    * `None`.
+    */
+  private def modelReferenceMarkdown(e: NameExpr): Option[String] =
+    try
+      e.symbol.symbolInfo match
+        case msi: ModelSymbolInfo =>
+          msi.dataType match
+            case rt: RelationType =>
+              Some(modelMarkdown(e.leafName, Nil, rt))
+            case _ =>
+              None
+        case _ =>
+          None
+    catch
+      case _: Throwable =>
+        None
+
+  /**
+    * Render `name: type` for a name expression that has a resolved, non-relation data type (i.e. a
+    * column or scalar attribute reference).
+    */
+  private def columnMarkdown(e: NameExpr): Option[String] =
+    val dt = e.dataType
+    if dt.isResolved && !dt.isRelationType && dt != DataType.UnknownType then
+      Some(codeBlock(s"${e.leafName}: ${dt.typeDescription}"))
+    else
+      None
+
+  /** Render a model signature: header (name + parameters) followed by the output schema. */
+  private def modelMarkdown(name: String, params: List[DefArg], rt: RelationType): String =
+    val header =
+      if params.isEmpty then
+        s"model ${name}"
+      else
+        val paramStr = params
+          .map(p => s"${p.name.name}: ${p.givenDataType.typeDescription}")
+          .mkString(", ")
+        s"model ${name}(${paramStr})"
+    val fields = schemaLines(rt)
+    val body   =
+      if fields.isEmpty then
+        ""
+      else
+        fields.mkString("\n", "\n", "")
+    codeBlock(s"${header}${body}")
+
+  /** Render a type definition: its name followed by its declared fields. */
+  private def typeMarkdown(t: TypeDef): String =
+    val fields = t
+      .elems
+      .collect { case f: FieldDef =>
+        s"  ${f.name.name}: ${f.fieldType.fullName}"
+      }
+    val body =
+      if fields.isEmpty then
+        ""
+      else
+        fields.mkString("\n", "\n", "")
+    codeBlock(s"type ${t.name.name}${body}")
+
+  /**
+    * Render just the schema (column: type lines) of a relation type, or `None` if it has no named
+    * fields.
+    */
+  private def schemaMarkdown(rt: RelationType): Option[String] =
+    val lines = schemaLines(rt)
+    if lines.isEmpty then
+      None
+    else
+      Some(lines.mkString("\n"))
+
+  /**
+    * Produce the indented `column: type` lines for a relation type, dropping unnamed columns and
+    * truncating over [[MaxSchemaColumns]] with a trailing "… N more" line.
+    */
+  private def schemaLines(rt: RelationType): List[String] =
+    val fields =
+      try
+        rt.fields
+      catch
+        case _: Throwable =>
+          Nil
+    val named = fields.filter(f => !f.name.isEmpty && f.name.name != "<NoName>")
+    val shown = named
+      .take(MaxSchemaColumns)
+      .map(f => s"  ${f.name.name}: ${f.dataType.typeDescription}")
+    if named.size > MaxSchemaColumns then
+      shown :+ s"  … ${named.size - MaxSchemaColumns} more"
+    else
+      shown
+
+  /** Wrap the given body in a fenced ```wvlet code block. */
+  private def codeBlock(body: String): String = s"```wvlet\n${body}\n```"
+
+  /** Convert a markdown body and the hovered node's span into a 1-based [[HoverResult]]. */
+  private def toResult(
+      markdown: String,
+      node: SyntaxTreeNode,
+      sourceFile: wvlet.lang.compiler.SourceFile
+  ): HoverResult =
+    val span = node.span
+    HoverResult(
+      content = markdown,
+      startLine = sourceFile.offsetToLine(span.start) + 1,
+      startColumn = sourceFile.offsetToColumn(span.start),
+      endLine = sourceFile.offsetToLine(span.end) + 1,
+      endColumn = sourceFile.offsetToColumn(span.end)
+    )
+
+end HoverProvider

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/HoverProviderTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/HoverProviderTest.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.lsp
+
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.WorkEnv
+import wvlet.uni.test.UniTest
+
+class HoverProviderTest extends UniTest:
+
+  private def newCompiler: Compiler = Compiler(CompilerOptions(workEnv = WorkEnv(path = ".")))
+
+  private def hover(content: String, offset: Int): Option[HoverResult] = HoverProvider.hover(
+    content,
+    offset,
+    newCompiler
+  )
+
+  test("should show the model schema when hovering a model reference"):
+    val src =
+      """model my_model = {
+        |  from [[1, "alice", 10]] as person(id, name, age)
+        |}
+        |from my_model""".stripMargin
+    // Place the cursor on the `my_model` reference in the last line
+    val offset = src.lastIndexOf("my_model") + 1
+    val result = hover(src, offset)
+    result.isDefined shouldBe true
+    val content = result.get.content
+    content shouldContain "model my_model"
+    content shouldContain "id: long"
+    content shouldContain "name: string"
+    content shouldContain "age: long"
+
+  test("should show name and type when hovering a column reference"):
+    val src = "from [[1, \"alice\", 10]] as person(id, name, age)\nselect name"
+    // Cursor on the `name` column in the select
+    val offset = src.lastIndexOf("name") + 1
+    val result = hover(src, offset)
+    result.isDefined shouldBe true
+    result.get.content shouldContain "name: string"
+
+  test("should return the source range of the hovered node"):
+    val src    = "from [[1, \"alice\"]] as person(id, name)\nselect name"
+    val offset = src.lastIndexOf("name") + 1
+    val result = hover(src, offset)
+    result.isDefined shouldBe true
+    // The `select name` is on the 2nd line (1-based)
+    result.get.startLine shouldBe 2
+    result.get.startColumn shouldBe (src.lastIndexOf("name") - src.lastIndexOf("\n"))
+
+  test("should return None when hovering whitespace with no node"):
+    val src = "from [[1, \"alice\"]] as person(id, name)\n\n"
+    // Cursor on the trailing empty line
+    val result = hover(src, src.length)
+    result shouldBe None
+
+  test("should return None for an empty source"):
+    hover("", 0) shouldBe None
+
+  test("should not throw on incomplete input with a trailing from"):
+    // Must not throw; typing of an incomplete query may fail, yielding None
+    hover("from ", 5) shouldBe None
+
+  test("should not throw on an incomplete select projection"):
+    val src = "from [[1, \"alice\", 10]] as person(id, name, age)\nselect "
+    // Must not throw regardless of whether a hover can be produced
+    hover(src, src.length)
+
+end HoverProviderTest

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -19,6 +19,7 @@ import wvlet.lang.BuildInfo
 import wvlet.lang.compiler.parser.ParserPhase
 import wvlet.lang.compiler.lsp.CompletionItem
 import wvlet.lang.compiler.lsp.CompletionProvider
+import wvlet.lang.compiler.lsp.HoverProvider
 import wvlet.lang.model.plan.*
 import wvlet.uni.weaver.Weaver
 import wvlet.uni.weaver.codec.PrimitiveWeaver.given
@@ -287,6 +288,51 @@ object WvletJS:
 
   end getCompletionItems
 
+  // Cached compiler instance for hover (avoids repeated initialization and filesystem scans)
+  private lazy val hoverCompiler = Compiler(CompilerOptions(workEnv = WorkEnv(path = ".")))
+
+  /**
+    * Compute hover information (type / model signature) for the given source at the given cursor
+    * position.
+    *
+    * @param content
+    *   The Wvlet source code
+    * @param line
+    *   1-based line number of the cursor
+    * @param column
+    *   1-based column number of the cursor
+    * @return
+    *   JSON object `{content, startLine, startColumn, endLine, endColumn}` describing the hovered
+    *   node, or the JSON literal `null` when there is nothing to show (unknown position, unresolved
+    *   type, or incomplete input). `content` is markdown; line/column values are 1-based.
+    */
+  @JSExport
+  def getHover(content: String, line: Int, column: Int): String =
+    val result =
+      try
+        val sourceFile = CompilationUnit.fromWvletString(content).sourceFile
+        sourceFile.ensureLoaded
+        val offset = sourceFile.offsetAt(wvlet.lang.api.LinePosition(line, column))
+        HoverProvider.hover(content, offset, hoverCompiler)
+      catch
+        case _: Throwable =>
+          None
+
+    result match
+      case Some(h) =>
+        val hover = LspHover(
+          content = h.content,
+          startLine = h.startLine,
+          startColumn = h.startColumn,
+          endLine = h.endLine,
+          endColumn = h.endColumn
+        )
+        Weaver.of[LspHover].toJson(hover)
+      case None =>
+        "null"
+
+  end getHover
+
 end WvletJS
 
 /**
@@ -318,6 +364,12 @@ case class LspSymbol(
     endLine: Int,
     endColumn: Int
 )
+
+/**
+  * LSP hover representation for JSON serialization. `content` is markdown text; the line/column
+  * fields describe the 1-based source range of the hovered node.
+  */
+case class LspHover(content: String, startLine: Int, startColumn: Int, endLine: Int, endColumn: Int)
 
 /**
   * LSP SymbolKind constants (subset from the LSP specification)


### PR DESCRIPTION
## What

Adds LSP **hover** support (type information / model signatures) to the Wvlet language server, building on the code-completion foundation from #1882.

Hovering a symbol now shows:
- **Model reference or definition** — the model signature: name, parameters (if any), and output schema (`column: type` lines)
- **Column / attribute reference** — `name: type`
- **Relation step** (from / where / select) — its output schema
- **Type definition** — its declared fields

## How

- **`wvlet.lang.compiler.lsp.HoverProvider`** (cross-built, JVM + Scala.js): `hover(content, offset, compiler): Option[HoverResult]`. Runs a best-effort full compile, finds the innermost typed node covering the cursor (reusing the same span-based node search as `CompletionProvider`), and renders a fenced ```` ```wvlet ```` markdown block. Parsing/typing is wrapped defensively so incomplete source yields `None` instead of throwing or showing a noisy tooltip. Schemas over 30 columns are truncated with a `… N more` line. `HoverResult` carries the markdown plus the hovered node's 1-based source range.
- **`WvletJS.getHover(content, line, column)`**: JSON export mirroring `getCompletionItems`, returning `{content, startLine, startColumn, endLine, endColumn}` or the literal `null` when there is nothing to show.
- **TypeScript**: `LspHover` added to `sdks/typescript/src/types.ts` and the `getHover` method to the `WvletJSType` declaration in `lib/main.d.ts`.
- **`vscode-wvlet/src/server.ts`**: advertises `hoverProvider: true` and implements `connection.onHover`, returning Markdown contents and the node range (converting 1-based → 0-based).
- **Docs**: `website/docs/usage/vscode.md` gains a brief user-facing Hover Information section.

## Testing

- `HoverProviderTest` (JVM, `UniTest`): model-reference schema, column `name: type`, source-range, whitespace/empty → `None`, incomplete input doesn't throw — 7 tests.
- `hover.test.ts` (vitest, drives the linked Scala.js bundle) — 4 tests.

```
langJVM lsp:  15 tests, 15 passed (CompletionProviderTest + HoverProviderTest)
vitest:       3 files, 15 tests passed
projectJVM/Test/compile + projectJS/Test/compile: success
vscode-wvlet esbuild compile: Build complete
```

## Notes / limitations

- The JS catalog is an empty `InMemoryCatalog`, so hover surfaces model/type info defined in the source file only (no external catalog metadata) — consistent with completion.
- Integer literals resolve to `long`, so inline-relation schemas show `long` for integer columns.

Related: wvlet/wvlet#1612 (does not close it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)