### PR TITLE
feature: Add LSP go-to-definition for models and types

### DIFF
--- a/sdks/typescript/lib/main.d.ts
+++ b/sdks/typescript/lib/main.d.ts
@@ -48,6 +48,15 @@ export interface WvletJSType {
    * @returns JSON object ({content, startLine, startColumn, endLine, endColumn}) or the literal `null` when there is nothing to show
    */
   getHover(content: string, line: number, column: number): string;
+
+  /**
+   * Compute the go-to-definition target (model / type definition) for a Wvlet source at the given cursor position as JSON
+   * @param content The Wvlet source code
+   * @param line 1-based line number of the cursor
+   * @param column 1-based column number of the cursor
+   * @returns JSON object ({startLine, startColumn, endLine, endColumn}) or the literal `null` when there is nothing to resolve
+   */
+  getDefinition(content: string, line: number, column: number): string;
 }
 
 export const WvletJS: WvletJSType;

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -145,3 +145,15 @@ export interface LspHover {
   endLine: number;
   endColumn: number;
 }
+
+/**
+ * LSP go-to-definition target from the Wvlet compiler.
+ * The line/column fields are the 1-based source range of the target
+ * model/type definition.
+ */
+export interface LspDefinition {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}

--- a/sdks/typescript/tests/definition.test.ts
+++ b/sdks/typescript/tests/definition.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+// The go-to-definition API is exposed directly on the Scala.js WvletJS module used by the LSP server.
+import { WvletJS } from '../lib/main.js';
+import type { LspDefinition } from '../src/types.js';
+
+function definition(
+  content: string,
+  line: number,
+  column: number
+): LspDefinition | null {
+  return JSON.parse(WvletJS.getDefinition(content, line, column));
+}
+
+describe('WvletJS.getDefinition', () => {
+  it('should jump from a model reference to its definition', () => {
+    const src =
+      'model my_model = {\n  from [[1, "alice", 10]] as person(id, name, age)\n}\nfrom my_model';
+    // Cursor on `my_model` in the last line (line 4, column 7)
+    const result = definition(src, 4, 7);
+    expect(result).not.toBeNull();
+    expect(result?.startLine).toBe(1);
+    expect(result?.startColumn).toBe(1);
+  });
+
+  it('should jump from a type reference to its definition', () => {
+    const src =
+      'type point = {\n  x: long\n  y: long\n}\ntype line = {\n  start: point\n  stop: point\n}';
+    // Cursor on the `point` reference in the `line` definition (line 6, column 10)
+    const result = definition(src, 6, 10);
+    expect(result).not.toBeNull();
+    expect(result?.startLine).toBe(1);
+  });
+
+  it('should return null when the cursor is on the definition itself', () => {
+    const src =
+      'model my_model = {\n  from [[1, "alice", 10]] as person(id, name, age)\n}\nfrom my_model';
+    // Cursor on `my_model` within its own definition (line 1, column 7)
+    expect(definition(src, 1, 7)).toBeNull();
+  });
+
+  it('should return null for an unknown reference', () => {
+    expect(definition('from unknown_model', 1, 7)).toBeNull();
+  });
+
+  it('should not throw on incomplete input', () => {
+    expect(definition('from ', 1, 6)).toBeNull();
+  });
+});

--- a/vscode-wvlet/src/server.ts
+++ b/vscode-wvlet/src/server.ts
@@ -15,6 +15,7 @@ import {
   CompletionItemKind,
   Hover,
   MarkupKind,
+  Location,
 } from 'vscode-languageserver/node';
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -25,6 +26,7 @@ import type {
   LspSymbol,
   LspCompletionItem,
   LspHover,
+  LspDefinition,
 } from '../../sdks/typescript/src/types';
 
 // The Scala.js module exports WvletJS as a named export
