### PR TITLE
feature: Publish the VS Code extension on release tags

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -3,6 +3,10 @@ name: VS Code
 on:
   push:
     branches: [ main ]
+    # Release tags publish the extension together with the other artifacts (npm, Maven).
+    # The tag must match vscode-wvlet/package.json; a -rc/-pre suffix publishes a pre-release.
+    tags:
+      - 'v*.*.*'
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -21,10 +25,12 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      vscode: ${{ steps.filter.outputs.vscode }}
+      # Tag pushes always build (the path filter has no base to diff against on a tag)
+      vscode: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || steps.filter.outputs.vscode }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         id: filter
         with:
           filters: |
@@ -72,6 +78,16 @@ jobs:
     - name: Package extension
       run: pnpm run build-vscode-extension
 
+    # Drive the exact packaged artifact over LSP stdio (initialize, go-to-definition,
+    # hover). 2026.1.0 shipped with a silently dead language server; this gate makes
+    # that class of packaging regression fail the build instead.
+    - name: Smoke test packaged extension
+      run: |
+        VSIX=$(ls vscode-wvlet/*.vsix)
+        rm -rf /tmp/vsix-smoke && mkdir -p /tmp/vsix-smoke
+        unzip -q "$VSIX" -d /tmp/vsix-smoke
+        node vscode-wvlet/scripts/lsp-smoke.mjs /tmp/vsix-smoke/extension/out/server.js
+
     - name: Upload VSIX artifact
       uses: actions/upload-artifact@v7
       with:
@@ -79,25 +95,53 @@ jobs:
         path: vscode-wvlet/*.vsix
         retention-days: 30
 
-    - name: Determine release type
-      if: github.event.inputs.publish == 'true'
-      id: release_type
+    # Two publish paths share the steps below:
+    #   - Release tag vX.Y.Z: publish stable; vX.Y.Z-rc1 etc.: publish pre-release.
+    #     The numeric tag version must equal vscode-wvlet/package.json (fail loudly on
+    #     mismatch rather than publish a stale version). Versions already on the
+    #     Marketplace are skipped, so re-running a tag pipeline is idempotent.
+    #   - Manual dispatch with publish=true: legacy path for out-of-band releases;
+    #     patch != 0 publishes as pre-release (unchanged behavior).
+    - name: Plan Marketplace release
+      if: github.event.inputs.publish == 'true' || startsWith(github.ref, 'refs/tags/v')
+      id: release_plan
       run: |
         VERSION=$(node -p "require('./vscode-wvlet/package.json').version")
-        PATCH=$(echo $VERSION | cut -d'.' -f3)
-        if [ "$PATCH" = "0" ]; then
-          echo "type=stable" >> $GITHUB_OUTPUT
-          echo "Release type: stable (version $VERSION)"
+        PUBLISH=true
+        TYPE=stable
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          PATCH=$(echo "$VERSION" | cut -d'.' -f3)
+          if [ "$PATCH" != "0" ]; then
+            TYPE=pre-release
+          fi
         else
-          echo "type=pre-release" >> $GITHUB_OUTPUT
-          echo "Release type: pre-release (version $VERSION)"
+          TAG="${GITHUB_REF#refs/tags/v}"
+          BASE="${TAG%%-*}"
+          if [ "$BASE" != "$VERSION" ]; then
+            echo "::error::Release tag v${TAG} does not match vscode-wvlet/package.json version ${VERSION}. Bump the extension version in the release commit."
+            exit 1
+          fi
+          if [ "$TAG" != "$BASE" ]; then
+            TYPE=pre-release
+          fi
         fi
+        PUBLISHED=$(curl -sf "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
+          -H "Content-Type: application/json" -H "Accept: application/json;api-version=3.0-preview.1" \
+          -d '{"filters":[{"criteria":[{"filterType":7,"value":"wvlet.wvlet"}]}],"flags":1}' \
+          | jq -r --arg v "$VERSION" '[.results[0].extensions[0].versions[].version] | contains([$v])' || echo "unknown")
+        if [ "$PUBLISHED" = "true" ]; then
+          echo "::notice::wvlet.wvlet ${VERSION} is already on the Marketplace; skipping publish."
+          PUBLISH=false
+        fi
+        echo "publish=$PUBLISH" >> "$GITHUB_OUTPUT"
+        echo "type=$TYPE" >> "$GITHUB_OUTPUT"
+        echo "Release plan: publish=$PUBLISH type=$TYPE version=$VERSION"
 
     - name: Publish to VS Code Marketplace
-      if: github.event.inputs.publish == 'true'
+      if: steps.release_plan.outputs.publish == 'true'
       run: |
         cd vscode-wvlet
-        if [ "${{ steps.release_type.outputs.type }}" = "pre-release" ]; then
+        if [ "${{ steps.release_plan.outputs.type }}" = "pre-release" ]; then
           pnpm exec vsce publish --no-dependencies --pre-release --pat ${{ secrets.VSCE_PAT }}
         else
           pnpm exec vsce publish --no-dependencies --pat ${{ secrets.VSCE_PAT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,15 @@ The project uses SBT plugins for cross-platform publishing. Check `project/relea
 
 Wvlet follows semi-calendar versioning: `YYYY.(milestone month).(patch)` — e.g., `2026.3.0` is the first release of the 2026 month-3 milestone. The middle segment is the milestone month (not a semver minor), and the patch increments within a milestone. This scheme applies across release artifacts (Scala artifacts, npm packages, the VS Code extension).
 
+### Unified release cycle
+
+Pushing a release tag `vX.Y.Z` publishes all artifacts, including npm packages and the VS Code extension. For the extension:
+- The tag version must equal `vscode-wvlet/package.json` — bump it (plus CHANGELOG) in the release commit, or the publish job fails loudly
+- A suffixed tag (e.g. `v2026.4.0-rc1`) publishes the extension as a Marketplace pre-release; plain tags publish stable
+- Versions already on the Marketplace are skipped, so re-running a tag pipeline is safe
+- Every build smoke-tests the packaged vsix over LSP stdio (`vscode-wvlet/scripts/lsp-smoke.mjs`) before it can be published — never bypass this gate
+- Manual out-of-band extension releases remain possible via the "VS Code" workflow dispatch with publish=true (patch != 0 publishes as pre-release)
+
 ## Git & Development Workflow
 
 ### Development Process

--- a/vscode-wvlet/scripts/lsp-smoke.mjs
+++ b/vscode-wvlet/scripts/lsp-smoke.mjs
@@ -19,17 +19,20 @@ const server = spawn('node', [serverPath, '--stdio']);
 let buf = Buffer.alloc(0);
 const pending = new Map();
 let nextId = 1;
+// Set before every intentional termination; any other server exit is a failure
+let finished = false;
 
 const timeout = setTimeout(() => {
   console.error('LSP smoke test timed out after 60s');
+  finished = true;
   server.kill();
   process.exit(1);
 }, 60_000);
 
 server.stderr.on('data', (d) => process.stderr.write(d));
 server.on('exit', (code) => {
-  if (pending.size > 0) {
-    console.error(`server exited early (code ${code}) with requests in flight`);
+  if (!finished) {
+    console.error(`server exited unexpectedly (code ${code})`);
     process.exit(1);
   }
 });
@@ -114,6 +117,7 @@ const hoverText = JSON.stringify(hover.result?.contents ?? '');
 check('hover types a column through the model', hoverText.includes('long'), hoverText.slice(0, 120));
 
 clearTimeout(timeout);
+finished = true;
 server.kill();
 if (failures.length > 0) {
   console.error(`LSP smoke test failed: ${failures.length} check(s)`);

--- a/vscode-wvlet/scripts/lsp-smoke.mjs
+++ b/vscode-wvlet/scripts/lsp-smoke.mjs
@@ -1,0 +1,123 @@
+// LSP smoke test for the packaged extension (#1887 follow-up).
+//
+// Drives the given server bundle over real LSP stdio — the same protocol and
+// artifact the editor uses — so a packaging regression (missing compiler bundle,
+// broken module resolution) fails the release instead of shipping silently dead,
+// as happened with 2026.1.0.
+//
+// Usage: node scripts/lsp-smoke.mjs <path/to/out/server.js>
+
+import { spawn } from 'node:child_process';
+
+const serverPath = process.argv[2];
+if (!serverPath) {
+  console.error('usage: node scripts/lsp-smoke.mjs <path/to/server.js>');
+  process.exit(2);
+}
+
+const server = spawn('node', [serverPath, '--stdio']);
+let buf = Buffer.alloc(0);
+const pending = new Map();
+let nextId = 1;
+
+const timeout = setTimeout(() => {
+  console.error('LSP smoke test timed out after 60s');
+  server.kill();
+  process.exit(1);
+}, 60_000);
+
+server.stderr.on('data', (d) => process.stderr.write(d));
+server.on('exit', (code) => {
+  if (pending.size > 0) {
+    console.error(`server exited early (code ${code}) with requests in flight`);
+    process.exit(1);
+  }
+});
+
+server.stdout.on('data', (d) => {
+  buf = Buffer.concat([buf, d]);
+  for (;;) {
+    const headerEnd = buf.indexOf('\r\n\r\n');
+    if (headerEnd < 0) {
+      return;
+    }
+    const header = buf.slice(0, headerEnd).toString();
+    const len = parseInt(/Content-Length: (\d+)/.exec(header)[1], 10);
+    if (buf.length < headerEnd + 4 + len) {
+      return;
+    }
+    const msg = JSON.parse(buf.slice(headerEnd + 4, headerEnd + 4 + len).toString());
+    buf = buf.slice(headerEnd + 4 + len);
+    if (msg.id !== undefined && pending.has(msg.id)) {
+      pending.get(msg.id)(msg);
+      pending.delete(msg.id);
+    }
+  }
+});
+
+function send(obj) {
+  const s = JSON.stringify(obj);
+  server.stdin.write(`Content-Length: ${Buffer.byteLength(s)}\r\n\r\n${s}`);
+}
+
+function request(method, params) {
+  return new Promise((resolve) => {
+    const id = nextId++;
+    pending.set(id, resolve);
+    send({ jsonrpc: '2.0', id, method, params });
+  });
+}
+
+const failures = [];
+function check(name, condition, detail) {
+  if (condition) {
+    console.log(`ok: ${name}`);
+  } else {
+    failures.push(name);
+    console.error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+const init = await request('initialize', { processId: null, rootUri: null, capabilities: {} });
+const caps = init.result?.capabilities ?? {};
+check('initialize returns capabilities', init.result !== undefined);
+check('definition provider advertised', caps.definitionProvider === true);
+check('hover provider advertised', caps.hoverProvider === true);
+check(
+  'dot completion trigger advertised',
+  (caps.completionProvider?.triggerCharacters ?? []).includes('.'),
+  JSON.stringify(caps.completionProvider)
+);
+send({ jsonrpc: '2.0', method: 'initialized', params: {} });
+
+const uri = 'file:///smoke/check.wv';
+const text = 'model m1 = {\n  from [[1, 2]] as t(a, b)\n}\n\nfrom m1\nselect a\n';
+send({
+  jsonrpc: '2.0',
+  method: 'textDocument/didOpen',
+  params: { textDocument: { uri, languageId: 'wvlet', version: 1, text } },
+});
+
+// Cursor on the `m1` reference (0-based line 4) must resolve to the model definition
+const def = await request('textDocument/definition', {
+  textDocument: { uri },
+  position: { line: 4, character: 6 },
+});
+check('go-to-definition resolves a model reference', def.result?.range?.start?.line === 0, JSON.stringify(def.result));
+
+// Hover on column `a` in the projection must report its type from the model schema
+const hover = await request('textDocument/hover', {
+  textDocument: { uri },
+  position: { line: 5, character: 8 },
+});
+const hoverText = JSON.stringify(hover.result?.contents ?? '');
+check('hover types a column through the model', hoverText.includes('long'), hoverText.slice(0, 120));
+
+clearTimeout(timeout);
+server.kill();
+if (failures.length > 0) {
+  console.error(`LSP smoke test failed: ${failures.length} check(s)`);
+  process.exit(1);
+}
+console.log('LSP smoke test passed');
+process.exit(0);


### PR DESCRIPTION
## Summary

Unifies the VS Code extension release cycle with the rest of the project: pushing a `vX.Y.Z` release tag now publishes the extension together with the npm/Maven artifacts, replacing the separate manual workflow dispatch.

The manual gate existed to allow verifying the packaged artifact before publishing (the 2026.1.0 dead-LSP lesson). Those safety properties are now automated:

- **Version assertion**: the tag version must equal `vscode-wvlet/package.json` — the publish job fails loudly on mismatch instead of publishing a stale version. The extension bump (+ CHANGELOG) becomes part of the release commit.
- **LSP stdio smoke gate** (`vscode-wvlet/scripts/lsp-smoke.mjs`): every build — PRs and main included — unzips the exact packaged vsix and drives `out/server.js` over real LSP stdio: initialize capabilities (definition/hover/`.`-trigger), go-to-definition on a model reference, hover typing a column. A packaging regression that ships a dead server now fails CI instead of reaching the Marketplace. Verified against the published 2026.3.0 vsix (passes) — the same checks that caught nothing wrong in today's manual release.
- **Idempotent re-runs**: versions already on the Marketplace are skipped via a gallery API check (Marketplace versions are immutable), so re-running a tag pipeline after a partial failure is safe. This also covers the transition case: the next `v2026.3.0` core tag will skip the already-published extension 2026.3.0.

Pre-release policy: a suffixed tag (`v2026.4.0-rc1`) publishes as a Marketplace **pre-release** with the numeric version from package.json; plain tags publish **stable**. The manual dispatch path remains for out-of-band releases with its existing patch-digit rule.

## Verification

- `actionlint` clean
- The release-plan logic was simulated for all five cases (new tag → stable; rc tag → pre-release; tag/package.json mismatch → hard error; already-published version → skip, tested live against the real Marketplace listing; dispatch patch≠0 → pre-release)
- The smoke script passes against the CI-built 2026.3.0 vsix
- CLAUDE.md documents the unified flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)