### PR TITLE
fix: Preserve concrete DataType on ConnectorCatalog JSON cache round-trip

### DIFF
--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/ConnectorCatalog.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/ConnectorCatalog.scala
@@ -36,8 +36,8 @@ class ConnectorCatalog(
 ) extends Catalog
     with LogSupport:
 
-  private given Weaver[Catalog.TableDef] = Weaver.of[Catalog.TableDef]
-  private val tableDefCodec              = summon[Weaver[List[Catalog.TableDef]]]
+  // Resolves via Catalog.tableDefWeaver, which preserves concrete column DataTypes (#1891)
+  private val tableDefCodec = summon[Weaver[List[Catalog.TableDef]]]
 
   private val tablesInSchemaCache = Caffeine
     .newBuilder()

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/Catalog.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/Catalog.scala
@@ -23,6 +23,8 @@ import wvlet.lang.model.DataType.NamedType
 import wvlet.lang.model.DataType.SchemaType
 import wvlet.lang.compiler.DBType
 import wvlet.lang.compiler.Name
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import java.lang.invoke.MethodHandles.loop
 
@@ -185,6 +187,13 @@ object Catalog:
       }
 
   case class TableColumn(name: String, dataType: DataType, properties: Map[String, Any] = Map.empty)
+
+  /**
+    * Weavers derived where DataType's string codec is in scope, so that JSON/MessagePack
+    * serialization of table metadata preserves concrete column types (#1891)
+    */
+  given tableColumnWeaver: Weaver[TableColumn] = Weaver.of[TableColumn]
+  given tableDefWeaver: Weaver[TableDef]       = Weaver.of[TableDef]
 
   sealed trait CreateMode
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/DataType.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/DataType.scala
@@ -26,6 +26,12 @@ import wvlet.lang.model.DataType.PrimitiveType
 import wvlet.lang.model.DataType.TypeParameter
 import wvlet.lang.model.expr.NameExpr
 import wvlet.uni.log.LogSupport
+import wvlet.uni.msgpack.spi.Packer
+import wvlet.uni.msgpack.spi.Unpacker
+import wvlet.uni.msgpack.spi.ValueType
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.WeaverConfig
+import wvlet.uni.weaver.WeaverContext
 
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -125,6 +131,38 @@ case class RelationTypeList(override val typeName: TypeName, inputRelationTypes:
   }
 
 object DataType extends LogSupport:
+  /**
+    * Serialize DataType as a single parseable string so that JSON/MessagePack round-trips preserve
+    * the concrete type (e.g., decimal(10,2), array(string), timestamp with time zone). Without
+    * this, derived weavers fall back to a structural encoding of the abstract class that degrades
+    * to a bare type name on read (#1891). `toString` is used because it keeps timestamp time-zone
+    * information, unlike `sqlExpr`; the trailing `?` that `typeDescription` appends for unresolved
+    * types is stripped before parsing.
+    */
+  given weaver: Weaver[DataType] =
+    new Weaver[DataType]:
+      override def pack(p: Packer, v: DataType, config: WeaverConfig): Unit = p.packString(
+        v.toString
+      )
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.STRING =>
+            try
+              val s = u.unpackString
+              context.setObject(parse(s.stripSuffix("?")))
+            catch
+              case NonFatal(e) =>
+                context.setError(e)
+          case ValueType.NIL =>
+            u.unpackNil
+            context.setNull
+          case other =>
+            u.skipValue
+            context.setError(
+              IllegalArgumentException(s"Cannot convert ${other} to DataType, expected STRING")
+            )
+
   def parse(s: String): DataType =
     try
       if s == null || s.isEmpty then
