### PR TITLE
feature: Navigate to model/type definitions in other workspace files from the editor

### DIFF
--- a/sdks/typescript/lib/main.d.ts
+++ b/sdks/typescript/lib/main.d.ts
@@ -58,11 +58,12 @@ export interface WvletJSType {
   getHover(content: string, line: number, column: number): string;
 
   /**
-   * Compute the go-to-definition target (model / type definition) for a Wvlet source at the given cursor position as JSON
+   * Compute the go-to-definition target (model / type definition) for a Wvlet source at the given cursor position as JSON.
+   * The definition may live in another workspace file (see setWorkspacePath); in that case `path` carries the defining file's local path
    * @param content The Wvlet source code
    * @param line 1-based line number of the cursor
    * @param column 1-based column number of the cursor
-   * @returns JSON object ({startLine, startColumn, endLine, endColumn}) or the literal `null` when there is nothing to resolve
+   * @returns JSON object ({startLine, startColumn, endLine, endColumn, path?}) or the literal `null` when there is nothing to resolve. `path` is absent when the definition is in the requested document itself
    */
   getDefinition(content: string, line: number, column: number): string;
 }

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -156,4 +156,9 @@ export interface LspDefinition {
   startColumn: number;
   endLine: number;
   endColumn: number;
+  /**
+   * Path of the workspace file containing the definition;
+   * absent when the definition is in the requested document itself.
+   */
+  path?: string | null;
 }

--- a/sdks/typescript/tests/definition.test.ts
+++ b/sdks/typescript/tests/definition.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 // The go-to-definition API is exposed directly on the Scala.js WvletJS module used by the LSP server.
 import { WvletJS } from '../lib/main.js';
 import type { LspDefinition } from '../src/types.js';
@@ -44,5 +47,50 @@ describe('WvletJS.getDefinition', () => {
 
   it('should not throw on incomplete input', () => {
     expect(definition('from ', 1, 6)).toBeNull();
+  });
+});
+
+// Cross-file navigation: once setWorkspacePath points at a project folder, definitions in
+// other workspace files resolve and carry the defining file's path.
+describe('WvletJS.getDefinition across workspace files', () => {
+  const defsSource =
+    'model shared_model = {\n  from [[1, "alice", 10]] as person(id, name, age)\n}\n';
+
+  let projectDir: string;
+  let defsPath: string;
+
+  beforeAll(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'wvlet-definition-'));
+    defsPath = join(projectDir, 'defs.wv');
+    writeFileSync(defsPath, defsSource);
+    WvletJS.setWorkspacePath(projectDir);
+  });
+
+  afterAll(() => {
+    // Restore the default so other test files keep seeing an empty workspace
+    WvletJS.setWorkspacePath('.');
+    if (projectDir) {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should report the defining file path for a model in another workspace file', () => {
+    // Cursor on `shared_model` (line 1, column 7)
+    const result = definition('from shared_model', 1, 7);
+    expect(result).not.toBeNull();
+    expect(result?.path).toBe(defsPath);
+    // `model shared_model` starts on line 1 of defs.wv
+    expect(result?.startLine).toBe(1);
+    expect(result?.startColumn).toBe(1);
+  });
+
+  it('should not report a path for a same-document definition', () => {
+    const src =
+      'model my_model = {\n  from shared_model\n}\nfrom my_model';
+    // Cursor on `my_model` in the last line (line 4, column 7)
+    const result = definition(src, 4, 7);
+    expect(result).not.toBeNull();
+    expect(result?.startLine).toBe(1);
+    expect(result?.path ?? null).toBeNull();
   });
 });

--- a/spec/lsp/defs.wv
+++ b/spec/lsp/defs.wv
@@ -1,0 +1,9 @@
+-- Workspace definitions referenced by LSP cross-file navigation tests
+model shared_model = {
+  from [[1, "alice", 10]] as person(id, name, age)
+}
+
+type shared_point = {
+  x: long
+  y: long
+}

