### PR TITLE
feature: Warn on duplicate type definitions with conflicting table bindings

### DIFF
--- a/website/docs/usage/catalog-import.md
+++ b/website/docs/usage/catalog-import.md
@@ -80,6 +80,24 @@ A few notes on what gets imported:
   duplicate-definition warning and deterministically uses the definition from the first file
   in source-file name order. Rename one of them to remove the ambiguity.
 
+## Duplicate type names across schemas
+
+When two schemas define a table with the same name (e.g. `mydb.sales.orders` and
+`mydb.marketing.orders`), the import writes a `type orders in ...` definition into both schema
+files. The compiler can only resolve the name through one of them, so it reports a warning:
+
+```
+[warning] Duplicate type definition 'orders' (bound to mydb.marketing): also defined at
+catalog/mydb/sales.wv:1:1 (bound to mydb.sales). Only the definition in catalog/mydb/sales.wv
+is used for name lookup.
+```
+
+Queries that reference the winning definition keep working; references to the other schema's
+table may not resolve to the schema you expect. To fix the warning, keep only the schema you
+query (`wvlet catalog import --schema sales`), or remove one of the definitions — for
+hand-written types, rename one of them. The warning never fails the compilation, even with
+`wvlet compile --strict`.
+
 ## Keeping catalogs up to date
 
 Re-running `wvlet catalog import` overwrites the generated files. The output is deterministic —

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -152,12 +152,7 @@ object RelationRefResolver extends ContextLogSupport:
   private def tableBindingOf(sym: Symbol): Option[TableBinding] =
     sym.tree match
       case t: TypeDef =>
-        t.defContexts
-          .iterator
-          .map(d => nameParts(d.contextType))
-          .collectFirst { case catalog :: schema :: Nil =>
-            TableBinding(catalog, schema)
-          }
+        t.tableBinding.map((catalog, schema) => TableBinding(catalog, schema))
       case _ =>
         None
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
@@ -32,6 +32,7 @@ import wvlet.lang.compiler.Symbol
 import wvlet.lang.compiler.TermName
 import wvlet.lang.compiler.TypeSymbol
 import wvlet.lang.compiler.TypeSymbolInfo
+import wvlet.lang.compiler.typer.DuplicateTypeDefinition
 import wvlet.lang.compiler.typer.ModelDefCompleter
 import wvlet.lang.model.DataType.NamedType
 import wvlet.lang.model.DataType.SchemaType
@@ -295,6 +296,55 @@ object SymbolLabeler extends Phase("symbol-labeler"):
       contextNames = defContexts.map(x => Name.typeName(x.contextType.leafName))
     )
 
+  /**
+    * True when two same-name type definitions carry conflicting table bindings: the bindings differ
+    * case-insensitively and at least one side is a two-part `<catalog>.<schema>` binding. Unbound
+    * duplicates (including single-part dialect scopes like `in duckdb`) merge intentionally and
+    * never conflict
+    */
+  private def bindingsConflict(a: Option[(String, String)], b: Option[(String, String)]): Boolean =
+    def norm(x: Option[(String, String)]) = x.map((c, s) => (c.toLowerCase, s.toLowerCase))
+    (a.isDefined || b.isDefined) && norm(a) != norm(b)
+
+  private def bindingString(t: TypeDef): Option[String] = t.tableBinding.map((c, s) => s"${c}.${s}")
+
+  /**
+    * Warn when the freshly indexed type definition shares its name with a definition in another
+    * (non-preset) compilation unit under a conflicting table binding. Name lookup resolves such
+    * duplicates silently by file-name order (#93), so the shadowed schema binding never matches
+    */
+  private def warnCrossFileDuplicateTypeDefs(t: TypeDef)(using ctx: Context): Unit =
+    if !ctx.compilationUnit.isPreset then
+      val entries = ctx
+        .global
+        .symbolIndex
+        .visibleEntries(
+          t.name,
+          ctx.compilationUnit.packageName,
+          ctx.importDefs.map(_.importRef.fullName)
+        )
+      if entries.sizeIs > 1 then
+        // visibleEntries is file-name-sorted and includes this unit's fresh entry, so the head
+        // is the definition that findSymbolByName actually uses
+        val winnerFileName = entries.head.fileName
+        entries
+          .withFilter(e => !(e.unit eq ctx.compilationUnit) && !e.unit.isPreset)
+          .foreach { e =>
+            e.symbol.tree match
+              case other: TypeDef if bindingsConflict(other.tableBinding, t.tableBinding) =>
+                ctx.addTyperError(
+                  DuplicateTypeDefinition(
+                    typeName = t.name.name,
+                    thisBinding = bindingString(t),
+                    otherBinding = bindingString(other),
+                    otherLocation = e.unit.sourceFile.sourceLocationAt(other.span.start),
+                    winnerFileName = winnerFileName,
+                    span = t.span
+                  )
+                )
+              case _ =>
+          }
+
   private def registerTypeDefSymbol(t: TypeDef)(using ctx: Context): Symbol =
     val typeName = t.name
 