@@ -74,6 +76,7 @@ connection.onInitialize((_params: InitializeParams): InitializeResult => {
         triggerCharacters: ['.'],
       },
       hoverProvider: true,
+      definitionProvider: true,
     },
   };
 });
@@ -259,6 +262,51 @@ connection.onHover(async (params): Promise<Hover | null> => {
   } catch (e) {
     connection.console.error(
       `Hover error: ${e instanceof Error ? e.message : String(e)}`
+    );
+    return null;
+  }
+});
+
+connection.onDefinition(async (params): Promise<Location | null> => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) {
+    return null;
+  }
+
+  const module = await getWvletJS();
+  if (!module) {
+    return null;
+  }
+
+  try {
+    // Convert from 0-based (LSP) to 1-based (Wvlet)
+    const line = params.position.line + 1;
+    const column = params.position.character + 1;
+    const resultJson = module.WvletJS.getDefinition(
+      document.getText(),
+      line,
+      column
+    );
+    const definition: LspDefinition | null = JSON.parse(resultJson);
+    if (!definition) {
+      return null;
+    }
+
+    // Single-document scope: the definition lives in the same document
+    return {
+      uri: document.uri,
+      range: {
+        // Convert from 1-based (Wvlet) to 0-based (LSP)
+        start: Position.create(
+          definition.startLine - 1,
+          definition.startColumn - 1
+        ),
+        end: Position.create(definition.endLine - 1, definition.endColumn - 1),
+      },
+    };
+  } catch (e) {
+    connection.console.error(
+      `Definition error: ${e instanceof Error ? e.message : String(e)}`
     );
     return null;
   }

--- a/website/docs/usage/vscode.md
+++ b/website/docs/usage/vscode.md
@@ -22,6 +22,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Document Outline**: Models, types, vals, and flows appear in the outline view
 - **Code Completion**: Context-aware suggestions as you type
 - **Hover Information**: Type and schema details when you hover over models and columns
+- **Go to Definition**: Jump from a model or type reference to its definition
 
 ## Code Completion
 
@@ -48,6 +49,17 @@ Hover over a symbol to see its type information in a tooltip:
 Hover relies on type resolution, so it appears once the surrounding query is complete
 enough to be analyzed. When the cursor is not on a symbol with a resolved type, no tooltip
 is shown.
