### PR TITLE
internal: Prepare VS Code extension 2026.3.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,11 @@ test _.output should be """
 
 ## Release Process
 
-The project follows semantic versioning and uses SBT plugins for cross-platform publishing. Check `project/release.rb` for release automation scripts.
+The project uses SBT plugins for cross-platform publishing. Check `project/release.rb` for release automation scripts.
+
+### Versioning
+
+Wvlet follows semi-calendar versioning: `YYYY.(milestone month).(patch)` — e.g., `2026.3.0` is the first release of the 2026 month-3 milestone. The middle segment is the milestone month (not a semver minor), and the patch increments within a milestone. This scheme applies across release artifacts (Scala artifacts, npm packages, the VS Code extension).
 
 ## Git & Development Workflow
 

--- a/vscode-wvlet/CHANGELOG.md
+++ b/vscode-wvlet/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the Wvlet extension will be documented in this file.
 
+## [2026.3.0] - 2026-07-13
+
+### Added
+- Workspace-aware language server: each file is analyzed together with the other
+  `.wv` sources of the workspace, including table types imported into the
+  `catalog/` folder by `wvlet catalog import`, so table references resolve
+  offline in diagnostics, hover, and completion
+- Go to Definition works across workspace files: jump from a model or type
+  reference to its definition in another `.wv` file, including imported catalog
+  types
+- Dot-triggered member completion: typing `.` after a table or alias suggests
+  its columns; after a schema name, the tables of that schema. General
+  completion adds workspace definitions and SQL function names, including
+  engine functions imported via `wvlet catalog import`
+- Typing diagnostics: type errors and warnings are now reported inline in the
+  editor (previously only the first syntax error was shown), including a new
+  warning when the same type name is bound to different database schemas
+
 ## [2026.2.0] - 2026-07-10
 
 ### Changed

--- a/vscode-wvlet/package.json
+++ b/vscode-wvlet/package.json
@@ -2,7 +2,7 @@
   "name": "wvlet",
   "displayName": "Wvlet",
   "description": "Wvlet query language support for Visual Studio Code",
-  "version": "2026.2.0",
+  "version": "2026.3.0",
   "engines": {
     "vscode": "^1.116.0"
   },


### PR DESCRIPTION
## Summary

Version bump + changelog for the 2026.3.0 extension release, shipping the workspace-aware language server features merged since 2026.2.0:

- Workspace source loading incl. `catalog/` table types (#1893, #1881)
- Cross-file Go to Definition (#1900)
- Dot-triggered member completion + imported engine function names (#1895, #1897)
- Inline typing diagnostics incl. the duplicate type-binding warning (#1899) — replaces the previous first-syntax-error-only behavior

Local smoke check: `sdkJs/fastLinkJS` + esbuild build passes, and the built `out/server.js` initializes over LSP stdio advertising `definitionProvider`.

## Release steps after merge

1. Actions → **VS Code** workflow → Run with publish=true (VSCE_PAT configured)
2. Before publishing, verify the CI-built vsix over LSP stdio (per the 2026.1.0 lesson: always test the packaged artifact, not the source tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)