@@ -303,6 +353,22 @@ object SymbolLabeler extends Phase("symbol-labeler"):
         // Symbol is already assigned if context-specific types and functions (e.g., in duckdb, in trino) are defined
         t.symbol = sym
         trace(s"Attach symbol ${sym} to ${t.name} ${t.locationString(using ctx)}")
+        // Same-name definitions merge into one symbol on purpose (dialect extensions like
+        // `type string in duckdb`), but conflicting table bindings would shadow each other
+        sym.tree match
+          case prev: TypeDef
+              if (prev ne t) && bindingsConflict(prev.tableBinding, t.tableBinding) =>
+            ctx.addTyperError(
+              DuplicateTypeDefinition(
+                typeName = typeName.name,
+                thisBinding = bindingString(t),
+                otherBinding = bindingString(prev),
+                otherLocation = ctx.sourceLocationAt(prev.span),
+                winnerFileName = ctx.compilationUnit.sourceFile.fileName,
+                span = t.span
+              )
+            )
+          case _ =>
         // Locate the type scope without forcing a pending lazy completion: forcing here would
         // resolve parent types before all compilation units are labeled
         val knownTypeScope =
@@ -359,6 +425,7 @@ object SymbolLabeler extends Phase("symbol-labeler"):
         sym.tree = t
         // Enter after the completer installation so the symbol is indexed with its name
         ctx.enterGlobalSymbol(sym)
+        warnCrossFileDuplicateTypeDefs(t)
 
         t.symbol = sym
         ctx.scope.add(typeName, sym)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/CompletionProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/CompletionProvider.scala
@@ -479,28 +479,13 @@ object CompletionProvider:
       currentUnit: CompilationUnit,
       qualifier: List[String]
   ): List[CompletionItem] =
-    def nameParts(e: wvlet.lang.model.expr.Expression): List[String] =
-      e match
-        case i: wvlet.lang.model.expr.Identifier =>
-          List(i.leafName)
-        case wvlet.lang.model.expr.DotRef(q, name: wvlet.lang.model.expr.Identifier, _, _) =>
-          nameParts(q) match
-            case Nil =>
-              Nil
-            case parts =>
-              parts :+ name.leafName
-        case _ =>
-          Nil
-    def bindingMatches(contextParts: List[String]): Boolean =
-      contextParts match
-        case catalog :: schema :: Nil =>
-          qualifier match
-            case s :: Nil =>
-              s.equalsIgnoreCase(schema)
-            case c :: s :: Nil =>
-              c.equalsIgnoreCase(catalog) && s.equalsIgnoreCase(schema)
-            case _ =>
-              false
+    def bindingMatches(binding: (String, String)): Boolean =
+      val (catalog, schema) = binding
+      qualifier match
+        case s :: Nil =>
+          s.equalsIgnoreCase(schema)
+        case c :: s :: Nil =>
+          c.equalsIgnoreCase(catalog) && s.equalsIgnoreCase(schema)
         case _ =>
           false
     def tableTypes(plan: LogicalPlan): List[CompletionItem] =
