### PR TITLE
internal: Promote VS Code extension to stable 2026.2.0

### DIFF
--- a/vscode-wvlet/CHANGELOG.md
+++ b/vscode-wvlet/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wvlet extension will be documented in this file.
 
+## [2026.2.0] - 2026-07-10
+
+### Changed
+- Stable release of the language server introduced in 2026.1.x. Includes all
+  fixes from the 2026.1.1 pre-release; no functional changes since 2026.1.1.
+
 ## [2026.1.1] - 2026-07-10 (Pre-release)
 
 ### Fixed

--- a/vscode-wvlet/package.json
+++ b/vscode-wvlet/package.json
@@ -2,7 +2,7 @@
   "name": "wvlet",
   "displayName": "Wvlet",
   "description": "Wvlet query language support for Visual Studio Code",
-  "version": "2026.1.1",
+  "version": "2026.2.0",
   "engines": {
     "vscode": "^1.116.0"
   },


### PR DESCRIPTION
## Summary
Promotes the VS Code extension to a stable release. Identical content to the verified 2026.1.1 pre-release — version bump and changelog entry only.

- `2026.2.0` chosen over `2026.1.0` so the stable version sorts above the `2026.1.1` pre-release (the original `2026.1.0` shipped with a non-functional language server and was superseded).
- The 2026.1.1 pre-release was verified end-to-end: CI-built vsix driven over LSP stdio (compiler loads, diagnostics/completion/hover/definition all served).

## Publish
After merge: Actions → "VS Code" workflow → Run workflow with publish=true. Patch `0` → auto-detected as **stable**.

Related: #1612

🤖 Generated with [Claude Code](https://claude.com/claude-code)