+
+## Go to Definition
+
+Place the cursor on a model or type reference and use **Go to Definition** (`F12`, or
+`Cmd`/`Ctrl` + click) to jump to the `model` or `type` statement that defines it. For
+example, from `from my_model` you can jump to the `model my_model = ...` definition, and
+from a type reference to its `type` declaration.
+
+Definitions are resolved within the current file only: the language server compiles each
+document standalone, so references to models or types defined in other files are not
+navigated. Cross-file and workspace-wide navigation is future work.
 
 ## Example
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/DefinitionProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/DefinitionProvider.scala
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.lsp
+
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.SourceFile
+import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.model.SyntaxTreeNode
+import wvlet.lang.model.expr.NameExpr
+import wvlet.lang.model.plan.*
+
+/**
+  * The result of a go-to-definition request: the 1-based source range of the definition the cursor
+  * resolves to. Only same-document definitions are returned, so the editor navigates within the
+  * current file.
+  *
+  * @param startLine
+  *   1-based line of the definition range start
+  * @param startColumn
+  *   1-based column of the definition range start
+  * @param endLine
+  *   1-based line of the definition range end
+  * @param endColumn
+  *   1-based column of the definition range end
+  */
+case class DefinitionResult(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int)
+
+/**
+  * Provides go-to-definition for the Wvlet language: given a cursor on a model or type reference,
+  * it returns the source range of the defining `model`/`type` statement.
+  *
+  * Like [[CompletionProvider]] and [[HoverProvider]], this lives in the cross-built `wvlet-lang`
+  * module so it runs on both the JVM and Scala.js and can be unit tested on the JVM. Definition
+  * requests fire on possibly incomplete source, so the best-effort compile is wrapped defensively:
+  * any failure yields `None` rather than throwing.
+  *
+  * Resolution combines two strategies for robustness:
+  *   - The resolved symbol chain: when full typing succeeds, a reference node carries a symbol
+  *     whose `tree` is the defining `ModelDef`/`TypeDef`.
+  *   - A name fallback: the referenced identifier is matched against the top-level `model`/`type`
+  *     names collected from a parse-only pass, so navigation keeps working when full typing fails
+  *     (e.g. a later statement has an error).
+  *
+  * This is single-document only: the language server compiles each document standalone, so
+  * definitions resolve within the same file. Cross-file / workspace navigation is future work.
+  */
+object DefinitionProvider:
+
+  /** A top-level model or type definition collected from a parse-only pass. */
+  private case class DefinitionEntry(name: String, node: SyntaxTreeNode)
+
+  /**
+    * Compute the definition target for the given source at the given character offset.
+    *
+    * This never throws: parsing and typing are attempted defensively so that a partially written
+    * query does not surface an error to the editor. Returns `None` when the cursor is not on a
+    * resolvable model/type reference (e.g. on whitespace, a keyword, the definition itself, or an
+    * unknown name).
+    *
+    * @param content
+    *   The full Wvlet source text
+    * @param offset
+    *   0-based character offset of the cursor
+    * @param compiler
+    *   A compiler used for the best-effort full typing pass that resolves symbols
+    */
+  def definition(content: String, offset: Int, compiler: Compiler): Option[DefinitionResult] =
+    try
+      // Collect top-level model/type definitions with a parse-only pass (resilient to parse errors)
+      val parseUnit   = CompilationUnit.fromWvletString(content)
+      val definitions =
+        try
+          parseUnit.unresolvedPlan = ParserPhase.parseOnly(parseUnit)
+          collectDefinitions(parseUnit.unresolvedPlan)
+        catch
+          case _: Throwable =>
+            Nil
+
+      // Best-effort full typing so that references carry resolved symbols. If typing fails, fall
+      // back to the parse-only plan so that name-based resolution still works.
+      val typedUnit  = CompilationUnit.fromWvletString(content)
+      val searchUnit =
+        try
+          compiler.compileSingleUnit(typedUnit)
+          if typedUnit.resolvedPlan.nonEmpty then
+            typedUnit
+          else
+            parseUnit
+        catch
+          case _: Throwable =>
+            parseUnit
+
+      val searchPlan =
+        if searchUnit eq typedUnit then
+          typedUnit.resolvedPlan
+        else
+          parseUnit.unresolvedPlan
+      if searchPlan.isEmpty then
+        None
+      else
+        val sourceFile = searchUnit.sourceFile
+        sourceFile.ensureLoaded
+        // Candidate nodes covering the cursor, innermost (smallest span) first
+        val candidates = searchPlan
+          .collectAllNodes
+          .filter(n => n.span.exists && n.span.containsInclusive(offset))
+          .sortBy(_.span.size)
+        candidates
+          .iterator
+          .flatMap { n =>
+            // Resolving a single candidate may fail on an incomplete/malformed AST; skip it so an
+            // enclosing candidate can still resolve.
+            try
+              definitionFor(n, definitions, offset).map(d => toResult(d, sourceFile))
+            catch
+              case _: Throwable =>
+                None
+          }
+          .nextOption()
+    catch
+      case _: Throwable =>
+        // Go-to-definition is opportunistic: never surface a compile error to the editor
+        None
+
+  end definition
+
+  /**
+    * Collect the top-level `model` and `type` definitions of the given plan. Like
+    * [[CompletionProvider.definitionItems]], this recurses only into `PackageDef` containers, since
+    * only top-level definitions are referenceable from other statements.
+    */
+  private def collectDefinitions(plan: LogicalPlan): List[DefinitionEntry] =
+    val buf                        = List.newBuilder[DefinitionEntry]
+    def loop(p: LogicalPlan): Unit =
+      p match
+        case pkg: PackageDef =>
+          pkg.statements.foreach(loop)
+        case m: ModelDef =>
+          buf += DefinitionEntry(m.name.name, m)
+        case t: TypeDef =>
+          buf += DefinitionEntry(t.name.name, t)
+        case _ =>
+    loop(plan)
+    buf.result()
+
+  /**
+    * Resolve the defining `ModelDef`/`TypeDef` for a single candidate node, or `None` if the node
+    * is not a model/type reference. The resolved symbol's definition tree is preferred; the
+    * collected definition names are used as a fallback when typing did not resolve the symbol.
+    *
+    * A definition whose span contains the cursor is treated as "already at the definition" and
+    * yields `None`, so navigating from the definition itself (or a keyword/name within it) does not
+    * jump to itself.
+    */
+  private def definitionFor(
+      node: SyntaxTreeNode,
+      definitions: List[DefinitionEntry],
+      offset: Int
+  ): Option[SyntaxTreeNode] =
+    val bySymbol =
+      try
+        val sym = node.symbol
+        if sym.isDefined then
+          sym.tree match
+            case d: ModelDef =>
+              Some(d)
+            case d: TypeDef =>
+              Some(d)
+            case _ =>
+              None
+        else
+          None
+      catch
+        case _: Throwable =>
+          None
+
+    bySymbol
+      .orElse {
+        referenceName(node).flatMap { name =>
+          definitions.find(_.name == name).map(_.node)
+        }
+      }
+      .filter(d => d.span.exists && !d.span.containsInclusive(offset))
+
+  /**
+    * The referenced model/type name carried by a node, or `None` if the node is not a name-like
+    * reference. Definitions themselves store their name as a compiler `Name` (not a child node), so
+    * they are not mistaken for references here.
+    */
+  private def referenceName(node: SyntaxTreeNode): Option[String] =
+    node match
+      case m: ModelScan =>
+        Some(m.name.name)
+      case t: TableRef =>
+        Some(t.name.leafName)
+      case n: NameExpr =>
+        Some(n.leafName)
+      case _ =>
+        None
+
+  /** Convert a definition node's span into a 1-based [[DefinitionResult]]. */
+  private def toResult(node: SyntaxTreeNode, sourceFile: SourceFile): DefinitionResult =
+    val span = node.span
+    DefinitionResult(
+      startLine = sourceFile.offsetToLine(span.start) + 1,
+      startColumn = sourceFile.offsetToColumn(span.start),
+      endLine = sourceFile.offsetToLine(span.end) + 1,
+      endColumn = sourceFile.offsetToColumn(span.end)
+    )
+
+end DefinitionProvider

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/DefinitionProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/DefinitionProvider.scala
@@ -78,39 +78,36 @@ object DefinitionProvider:
     */
   def definition(content: String, offset: Int, compiler: Compiler): Option[DefinitionResult] =
     try