@@ -509,7 +494,7 @@ object CompletionProvider:
         p match
           case pkg: PackageDef =>
             pkg.statements.foreach(loop)
-          case t: TypeDef if t.defContexts.exists(d => bindingMatches(nameParts(d.contextType))) =>
+          case t: TypeDef if t.tableBinding.exists(bindingMatches) =>
             buf += CompletionItem(t.name.name, CompletionItemKind.Struct, "table")
           case _ =>
       loop(plan)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -94,16 +94,24 @@ object Typer extends Phase("typer") with LogSupport:
     // Attach the collected type errors to the unit as diagnostics and report them
     unit.typerErrors = preScanCtx.typerErrors
     if preScanCtx.hasTyperErrors then
-      warn(s"Typing errors in ${unit.sourceFile.fileName}:")
+      warn(s"Typing diagnostics in ${unit.sourceFile.fileName}:")
       preScanCtx
         .typerErrors
         .foreach { err =>
-          warn(s"  ${err.message} at ${err.sourceLocation(using context)}")
+          val label =
+            err.severity match
+              case TyperError.Severity.Warning =>
+                "[warning]"
+              case TyperError.Severity.Error =>
+                "[error]"
+          warn(s"  ${label} ${err.message} at ${err.sourceLocation(using context)}")
         }
+      // Warnings (e.g., duplicate type definitions) never fail the compilation, even in
+      // strict mode
       if context.global.compilerOptions.failOnTypeErrors then
         preScanCtx
           .typerErrors
