### PR TITLE
feature: Add a stateful asSqlConnector view to DuckDBConnector

### DIFF
--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/duckdb/DuckDBConnector.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/duckdb/DuckDBConnector.scala
@@ -21,6 +21,11 @@ import wvlet.lang.compiler.Name
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.model.DataType
 import wvlet.lang.model.DataType.NamedType
+import wvlet.lang.compiler.analyzer.duckdb.DuckDB as DuckDBFacade
+import wvlet.lang.compiler.analyzer.duckdb.DuckDBSqlConnector
+import wvlet.lang.compiler.connector.QueryHandle
+import wvlet.lang.compiler.connector.SqlConnector
+import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.connector.ThreadUtil
 import wvlet.lang.connector.DBConnection
 import wvlet.lang.connector.DBConnector
@@ -73,6 +78,34 @@ class DuckDBConnector(workEnv: WorkEnv, prepareTPCH: Boolean = false, prepareTPC
       stmt.execute("install tpcds")
       stmt.execute("load tpcds")
       stmt.execute("call dsdgen(sf = 0.01)")
+
+  /**
+    * Cross-platform [[SqlConnector]] view over this connector's long-lived connection. Unlike the
+    * stateless [[DuckDBSqlConnector]], which opens a fresh in-memory DuckDB per submit, every
+    * statement here runs through [[withConnection]], so in-memory tables persist across submits —
+    * the session state the runner and REPL rely on.
+    *
+    * DuckDB executes in-process and synchronously, so `submit` returns an already-finished handle
+    * and `cancel` is a no-op. Closing the view is also a no-op: the connection lifecycle stays
+    * owned by this connector.
+    *
+    * Deliberately NOT exposed via the [[DBConnector.sqlConnector]] capability: that hook routes
+    * `QueryExecutor`'s display path through varchar-coerced cross-platform rows, which would
+    * downgrade DuckDB's typed JDBC results to strings (breaking typed `test _.rows` spec assertions
+    * and typed web-UI values). Callers that want the cross-platform surface use this accessor
+    * explicitly.
+    */
+  lazy val asSqlConnector: SqlConnector =
+    new SqlConnector:
+      override def submit(sql: String)(using QueryProgressMonitor): QueryHandle =
+        val result = withConnection { conn =>
+          Using.resource(conn.createStatement()) { stmt =>
+            DuckDBFacade.executeStatement(stmt, sql)
+          }
+        }
+        DuckDBSqlConnector.completedHandle(result)
+
+      override def close(): Unit = ()
 
   override private[connector] def newConnection: DBConnection =
     // For in-memory DuckDB, the connection will be created only once

--- a/wvlet-lang/.jvm/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
+++ b/wvlet-lang/.jvm/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
@@ -53,21 +53,30 @@ trait DuckDBCompat:
     */
   def execute(sql: String): QueryResult = withConnection { conn =>
     withResource(conn.createStatement()) { stmt =>
-      // JDBC's executeQuery() rejects statements that produce no ResultSet, so dispatch on
-      // execute() and fall back to the update count for COPY/DDL statements.
-      if stmt.execute(sql) then
-        withResource(stmt.getResultSet)(readResult)
-      else
-        val count = stmt.getUpdateCount
-        if count < 0 then
-          QueryResult(Nil, Nil)
-        else
-          QueryResult(
-            List(NamedType(Name.termName("Count"), DataType.LongType)),
-            List(QueryResultRow(List(Some(count.toString))))
-          )
+      executeStatement(stmt, sql)
     }
   }
+
+  /**
+    * Run `sql` on a caller-provided JDBC statement and materialize the result. Shared by the
+    * fresh-connection [[execute]] above and the runner's stateful `DuckDBConnector.asSqlConnector`
+    * view, which supplies a statement bound to its long-lived connection so in-memory tables
+    * persist across calls.
+    */
+  private[lang] def executeStatement(stmt: java.sql.Statement, sql: String): QueryResult =
+    // JDBC's executeQuery() rejects statements that produce no ResultSet, so dispatch on
+    // execute() and fall back to the update count for COPY/DDL statements.
+    if stmt.execute(sql) then
+      withResource(stmt.getResultSet)(readResult)
+    else
+      val count = stmt.getUpdateCount
+      if count < 0 then
+        QueryResult(Nil, Nil)
+      else
+        QueryResult(
+          List(NamedType(Name.termName("Count"), DataType.LongType)),
+          List(QueryResultRow(List(Some(count.toString))))
+        )
 
   private def readResult(rs: ResultSet): QueryResult =
     val metadata = rs.getMetaData

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSqlConnector.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSqlConnector.scala
@@ -34,9 +34,9 @@ import wvlet.lang.compiler.query.QueryProgressMonitor
   *
   * Each `submit` invokes `DuckDB.execute(sql)`, which on JVM opens a fresh in-memory `jdbc:duckdb:`
   * connection per call; in-memory tables don't persist across calls. The runner's JVM
-  * `DuckDBConnector` keeps using its long-lived JDBC connection for that reason; this
-  * cross-platform `SqlConnector` is the right tool for one-shot CLI queries against ephemeral
-  * DuckDB instances.
+  * `DuckDBConnector` exposes a stateful `asSqlConnector` view over its long-lived connection for
+  * session-preserving execution; this cross-platform `SqlConnector` is the right tool for one-shot
+  * CLI queries against ephemeral DuckDB instances.
   */
 class DuckDBSqlConnector extends SqlConnector:
 
@@ -53,9 +53,9 @@ object DuckDBSqlConnector:
   /**
     * Build a [[QueryHandle]] that wraps an already-materialized [[QueryResult]]. Used for backends
     * (DuckDB today) whose `submit` is synchronous so callers still see the trait's submit/await/
-    * cancel surface.
+    * cancel surface. Also reused by the runner's stateful `DuckDBConnector.asSqlConnector` view.
     */
-  private[duckdb] def completedHandle(result: QueryResult): QueryHandle =
+  private[lang] def completedHandle(result: QueryResult): QueryHandle =
     new QueryHandle:
       override def queryId: Option[String] = None
       override def state: QueryState       = QueryState.Finished

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -853,11 +853,11 @@ class QueryExecutor(
           val result =
             connector.sqlConnector match
               case Some(sc) =>
-                // PR-B: route Trino through the HTTP-backed SqlConnector view added in PR-A.
-                // No JDBC ResultSet, no `JDBCCodec` — `QueryResult.rows` already comes back as
-                // `Seq[Option[String]]` per column, which is the same shape DuckDB's
-                // `varchar`-coerced JDBC path produces downstream. DuckDB stays on the JDBC
-                // path below until it gets its own `SqlConnector` (PR-C+ in this series).
+                // Engines that execute over HTTP instead of JDBC (Trino) return rows as
+                // `Seq[Option[String]]` per column — no JDBC ResultSet, no `JDBCCodec`. DuckDB
+                // deliberately stays on the JDBC branch below even though it has a stateful
+                // `asSqlConnector` view: the cross-platform rows are varchar-coerced, and the
+                // JDBC path preserves typed values for `test _.rows` assertions and the web UI.
                 tableRowsFromXP(sc.execute(generatedSQL.sql))
               case None =>
                 connector.runQuery(generatedSQL.sql) { rs =>

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/duckdb/DuckDBConnectorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/connector/duckdb/DuckDBConnectorTest.scala
@@ -16,6 +16,8 @@ package wvlet.lang.runner.connector.duckdb
 import wvlet.lang.connector.duckdb.DuckDBConnector
 
 import wvlet.lang.compiler.Name
+import wvlet.lang.compiler.connector.QueryState
+import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.model.DataType
 import wvlet.lang.model.DataType.NamedType
 import wvlet.lang.test.WvletDITest
@@ -66,5 +68,38 @@ class DuckDBConnectorTest extends WvletDITest:
     val duckdb    = dep[DuckDBConnector]
     val functions = duckdb.listFunctions("memory")
     functions shouldNotBe empty
+
+  test("should preserve in-memory tables across asSqlConnector submits"):
+    given QueryProgressMonitor = QueryProgressMonitor.noOp
+    val duckdb                 = dep[DuckDBConnector]
+    val sc                     = duckdb.asSqlConnector
+
+    sc.execute("create table sql_connector_state(id bigint)")
+    sc.execute("insert into sql_connector_state values (1), (2), (3)")
+    val r = sc.execute("select count(*) as cnt from sql_connector_state")
+    r.rowCount shouldBe 1
+    r.rows.head.values.head shouldBe Some("3")
+
+    // The view shares the connector's long-lived connection, so the table is also visible
+    // through the JDBC-side metadata methods
+    duckdb.getTableDef("memory", "main", "sql_connector_state") shouldBe defined
+    duckdb.dropTable("memory", "main", "sql_connector_state")
+
+  test("should keep the typed JDBC path as the default query route"):
+    // The stateful view is opt-in: exposing it via the `sqlConnector` capability would switch
+    // QueryExecutor to varchar-coerced cross-platform rows and lose typed results
+    val duckdb = dep[DuckDBConnector]
+    duckdb.sqlConnector shouldBe empty
+
+  test("should return an already-finished handle from asSqlConnector.submit"):
+    given QueryProgressMonitor = QueryProgressMonitor.noOp
+    val duckdb                 = dep[DuckDBConnector]
+    val h                      = duckdb.asSqlConnector.submit("select 1 as one")
+    h.state shouldBe QueryState.Finished
+    h.queryId shouldBe None
+    // cancel is a no-op after completion; await stays idempotent
+    h.cancel()
+    h.await().rows.head.values.head shouldBe Some("1")
+    h.close()
 
 end DuckDBConnectorTest


### PR DESCRIPTION
## Summary

Follow-up to #1723. Gives the runner's `DuckDBConnector` a stateful cross-platform `SqlConnector` view (`asSqlConnector`) over its long-lived connection — the DuckDB counterpart of `TrinoConnector.asSqlConnector` (#1718). Unlike the stateless `DuckDBSqlConnector` from #1723, which opens a fresh in-memory DuckDB per `submit`, this view runs every statement through `withConnection`, so in-memory tables persist across submits (the session state the runner and REPL rely on).

- Extracts `DuckDBCompat.executeStatement` (JVM) so the ResultSet/update-count materialization logic is shared between the fresh-connection `DuckDB.execute` and the new view, instead of duplicated
- Widens `DuckDBSqlConnector.completedHandle` to `private[lang]` for reuse

## Why the view is not wired into QueryExecutor

An earlier revision also overrode `DBConnector.sqlConnector` so `QueryExecutor` would route DuckDB through the cross-platform path (as Trino does since #1719). The runner spec suite rejected it: cross-platform `QueryResult` rows are varchar-coerced (`Seq[Option[String]]`), so typed `test _.rows` assertions like `[[1, "alice"]]` fail — the values render identically but arrive as strings instead of typed ints. Trino accepted that trade because it has no JDBC path at all; for DuckDB it would be a fidelity regression for spec tests and the web UI.

So DuckDB deliberately stays on the typed JDBC display path, and the decision is documented at the `QueryExecutor` dispatch site and on `asSqlConnector`. Flipping the display path can revisit once the cross-platform `QueryResult` carries typed values.

## Verification

- `runner/testOnly *` — 547 tests, 0 failures (includes 3 new tests: state persistence across submits, `sqlConnector` stays empty, already-finished handle semantics)
- `projectJVM/Test/compile`, `projectJS/Test/compile` — green
- `scalafmtAll` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ECRJsyin39ChuubazJ5Rk