### PR TITLE
fix: Embed libduckdb rpath entries in native binaries so they load outside dev machines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,12 @@ sbt:wvlet> wvc/nativeLink
 
 Note: The `wv` command is implemented in WvletREPLMain, while `wvlet` is implemented in WvletMain.
 
+Native builds also need DuckDB's C API: `duckdb.h` on the include path and libduckdb on the
+library path (`brew install duckdb`, or set `CPATH` / `LIBRARY_PATH` for non-standard
+locations). Built binaries embed `/opt/homebrew/lib` and `/usr/local/lib` as rpath entries for
+locating libduckdb at runtime; set `WVLET_NATIVE_LIB_PATH=<dir>` at build time to embed an
+additional lookup directory (see `nativeLibRpathLinking` in build.sbt).
+
 ### Code Formatting
 
 Ensure the code is formatted with `scalafmtAll` command for consistent code style. CI will check formatting on pull requests.

--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,39 @@ val uniNativeCurlLinking =
     c.withLinkingOptions(c.linkingOptions :+ "-lcurl")
   }
 
+// libduckdb is linked dynamically (macOS install name `@rpath/libduckdb.dylib`), but Scala
+// Native bakes no rpath into the produced binaries. On machines where libduckdb lives outside
+// the loader's default search path (e.g. Homebrew's /opt/homebrew/lib), the binary then fails
+// at load time for every command — even ones that never touch DuckDB — with
+// `dyld: Library not loaded: @rpath/libduckdb.dylib ... Reason: no LC_RPATH's found`.
+// Embed the common install prefixes as rpath entries, plus any extra directories given via the
+// path-separated WVLET_NATIVE_LIB_PATH environment variable (also added as `-L` link paths so
+// a single variable covers both link-time and run-time lookup of a custom libduckdb).
+// Windows has no rpath concept and `-Wl,-rpath` breaks its link step, so skip it there.
+val nativeLibRpathLinking =
+  nativeConfig ~= { c =>
+    val targetsWindows = c
+      .targetTriple
+      .orElse(sys.env.get("SCALANATIVE_TARGET_TRIPLE"))
+      .map(_.contains("windows"))
+      .getOrElse(scala.util.Properties.isWin)
+    if (targetsWindows)
+      c
+    else {
+      val extraDirs = sys
+        .env
+        .get("WVLET_NATIVE_LIB_PATH")
+        .toSeq
+        .flatMap(_.split(java.io.File.pathSeparator))
+        .map(_.trim)
+        .filter(_.nonEmpty)
+      val rpathDirs = (extraDirs ++ Seq("/opt/homebrew/lib", "/usr/local/lib")).distinct
+      val options = extraDirs.map(dir => s"-L${dir}") ++
+        rpathDirs.map(dir => s"-Wl,-rpath,${dir}")
+      c.withLinkingOptions(c.linkingOptions ++ options)
+    }
+  }
+
 lazy val jvmProjects: Seq[ProjectReference] = Seq(
   api.jvm,
   httpServer,
@@ -243,7 +276,7 @@ val specRunnerSettings = Seq(
 lazy val wvc = project
   .enablePlugins(ScalaNativePlugin)
   .in(file("wvc"))
-  .settings(buildSettings, name := "wvc")
+  .settings(buildSettings, name := "wvc", nativeLibRpathLinking)
   .dependsOn(lang.native, cliCore.native)
 
 lazy val wvcLib = project
@@ -267,7 +300,9 @@ lazy val wvcLib = project
         case None =>
           baseConfig
       }
-    }
+    },
+    // Applied after the target-triple override above so the Windows gate sees the final triple
+    nativeLibRpathLinking
   )
   .dependsOn(wvc)
 
@@ -307,7 +342,9 @@ def nativeCrossProject(
           .withCompileOptions(c.compileOptions ++ compileOptions)
           .withLinkingOptions(c.linkingOptions ++ linkerOptions)
           .withBuildTarget(BuildTarget.libraryDynamic)
-      }
+      },
+      // Applied after the target-triple override above so the Windows gate sees the final triple
+      nativeLibRpathLinking
     )
     .dependsOn(wvcLib)
 }