@@ -436,7 +474,10 @@ object DataType extends LogSupport:
 
   val knownTypeNames: Set[String] = (
     primitiveTypeTable.map(_._1.name) ++ knownGenericTypeNames.map(_.name) ++
-      Set("array", "map", "row", "struct")
+      // decimal and time are parsed with dedicated grammar rules, so they are not in the
+      // primitive type table, but they must not be mistaken for type variables when they
+      // appear nested in type parameters, e.g., array(decimal(10,2))
+      Set("array", "map", "row", "struct", "decimal", "time")
   ).toSet
 
   def isKnownTypeName(s: String): Boolean = knownTypeNames.contains(s)

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/DataType.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/DataType.scala
@@ -141,9 +141,11 @@ object DataType extends LogSupport:
     */
   given weaver: Weaver[DataType] =
     new Weaver[DataType]:
-      override def pack(p: Packer, v: DataType, config: WeaverConfig): Unit = p.packString(
-        v.toString
-      )
+      override def pack(p: Packer, v: DataType, config: WeaverConfig): Unit =
+        if v == null then
+          p.packNil
+        else
+          p.packString(v.toString)
 
       override def unpack(u: Unpacker, context: WeaverContext): Unit =
         u.getNextValueType match
@@ -476,8 +478,10 @@ object DataType extends LogSupport:
     primitiveTypeTable.map(_._1.name) ++ knownGenericTypeNames.map(_.name) ++
       // decimal and time are parsed with dedicated grammar rules, so they are not in the
       // primitive type table, but they must not be mistaken for type variables when they
-      // appear nested in type parameters, e.g., array(decimal(10,2))
-      Set("array", "map", "row", "struct", "decimal", "time")
+      // appear nested in type parameters, e.g., array(decimal(10,2)). record and interval
+      // have no dedicated grammar (they parse as GenericType), but recognizing the names
+      // keeps nested forms like array(record(int,string)) parseable
+      Set("array", "map", "row", "struct", "decimal", "time", "record", "interval")
   ).toSet
 
   def isKnownTypeName(s: String): Boolean = knownTypeNames.contains(s)

--- a/wvlet-lang/src/test/scala/wvlet/lang/model/DataTypeWeaverTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/model/DataTypeWeaverTest.scala
@@ -54,6 +54,11 @@ class DataTypeWeaverTest extends UniTest:
     roundTrip("map(string,int)")
     roundTrip("map(string,decimal(10,2))")
     roundTrip("array(timestamp with time zone)")