+      val unit = CompilationUnit.fromWvletString(content)
+
       // Collect top-level model/type definitions with a parse-only pass (resilient to parse errors)
-      val parseUnit   = CompilationUnit.fromWvletString(content)
       val definitions =
         try
-          parseUnit.unresolvedPlan = ParserPhase.parseOnly(parseUnit)
-          collectDefinitions(parseUnit.unresolvedPlan)
+          unit.unresolvedPlan = ParserPhase.parseOnly(unit)
+          collectDefinitions(unit.unresolvedPlan)
         catch
           case _: Throwable =>
             Nil
 
-      // Best-effort full typing so that references carry resolved symbols. If typing fails, fall
-      // back to the parse-only plan so that name-based resolution still works.
-      val typedUnit  = CompilationUnit.fromWvletString(content)
-      val searchUnit =
-        try
-          compiler.compileSingleUnit(typedUnit)
-          if typedUnit.resolvedPlan.nonEmpty then
-            typedUnit
-          else
-            parseUnit
-        catch
-          case _: Throwable =>
-            parseUnit
+      // Best-effort full typing so that references carry resolved symbols. Compiling re-parses the
+      // unit, but the collected definition nodes stay valid: only their spans are used, and the
+      // spans index the same content. If typing fails, the unresolved (parse-only) plan below keeps
+      // name-based resolution working.
+      try
+        compiler.compileSingleUnit(unit)
+      catch
+        case _: Throwable =>
+        // Ignore compile errors — fall back to the parse-only plan
 
       val searchPlan =