@@ -507,7 +544,8 @@ lazy val cliCore = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     uniNativeCurlLinking,
     nativeConfig ~= { c =>
       c.withLinkingOptions(c.linkingOptions :+ "-lduckdb")
-    }
+    },
+    nativeLibRpathLinking
   )
   .dependsOn(lang)
 

--- a/website/docs/development/build.md
+++ b/website/docs/development/build.md
@@ -56,6 +56,19 @@ Wvlet can be compiled to a native library using Scala Native, which compiles Sca
 To build native libraries, you need to install `clang`, `llvm`, `libstdc++-12-dev`, and `libgc` (Boehm GC) on your system. See also [Scala Native Setup](https://scala-native.org/en/latest/user/setup.html). 
 :::
 
+### DuckDB Dependency
+
+Native binaries link [libduckdb](https://duckdb.org/docs/installation/) dynamically, so both `duckdb.h` and the libduckdb shared library must be visible to the C compiler and linker. Installing DuckDB with a package manager (e.g. `brew install duckdb` on macOS) is usually enough. If they are installed in a non-standard location, point the standard clang environment variables at them before building:
+
+```bash
+# Directory containing duckdb.h
+export CPATH=/path/to/duckdb/include
+# Directory containing libduckdb.dylib (macOS) or libduckdb.so (Linux)
+export LIBRARY_PATH=/path/to/duckdb/lib
+```
+
+At runtime, the built binaries look up libduckdb in the standard loader locations plus `/opt/homebrew/lib` and `/usr/local/lib`, which are embedded as rpath entries. To run with a libduckdb installed elsewhere, either set `WVLET_NATIVE_LIB_PATH=/path/to/duckdb/lib` at **build time** (the directory is embedded as an additional `-L`/rpath entry), or set `DYLD_LIBRARY_PATH` (macOS) / `LD_LIBRARY_PATH` (Linux) when launching the binary.
+
 To build libwvlet.so (Linux) or libwvlet.dylib (macOS), run the following command:
 
 ```bash


### PR DESCRIPTION
## Summary

The native binaries (`cliCoreNative`, `wvc`, `wvcLib`) link libduckdb dynamically (macOS install name `@rpath/libduckdb.dylib`) but baked in no `LC_RPATH`. On a machine where libduckdb is not in a standard dyld/ld.so location, the binary failed at load time for **every** command — even `version`/`compile`, which never touch DuckDB:

```
dyld: Library not loaded: @rpath/libduckdb.dylib ... Reason: no LC_RPATH's found
```

The only workaround was `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` on every invocation.

## Changes

- Add a shared `nativeLibRpathLinking` setting that embeds `/opt/homebrew/lib` and `/usr/local/lib` as rpath entries in `cliCoreNative`, `wvc`, `wvcLib`, and `nativeCrossProject` binaries
- Support a path-separated `WVLET_NATIVE_LIB_PATH` environment variable for custom libduckdb locations — its directories are embedded as both `-L` link paths and rpath entries, so one variable covers link time and run time
- Skip the rpath flags when targeting Windows (no rpath concept there; `-Wl,-rpath` breaks the link). The gate reads the final target triple, so wvcLib's `SCALANATIVE_TARGET_TRIPLE` cross-builds are handled
- Document the native build prerequisites (`duckdb.h` / libduckdb via `CPATH` / `LIBRARY_PATH`) and the runtime lookup behavior in CLAUDE.md and `website/docs/development/build.md`

## Verification

Tested on a macOS machine with **no** libduckdb in any standard path (the exact failure scenario):

- Before: `cliCoreNative/nativeLink` failed compiling `wvlet_duckdb_helpers.c` (missing `duckdb.h`), and previously-built binaries failed at load with `no LC_RPATH's found`
- After: building with `CPATH` and `WVLET_NATIVE_LIB_PATH` pointing at an extracted libduckdb 1.5.2 release succeeds; `otool -l` shows the three LC_RPATH entries; `wvlet-cli-core version` and `compile -q "from lineitem select count(*)"` run without `DYLD_LIBRARY_PATH`

A follow-up (not in this PR) could dlopen libduckdb lazily so non-DuckDB commands work with no libduckdb installed at all; on Linux the loader requires all `DT_NEEDED` libraries at load time, so rpath + docs is the portable near-term fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)