--- a/vscode-wvlet/src/server.ts
+++ b/vscode-wvlet/src/server.ts
@@ -19,7 +19,8 @@ import {
 } from 'vscode-languageserver/node';
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { isAbsolute, resolve } from 'node:path';
 
 import type { WvletJSType } from '../../sdks/typescript/lib/main';
 import type {
@@ -314,9 +315,28 @@ connection.onDefinition(async (params): Promise<Location | null> => {
       return null;
     }
 
-    // Single-document scope: the definition lives in the same document
+    // Without a path the definition is in the requested document itself (this also covers
+    // unsaved buffers: the compiler sees the document as an in-memory snapshot). With a path,
+    // the definition lives in another workspace file.
+    let uri = document.uri;
+    if (definition.path) {
+      const definitionPath = isAbsolute(definition.path)
+        ? definition.path
+        : resolve(workspacePath ?? '.', definition.path);
+      // Prefer the open document's URI when it denotes the same file, so a dirty (unsaved)
+      // buffer of that file is targeted instead of its on-disk copy
+      let sameFile = false;
+      try {
+        sameFile = definitionPath === fileURLToPath(document.uri);
+      } catch {
+        // Not a file:// URI (e.g. an untitled buffer): navigate to the definition file
+      }
+      if (!sameFile) {
+        uri = pathToFileURL(definitionPath).toString();
+      }
+    }
     return {
-      uri: document.uri,
+      uri,
       range: {
         // Convert from 1-based (Wvlet) to 0-based (LSP)
         start: Position.create(

--- a/vscode-wvlet/src/server.ts
+++ b/vscode-wvlet/src/server.ts
@@ -327,7 +327,12 @@ connection.onDefinition(async (params): Promise<Location | null> => {
       // buffer of that file is targeted instead of its on-disk copy
       let sameFile = false;
       try {
-        sameFile = definitionPath === fileURLToPath(document.uri);
+        const docPath = fileURLToPath(document.uri);
+        // Windows paths are case-insensitive (e.g. drive-letter casing C:\ vs c:\)
+        sameFile =
+          process.platform === 'win32'
+            ? definitionPath.toLowerCase() === docPath.toLowerCase()
+            : definitionPath === docPath;
       } catch {
         // Not a file:// URI (e.g. an untitled buffer): navigate to the definition file
       }

--- a/website/docs/usage/vscode.md
+++ b/website/docs/usage/vscode.md
@@ -22,7 +22,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Document Outline**: Models, types, vals, and flows appear in the outline view
 - **Code Completion**: Context-aware suggestions as you type
 - **Hover Information**: Type and schema details when you hover over models and columns
-- **Go to Definition**: Jump from a model or type reference to its definition
+- **Go to Definition**: Jump from a model or type reference to its definition, also across workspace files
 
 ## Code Completion
 
@@ -64,9 +64,11 @@ Place the cursor on a model or type reference and use **Go to Definition** (`F12
 example, from `from my_model` you can jump to the `model my_model = ...` definition, and
 from a type reference to its `type` declaration.
 
-Go to Definition jumps within the current file. References to models or types defined in
-other workspace files resolve for diagnostics, completion, and hover, but navigating to
-their defining file is future work.
+Go to Definition works across the files of your workspace: a reference to a model or type
+defined in another `.wv` file — including table types imported into the `catalog/` folder by
+[`wvlet catalog import`](./catalog-import.md) — opens the defining file at the definition.
+When the same name is defined both in the current file and elsewhere, the definition in the
+current file wins.
 
 ## Working with Database Tables
 
@@ -88,8 +90,6 @@ sources are found.
   known — from a `model`/`type` definition in the workspace or from an imported catalog
   (see above). File sources such as `from 'data.json'` do not yet carry a schema in the
   editor.
-- **Same-file navigation**: Go to Definition only jumps to definitions in the file you are
-  editing; cross-file navigation is future work.
 - **Requires an analyzable query**: Column completion and hover rely on type
   resolution, so they appear once the surrounding query is complete enough to be
   analyzed. While a query is still being written, keyword and definition-name

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/DefinitionProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/DefinitionProvider.scala
@@ -15,7 +15,7 @@ package wvlet.lang.compiler.lsp
 
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Compiler
-import wvlet.lang.compiler.SourceFile
+import wvlet.lang.compiler.LocalFile
 import wvlet.lang.compiler.parser.ParserPhase
 import wvlet.lang.model.SyntaxTreeNode
 import wvlet.lang.model.expr.NameExpr
@@ -23,8 +23,9 @@ import wvlet.lang.model.plan.*
 
 /**
   * The result of a go-to-definition request: the 1-based source range of the definition the cursor
-  * resolves to. Only same-document definitions are returned, so the editor navigates within the
-  * current file.
+  * resolves to. When `path` is empty, the definition is in the requested document itself; when set,
+  * it is the local file path of the workspace file that contains the definition, so the editor can
+  * navigate across files.
   *
   * @param startLine
   *   1-based line of the definition range start
@@ -34,8 +35,17 @@ import wvlet.lang.model.plan.*
   *   1-based line of the definition range end
   * @param endColumn
   *   1-based column of the definition range end
+  * @param path
+  *   Path of the file containing the definition, or `None` when the definition is in the requested
+  *   document
   */
-case class DefinitionResult(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int)
+case class DefinitionResult(
+    startLine: Int,
+    startColumn: Int,
+    endLine: Int,
+    endColumn: Int,
+    path: Option[String] = None
+)
 
 /**
   * Provides go-to-definition for the Wvlet language: given a cursor on a model or type reference,
@@ -47,19 +57,28 @@ case class DefinitionResult(startLine: Int, startColumn: Int, endLine: Int, endC
   * any failure yields `None` rather than throwing.
   *
   * Resolution combines two strategies for robustness:
-  *   - The resolved symbol chain: when full typing succeeds, a reference node carries a symbol
-  *     whose `tree` is the defining `ModelDef`/`TypeDef`.
-  *   - A name fallback: the referenced identifier is matched against the top-level `model`/`type`
-  *     names collected from a parse-only pass, so navigation keeps working when full typing fails
-  *     (e.g. a later statement has an error).
+  *   - The resolved symbol chain: when a reference node carries a symbol whose `tree` is the
+  *     defining `ModelDef`/`TypeDef`, the symbol also records its defining compilation unit.
+  *   - A name lookup: the referenced identifier is matched against the top-level `model`/`type`
+  *     names of the current document (collected from a parse-only pass, so navigation keeps working
+  *     when full typing fails) and then against those of the other workspace units loaded by the
+  *     compiler.
   *
-  * This is single-document only: the language server compiles each document standalone, so
-  * definitions resolve within the same file. Cross-file / workspace navigation is future work.
+  * The document is compiled together with the other workspace sources (including the `catalog/`
+  * folder), so a definition may live in another file: such results carry the defining file's path.
+  * Current-document definitions always take precedence, matching the compiler's shadowing rule for
+  * duplicate top-level names.
   */
 object DefinitionProvider:
 
-  /** A top-level model or type definition collected from a parse-only pass. */
-  private case class DefinitionEntry(name: String, node: SyntaxTreeNode)
+  /**
+    * A top-level model or type definition, paired with the compilation unit that contains it so
+    * that cross-file targets can report the defining file
+    */
+  private case class DefinitionEntry(name: String, node: SyntaxTreeNode, unit: CompilationUnit)
+
+  /** A resolved definition node paired with the compilation unit that defines it. */
+  private case class DefinitionTarget(node: SyntaxTreeNode, unit: CompilationUnit)
 
   /**
     * Compute the definition target for the given source at the given character offset.
@@ -79,11 +98,12 @@ object DefinitionProvider:
   def definition(content: String, offset: Int, compiler: Compiler): Option[DefinitionResult] =
     val unit = CompilationUnit.fromWvletString(content)
     try
-      // Collect top-level model/type definitions with a parse-only pass (resilient to parse errors)
-      val definitions =
+      // Collect top-level model/type definitions of the current document with a parse-only pass
+      // (resilient to parse errors)
+      val localDefinitions =
         try
           unit.unresolvedPlan = ParserPhase.parseOnly(unit)
-          collectDefinitions(unit.unresolvedPlan)
+          collectDefinitions(unit.unresolvedPlan, unit)
         catch
           case _: Throwable =>
             Nil
@@ -98,6 +118,10 @@ object DefinitionProvider:
         case _: Throwable =>
         // Ignore compile errors — fall back to the parse-only plan
 
+      // Current-document definitions come first so they shadow same-named workspace definitions,
+      // matching the compiler's duplicate-name resolution
+      val definitions = localDefinitions ++ workspaceDefinitions(compiler, unit)
+
       val searchPlan =
         if unit.resolvedPlan.nonEmpty then
           unit.resolvedPlan
@@ -106,8 +130,7 @@ object DefinitionProvider:
       if searchPlan.isEmpty then
         None
       else
-        val sourceFile = unit.sourceFile
-        sourceFile.ensureLoaded
+        unit.sourceFile.ensureLoaded
         // Candidate nodes covering the cursor, innermost (smallest span) first
         val candidates = searchPlan
           .collectAllNodes
@@ -119,7 +142,7 @@ object DefinitionProvider:
             // Resolving a single candidate may fail on an incomplete/malformed AST; skip it so an
             // enclosing candidate can still resolve.
             try
-              definitionFor(n, definitions, offset).map(d => toResult(d, sourceFile))
+              definitionFor(n, definitions, offset, unit).flatMap(t => toResult(t, unit))
             catch
               case _: Throwable =>
                 None
@@ -142,43 +165,81 @@ object DefinitionProvider:
     * [[CompletionProvider.definitionItems]], this recurses only into `PackageDef` containers, since
     * only top-level definitions are referenceable from other statements.
     */
-  private def collectDefinitions(plan: LogicalPlan): List[DefinitionEntry] =
+  private def collectDefinitions(plan: LogicalPlan, unit: CompilationUnit): List[DefinitionEntry] =
     val buf                        = List.newBuilder[DefinitionEntry]
     def loop(p: LogicalPlan): Unit =
       p match
         case pkg: PackageDef =>
           pkg.statements.foreach(loop)
         case m: ModelDef =>
-          buf += DefinitionEntry(m.name.name, m)
+          buf += DefinitionEntry(m.name.name, m, unit)
         case t: TypeDef =>
-          buf += DefinitionEntry(t.name.name, t)
+          buf += DefinitionEntry(t.name.name, t, unit)
         case _ =>
     loop(plan)
     buf.result()
 
   /**
+    * Collect the top-level `model`/`type` definitions of the workspace units loaded by the
+    * compiler, so that references resolve across files. Preset units (the built-in stdlib) are
+    * skipped: their in-memory sources have no file the editor could open. A workspace unit that has
+    * not been compiled yet is parsed on the fly, without mutating its cached state.
+    */
+  private def workspaceDefinitions(
+      compiler: Compiler,
+      currentUnit: CompilationUnit
+  ): List[DefinitionEntry] = compiler
+    .compilationUnitsInSourcePaths
+    .filter(u => !u.isPreset && !(u.sourceFile eq currentUnit.sourceFile))
+    .flatMap { u =>
+      try
+        val plan =
+          if u.resolvedPlan.nonEmpty then
+            u.resolvedPlan
+          else if u.unresolvedPlan.nonEmpty then
+            u.unresolvedPlan
+          else
+            ParserPhase.parseOnly(u, isContextUnit = false)
+        collectDefinitions(plan, u)
+      catch
+        case _: Throwable =>
+          // A workspace file that fails to parse contributes no definitions
+          Nil
+    }
+
+  /**
     * Resolve the defining `ModelDef`/`TypeDef` for a single candidate node, or `None` if the node
     * is not a model/type reference. The resolved symbol's definition tree is preferred; the
-    * collected definition names are used as a fallback when typing did not resolve the symbol.
+    * collected definition names (current document first, then the other workspace files) are used
+    * as a fallback when typing did not resolve the symbol. Either way the definition may live in
+    * another workspace file.
     *
-    * A definition whose span contains the cursor is treated as "already at the definition" and
-    * yields `None`, so navigating from the definition itself (or a keyword/name within it) does not
-    * jump to itself.
+    * A same-document definition whose span contains the cursor is treated as "already at the
+    * definition" and yields `None`, so navigating from the definition itself (or a keyword/name
+    * within it) does not jump to itself. The check is skipped for cross-file targets: their spans
+    * index a different file, so containing the cursor offset is coincidental.
     */
   private def definitionFor(
       node: SyntaxTreeNode,
       definitions: List[DefinitionEntry],
-      offset: Int
-  ): Option[SyntaxTreeNode] =
+      offset: Int,
+      currentUnit: CompilationUnit
+  ): Option[DefinitionTarget] =
     val bySymbol =
       try
         val sym = node.symbol
         if sym.isDefined then
           sym.tree match
-            case d: ModelDef =>
-              Some(d)
-            case d: TypeDef =>
-              Some(d)
+            case d @ (_: ModelDef | _: TypeDef) =>
+              // Symbols not tied to a single source definition report CompilationUnit.empty;
+              // treat those as defined in the current document
+              val definingUnit = sym.compilationUnit
+              val unit         =
+                if definingUnit.isEmpty then
+                  currentUnit
+                else
+                  definingUnit
+              Some(DefinitionTarget(d, unit))
             case _ =>
               None
         else
@@ -190,10 +251,15 @@ object DefinitionProvider:
     bySymbol
       .orElse {
         referenceName(node).flatMap { name =>
-          definitions.find(_.name == name).map(_.node)
+          definitions.find(_.name == name).map(d => DefinitionTarget(d.node, d.unit))
         }
       }
-      .filter(d => d.span.exists && !d.span.containsInclusive(offset))
+      .filter { t =>
+        val sameDocument = t.unit.sourceFile eq currentUnit.sourceFile
+        t.node.span.exists && !(sameDocument && t.node.span.containsInclusive(offset))
+      }
+
+  end definitionFor
 
   /**
     * The referenced model/type name carried by a node, or `None` if the node is not a name-like
@@ -211,14 +277,39 @@ object DefinitionProvider:
       case _ =>
         None
 
-  /** Convert a definition node's span into a 1-based [[DefinitionResult]]. */
-  private def toResult(node: SyntaxTreeNode, sourceFile: SourceFile): DefinitionResult =
-    val span = node.span
-    DefinitionResult(
-      startLine = sourceFile.offsetToLine(span.start) + 1,
-      startColumn = sourceFile.offsetToColumn(span.start),
-      endLine = sourceFile.offsetToLine(span.end) + 1,
-      endColumn = sourceFile.offsetToColumn(span.end)
-    )
+  /**
+    * Convert a definition target's span into a 1-based [[DefinitionResult]], using the defining
+    * unit's source file so that cross-file spans map to the correct lines. Cross-file targets carry
+    * the defining file's path; targets in a file the editor cannot open (preset stdlib or other
+    * in-memory sources) yield `None`.
+    */
+  private def toResult(
+      target: DefinitionTarget,
+      currentUnit: CompilationUnit
+  ): Option[DefinitionResult] =
+    val sourceFile   = target.unit.sourceFile
+    val sameDocument = sourceFile eq currentUnit.sourceFile
+    val path         =
+      if sameDocument then
+        // The definition is in the requested document (which may be an unsaved buffer)
+        Some(None)
+      else
+        sourceFile.file match
+          case f: LocalFile =>
+            Some(Some(f.path))
+          case _ =>
+            // Preset stdlib or other non-local sources have no file the editor can navigate to
+            None
+    path.map { p =>
+      sourceFile.ensureLoaded
+      val span = target.node.span
+      DefinitionResult(
+        startLine = sourceFile.offsetToLine(span.start) + 1,
+        startColumn = sourceFile.offsetToColumn(span.start),
+        endLine = sourceFile.offsetToLine(span.end) + 1,
+        endColumn = sourceFile.offsetToColumn(span.end),
+        path = p
+      )
+    }
 
 end DefinitionProvider

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/DefinitionProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/DefinitionProvider.scala
@@ -183,7 +183,11 @@ object DefinitionProvider:
     * Collect the top-level `model`/`type` definitions of the workspace units loaded by the
     * compiler, so that references resolve across files. Preset units (the built-in stdlib) are
     * skipped: their in-memory sources have no file the editor could open. A workspace unit that has
-    * not been compiled yet is parsed on the fly, without mutating its cached state.
+    * not been compiled yet (e.g. when the best-effort compile aborted early) is parsed on the fly,
+    * and the plan is cached back into the unit — the same assignment [[ParserPhase.run]] performs —
+    * so repeated definition requests do not re-parse it. A later compile still re-parses the unit
+    * (the parser phase is not marked finished), and [[CompilationUnit.reload]] discards the cached
+    * plan when the file changes.
     */
   private def workspaceDefinitions(
       compiler: Compiler,
@@ -199,7 +203,8 @@ object DefinitionProvider:
           else if u.unresolvedPlan.nonEmpty then
             u.unresolvedPlan
           else
-            ParserPhase.parseOnly(u, isContextUnit = false)
+            u.unresolvedPlan = ParserPhase.parseOnly(u, isContextUnit = false)
+            u.unresolvedPlan
         collectDefinitions(plan, u)
       catch
         case _: Throwable =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/DefinitionProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/DefinitionProvider.scala
@@ -119,8 +119,9 @@ object DefinitionProvider:
         // Ignore compile errors — fall back to the parse-only plan
 
       // Current-document definitions come first so they shadow same-named workspace definitions,
-      // matching the compiler's duplicate-name resolution
-      val definitions = localDefinitions ++ workspaceDefinitions(compiler, unit)
+      // matching the compiler's duplicate-name resolution. Lazy (memoized) so that workspace
+      // definitions are only collected when a candidate actually needs the name fallback
+      lazy val definitions = localDefinitions ++ workspaceDefinitions(compiler, unit)
 
       val searchPlan =
         if unit.resolvedPlan.nonEmpty then
@@ -226,7 +227,9 @@ object DefinitionProvider:
     */
   private def definitionFor(
       node: SyntaxTreeNode,
-      definitions: List[DefinitionEntry],
+      // Call-by-name so the caller's lazy (memoized) definition list is only forced when the
+      // name fallback below is reached
+      definitions: => List[DefinitionEntry],
       offset: Int,
       currentUnit: CompilationUnit
   ): Option[DefinitionTarget] =

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/DefinitionProviderTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/DefinitionProviderTest.scala
@@ -22,8 +22,17 @@ class DefinitionProviderTest extends UniTest:
 
   private def newCompiler: Compiler = Compiler(CompilerOptions(workEnv = WorkEnv(path = ".")))
 
+  // A compiler whose workspace contains spec/lsp/defs.wv (defines `shared_model` and
+  // `shared_point`), used for cross-file navigation tests
+  private def workspaceCompiler: Compiler = Compiler(
+    CompilerOptions(sourceFolders = List("spec/lsp"), workEnv = WorkEnv(path = "spec/lsp"))
+  )
+
   private def definition(content: String, offset: Int): Option[DefinitionResult] =
     DefinitionProvider.definition(content, offset, newCompiler)
+
+  private def workspaceDefinition(content: String, offset: Int): Option[DefinitionResult] =
+    DefinitionProvider.definition(content, offset, workspaceCompiler)
 
   test("should jump from a model reference to its model definition"):
     val src =
@@ -37,6 +46,8 @@ class DefinitionProviderTest extends UniTest:
     // The `model my_model` definition starts on line 1
     result.map(_.startLine) shouldBe Some(1)
     result.map(_.startColumn) shouldBe Some(1)
+    // Same-document definitions carry no file path
+    result.flatMap(_.path) shouldBe None
 
   test("should jump from a type reference to its type definition"):
     val src =
@@ -104,5 +115,46 @@ class DefinitionProviderTest extends UniTest:
 
   test("should return None for an empty source"):
     definition("", 0) shouldBe None
+
+  test("should jump to a model defined in another workspace file"):
+    val src    = "from shared_model"
+    val offset = src.indexOf("shared_model") + 1
+    val result = workspaceDefinition(src, offset)
+    // `model shared_model` is defined on line 2 of spec/lsp/defs.wv
+    result.flatMap(_.path).exists(_.endsWith("defs.wv")) shouldBe true
+    result.map(_.startLine) shouldBe Some(2)
+
+  test("should jump to a type defined in another workspace file"):
+    val src =
+      """type my_line = {
+        |  start: shared_point
+        |  stop: shared_point
+        |}""".stripMargin
+    val offset = src.indexOf("start: shared_point") + "start: ".length + 1
+    val result = workspaceDefinition(src, offset)
+    // `type shared_point` is defined on line 6 of spec/lsp/defs.wv
+    result.flatMap(_.path).exists(_.endsWith("defs.wv")) shouldBe true
+    result.map(_.startLine) shouldBe Some(6)
+
+  test("should prefer a same-document definition that shadows a workspace model"):
+    val src =
+      """model shared_model = {
+        |  from [[2, "bob", 20]] as person(id, name, age)
+        |}
+        |from shared_model""".stripMargin
+    val offset = src.lastIndexOf("shared_model") + 1
+    val result = workspaceDefinition(src, offset)
+    // The redefinition in the current document wins over spec/lsp/defs.wv
+    result.map(_.startLine) shouldBe Some(1)
+    result.flatMap(_.path) shouldBe None
+
+  test("should not navigate to a preset stdlib definition"):
+    // `long` resolves to a stdlib type, which has no local file the editor could open
+    val src =
+      """type my_point = {
+        |  x: long
+        |}""".stripMargin
+    val offset = src.indexOf("x: long") + "x: ".length + 1
+    definition(src, offset) shouldBe None
 
 end DefinitionProviderTest

--- a/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
+++ b/wvlet-sdk-js/src/main/scala/wvlet/lang/sdk/js/WvletJS.scala
@@ -378,10 +378,11 @@ object WvletJS:
     * @param column
     *   1-based column number of the cursor
     * @return
-    *   JSON object `{startLine, startColumn, endLine, endColumn}` describing the 1-based source
-    *   range of the definition, or the JSON literal `null` when the cursor is not on a resolvable
-    *   model/type reference (unknown position, keyword, whitespace, the definition itself, or an
-    *   unknown name). Only same-document definitions are returned.
+    *   JSON object `{startLine, startColumn, endLine, endColumn, path?}` describing the 1-based
+    *   source range of the definition, or the JSON literal `null` when the cursor is not on a
+    *   resolvable model/type reference (unknown position, keyword, whitespace, the definition
+    *   itself, or an unknown name). `path` is the local path of the workspace file containing the
+    *   definition; it is absent when the definition is in the requested document itself.
     */
   @JSExport
   def getDefinition(content: String, line: Int, column: Int): String =
@@ -401,7 +402,8 @@ object WvletJS:
           startLine = d.startLine,
           startColumn = d.startColumn,
           endLine = d.endLine,
-          endColumn = d.endColumn
+          endColumn = d.endColumn,
+          path = d.path
         )
         Weaver.of[LspDefinition].toJson(definition)
       case None =>
@@ -449,9 +451,17 @@ case class LspHover(content: String, startLine: Int, startColumn: Int, endLine: 
 
 /**
   * LSP go-to-definition representation for JSON serialization. The line/column fields describe the
-  * 1-based source range of the target model/type definition.
+  * 1-based source range of the target model/type definition. `path` is the local path of the
+  * workspace file containing the definition; it is `None` (absent in JSON) when the definition is
+  * in the requested document itself.
   */
-case class LspDefinition(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int)
+case class LspDefinition(
+    startLine: Int,
+    startColumn: Int,
+    endLine: Int,
+    endColumn: Int,
+    path: Option[String] = None
+)
 
 /**
   * LSP SymbolKind constants (subset from the LSP specification)


### PR DESCRIPTION
## Summary

Go-to-definition in the LSP was single-document only: resolution already compiled the open document together with the workspace sources (#1893), but the reporting layer always converted the definition span against the requested document and the editor hardcoded the current file's URI. This PR threads the defining compilation unit through the whole chain, so **Go to Definition now jumps across workspace files**, including into `catalog/` files generated by `wvlet catalog import`.

### Changes

- **`DefinitionProvider` (wvlet-lang)**
  - `DefinitionResult` gains `path: Option[String]` — `None` means the definition is in the requested document (covers unsaved buffers); `Some(p)` is the defining file's local path, reported only for `LocalFile`-backed units.
  - Definition targets carry their defining `CompilationUnit`; spans are converted with the *target* unit's `SourceFile`, so cross-file line/column ranges are correct.
  - The top-level model/type name lookup now spans all non-preset workspace units loaded by the compiler, with current-document definitions taking precedence (matching the compiler's shadowing rule for duplicate top-level names).
  - The "already at the definition" self-jump filter only applies to same-document targets — a cross-file span containing the cursor offset is coincidental.
  - Latent bug fix: references resolving into the preset stdlib (e.g. `long`) now yield no result instead of a bogus in-file range converted against the wrong document.
- **`WvletJS` (Scala.js SDK)**: `LspDefinition` serializes the optional `path` field.
- **TypeScript SDK**: `LspDefinition.path?: string | null` type + updated `lib/main.d.ts` docs.
- **VS Code extension (`server.ts`)**: when `path` is present, builds the target URI with `pathToFileURL` (resolving relative paths against the workspace root); prefers the open document's URI when the path denotes the same file so dirty buffers are targeted.
- **Docs**: `website/docs/usage/vscode.md` updated; removed the same-file-only limitation.
- **Test fixture**: new `spec/lsp/defs.wv` with `shared_model` / `shared_point` used by workspace navigation tests.

### Design note

The originally planned symbol-based cross-file resolution (`sym.compilationUnit`) is kept as the preferred path, but reference nodes (`ModelScan`, type identifiers) currently carry no symbols after typing, so the workspace-wide name lookup is what makes cross-file navigation work in practice.

## Testing

- `DefinitionProviderTest` (13 tests, JVM and Scala.js): cross-file model/type navigation with `path` ending in `defs.wv` and correct target lines, same-document results carry no path, current-document shadowing of a workspace model, stdlib references yield `None`, plus all pre-existing cases.
- TypeScript SDK: `sdks/typescript` vitest suite (47 tests) including a new cross-file block using a temp workspace (`setWorkspacePath`), asserting the absolute defining path and the absence of `path` for same-document results.
- `projectJVM/Test/compile`, `projectJS/Test/compile`, `langJVM/test`, `sdkJs/fastLinkJS` all pass; `scalafmtAll` applied; vscode-wvlet esbuild build passes (the `tsc --noEmit` rootDir complaint is pre-existing on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)