-        if searchUnit eq typedUnit then
-          typedUnit.resolvedPlan
+        if unit.resolvedPlan.nonEmpty then
+          unit.resolvedPlan
         else
-          parseUnit.unresolvedPlan
+          unit.unresolvedPlan
       if searchPlan.isEmpty then
         None
       else
-        val sourceFile = searchUnit.sourceFile
+        val sourceFile = unit.sourceFile
         sourceFile.ensureLoaded
         // Candidate nodes covering the cursor, innermost (smallest span) first
         val candidates = searchPlan

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/DefinitionProviderTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/DefinitionProviderTest.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.lsp
+
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.WorkEnv
+import wvlet.uni.test.UniTest
+
+class DefinitionProviderTest extends UniTest:
+
+  private def newCompiler: Compiler = Compiler(CompilerOptions(workEnv = WorkEnv(path = ".")))
+
+  private def definition(content: String, offset: Int): Option[DefinitionResult] =
+    DefinitionProvider.definition(content, offset, newCompiler)
+
+  test("should jump from a model reference to its model definition"):
+    val src =
+      """model my_model = {
+        |  from [[1, "alice", 10]] as person(id, name, age)
+        |}
+        |from my_model""".stripMargin
+    // Cursor on the `my_model` reference in the last line
+    val offset = src.lastIndexOf("my_model") + 1
+    val result = definition(src, offset)
+    result.isDefined shouldBe true
+    // The `model my_model` definition starts on line 1
+    result.get.startLine shouldBe 1
+    result.get.startColumn shouldBe 1
+
+  test("should jump from a type reference to its type definition"):
+    val src =
+      """type point = {
+        |  x: long
+        |  y: long
+        |}
+        |type line = {
+        |  start: point
+        |  stop: point
+        |}""".stripMargin
+    // Cursor on the first `point` reference in the `line` definition
+    val offset = src.indexOf("start: point") + "start: ".length + 1
+    val result = definition(src, offset)
+    result.isDefined shouldBe true
+    // The `type point` definition starts on line 1
+    result.get.startLine shouldBe 1
+    result.get.startColumn shouldBe 1
+
+  test("should resolve a model reference by name when later typing fails"):
+    // The second query references an unknown column, so full typing fails; the model reference must
+    // still resolve to its definition via the name fallback.
+    val src =
+      """model my_model = {
+        |  from [[1, "alice", 10]] as person(id, name, age)
+        |}
+        |from my_model
+        |from [[1]] as t(x)
+        |select does_not_exist""".stripMargin
+    val offset = src.indexOf("from my_model") + "from ".length + 1
+    val result = definition(src, offset)
+    result.isDefined shouldBe true
+    result.get.startLine shouldBe 1
+
+  test("should return None when the cursor is on the definition itself"):
+    val src =
+      """model my_model = {
+        |  from [[1, "alice", 10]] as person(id, name, age)
+        |}
+        |from my_model""".stripMargin
+    // Cursor on the `my_model` name within its own definition on line 1
+    val offset = src.indexOf("my_model") + 1
+    definition(src, offset) shouldBe None
+
+  test("should return None when the cursor is on a keyword"):
+    val src =
+      """model my_model = {
+        |  from [[1, "alice", 10]] as person(id, name, age)
+        |}
+        |from my_model""".stripMargin
+    // Cursor on the `from` keyword in the last line
+    val offset = src.lastIndexOf("from")
+    definition(src, offset) shouldBe None
+
+  test("should return None when hovering trailing whitespace"):
+    val src = "from [[1, \"alice\"]] as person(id, name)\n\n"
+    definition(src, src.length) shouldBe None
+
+  test("should return None for an unknown reference"):
+    val src    = "from unknown_model"
+    val offset = src.lastIndexOf("unknown_model") + 1
+    definition(src, offset) shouldBe None
+
+  test("should not throw on incomplete input with a trailing from"):
+    // Must not throw; typing of an incomplete query may fail, yielding None
+    definition("from ", 5) shouldBe None
+
+  test("should return None for an empty source"):
+    definition("", 0) shouldBe None
+
+end DefinitionProviderTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/DefinitionProviderTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/DefinitionProviderTest.scala
@@ -34,10 +34,9 @@ class DefinitionProviderTest extends UniTest:
     // Cursor on the `my_model` reference in the last line
     val offset = src.lastIndexOf("my_model") + 1
     val result = definition(src, offset)
