### PR TITLE
internal: Prepare VS Code extension 2026.1.0 release with working LSP bundle

### DIFF
--- a/vscode-wvlet/.vscodeignore
+++ b/vscode-wvlet/.vscodeignore
@@ -6,6 +6,7 @@ npm-debug.log*
 .git/
 .gitignore
 *.vsix
+out/**/*.map
 package-lock.json
 tsconfig.json
 esbuild.js

--- a/vscode-wvlet/CHANGELOG.md
+++ b/vscode-wvlet/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the Wvlet extension will be documented in this file.
 
+## [2026.1.0] - 2026-07-10
+
+### Added
+- Language server for the Wvlet language, powered by the Scala.js Wvlet compiler:
+  - Error and warning diagnostics reported inline as you type
+  - Document outline for models, types, vals, and flows
+  - Code completion for keywords, in-file models, and column names
+  - Hover with type information for columns and expressions, and signatures for models and types
+  - Go-to-definition for models and types
+
+Language server features currently resolve symbols within the same file only;
+cross-file references are not yet followed.
+
+### Fixed
+- Packaged the Scala.js compiler bundle into the language server so the
+  installed extension can load it without any external files or native
+  dependencies (the DuckDB `koffi` FFI, which the language server never uses, is
+  stubbed out so it no longer breaks the bundle).
+
 ## [2025.2.0] - 2025-01-29
 
 ### Changed

--- a/vscode-wvlet/README.md
+++ b/vscode-wvlet/README.md
@@ -18,9 +18,13 @@ This extension provides syntax highlighting and language support for the Wvlet q
   - Word pattern recognition
 
 - **Language Server**:
-  - Inline compilation diagnostics
+  - Inline compilation diagnostics (errors and warnings as you type)
   - Document outline (models, types, vals, and flows)
-  - Code completion for keywords, in-file definitions, and column names
+  - Code completion for keywords, in-file models, and column names
+  - Hover with type information for columns and expressions, and signatures for models and types
+  - Go-to-definition for models and types
+
+  Language server features currently resolve symbols within the same file only.
 
 ## Supported File Extensions
 

--- a/vscode-wvlet/esbuild.js
+++ b/vscode-wvlet/esbuild.js
@@ -2,6 +2,26 @@ const esbuild = require('esbuild');
 
 const isWatch = process.argv.includes('--watch');
 
+// The Scala.js compiler bundle (sdks/typescript/lib/main.js) statically imports
+// `koffi`, the native FFI used only by the DuckDB query connector. The language
+// server never executes queries, so that binding is never referenced. Bundling
+// koffi as CJS breaks it (its `createRequire(import.meta.url)` resolves to
+// undefined, and its native `.node` addons cannot be inlined). Replace koffi
+// with an empty stub so the bundle stays self-contained and side-effect free.
+const stubKoffiPlugin = {
+  name: 'stub-koffi',
+  setup(build) {
+    build.onResolve({ filter: /^koffi$/ }, () => ({
+      path: 'koffi',
+      namespace: 'stub-koffi',
+    }));
+    build.onLoad({ filter: /.*/, namespace: 'stub-koffi' }, () => ({
+      contents: 'export default {};',
+      loader: 'js',
+    }));
+  },
+};
+
 /** @type {import('esbuild').BuildOptions} */
 const extensionConfig = {
   entryPoints: ['src/extension.ts'],
@@ -23,6 +43,7 @@ const serverConfig = {
   platform: 'node',
   target: 'node18',
   sourcemap: true,
+  plugins: [stubKoffiPlugin],
 };
 
 async function build() {

--- a/vscode-wvlet/package.json
+++ b/vscode-wvlet/package.json
@@ -2,7 +2,7 @@
   "name": "wvlet",
   "displayName": "Wvlet",
   "description": "Wvlet query language support for Visual Studio Code",
-  "version": "2025.3.0",
+  "version": "2026.1.0",
   "engines": {
     "vscode": "^1.116.0"
   },


### PR DESCRIPTION
## Summary

Prepares (does **not** publish) the VS Code extension release that ships the new Wvlet **language server** for the first time (LSP features added in #1882 completion, #1883 hover, #1884 go-to-definition, #1885 corpus test, on top of the initial server in #1612).

While verifying the packaged `.vsix`, I found the shipped LSP **did not actually work**, and fixed it.

Refs wvlet/wvlet#1612 (kept open).

## Packaging verdict — was the LSP bundle included before this change?

The compiler bundle *was* inlined into `out/server.js` by esbuild (server.js is ~11 MB), so files were present — but the LSP was **broken at runtime**. Driving the packaged `server.js` over LSP stdio produced:

```
Failed to load Wvlet compiler: The argument 'filename' must be a file URL object,
file URL string, or absolute path string. Received undefined
```

**Root cause:** the Scala.js `main.js` has an eager top-level `import * as $i_koffi from "koffi"` (native DuckDB FFI), even though the binding is referenced **0 times** by the linked output. esbuild bundles koffi's `static.js` as CJS, where `createRequire(import.meta.url)` becomes `createRequire(undefined)` and throws on module load. Result: `getWvletJS()` always failed and **every** LSP feature (diagnostics, outline, completion, hover, definition) silently returned empty.

**Fix (minimal):** stub `koffi` to an empty module in the esbuild server config (`vscode-wvlet/esbuild.js`). The language server never executes queries, so koffi is never needed. The bundle stays fully self-contained — no external files, no native dependencies, no `node_modules` shipped.

## Functional-check evidence (packaged vsix, driven over LSP stdio)

- `Wvlet compiler loaded (version: 2026.2.0+11-155bb138)` — compiler loads from the installed bundle
- `initialize` advertises documentSymbol / completion / hover / definition providers
- `textDocument/publishDiagnostics` returns valid results (empty for a clean query)
- `textDocument/completion` returns **102** items
- `textDocument/documentSymbol` returns models/types from a real `spec/basic` file
- Checks re-run after every packaging change, including the final source-map exclusion

## Changes

- `vscode-wvlet/esbuild.js` — stub koffi in the server bundle
- `vscode-wvlet/package.json` — version `2025.3.0` → **`2026.1.0`**
- `vscode-wvlet/CHANGELOG.md` — `2026.1.0` entry (LSP features + packaging fix)
- `vscode-wvlet/README.md` — feature list now includes hover + go-to-definition (this becomes the Marketplace listing)
- `vscode-wvlet/.vscodeignore` — exclude `out/**/*.map` from the package (dev builds keep sourcemaps); vsix shrinks from 2.59 MB to **1.24 MB**

## Version rationale

Scheme is `YYYY.(milestone).(patch)`, stable = patch 0. Marketplace tops out at `2025.2.0` (checked via `vsce show wvlet.wvlet`); no `2026.x` exists. First 2026 milestone, stable → **`2026.1.0`** (confirmed by maintainer as a stable release). Final `.vsix`: **1.24 MB** (15 files, no source maps).

## How to publish (after merge)

1. Merge this PR to `main`.
2. GitHub → **Actions → "VS Code"** workflow → **Run workflow** with **publish = true**.
3. Patch is `0`, so the workflow publishes a **stable** release via `vsce publish --no-dependencies` (uses the already-configured `VSCE_PAT` secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)