### PR TITLE
feature: Add schema-bound table types for offline query validation

### DIFF
--- a/spec/basic/type-table-binding.wv
+++ b/spec/basic/type-table-binding.wv
@@ -1,4 +1,4 @@
--- Schema-bound table types (#1881): `type <name> in [<catalog>.]<schema>` binds a type to a
+-- Schema-bound table types (#1881): `type <name> in <catalog>.<schema>` binds a type to a
 -- table location so that references type-check without a live catalog connection and compile
 -- to qualified table scans
 
@@ -22,8 +22,8 @@ from memory.binding_test.bound_orders
 where id = 1
 test _.size should be 1
 
--- A type bound to the default schema resolves bare references
-type bound_products in main = {
+-- A type bound to the default catalog and schema resolves bare references
+type bound_products in memory.main = {
   id: int
   name: string
 }

--- a/spec/basic/type-table-binding.wv
+++ b/spec/basic/type-table-binding.wv
@@ -1,0 +1,36 @@
+-- Schema-bound table types (#1881): `type <name> in [<catalog>.]<schema>` binds a type to a
+-- table location so that references type-check without a live catalog connection and compile
+-- to qualified table scans
+
+execute sql"create schema if not exists binding_test"
+
+from [[1, 'apple'], [2, 'banana']] as t(id, name)
+save to binding_test.bound_orders
+
+type bound_orders in memory.binding_test = {
+  id: int
+  name: string
+}
+
+-- A schema-qualified reference resolves through the bound type
+from binding_test.bound_orders
+test _.size should be 2
+test _.columns should contain 'name'
+
+-- A catalog-qualified reference also matches the binding
+from memory.binding_test.bound_orders
+where id = 1
+test _.size should be 1
+
+-- A type bound to the default schema resolves bare references
+type bound_products in main = {
+  id: int
+  name: string
+}
+
+from [[1, 'pen']] as p(id, name)
+save to bound_products
+
+from bound_products
+test _.size should be 1
+test _.columns should contain 'id'

--- a/website/docs/syntax/data-models.md
+++ b/website/docs/syntax/data-models.md
@@ -40,8 +40,8 @@ type orders = {
 from orders
 ```
 
-To describe a table that lives in a specific schema (and optionally catalog) of your database,
-bind the type to its location with `in`:
+To describe a table that lives in a specific schema of your database, bind the type to its
+location with `in <catalog>.<schema>`:
 
 ```wvlet
 type orders in mydb.sales = {
@@ -54,8 +54,16 @@ from sales.orders
 from mydb.sales.orders
 ```
 
-A bare reference like `from orders` resolves through a bound type only when the binding matches
-the current catalog and schema of the compilation context, mirroring the search-path behavior of
-SQL engines. Type definitions take precedence over the live database catalog, so committed type
-files act like a lockfile: the compile-time schema stays deterministic even when the database
-changes, while queries still execute against the real tables.
+Notes on how bound types resolve:
+
+- Catalog and schema names are matched case-insensitively, following SQL identifier semantics.
+- A bare reference like `from orders` resolves through a bound type only when the binding
+  matches the current catalog and schema of the compilation context, mirroring the search-path
+  behavior of SQL engines.
+- The binding must be the two-part `<catalog>.<schema>` form. A single name after `in` keeps its
+  existing meaning as a dialect scope (e.g. `type string in duckdb`).
+- Connector names take precedence: a reference like `from myconnector.sales.orders` resolves
+  through the connector configured in your profile, not through a bound type.
+- Type definitions take precedence over the live database catalog, so committed type files act
+  like a lockfile: the compile-time schema stays deterministic even when the database changes,
+  while queries still execute against the real tables.

--- a/website/docs/syntax/data-models.md
+++ b/website/docs/syntax/data-models.md
@@ -24,3 +24,38 @@ limit 10
 ```
 
 Data models are often the units to __materialize query results into the target database tables__. If your data model needs to be accessed by multiple queries, materializing (or persisting) data models will reduce the cost of data processing and often accelerates the query processing.   
+
+### Describing Table Schemas with Types
+
+A `type` definition describes the schema (column names and types) of a table, so queries
+referencing the table can be type-checked without connecting to the database:
+
+```wvlet
+type orders = {
+  order_id: bigint
+  status: string
+}
+
+-- Type-checks against the type definition above, and compiles to `select * from orders`
+from orders
+```
+
+To describe a table that lives in a specific schema (and optionally catalog) of your database,
+bind the type to its location with `in`:
+
+```wvlet
+type orders in mydb.sales = {
+  order_id: bigint
+  status: string
+}
+
+-- Both resolve through the bound type and compile to a scan of mydb.sales.orders
+from sales.orders
+from mydb.sales.orders
+```
+
+A bare reference like `from orders` resolves through a bound type only when the binding matches
+the current catalog and schema of the compilation context, mirroring the search-path behavior of
+SQL engines. Type definitions take precedence over the live database catalog, so committed type
+files act like a lockfile: the compile-time schema stays deterministic even when the database
+changes, while queries still execute against the real tables.

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -116,8 +116,7 @@ object RelationRefResolver extends ContextLogSupport:
     nameParts(ref.name) match
       case Nil =>
         None
-      case qualifier :+ leaf
-          if qualifier.headOption.exists(context.connectorCatalog(_).isDefined) =>
+      case qualifier :+ leaf if qualifier.headOption.flatMap(context.connectorCatalog).isDefined =>
         // Connector names shadow catalog/schema names, and connector-qualified scans carry
         // routing metadata (connectorName) that bound types must not drop; leave the
         // reference to resolveConnectorQualifiedRef

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -16,7 +16,6 @@ package wvlet.lang.compiler.analyzer
 import wvlet.lang.catalog.Catalog.TableName
 import wvlet.lang.compiler.Context
 import wvlet.lang.compiler.ContextLogSupport
-import wvlet.lang.compiler.DBType
 import wvlet.lang.compiler.ModelSymbolInfo
 import wvlet.lang.compiler.Name
 import wvlet.lang.compiler.RelationAliasSymbolInfo
@@ -100,15 +99,9 @@ object RelationRefResolver extends ContextLogSupport:
           case _ =>
             ref
       case None =>
-        resolveTableType(ref, context) match
-          case Some(resolved) =>
-            resolved
-          case None =>
-            resolveConnectorQualifiedRef(ref, context) match
-              case Some(resolved) =>
-                resolved
-              case None =>
-                resolveFromDefaultCatalog(ref, context)
+        resolveTableType(ref, context)
+          .orElse(resolveConnectorQualifiedRef(ref, context))
+          .getOrElse(resolveFromDefaultCatalog(ref, context))
     end match
   end resolveTableRef
 
@@ -116,23 +109,27 @@ object RelationRefResolver extends ContextLogSupport:
     * Resolve a table reference through a type definition, so table schemas described as source
     * (e.g. an imported static catalog, #1881) type-check without a live catalog connection. A plain
     * `type orders = {...}` matches only a bare `from orders` reference; a schema-bound
-    * `type orders in [<catalog>.]<schema> = {...}` also matches schema/catalog-qualified references
+    * `type orders in <catalog>.<schema> = {...}` also matches schema/catalog-qualified references
     * and compiles to a scan of the bound location
     */
   private def resolveTableType(ref: TableRef, context: Context): Option[Relation] =
     nameParts(ref.name) match
       case Nil =>
         None
-      case parts =>
-        val leaf      = parts.last
-        val qualifier = parts.dropRight(1)
+      case qualifier :+ leaf
+          if qualifier.headOption.exists(context.connectorCatalog(_).isDefined) =>
+        // Connector names shadow catalog/schema names, and connector-qualified scans carry
+        // routing metadata (connectorName) that bound types must not drop; leave the
+        // reference to resolveConnectorQualifiedRef
+        None
+      case qualifier :+ leaf =>
         lookupType(Name.typeName(leaf), context).flatMap { sym =>
           sym.symbolInfo.dataType match
             case tpe: SchemaType =>
               tableBindingOf(sym) match
                 case Some(binding) if bindingMatches(qualifier, binding, context) =>
                   context.logTrace(s"Found a table type for ${leaf} bound to ${binding}")
-                  val tableName = TableName(binding.catalog, Some(binding.schema), leaf)
+                  val tableName = TableName(Some(binding.catalog), Some(binding.schema), leaf)
                   Some(TableScan(tableName, tpe, tpe.fields, ref.span))
                 case None if qualifier.isEmpty =>
                   context.logTrace(s"Found a table type for ${leaf}: ${tpe}")
@@ -146,12 +143,12 @@ object RelationRefResolver extends ContextLogSupport:
         }
 
   /**
-    * The table location that a type is bound to via `type <name> in [<catalog>.]<schema>`.
-    * Single-part contexts naming a known database type (e.g. `type string in duckdb`) are dialect
-    * scopes, not table bindings
+    * The table location that a type is bound to via `type <name> in <catalog>.<schema>`.
+    * Single-part contexts (e.g. `type string in duckdb`, or dialects extending them like
+    * `td_trino`) keep their dialect-scope meaning and never bind tables
     */
-  private case class TableBinding(catalog: Option[String], schema: String):
-    override def toString: String = (catalog.toList :+ schema).mkString(".")
+  private case class TableBinding(catalog: String, schema: String):
+    override def toString: String = s"${catalog}.${schema}"
 
   private def tableBindingOf(sym: Symbol): Option[TableBinding] =
     sym.tree match
@@ -159,34 +156,29 @@ object RelationRefResolver extends ContextLogSupport:
         t.defContexts
           .iterator
           .map(d => nameParts(d.contextType))
-          .collectFirst {
-            case schema :: Nil if !isDBTypeName(schema) =>
-              TableBinding(None, schema)
-            case catalog :: schema :: Nil =>
-              TableBinding(Some(catalog), schema)
+          .collectFirst { case catalog :: schema :: Nil =>
+            TableBinding(catalog, schema)
           }
       case _ =>
         None
-
-  private def isDBTypeName(s: String): Boolean = DBType
-    .values
-    .exists(_.toString.equalsIgnoreCase(s))
 
   private def bindingMatches(
       qualifier: List[String],
       binding: TableBinding,
       context: Context
   ): Boolean =
+    // Catalog/schema names are matched case-insensitively, following SQL identifier semantics
+    def sameName(a: String, b: String): Boolean = a.equalsIgnoreCase(b)
     qualifier match
       case Nil =>
         // A bare reference resolves through a bound type only when the binding points to the
         // context's current catalog/schema, mirroring SQL search-path behavior
-        binding.schema == context.defaultSchema &&
-        binding.catalog.forall(_ == context.catalog.catalogName)
+        sameName(binding.schema, context.defaultSchema) &&
+        sameName(binding.catalog, context.catalog.catalogName)
       case schema :: Nil =>
-        schema == binding.schema
+        sameName(schema, binding.schema)
       case catalog :: schema :: Nil =>
-        binding.catalog.contains(catalog) && schema == binding.schema
+        sameName(catalog, binding.catalog) && sameName(schema, binding.schema)
       case _ =>
         false
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -16,6 +16,7 @@ package wvlet.lang.compiler.analyzer
 import wvlet.lang.catalog.Catalog.TableName
 import wvlet.lang.compiler.Context
 import wvlet.lang.compiler.ContextLogSupport
+import wvlet.lang.compiler.DBType
 import wvlet.lang.compiler.ModelSymbolInfo
 import wvlet.lang.compiler.Name
 import wvlet.lang.compiler.RelationAliasSymbolInfo
@@ -44,7 +45,8 @@ object RelationRefResolver extends ContextLogSupport:
       case i: Identifier =>
         lookupType(i.toTermName, context)
       case d: DotRef =>
-        // TODO Load table schema from the given qualified name
+        // Qualified names resolve through schema-bound table types (resolveTableType),
+        // connector-qualified references, or the default catalog
         None
       case _ =>
         None
@@ -98,14 +100,10 @@ object RelationRefResolver extends ContextLogSupport:
           case _ =>
             ref
       case None =>
-        // Lookup known types
-        val tblType = Name.typeName(ref.name.leafName)
-        lookupType(tblType, context).map(_.symbolInfo.dataType) match
-          case Some(tpe: SchemaType) =>
-            context.logTrace(s"Found a table type for ${tblType}: ${tpe}")
-            val tableName = TableName.parse(tblType.toTermName.name)
-            TableScan(tableName, tpe, tpe.fields, ref.span)
-          case _ =>
+        resolveTableType(ref, context) match
+          case Some(resolved) =>
+            resolved
+          case None =>
             resolveConnectorQualifiedRef(ref, context) match
               case Some(resolved) =>
                 resolved
@@ -113,6 +111,84 @@ object RelationRefResolver extends ContextLogSupport:
                 resolveFromDefaultCatalog(ref, context)
     end match
   end resolveTableRef
+
+  /**
+    * Resolve a table reference through a type definition, so table schemas described as source
+    * (e.g. an imported static catalog, #1881) type-check without a live catalog connection. A plain
+    * `type orders = {...}` matches only a bare `from orders` reference; a schema-bound
+    * `type orders in [<catalog>.]<schema> = {...}` also matches schema/catalog-qualified references
+    * and compiles to a scan of the bound location
+    */
+  private def resolveTableType(ref: TableRef, context: Context): Option[Relation] =
+    nameParts(ref.name) match
+      case Nil =>
+        None
+      case parts =>
+        val leaf      = parts.last
+        val qualifier = parts.dropRight(1)
+        lookupType(Name.typeName(leaf), context).flatMap { sym =>
+          sym.symbolInfo.dataType match
+            case tpe: SchemaType =>
+              tableBindingOf(sym) match
+                case Some(binding) if bindingMatches(qualifier, binding, context) =>
+                  context.logTrace(s"Found a table type for ${leaf} bound to ${binding}")
+                  val tableName = TableName(binding.catalog, Some(binding.schema), leaf)
+                  Some(TableScan(tableName, tpe, tpe.fields, ref.span))
+                case None if qualifier.isEmpty =>
+                  context.logTrace(s"Found a table type for ${leaf}: ${tpe}")
+                  Some(TableScan(TableName(None, None, leaf), tpe, tpe.fields, ref.span))
+                case _ =>
+                  // The reference qualifier does not point to the type's bound location;
+                  // leave it to connector/catalog resolution
+                  None
+            case _ =>
+              None
+        }
+
+  /**
+    * The table location that a type is bound to via `type <name> in [<catalog>.]<schema>`.
+    * Single-part contexts naming a known database type (e.g. `type string in duckdb`) are dialect
+    * scopes, not table bindings
+    */
+  private case class TableBinding(catalog: Option[String], schema: String):
+    override def toString: String = (catalog.toList :+ schema).mkString(".")
+
+  private def tableBindingOf(sym: Symbol): Option[TableBinding] =
+    sym.tree match
+      case t: TypeDef =>
+        t.defContexts
+          .iterator
+          .map(d => nameParts(d.contextType))
+          .collectFirst {
+            case schema :: Nil if !isDBTypeName(schema) =>
+              TableBinding(None, schema)
+            case catalog :: schema :: Nil =>
+              TableBinding(Some(catalog), schema)
+          }
+      case _ =>
+        None
+
+  private def isDBTypeName(s: String): Boolean = DBType
+    .values
+    .exists(_.toString.equalsIgnoreCase(s))
+
+  private def bindingMatches(
+      qualifier: List[String],
+      binding: TableBinding,
+      context: Context
+  ): Boolean =
+    qualifier match
+      case Nil =>
+        // A bare reference resolves through a bound type only when the binding points to the
+        // context's current catalog/schema, mirroring SQL search-path behavior
+        binding.schema == context.defaultSchema &&
+        binding.catalog.forall(_ == context.catalog.catalogName)
+      case schema :: Nil =>
+        schema == binding.schema
+      case catalog :: schema :: Nil =>
+        binding.catalog.contains(catalog) && schema == binding.schema
+      case _ =>
+        false
 
   /**
     * Resolve `from <connector>.<table>`, `from <connector>.<schema>.<table>`, or `from

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1402,14 +1402,28 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
             case WvletToken.COLON | WvletToken.EQ | WvletToken.EXTENDS =>
             // ok
             case _ =>
-              // A context is either a dialect name (in duckdb) or a qualified table location
-              // for schema-bound table types (in sales, in mydb.sales)
+              // A context is either a dialect name (in duckdb) or a catalog.schema table
+              // location for schema-bound table types (in mydb.sales)
               var nameOrType: NameExpr = identifier()
-              while scanner.lookAhead().token == WvletToken.DOT do
+              if scanner.lookAhead().token == WvletToken.DOT then
                 consume(WvletToken.DOT)
-                nameOrType = DotRef(nameOrType, identifier(), DataType.UnknownType, spanFrom(t))
+                nameOrType = DotRef(
+                  nameOrType,
+                  identifierSingle(),
+                  DataType.UnknownType,
+                  spanFrom(t)
+                )
+                if scanner.lookAhead().token == WvletToken.DOT then
+                  throw StatusCode
+                    .SYNTAX_ERROR
+                    .newException(
+                      s"context must be a dialect name or <catalog>.<schema>: ${nameOrType
+                          .fullName}",
+                      t.sourceLocation
+                    )
               scopes += DefContext(None, nameOrType, spanFrom(t))
               nextScope
+        end nextScope
         nextScope
         scopes.result()
       case _ =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1402,7 +1402,12 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
             case WvletToken.COLON | WvletToken.EQ | WvletToken.EXTENDS =>
             // ok
             case _ =>
-              val nameOrType = identifier()
+              // A context is either a dialect name (in duckdb) or a qualified table location
+              // for schema-bound table types (in sales, in mydb.sales)
+              var nameOrType: NameExpr = identifier()
+              while scanner.lookAhead().token == WvletToken.DOT do
+                consume(WvletToken.DOT)
+                nameOrType = DotRef(nameOrType, identifier(), DataType.UnknownType, spanFrom(t))
               scopes += DefContext(None, nameOrType, spanFrom(t))
               nextScope
         nextScope

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/TypeTableBindingTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/TypeTableBindingTest.scala
@@ -15,6 +15,7 @@ package wvlet.lang.compiler.analyzer
 
 import wvlet.uni.test.UniTest
 import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.CompileResult
 import wvlet.lang.compiler.Compiler
 import wvlet.lang.compiler.CompilerOptions
 import wvlet.lang.compiler.Name
@@ -23,7 +24,7 @@ import wvlet.lang.compiler.codegen.GenSQL
 import wvlet.lang.model.plan.TypeDef
 
 /**
-  * Schema-bound table types (`type <name> in [<catalog>.]<schema> = {...}`, #1881) let queries
+  * Schema-bound table types (`type <name> in <catalog>.<schema> = {...}`, #1881) let queries
   * against database tables type-check without a live catalog connection, and compile into scans of
   * the bound table location
   */
@@ -36,55 +37,73 @@ class TypeTableBindingTest extends UniTest:
       |}
       |""".stripMargin
 
-  private def compileQuery(typeDefs: String, query: String): (String, wvlet.lang.compiler.Context) =
+  private def compile(typeDefs: String, query: String): CompileResult =
     val compiler  = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
     val typeUnit  = CompilationUnit.fromWvletString(typeDefs)
     val queryUnit = CompilationUnit.fromWvletString(query)
+    compiler.compileMultipleUnits(List(typeUnit), queryUnit)
+
+  private def compileToSQL(typeDefs: String, query: String): String =
+    val queryUnit = CompilationUnit.fromWvletString(query)
+    val compiler  = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+    val typeUnit  = CompilationUnit.fromWvletString(typeDefs)
     val result    = compiler.compileMultipleUnits(List(typeUnit), queryUnit)
-    val sql       = GenSQL.generateSQL(queryUnit)(using result.context)
-    (sql, result.context)
+    GenSQL.generateSQL(queryUnit)(using result.context)
 
   test("parse a catalog.schema binding in the type definition context") {
-    val (_, context) = compileQuery(ordersType, "from sales.orders\n")
-    val sym          = context.findSymbolByName(Name.typeName("orders"))
-    sym.isDefined shouldBe true
-    sym.get.tree match
-      case t: TypeDef =>
+    val result = compile(ordersType, "from sales.orders\n")
+    result.context.findSymbolByName(Name.typeName("orders")).map(_.tree) match
+      case Some(t: TypeDef) =>
         t.defContexts.map(_.contextType.fullName) shouldBe List("mydb.sales")
       case other =>
         fail(s"Expected a TypeDef tree, but got: ${other}")
   }
 
+  test("reject bindings with more than two name parts") {
+    val result = compile(
+      "type orders in mycat.sales.extra = {\n  order_id: bigint\n}\n",
+      "from orders\n"
+    )
+    result.hasFailures shouldBe true
+    result.failureReport.values.exists(_.getMessage.contains("<catalog>.<schema>")) shouldBe true
+  }
+
   test("resolve a schema-qualified reference through the bound type") {
-    val (sql, _) = compileQuery(ordersType, "from sales.orders select order_id\n")
+    val sql = compileToSQL(ordersType, "from sales.orders select order_id\n")
     sql shouldContain "mydb.sales.orders"
     sql shouldContain "order_id"
   }
 
   test("resolve a catalog-qualified reference through the bound type") {
-    val (sql, _) = compileQuery(ordersType, "from mydb.sales.orders\n")
+    val sql = compileToSQL(ordersType, "from mydb.sales.orders\n")
+    sql shouldContain "mydb.sales.orders"
+  }
+
+  test("match catalog and schema names case-insensitively") {
+    val sql = compileToSQL(ordersType, "from MyDB.SALES.orders\n")
     sql shouldContain "mydb.sales.orders"
   }
 
   test("leave references to other schemas unresolved by the bound type") {
-    val (sql, _) = compileQuery(ordersType, "from archive.orders\n")
+    val sql = compileToSQL(ordersType, "from archive.orders\n")
     sql shouldContain "archive.orders"
     sql shouldNotContain "mydb.sales.orders"
   }
 
   test("skip bare references when the binding points outside the default schema") {
-    val (sql, _) = compileQuery(ordersType, "from orders\n")
+    val sql = compileToSQL(ordersType, "from orders\n")
     sql shouldNotContain "sales"
   }
 
-  test("resolve bare references when the binding matches the default schema") {
+  test("resolve bare references when the binding matches the default catalog and schema") {
+    // The compiler's default catalog/schema is memory/main when not configured
     val typeDef =
-      """type orders in main = {
+      """type orders in memory.main = {
         |  order_id: bigint
         |}
         |""".stripMargin
-    val (sql, _) = compileQuery(typeDef, "from orders\n")
-    sql shouldContain "main.orders"
+    val sql = compileToSQL(typeDef, "from orders\n")
+    sql shouldContain "memory.main.orders"
   }
 
   test("keep plain table types matching only bare references") {
@@ -93,23 +112,32 @@ class TypeTableBindingTest extends UniTest:
         |  event_id: bigint
         |}
         |""".stripMargin
-    val (bareSql, _) = compileQuery(typeDef, "from events\n")
+    val bareSql = compileToSQL(typeDef, "from events\n")
     bareSql shouldContain "events"
 
     // A qualified reference must not resolve through an unbound type by its leaf name
-    val (qualifiedSql, _) = compileQuery(typeDef, "from staging.events\n")
+    val qualifiedSql = compileToSQL(typeDef, "from staging.events\n")
     qualifiedSql shouldContain "staging.events"
   }
 
-  test("keep dialect contexts as non-binding scopes") {
+  test("keep single-part contexts as non-binding dialect scopes") {
+    // Dialect contexts are an open set (e.g. `type td_trino extends trino` in the stdlib),
+    // so any single-part context keeps the previous unbound-type behavior
     val typeDef =
       """type metrics in duckdb = {
         |  value: double
         |}
+        |type points in custom_dialect = {
+        |  x: double
+        |}
         |""".stripMargin
-    val (sql, _) = compileQuery(typeDef, "from metrics\n")
+    val sql = compileToSQL(typeDef, "from metrics\n")
     sql shouldContain "metrics"
     sql shouldNotContain "duckdb.metrics"
+
+    val customSql = compileToSQL(typeDef, "from points\n")
+    customSql shouldContain "points"
+    customSql shouldNotContain "custom_dialect"
   }
 
 end TypeTableBindingTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/TypeTableBindingTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/TypeTableBindingTest.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.Name
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.compiler.codegen.GenSQL
+import wvlet.lang.model.plan.TypeDef
+
+/**
+  * Schema-bound table types (`type <name> in [<catalog>.]<schema> = {...}`, #1881) let queries
+  * against database tables type-check without a live catalog connection, and compile into scans of
+  * the bound table location
+  */
+class TypeTableBindingTest extends UniTest:
+
+  private val ordersType =
+    """type orders in mydb.sales = {
+      |  order_id: bigint
+      |  status: string
+      |}
+      |""".stripMargin
+
+  private def compileQuery(typeDefs: String, query: String): (String, wvlet.lang.compiler.Context) =
+    val compiler  = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+    val typeUnit  = CompilationUnit.fromWvletString(typeDefs)
+    val queryUnit = CompilationUnit.fromWvletString(query)
+    val result    = compiler.compileMultipleUnits(List(typeUnit), queryUnit)
+    val sql       = GenSQL.generateSQL(queryUnit)(using result.context)
+    (sql, result.context)
+
+  test("parse a catalog.schema binding in the type definition context") {
+    val (_, context) = compileQuery(ordersType, "from sales.orders\n")
+    val sym          = context.findSymbolByName(Name.typeName("orders"))
+    sym.isDefined shouldBe true
+    sym.get.tree match
+      case t: TypeDef =>
+        t.defContexts.map(_.contextType.fullName) shouldBe List("mydb.sales")
+      case other =>
+        fail(s"Expected a TypeDef tree, but got: ${other}")
+  }
+
+  test("resolve a schema-qualified reference through the bound type") {
+    val (sql, _) = compileQuery(ordersType, "from sales.orders select order_id\n")
+    sql shouldContain "mydb.sales.orders"
+    sql shouldContain "order_id"
+  }
+
+  test("resolve a catalog-qualified reference through the bound type") {
+    val (sql, _) = compileQuery(ordersType, "from mydb.sales.orders\n")
+    sql shouldContain "mydb.sales.orders"
+  }
+
+  test("leave references to other schemas unresolved by the bound type") {
+    val (sql, _) = compileQuery(ordersType, "from archive.orders\n")
+    sql shouldContain "archive.orders"
+    sql shouldNotContain "mydb.sales.orders"
+  }
+
+  test("skip bare references when the binding points outside the default schema") {
+    val (sql, _) = compileQuery(ordersType, "from orders\n")
+    sql shouldNotContain "sales"
+  }
+
+  test("resolve bare references when the binding matches the default schema") {
+    val typeDef =
+      """type orders in main = {
+        |  order_id: bigint
+        |}
+        |""".stripMargin
+    val (sql, _) = compileQuery(typeDef, "from orders\n")
+    sql shouldContain "main.orders"
+  }
+
+  test("keep plain table types matching only bare references") {
+    val typeDef =
+      """type events = {
+        |  event_id: bigint
+        |}
+        |""".stripMargin
+    val (bareSql, _) = compileQuery(typeDef, "from events\n")
+    bareSql shouldContain "events"
+
+    // A qualified reference must not resolve through an unbound type by its leaf name
+    val (qualifiedSql, _) = compileQuery(typeDef, "from staging.events\n")
+    qualifiedSql shouldContain "staging.events"
+  }
+
+  test("keep dialect contexts as non-binding scopes") {
+    val typeDef =
+      """type metrics in duckdb = {
+        |  value: double
+        |}
+        |""".stripMargin
+    val (sql, _) = compileQuery(typeDef, "from metrics\n")
+    sql shouldContain "metrics"
+    sql shouldNotContain "duckdb.metrics"
+  }
+
+end TypeTableBindingTest


### PR DESCRIPTION
## Summary

First PR for the static catalog design in #1881 (design: https://github.com/wvlet/wvlet/issues/1881#issuecomment-4948445808): the `type <name> in <catalog>.<schema>` qualification syntax, so table schemas described as Wvlet source can be used to type-check queries offline.

```wvlet
type orders in mydb.sales = {
  order_id: bigint
  status: string
}

from sales.orders        -- resolves through the bound type
from mydb.sales.orders   -- also matches the binding
-- both compile to a scan of mydb.sales.orders
```

## Changes

- **Parser**: `in` contexts on type definitions accept a two-part dotted name (`WvletParser.context()`). Contexts with 3+ parts or non-identifier parts are a syntax error. Single-part contexts (e.g. `type string in duckdb`, or stdlib dialects like `td_trino`) keep their existing dialect-scope meaning unchanged, and plain `type x = {...}` is untouched.
- **Resolver** (`RelationRefResolver`): the known-type fallback is extracted into `resolveTableType`, which:
  - resolves schema/catalog-qualified references (`from sales.orders`) through the bound type and emits a qualified `TableScan` (previously the `DotRef` case was a TODO and the qualifier was silently dropped when an unrelated type shared the leaf name — now the qualifier must match the binding, or resolution falls through to connector/catalog lookup);
  - resolves bare references (`from orders`) through a bound type only when the binding matches the context's default catalog/schema, mirroring SQL search-path behavior;
  - matches catalog/schema names case-insensitively, following SQL identifier semantics;
  - never intercepts references whose qualifier head names a profile connector, so connector-qualified scans keep their `connectorName` routing metadata for cross-engine execution;
  - keeps plain (unbound) types matching only bare references, exactly as before.

## Semantics notes

- Bindings are strictly two-part (`<catalog>.<schema>`). This keeps the open set of dialect context names (anything single-part) fully backward compatible.
- Bound types take precedence over the live catalog (same position as the existing type fallback), so committed type files act like a lockfile: deterministic compile-time schemas, while execution still hits the real tables.
- Duplicate type names across schemas currently merge into the first definition (pre-existing behavior of context-specific type registration); a duplicate-definition warning is a follow-up in the #1881 plan.

## Test plan

- [x] `TypeTableBindingTest` (10 cases): binding parse, 3-part rejection, qualified/catalog-qualified resolution, case-insensitive matching, qualifier mismatch fall-through, bare-ref search-path rule, unbound-type behavior, dialect contexts (incl. custom names) unchanged
- [x] End-to-end spec `spec/basic/type-table-binding.wv` against DuckDB (creates real tables, resolves through bound types, verifies results)
- [x] `langJVM/test`, `RunnerSpecBasic` (130 passed), `ParserSpecBasic`, `TyperCoverageCheck` ratchet
- [x] `projectJS/Test/compile`, `projectNative/Test/compile`, `scalafmtAll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)