-    result.isDefined shouldBe true
     // The `model my_model` definition starts on line 1
-    result.get.startLine shouldBe 1
-    result.get.startColumn shouldBe 1
+    result.map(_.startLine) shouldBe Some(1)
+    result.map(_.startColumn) shouldBe Some(1)
 
   test("should jump from a type reference to its type definition"):
     val src =
@@ -52,10 +51,9 @@ class DefinitionProviderTest extends UniTest:
     // Cursor on the first `point` reference in the `line` definition
     val offset = src.indexOf("start: point") + "start: ".length + 1
     val result = definition(src, offset)
-    result.isDefined shouldBe true
     // The `type point` definition starts on line 1
-    result.get.startLine shouldBe 1
-    result.get.startColumn shouldBe 1
+    result.map(_.startLine) shouldBe Some(1)
+    result.map(_.startColumn) shouldBe Some(1)
 
   test("should resolve a model reference by name when later typing fails"):
     // The second query references an unknown column, so full typing fails; the model reference must
@@ -69,8 +67,7 @@ class DefinitionProviderTest extends UniTest:
         |select does_not_exist""".stripMargin
     val offset = src.indexOf("from my_model") + "from ".length + 1
     val result = definition(src, offset)
-    result.isDefined shouldBe true
-    result.get.startLine shouldBe 1
+    result.map(_.startLine) shouldBe Some(1)
 
   test("should return None when the cursor is on the definition itself"):
     val src =

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -19,6 +19,7 @@ import wvlet.lang.BuildInfo
 import wvlet.lang.compiler.parser.ParserPhase
 import wvlet.lang.compiler.lsp.CompletionItem
 import wvlet.lang.compiler.lsp.CompletionProvider
+import wvlet.lang.compiler.lsp.DefinitionProvider
 import wvlet.lang.compiler.lsp.HoverProvider
 import wvlet.lang.model.plan.*
 import wvlet.uni.weaver.Weaver
@@ -333,6 +334,52 @@ object WvletJS:
 
   end getHover
 
+  // Cached compiler instance for go-to-definition (avoids repeated initialization and filesystem
+  // scans)
+  private lazy val definitionCompiler = Compiler(CompilerOptions(workEnv = WorkEnv(path = ".")))
+
+  /**
+    * Compute the go-to-definition target (the model / type definition) for the given source at the
+    * given cursor position.
+    *
+    * @param content
+    *   The Wvlet source code
+    * @param line
+    *   1-based line number of the cursor
+    * @param column
+    *   1-based column number of the cursor
+    * @return
+    *   JSON object `{startLine, startColumn, endLine, endColumn}` describing the 1-based source
+    *   range of the definition, or the JSON literal `null` when the cursor is not on a resolvable
+    *   model/type reference (unknown position, keyword, whitespace, the definition itself, or an
+    *   unknown name). Only same-document definitions are returned.
+    */
+  @JSExport
+  def getDefinition(content: String, line: Int, column: Int): String =
+    val result =
+      try
+        val sourceFile = CompilationUnit.fromWvletString(content).sourceFile
+        sourceFile.ensureLoaded
+        val offset = sourceFile.offsetAt(wvlet.lang.api.LinePosition(line, column))
+        DefinitionProvider.definition(content, offset, definitionCompiler)
+      catch
+        case _: Throwable =>
+          None
+
+    result match
+      case Some(d) =>
+        val definition = LspDefinition(
+          startLine = d.startLine,
+          startColumn = d.startColumn,
+          endLine = d.endLine,
+          endColumn = d.endColumn
+        )
+        Weaver.of[LspDefinition].toJson(definition)
+      case None =>
+        "null"
+
+  end getDefinition
+
 end WvletJS
 
 /**
@@ -370,6 +417,12 @@ case class LspSymbol(
   * fields describe the 1-based source range of the hovered node.
   */
 case class LspHover(content: String, startLine: Int, startColumn: Int, endLine: Int, endColumn: Int)
+
+/**
+  * LSP go-to-definition representation for JSON serialization. The line/column fields describe the
+  * 1-based source range of the target model/type definition.
+  */
+case class LspDefinition(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int)
 
 /**
   * LSP SymbolKind constants (subset from the LSP specification)


### PR DESCRIPTION
## Overview

Adds **go-to-definition** to the Wvlet language server, completing the LSP triad after code completion (#1882) and hover (#1883). Placing the cursor on a model or type reference and invoking *Go to Definition* (`F12` / `Cmd`+click) jumps to the defining `model` / `type` statement.

## What was implemented

- **`DefinitionProvider`** (`wvlet-lang/.../compiler/lsp`): cross-built core logic returning a `DefinitionResult` with the 1-based source range of the definition. It reuses the same span-search / innermost-out candidate iteration as `HoverProvider` and resolves references two ways:
  - **Resolved symbol chain** — when full typing succeeds, a reference node carries a symbol whose `tree` is the defining `ModelDef` / `TypeDef`.
  - **Name fallback** — the identifier is matched against top-level `model` / `type` names collected from a parse-only pass, so navigation keeps working when later statements fail to type.
  - A definition whose span contains the cursor is treated as "already at the definition" → no jump. Keywords, whitespace, and unknown names resolve to `None`. Never throws.
- **JS export** `WvletJS.getDefinition(content, line, column)` returning `{startLine, startColumn, endLine, endColumn}` JSON or `null`, mirroring `getHover`.
- **TypeScript**: `LspDefinition` type + `getDefinition` on `WvletJSType`.
- **VS Code server** (`vscode-wvlet/src/server.ts`): `definitionProvider: true` capability + `connection.onDefinition` returning a `Location` with the document's own URI and the converted 0-based range.
- **Docs**: a Go to Definition section in `website/docs/usage/vscode.md`, noting the same-file limitation.

## Limitations

Single-document scope: the language server compiles each document standalone, so references to models / types defined in other files are not navigated. Cross-file / workspace navigation is future work.

## Testing

- `DefinitionProviderTest` (9 JVM UniTest cases): model reference → model def, type reference → type def, name-fallback when later typing fails, cursor-on-definition → None, keyword/whitespace/unknown → None, incomplete input does not throw, empty source.
- `definition.test.ts` (5 vitest cases) driving the linked Scala.js bundle.
- All 24 `wvlet.lang.compiler.lsp.*` JVM tests pass (15 existing + 9 new); `projectJVM/Test/compile` and `projectJS/Test/compile` succeed; 20 vitest tests pass; vscode-wvlet esbuild build succeeds.

Related: wvlet/wvlet#1612 (this does not close it — "test with real .wv files" and "publish extension" remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)