### PR TITLE
internal: Add LSP corpus smoke test over real .wv files

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -11,6 +11,7 @@
     "build": "pnpm run build:scalajs && tsc",
     "test": "vitest",
     "test:ci": "vitest run",
+    "corpus:smoke": "node scripts/corpus-smoke.mjs",
     "lint": "tsc --noEmit",
     "prepublishOnly": "pnpm run build"
   },

--- a/sdks/typescript/scripts/corpus-lib.mjs
+++ b/sdks/typescript/scripts/corpus-lib.mjs
@@ -1,0 +1,141 @@
+// Shared helpers for the Wvlet LSP corpus smoke test.
+//
+// The corpus is the set of real `.wv` files committed under `spec/` in the repo.
+// These helpers derive a handful of cursor positions per file and exercise every
+// LSP-facing WvletJS API at each of them, so the full sweep (scripts/corpus-smoke.mjs)
+// and the CI subset (tests/corpus.test.ts) can share one implementation.
+//
+// NOTE: the WvletJS bundle is loaded by the caller and passed in, so this module
+// stays free of Scala.js coupling and can be imported from both a plain Node script
+// and a vitest test.
+
+import { readFileSync, globSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** Absolute path to the repository root (three levels up from sdks/typescript/scripts). */
+export const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+
+/**
+ * List the real `.wv` corpus files, sorted for determinism.
+ * Covers core functionality (spec/basic), TPC-H (spec/tpch), CDP behavior
+ * (spec/cdp_*), and intentionally-failing inputs (spec/neg).
+ */
+export function listCorpusFiles() {
+  return globSync('spec/{basic,tpch,cdp_*,neg}/*.wv', { cwd: REPO_ROOT }).sort();
+}
+
+/**
+ * A small, representative subset of the corpus for CI. One or two files are picked
+ * from each area so the vitest run stays fast while still spanning models, TPC-H,
+ * multi-statement queries, CDP files, and negative (error) inputs.
+ */
+export function representativeSubset(files) {
+  const pick = (prefix, n) => files.filter((f) => f.startsWith(prefix)).slice(0, n);
+  return [
+    ...pick('spec/basic/', 8),
+    ...pick('spec/tpch/', 3),
+    ...pick('spec/cdp_', 2),
+    ...pick('spec/neg/', 3),
+  ];
+}
+
+/** Read a corpus file's contents given a repo-relative path. */
+export function readCorpusFile(relPath) {
+  return readFileSync(REPO_ROOT + relPath, 'utf8');
+}
+
+/**
+ * Derive a handful of cursor positions (1-based line/column) to probe for a file:
+ * end of the first and last non-empty lines, the middle of the file, right after
+ * each `from ` occurrence and on the identifier following it, and EOF.
+ */
+export function derivePositions(content) {
+  const lines = content.split('\n');
+  const seen = new Set();
+  const out = [];
+  const add = (line, column) => {
+    if (line < 1 || column < 1) return;
+    const key = `${line}:${column}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push({ line, column });
+  };
+
+  const nonEmpty = lines
+    .map((text, i) => ({ line: i + 1, text }))
+    .filter((e) => e.text.trim().length > 0);
+  if (nonEmpty.length > 0) {
+    const first = nonEmpty[0];
+    const last = nonEmpty[nonEmpty.length - 1];
+    const middle = nonEmpty[Math.floor(nonEmpty.length / 2)];
+    add(first.line, first.text.length + 1); // end of first non-empty line
+    add(last.line, last.text.length + 1); // end of last non-empty line
+    add(middle.line, Math.max(1, Math.floor(middle.text.length / 2))); // middle
+  }
+
+  lines.forEach((text, i) => {
+    const re = /\bfrom\s+/g;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      const afterFrom = m.index + m[0].length; // 0-based offset just after 'from '
+      add(i + 1, afterFrom + 1); // right after `from `
+      const ident = text.slice(afterFrom).match(/^[A-Za-z_][\w.]*/);
+      if (ident) {
+        add(i + 1, afterFrom + Math.floor(ident[0].length / 2) + 1); // mid identifier
+      }
+    }
+  });
+
+  // EOF
+  const lastLine = lines[lines.length - 1] ?? '';
+  add(lines.length, lastLine.length + 1);
+  return out;
+}
+
+/**
+ * Exercise every LSP-facing WvletJS API against a file and return a result record.
+ * Each API call must return valid JSON and must not throw; violations are collected
+ * in `errors`. Per-call durations (ms) are recorded, and `maxCall` is the slowest.
+ *
+ * @param {object} WvletJS the Scala.js module exposing the LSP APIs
+ * @param {string} relPath repo-relative file path (used only for reporting)
+ * @param {string} content file contents
+ */
+export function runFile(WvletJS, relPath, content) {
+  const errors = [];
+  let maxCall = { ms: 0, api: '', pos: '' };
+
+  const call = (api, pos, fn) => {
+    const t0 = performance.now();
+    let raw;
+    let threw = false;
+    try {
+      raw = fn();
+    } catch (e) {
+      threw = true;
+      errors.push({ file: relPath, api, pos, message: `threw: ${e?.message ?? e}` });
+    }
+    const ms = performance.now() - t0;
+    if (ms > maxCall.ms) maxCall = { ms, api, pos };
+    if (!threw) {
+      try {
+        JSON.parse(raw);
+      } catch (e) {
+        errors.push({ file: relPath, api, pos, message: `invalid JSON: ${e?.message ?? e}` });
+      }
+    }
+    return ms;
+  };
+
+  call('analyzeDiagnostics', '-', () => WvletJS.analyzeDiagnostics(content));
+  call('getDocumentSymbols', '-', () => WvletJS.getDocumentSymbols(content));
+
+  for (const { line, column } of derivePositions(content)) {
+    const pos = `${line}:${column}`;
+    call('getCompletionItems', pos, () => WvletJS.getCompletionItems(content, line, column));
+    call('getHover', pos, () => WvletJS.getHover(content, line, column));
+    call('getDefinition', pos, () => WvletJS.getDefinition(content, line, column));
+  }
+
+  return { file: relPath, errors, maxCall };
+}

--- a/sdks/typescript/scripts/corpus-lib.mjs
+++ b/sdks/typescript/scripts/corpus-lib.mjs
@@ -9,7 +9,7 @@
 // stays free of Scala.js coupling and can be imported from both a plain Node script
 // and a vitest test.
 
-import { readFileSync, globSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 /** Absolute path to the repository root (three levels up from sdks/typescript/scripts). */
@@ -19,9 +19,26 @@ export const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
  * List the real `.wv` corpus files, sorted for determinism.
  * Covers core functionality (spec/basic), TPC-H (spec/tpch), CDP behavior
  * (spec/cdp_*), and intentionally-failing inputs (spec/neg).
+ *
+ * Implemented with readdirSync rather than fs.globSync so the harness works on
+ * every Node version allowed by this package's `engines` field (>=20.0.0);
+ * fs.globSync only exists in newer Node releases.
  */
 export function listCorpusFiles() {
-  return globSync('spec/{basic,tpch,cdp_*,neg}/*.wv', { cwd: REPO_ROOT }).sort();
+  const corpusDirs = readdirSync(REPO_ROOT + 'spec', { withFileTypes: true })
+    .filter(
+      (e) =>
+        e.isDirectory() &&
+        (e.name === 'basic' || e.name === 'tpch' || e.name === 'neg' || e.name.startsWith('cdp_'))
+    )
+    .map((e) => e.name);
+  const files = [];
+  for (const dir of corpusDirs) {
+    for (const name of readdirSync(`${REPO_ROOT}spec/${dir}`)) {
+      if (name.endsWith('.wv')) files.push(`spec/${dir}/${name}`);
+    }
+  }
+  return files.sort();
 }
 
 /**

--- a/sdks/typescript/scripts/corpus-smoke.mjs
+++ b/sdks/typescript/scripts/corpus-smoke.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Full Wvlet LSP corpus smoke test.
+//
+// Sweeps EVERY real `.wv` file under spec/{basic,tpch,cdp_*,neg} and calls all
+// LSP-facing WvletJS APIs (analyzeDiagnostics, getDocumentSymbols,
+// getCompletionItems, getHover, getDefinition) at several derived cursor positions
+// per file. Asserts every call returns valid JSON and never throws, records
+// per-file timing, and flags any single call slower than SLOW_MS.
+//
+// Usage:
+//   node sdks/typescript/scripts/corpus-smoke.mjs
+//   pnpm --filter @wvlet/wvlet run corpus:smoke
+//
+// Requires the Scala.js bundle at sdks/typescript/lib/main.js to be built first
+// (./sbt sdkJs/fastLinkJS). Exits non-zero if any call fails or exceeds SLOW_MS,
+// so it can gate a manual/CI check.
+
+import { WvletJS } from '../lib/main.js';
+import { listCorpusFiles, readCorpusFile, runFile } from './corpus-lib.mjs';
+
+const SLOW_MS = 2000;
+
+// The compiler logs Typer/Context warnings (via process.stdout.write) while
+// analyzing files that reference DuckDB tables/files absent from the JS catalog.
+// That noise is expected here, so filter those lines out unless CORPUS_VERBOSE is
+// set, keeping the report readable. Non-matching writes (including this script's
+// own report) pass through untouched.
+if (!process.env.CORPUS_VERBOSE) {
+  const noise = /\bwarn \[(Typer|Context)\]/;
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk, ...rest) => {
+    if (typeof chunk === 'string' && noise.test(chunk)) return true;
+    return origWrite(chunk, ...rest);
+  };
+}
+
+const files = listCorpusFiles();
+const results = [];
+const allErrors = [];
+const slow = [];
+
+const grandStart = performance.now();
+for (const file of files) {
+  const content = readCorpusFile(file);
+  const before = performance.now();
+  const res = runFile(WvletJS, file, content);
+  const elapsed = performance.now() - before;
+  results.push({ ...res, elapsed });
+  allErrors.push(...res.errors);
+  if (res.maxCall.ms > SLOW_MS) slow.push(res);
+}
+const grandMs = performance.now() - grandStart;
+
+// Report ---------------------------------------------------------------------
+const perFile = results.map((r) => ({ file: r.file, maxMs: r.maxCall.ms, elapsedMs: r.elapsed }));
+perFile.sort((a, b) => b.maxMs - a.maxMs);
+
+console.log('\n=== Wvlet LSP corpus smoke test ===');
+console.log(`files:        ${files.length}`);
+console.log(`wall time:    ${(grandMs / 1000).toFixed(1)}s`);
+console.log(`errors:       ${allErrors.length}`);
+console.log(`slow (>${SLOW_MS}ms single call): ${slow.length}`);
+
+console.log('\nSlowest single call per file (top 10):');
+for (const r of perFile.slice(0, 10)) {
+  console.log(`  ${r.maxMs.toFixed(0).padStart(5)}ms   ${r.file}`);
+}
+
+if (allErrors.length > 0) {
+  console.log('\nERRORS:');
+  for (const e of allErrors.slice(0, 50)) {
+    console.log(`  ${e.file}  ${e.api}@${e.pos}  ${e.message}`);
+  }
+}
+
+if (slow.length > 0) {
+  console.log('\nSLOW FILES:');
+  for (const r of slow) {
+    console.log(`  ${r.file}  slowest ${r.maxCall.ms.toFixed(0)}ms (${r.maxCall.api}@${r.maxCall.pos})`);
+  }
+}
+
+const ok = allErrors.length === 0 && slow.length === 0;
+console.log(`\nresult: ${ok ? 'PASS' : 'FAIL'}`);
+process.exit(ok ? 0 : 1);

--- a/sdks/typescript/scripts/corpus-smoke.mjs
+++ b/sdks/typescript/scripts/corpus-smoke.mjs
@@ -29,7 +29,9 @@ if (!process.env.CORPUS_VERBOSE) {
   const noise = /\bwarn \[(Typer|Context)\]/;
   const origWrite = process.stdout.write.bind(process.stdout);
   process.stdout.write = (chunk, ...rest) => {
-    if (typeof chunk === 'string' && noise.test(chunk)) return true;
+    // chunk may be a string or a Buffer; normalize before matching.
+    const text = typeof chunk === 'string' ? chunk : (chunk?.toString('utf8') ?? '');
+    if (noise.test(text)) return true;
     return origWrite(chunk, ...rest);
   };
 }

--- a/sdks/typescript/tests/corpus.test.ts
+++ b/sdks/typescript/tests/corpus.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+// The LSP APIs are exposed directly on the Scala.js WvletJS module used by the LSP server.
+import { WvletJS } from '../lib/main.js';
+import {
+  listCorpusFiles,
+  representativeSubset,
+  readCorpusFile,
+  runFile,
+} from '../scripts/corpus-lib.mjs';
+
+// CI subset of the real `.wv` corpus. The full sweep (all ~150 files) lives in
+// scripts/corpus-smoke.mjs; here we exercise a representative subset spanning
+// spec/basic (models, types, multi-statement), spec/tpch (large queries),
+// spec/cdp_* (CDP behavior), and spec/neg (intentionally-failing inputs) so the
+// vitest run stays fast enough for CI.
+//
+// The contract we assert for every file: every LSP-facing WvletJS API
+// (analyzeDiagnostics, getDocumentSymbols, getCompletionItems, getHover,
+// getDefinition), called at several derived cursor positions, returns valid JSON
+// and never throws. Unresolved-table/file diagnostics are EXPECTED on the JS
+// bundle (the catalog is empty), so we do not assert on diagnostic contents here.
+
+// A single LSP call should stay responsive; 2s is a generous ceiling.
+const SLOW_MS = 2000;
+
+const subset = representativeSubset(listCorpusFiles());
+
+describe('WvletJS LSP corpus smoke test', () => {
+  it('has a non-empty representative subset', () => {
+    expect(subset.length).toBeGreaterThan(5);
+  });
+
+  it.each(subset)('handles %s without throwing or invalid JSON', (file) => {
+    const content = readCorpusFile(file);
+    const { errors, maxCall } = runFile(WvletJS, file, content);
+    expect(errors, JSON.stringify(errors, null, 2)).toEqual([]);
+    expect(
+      maxCall.ms,
+      `slowest call ${maxCall.api}@${maxCall.pos} took ${maxCall.ms.toFixed(0)}ms`
+    ).toBeLessThan(SLOW_MS);
+  });
+});

--- a/vscode-wvlet/DEVELOPMENT.md
+++ b/vscode-wvlet/DEVELOPMENT.md
@@ -25,6 +25,38 @@ Example:
 pnpm --filter wvlet run package
 ```
 
+## LSP Corpus Smoke Test
+
+The language features (diagnostics, document symbols, completion, hover,
+go-to-definition) are provided by the Scala.js `WvletJS` bundle in
+`sdks/typescript`. A corpus smoke test exercises every LSP API against the real
+`.wv` files under `spec/{basic,tpch,cdp_*,neg}` to make sure no input crashes the
+providers, every response is valid JSON, and each call stays responsive (< 2s).
+
+```bash
+# 1. Build the Scala.js bundle (writes sdks/typescript/lib/main.js).
+#    NOTE: fastLinkJS clears sdks/typescript/lib/, which also holds the
+#    hand-written main.d.ts and README.md — back them up and restore afterwards,
+#    then confirm `git status` shows no deletions.
+./sbt sdkJs/fastLinkJS
+
+# 2. Full sweep over all ~150 corpus files (standalone script; exits non-zero on
+#    any error or slow call). Set CORPUS_VERBOSE=1 to see the compiler's own
+#    Typer/Context warnings, which are otherwise filtered out.
+pnpm --filter @wvlet/wvlet run corpus:smoke
+
+# 3. CI subset runs automatically as part of the vitest suite.
+pnpm --filter @wvlet/wvlet run test:ci
+```
+
+The full sweep lives in `sdks/typescript/scripts/corpus-smoke.mjs`; the CI subset
+is `sdks/typescript/tests/corpus.test.ts`. Both share position-derivation and
+per-file assertion logic from `sdks/typescript/scripts/corpus-lib.mjs`.
+
+Diagnostics that report unknown tables or missing files for specs that reference
+DuckDB tables/files are **expected** in this environment: the Scala.js bundle runs
+with an empty catalog, so those sources cannot be resolved.
+
 ## CI Requirements
 
 The CI will verify that `@types/vscode` version is compatible with the declared `engines.vscode` version. If there's a mismatch, the build will fail with an error message indicating the version incompatibility.

--- a/website/docs/usage/vscode.md
+++ b/website/docs/usage/vscode.md
@@ -61,6 +61,25 @@ Definitions are resolved within the current file only: the language server compi
 document standalone, so references to models or types defined in other files are not
 navigated. Cross-file and workspace-wide navigation is future work.
 
+## Known Limitations
+
+Language support is analyzed per file, so a few things are worth keeping in mind:
+
+- **Same-file scope**: Completion, hover, and Go to Definition only see models,
+  types, and other definitions in the file you are editing. References to
+  definitions in other files are not yet completed or navigated.
+- **Schema for database tables**: Column completion and hover show a schema only
+  when the language server can resolve it. Models defined in the same file get
+  full completion and hover (their columns and types are shown). Tables from your
+  database and file sources such as `from 'data.json'` do not yet carry a schema in
+  the editor, so hovering them or asking for their columns may return nothing.
+  Importing table schemas so they behave like in-file models is planned
+  ([#1881](https://github.com/wvlet/wvlet/issues/1881)).
+- **Requires an analyzable query**: Column completion and hover rely on type
+  resolution, so they appear once the surrounding query is complete enough to be
+  analyzed. While a query is still being written, keyword and definition-name
+  suggestions remain available.
+
 ## Example
 
 ![Wvlet syntax highlighting in VS Code](./vscode.png)


### PR DESCRIPTION
## Summary

Adds a corpus smoke test that exercises the Wvlet LSP features against the **real
`.wv` files** committed under `spec/{basic,tpch,cdp_*,neg}` (checklist item on
#1612), plus user-facing documentation of the current LSP limitations.

Every LSP-facing `WvletJS` API — `analyzeDiagnostics`, `getDocumentSymbols`,
`getCompletionItems`, `getHover`, `getDefinition` — is called at several derived
cursor positions per file (first/last non-empty line ends, file middle, right
after each `from ` and on the identifier following it, EOF). The contract asserted
for every file: valid JSON, never throws, and no single call slower than 2s.

## What's included

- `sdks/typescript/scripts/corpus-lib.mjs` — shared file listing, cursor-position
  derivation, and per-file assertion logic.
- `sdks/typescript/scripts/corpus-smoke.mjs` — full sweep over all ~150 corpus
  files with a timing report; exits non-zero on any error or >2s call.
  Run with `pnpm --filter @wvlet/wvlet run corpus:smoke`.
- `sdks/typescript/tests/corpus.test.ts` — representative CI subset (16 files
  spanning models, TPC-H, CDP, and negative inputs) via vitest, ~3s.
- `website/docs/usage/vscode.md` — new "Known Limitations" section.
- `vscode-wvlet/DEVELOPMENT.md` — how to run the smoke test (incl. the
  `main.d.ts`/`README.md` backup-restore dance around `sdkJs/fastLinkJS`).

## Corpus results (current `main` bundle)

| metric | value |
|---|---|
| files swept | 150 (basic 108, tpch 24, cdp_* 5, neg 13) |
| total API calls | ~3,400 |
| errors (crash / invalid JSON) | **0** |
| calls > 2s | **0** |
| slowest single call | ~0.5s (`spec/tpch/q19.wv`, `q21.wv`) |
| full sweep wall time | ~34s |
| CI subset (vitest) | 3.1s |

The LSP providers are robust: no input in the corpus — including the
intentionally-failing `spec/neg/` files — crashes any provider or returns
non-JSON. Per-call latency is well within an interactive budget; the only
noticeably heavier calls are the large multi-CTE TPC-H queries (still < 0.6s).

## Qualitative spot checks

- **`spec/basic/query.wv`** (model + multi-statement): Go to Definition on the
  `from person_q` reference correctly jumps to the `model person_q = { … }`
  definition (lines 2–4). Hover and column completion return nothing there because
  `person_q` reads from `person.json`, which is absent from the JS catalog — an
  expected consequence of empty-catalog analysis, not a provider bug.
- **Self-contained model** (`model m1 = { from [[1,"a",2]] as t(x,y,z) }`):
  completion after `from ` offers the model (`m1`) and its columns (`x`,`y`,`z`);
  hover shows the full schema markdown (```model m1 / x: long / y: string / …```).
  This confirms completion/hover work fully once a schema is resolvable.
- **`spec/basic/q4.wv`** (`type` defs): document symbols expose `person_t2`
  (kind 23); the definition suite covers jumping from a `type` reference to its
  declaration.
- **`spec/tpch/q1.wv`** (TPC-H): all APIs return valid JSON; unresolved-table
  diagnostics are expected (empty catalog).
- **`spec/neg/recursive-function-mutual.wv`**: returns diagnostics + a valid
  (empty) symbol array without crashing.

## Findings

- **No LSP crashes or wrong behavior found**, so no code fixes and no issues filed.
  The behavior gaps observed (no hover / column completion for models backed by
  external files or database tables) are all downstream of the empty JS catalog
  and single-file scope, and are already tracked (#1881 for schema import).
- **Observation (pre-existing, out of scope):** analyzing `spec/tpch/q9.wv`,
  `q16.wv`, `q19.wv` logs internal Typer warnings of the form
  `Type mismatch: expected boolean, got boolean`. This is a compiler log-quality
  quirk (expected == actual type) that is **not** surfaced as an LSP diagnostic;
  noted here for maintainers, not addressed in this PR.

## Documented limitations (user-facing)

Added to `website/docs/usage/vscode.md`:

- **Same-file scope** — completion, hover, and Go to Definition only see
  definitions in the current file.
- **Schema for database tables** — in-file models get full completion/hover;
  tables and file sources (`from 'data.json'`) do not yet carry an editor schema,
  so hover/column completion may be empty for them (#1881).
- **Requires an analyzable query** — column completion and hover appear once the
  query is complete enough to type-check; keyword/definition suggestions stay
  available while typing.

Related: #1612 (leaving it open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