-          .headOption
+          .find(_.severity == TyperError.Severity.Error)
           .foreach { first =>
             throw StatusCode
               .TYPE_ERROR

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperError.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/TyperError.scala
@@ -20,12 +20,22 @@ import wvlet.lang.model.expr.Expression
 import wvlet.lang.model.expr.Identifier
 import wvlet.lang.model.Type
 
+object TyperError:
+  /**
+    * Severity of a typing diagnostic. Warnings are reported to the user but never fail the
+    * compilation, even with failOnTypeErrors (--strict)
+    */
+  enum Severity:
+    case Warning,
+      Error
+
 /**
   * Base trait for typing errors
   */
 sealed trait TyperError:
   def message: String
   def span: Span
+  def severity: TyperError.Severity                      = TyperError.Severity.Error
   def sourceLocation(using ctx: Context): SourceLocation = ctx.sourceLocationAt(span)
 
 /**
@@ -59,3 +69,43 @@ case class InvalidFilterCondition(actualType: Type, expr: Expression) extends Ty
   * Generic typing error
   */
 case class GenericTyperError(message: String, span: Span) extends TyperError
+
+/**
+  * Warning for a type name defined more than once with conflicting table bindings, e.g., `type
+  * orders in mydb.sales` and `type orders in mydb.marketing` generated into different files by
+  * `wvlet catalog import`. Name lookup silently resolves through only one of the definitions (in
+  * file-name order), so the shadowed binding never matches (#93)
+  *
+  * @param thisBinding
+  *   the `catalog.schema` binding of the definition receiving this warning; None when the
+  *   definition has no table binding
+  * @param otherBinding
+  *   the `catalog.schema` binding of the conflicting definition; None when it has no table binding
+  * @param otherLocation
+  *   the location of the conflicting definition, precomputed from its own source file (the
+  *   ctx-based sourceLocation of this trait can only reach the current unit's file)
+  * @param winnerFileName
+  *   the file whose definition name lookup actually uses (file-name sort order); may be either side
+  * @param span
+  *   the span of the type definition in the unit receiving the warning
+  */
+case class DuplicateTypeDefinition(
+    typeName: String,
+    thisBinding: Option[String],
+    otherBinding: Option[String],
+    otherLocation: SourceLocation,
+    winnerFileName: String,
+    span: Span
+) extends TyperError:
+  override def severity: TyperError.Severity = TyperError.Severity.Warning
+
+  private def bindingLabel(binding: Option[String]): String = binding
+    .map(b => s"bound to ${b}")
+    .getOrElse("no table binding")
+
+  def message: String =
+    s"Duplicate type definition '${typeName}' (${bindingLabel(
+        thisBinding
+      )}): also defined at ${otherLocation.locationString} (${bindingLabel(
+        otherBinding
+      )}). Only the definition in ${winnerFileName} is used for name lookup."

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
@@ -69,7 +69,18 @@ case class TypeDef(
     parent: Option[NameExpr],
     elems: List[TypeElem],
     span: Span
-) extends LanguageStatement
+) extends LanguageStatement:
+
+  /**
+    * The `<catalog>.<schema>` table binding of `type <name> in <catalog>.<schema>`. Single-part
+    * contexts (e.g. `in duckdb`) are dialect scopes, never table bindings
+    */
+  def tableBinding: Option[(String, String)] = defContexts
+    .iterator
+    .map(_.contextType.nameParts)
+    .collectFirst { case catalog :: schema :: Nil =>
+      (catalog, schema)
+    }
 
 // type elements (def or column (field) definition)
 sealed trait TypeElem extends Expression

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/TypeTableBindingTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/TypeTableBindingTest.scala
@@ -21,6 +21,8 @@ import wvlet.lang.compiler.CompilerOptions
 import wvlet.lang.compiler.Name
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.compiler.codegen.GenSQL
+import wvlet.lang.compiler.typer.DuplicateTypeDefinition
+import wvlet.lang.compiler.typer.TyperError
 import wvlet.lang.model.plan.TypeDef
 
 /**
@@ -118,6 +120,96 @@ class TypeTableBindingTest extends UniTest:
     // A qualified reference must not resolve through an unbound type by its leaf name
     val qualifiedSql = compileToSQL(typeDef, "from staging.events\n")
     qualifiedSql shouldContain "staging.events"
+  }
+
+  private val marketingOrdersType =
+    """type orders in mydb.marketing = {
+      |  order_id: bigint
+      |  channel: string
+      |}
+      |""".stripMargin
+
+  private def compileUnits(typeDefsList: List[String], query: String): List[CompilationUnit] =
+    val compiler  = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+    val typeUnits = typeDefsList.map(CompilationUnit.fromWvletString)
+    val queryUnit = CompilationUnit.fromWvletString(query)
+    compiler.compileMultipleUnits(typeUnits, queryUnit)
+    typeUnits
+
+  private def duplicateWarnings(units: List[CompilationUnit]): List[DuplicateTypeDefinition] = units
+    .flatMap(_.typerErrors)
+    .collect { case d: DuplicateTypeDefinition =>
+      d
+    }
+
+  test("warn when the same type name is bound to different schemas in different files") {
+    val typeUnits = compileUnits(List(ordersType, marketingOrdersType), "from sales.orders\n")
+    val warnings  = duplicateWarnings(typeUnits)
+    warnings.size shouldBe 1
+    val w = warnings.head
+    w.severity shouldBe TyperError.Severity.Warning
+    w.message shouldContain "Duplicate type definition 'orders'"
+    w.message shouldContain "mydb.sales"
+    w.message shouldContain "mydb.marketing"
+    // The warning surfaces on the unit labeled after the first definition
+    duplicateWarnings(List(typeUnits(1))).size shouldBe 1
+    // Name lookup uses the file-name-sorted head; in-memory units are named by
+    // creation-ordered ULIDs, so the first unit wins
+    w.winnerFileName shouldBe typeUnits.head.sourceFile.fileName
+  }
+
+  test("not warn when the same type name has an identical binding across files") {
+    val upperCased = ordersType.replace("mydb.sales", "MYDB.SALES")
+    val typeUnits  = compileUnits(List(ordersType, upperCased), "from sales.orders\n")
+    duplicateWarnings(typeUnits) shouldBe Nil
+  }
+
+  test("not warn for dialect extensions or duplicated single-part contexts") {
+    // A base type extended for a dialect in the same file (like stdlib's `type string` +
+    // `type string in duckdb`) is intentional and never a table-binding conflict
+    val dialectExtension =
+      """type mystr = {
+        |  v: string
+        |}
+        |type mystr in duckdb = {
+        |  v: string
+        |}
+        |""".stripMargin
+    duplicateWarnings(compileUnits(List(dialectExtension), "from [[1]] as t(id)\n")) shouldBe Nil
+
+    // Single-part contexts are dialect scopes, not table bindings, in separate files too
+    val duckdbMetrics  = "type metrics in duckdb = {\n  value: double\n}\n"
+    val trinoMetrics   = "type metrics in trino = {\n  value: double\n}\n"
+    val singlePartOnly = compileUnits(List(duckdbMetrics, trinoMetrics), "from [[1]] as t(id)\n")
+    duplicateWarnings(singlePartOnly) shouldBe Nil
+  }
+
+  test("warn when a schema-bound type shares its name with an unbound type") {
+    val unbound   = "type orders = {\n  order_id: bigint\n}\n"
+    val typeUnits = compileUnits(List(unbound, ordersType), "from sales.orders\n")
+    val warnings  = duplicateWarnings(typeUnits)
+    warnings.size shouldBe 1
+    warnings.head.message shouldContain "no table binding"
+    warnings.head.message shouldContain "mydb.sales"
+  }
+
+  test("warn when one file binds the same type name to different schemas") {
+    val sameFile  = ordersType + marketingOrdersType
+    val typeUnits = compileUnits(List(sameFile), "from sales.orders\n")
+    val warnings  = duplicateWarnings(typeUnits)
+    warnings.size shouldBe 1
+    warnings.head.message shouldContain "mydb.sales"
+    warnings.head.message shouldContain "mydb.marketing"
+  }
+
+  test("not fail strict compilation on duplicate type definition warnings") {
+    val compiler  = Compiler(CompilerOptions(workEnv = WorkEnv(".")).withFailOnTypeErrors(true))
+    val typeUnits = List(ordersType, marketingOrdersType).map(CompilationUnit.fromWvletString)
+    val queryUnit = CompilationUnit.fromWvletString("from sales.orders\n")
+    // Duplicate-definition diagnostics are warnings and must not fail even in strict mode
+    val result = compiler.compileMultipleUnits(typeUnits, queryUnit)
+    result.hasFailures shouldBe false
+    duplicateWarnings(typeUnits).size shouldBe 1
   }
 
   test("keep single-part contexts as non-binding dialect scopes") {

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperDiagnosticsTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperDiagnosticsTest.scala
@@ -57,6 +57,17 @@ class TyperDiagnosticsTest extends UniTest:
     compileErrors("from [[1]] as t(id) | where unknown_col + 1 > 2") shouldBe Nil
   }
 
+  test("report type mismatches with error severity") {
+    val errors     = compileErrors("select 1 - 'a' as v")
+    val mismatches = errors.collect { case t: TypeMismatch =>
+      t
+    }
+    mismatches.nonEmpty shouldBe true
+    mismatches.foreach { m =>
+      m.severity shouldBe TyperError.Severity.Error
+    }
+  }
+
   test("fail the compilation on type errors when failOnTypeErrors is set") {
     val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")).withFailOnTypeErrors(true))
     val unit     = CompilationUnit.fromWvletString("select 1 - 'a' as v")

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -21,6 +21,7 @@ import wvlet.lang.compiler.lsp.CompletionItem
 import wvlet.lang.compiler.lsp.CompletionProvider
 import wvlet.lang.compiler.lsp.DefinitionProvider
 import wvlet.lang.compiler.lsp.HoverProvider
+import wvlet.lang.compiler.typer.TyperError
 import wvlet.lang.model.plan.*
 import wvlet.uni.weaver.Weaver
 import wvlet.uni.weaver.codec.PrimitiveWeaver.given
@@ -221,6 +222,32 @@ object WvletJS:
       // accumulate stale symbols that shadow the workspace files
       lspCompiler.releaseUnit(inputUnit)
     end try
+
+    // Surface the structured typer diagnostics of this document (typerErrors survives
+    // releaseUnit): duplicate-definition warnings and type errors (e.g. TypeMismatch), each
+    // with its own severity
+    val sourceFile = inputUnit.sourceFile
+    inputUnit
+      .typerErrors
+      .filter(_.span.exists)
+      .foreach { err =>
+        val severity =
+          err.severity match
+            case TyperError.Severity.Warning =>
+              "warning"
+            case TyperError.Severity.Error =>
+              "error"
+        diagnostics +=
+          LspDiagnostic(
+            line = sourceFile.offsetToLine(err.span.start) + 1,
+            column = sourceFile.offsetToColumn(err.span.start),
+            endLine = sourceFile.offsetToLine(err.span.end) + 1,
+            endColumn = sourceFile.offsetToColumn(err.span.end),
+            message = err.message,
+            severity = severity,
+            statusCode = err.getClass.getSimpleName
+          )
+      }
 
     given Weaver[LspDiagnostic] = Weaver.of[LspDiagnostic]
     summon[Weaver[List[LspDiagnostic]]].toJson(diagnostics.toList)


### PR DESCRIPTION
## Summary

When `wvlet catalog import` (#1889, #1890) generates the same type name into multiple schema files — e.g. `type orders in mydb.sales` in `catalog/mydb/sales.wv` and `type orders in mydb.marketing` in `catalog/mydb/marketing.wv` — name lookup silently resolves through only one definition by file-name order (#93). Queries against the shadowed schema stop matching the bound table without any signal to the user.

This PR makes the compiler report a structured **warning** (never an error) for such duplicates:

```
[warning] Duplicate type definition 'orders' (bound to mydb.marketing): also defined at catalog/mydb/sales.wv:1:1 (bound to mydb.sales). Only the definition in catalog/mydb/sales.wv is used for name lookup.
```

## Changes

- **`TypeDef.tableBinding`** (`model/plan/plan.scala`): shared extractor of the `<catalog>.<schema>` binding; `RelationRefResolver.tableBindingOf` and `CompletionProvider.boundTableItems` now reuse it instead of duplicating the defContexts pattern match.
- **`TyperError.Severity`** (`typer/TyperError.scala`): new `Warning`/`Error` severity on `TyperError` (default `Error`), plus the `DuplicateTypeDefinition` warning carrying both bindings, the conflicting location, and the winning file.
- **`SymbolLabeler`**: emits the warning when same-name type definitions carry conflicting bindings (case-insensitive), same-file or cross-file. Two-part binding vs. different two-part binding warns; bound vs. unbound warns; identical bindings, unbound duplicates, and single-part dialect scopes (`type string in duckdb`) stay silent, preserving intentional dialect-extension merging. Preset (stdlib) units are excluded.
- **`Typer.run`**: diagnostics log now prefixes each line with `[warning]`/`[error]`, and `--strict` (`failOnTypeErrors`) fails only on `Error`-severity diagnostics, so warnings never break CI validation.
- **LSP/editor** (`WvletJS.analyzeDiagnostics`): the current document's typer diagnostics are now returned with their severity, so the warning shows up as a squiggle in VS Code (the extension already maps `"warning"`). This also surfaces existing error-severity typer diagnostics (e.g. `TypeMismatch`) in the editor for the first time.
- **Docs**: new "Duplicate type names across schemas" section in `website/docs/usage/catalog-import.md` explaining what the warning means and how to resolve it.

## Tests

- `TypeTableBindingTest`: cross-file conflicting bindings warn (with severity, message content, and file-name-sorted winner); identical case-insensitive bindings don't; dialect extensions and single-part contexts don't; bound-vs-unbound warns; same-file conflicting bindings warn; `--strict` compiles duplicates without failing.
- `TyperDiagnosticsTest`: `TypeMismatch` keeps `Error` severity; strict mode still throws on real type errors.

All of `projectJVM/Test/compile`, `projectJS/Test/compile`, `langJVM/test` (930 tests), and `TyperCoverageCheck` pass; `scalafmtCheck` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)