+    // record and interval parse as GenericType (no dedicated grammar), but must round-trip
+    // and be recognized when nested in type parameters
+    roundTrip("record(int,string)")
+    roundTrip("array(record(int,string))")
+    roundTrip("array(interval)")
   }
 
   test("round-trip timestamp types") {

--- a/wvlet-lang/src/test/scala/wvlet/lang/model/DataTypeWeaverTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/model/DataTypeWeaverTest.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.model
+
+import wvlet.lang.catalog.Catalog
+import wvlet.lang.catalog.Catalog.TableName
+import wvlet.uni.test.UniTest
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
+
+class DataTypeWeaverTest extends UniTest:
+
+  private val weaver = summon[Weaver[DataType]]
+
+  private def roundTrip(typeExpr: String): Unit =
+    val dt       = DataType.parse(typeExpr)
+    val json     = weaver.toJson(dt)
+    val restored = weaver.fromJson(json)
+    restored shouldBe dt
+
+  test("round-trip primitive types") {
+    roundTrip("long")
+    roundTrip("int")
+    roundTrip("string")
+    roundTrip("boolean")
+    roundTrip("double")
+    roundTrip("date")
+    roundTrip("json")
+    roundTrip("null")
+  }
+
+  test("round-trip parameterized types") {
+    roundTrip("decimal(10,2)")
+    roundTrip("decimal(38,0)")
+    roundTrip("varchar(10)")
+    roundTrip("char(3)")
+  }
+
+  test("round-trip nested types") {
+    roundTrip("array(string)")
+    roundTrip("array(array(int))")
+    roundTrip("array(decimal(10,2))")
+    roundTrip("map(string,int)")
+    roundTrip("map(string,decimal(10,2))")
+    roundTrip("array(timestamp with time zone)")
+  }
+
+  test("round-trip timestamp types") {
+    roundTrip("timestamp")
+    roundTrip("timestamp(0) with time zone")
+    roundTrip("timestamp with time zone")
+    roundTrip("timestamp without time zone")
+    roundTrip("time with time zone")
+  }
+
+  test("round-trip TableDef through the derived weaver as in ConnectorCatalog") {
+    // Mirrors the JSON cache codec in ConnectorCatalog (#1891)
+    val tableDefCodec = summon[Weaver[List[Catalog.TableDef]]]
+
+    val defs = List(
+      Catalog.TableDef(
+        tableName = TableName(Some("memory"), Some("sales"), "orders"),
+        columns = List(
+          Catalog.TableColumn("order_id", DataType.parse("long")),
+          Catalog.TableColumn("price", DataType.parse("decimal(10,2)")),
+          Catalog.TableColumn("tags", DataType.parse("array(string)")),
+          Catalog.TableColumn("created_at", DataType.parse("timestamp with time zone"))
+        )
+      )
+    )
+
+    val json     = tableDefCodec.toJson(defs)
+    val restored = tableDefCodec.fromJson(json)
+    restored.size shouldBe 1
+    restored.head.tableName shouldBe defs.head.tableName
+    restored.head.columns.map(_.name) shouldBe defs.head.columns.map(_.name)
+    // The essential #1891 assertion: column data types survive the round-trip
+    restored.head.columns.map(_.dataType) shouldBe defs.head.columns.map(_.dataType)
+  }
+
+end DataTypeWeaverTest


### PR DESCRIPTION
## Problem

Fixes #1891. `ConnectorCatalog` caches `List[Catalog.TableDef]` as JSON, but the round-trip was lossy for `DataType`: with no custom codec in scope, the derived weaver fell back to a structural encoding of the abstract `DataType` class, so a column typed `long` came back as `longtype` (and `decimal(10,2)` → `decimaltype`, `array(string)` → `arraytype`, ...). Any consumer reading table metadata within the 5-minute cache TTL saw degraded column types; `wv catalog import` bypasses the cache for this reason.

## Changes

- **`given Weaver[DataType]` string codec in the `DataType` companion**: serializes the parseable string form (`toString`, which keeps `with time zone` for timestamps, unlike `sqlExpr`; a trailing `?` from unresolved types is stripped before parsing) and deserializes with `DataType.parse`. Living in the companion's implicit scope, it is shared by every Weaver user.
- **Derived `Weaver[TableColumn]`/`Weaver[TableDef]` in the `Catalog` companion**, where the DataType codec is in scope. This is needed because weaver derivation resolves field codecs at the derivation site: without a given for `TableColumn`, the `Seq[TableColumn]` field fell back to a Surface-driven runtime weaver that never consults the DataType codec. `ConnectorCatalog` now just summons `Weaver[List[Catalog.TableDef]]`.
- **Parser fix**: `decimal` and `time` were missing from `knownTypeNames`, so nested forms like `array(decimal(10,2))` were mis-parsed as type variables and failed. They are parsed with dedicated grammar rules and are now recognized inside type parameters — required for the codec to round-trip array-of-decimal columns.

Stale cache files in the old object format self-heal: the decode failure is caught, logged, and a fresh scan overwrites the cache file.

## Tests

New `DataTypeWeaverTest` (wvlet-lang): round-trips primitives, parameterized types (`decimal(10,2)`, `varchar(10)`, `char(3)`), nested types (`array(array(int))`, `array(decimal(10,2))`, `map(string,decimal(10,2))`, `array(timestamp with time zone)`), timestamp variants, and a `TableDef` list through the exact codec shape used by `ConnectorCatalog` — asserting column data types survive (the direct #1891 repro; it fails with `longtype`/`decimaltype`/... without the fix).

`langJVM/test` (874 tests), `projectJVM/Test/compile`, `projectJS/Test/compile`, and `scalafmtAll` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)