### PR TITLE
fix: Prevent REPL statement compilation from racing background warm-up

### DIFF
--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/ConnectorCatalog.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/ConnectorCatalog.scala
@@ -26,7 +26,6 @@ import wvlet.uni.weaver.Weaver
 import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import java.util.concurrent.TimeUnit
-import scala.jdk.CollectionConverters.*
 
 class ConnectorCatalog(
     val catalogName: String,
@@ -75,8 +74,10 @@ class ConnectorCatalog(
   ThreadUtil.runBackgroundTask(() => init())
 
   private def init(): Unit =
-    // Pre-load tables in defaultSchema and information_schema
-    tablesInSchemaCache.getAll(List(defaultSchema, "information_schema").asJava)
+    // Pre-load tables in defaultSchema and information_schema. Load keys one by one:
+    // getAll requires a CacheLoader with a loadAll implementation, which the lambda-based
+    // loader lacks, and would fail with UnsupportedOperationException
+    List(defaultSchema, "information_schema").foreach(schema => tablesInSchemaCache.get(schema))
 
   override def dbType: DBType = dbConnector.dbType
 

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
@@ -130,17 +130,38 @@ class WvletScriptRunner(
         )
       }
 
-    // Pre-compile files in the source paths
-    if config.precompileSourcePaths then
-      threadManager.runBackgroundTask { () =>
-        val result = c.compileSourcePaths(contextFile = None)
-        // Report compilation errors in the initialization phases
-        if result.hasFailures then
-          workEnv.logError(result.failureException)
-      }
     c
 
   end compiler
+
+  // Warm up the compiler by pre-compiling files in the source paths while the REPL is starting
+  // up. The compiler's symbol table is not thread-safe, so runStatement must join this task
+  // before compiling a statement; otherwise the two compilations race and fail with spurious
+  // cyclic-reference errors
+  private val precompileTask: Option[java.util.concurrent.Future[?]] =
+    if config.precompileSourcePaths then
+      Some(
+        threadManager.runBackgroundTask { () =>
+          val result = compiler.compileSourcePaths(contextFile = None)
+          // Report compilation errors in the initialization phases
+          if result.hasFailures then
+            workEnv.logError(result.failureException)
+        }
+      )
+    else
+      None
+
+  private def awaitPrecompile(): Unit = precompileTask.foreach { task =>
+    try
+      task.get()
+    catch
+      case _: InterruptedException =>
+        Thread.currentThread().interrupt()
+      // Compilation failures are already logged inside the task. Any other failure will
+      // resurface when the statement itself is compiled, so only record it for debugging
+      case e: Exception =>
+        debug(e)
+  }
 
   def runStatement(request: QueryRequest)(using
       queryProgressMonitor: QueryProgressMonitor
@@ -148,6 +169,8 @@ class WvletScriptRunner(
     val newUnit = CompilationUnit.fromWvletString(request.query)
     units = newUnit :: units
 
+    // The compiler must not be used concurrently with the background warm-up compilation
+    awaitPrecompile()
     try
       queryProgressMonitor.startCompile(newUnit)
       val compileResult = compiler.compileSingleUnit(contextUnit = newUnit)


### PR DESCRIPTION
## Summary

Fixes the flaky `WvletREPLMainTest` failure ("no duplicate models after redefining with same name") that has been intermittently breaking CI on unrelated PRs (#1908, #1913 both needed reruns).

**Root cause:** `WvletScriptRunner` pre-compiles the source folders in a background thread using the same `Compiler`/symbol table that the main thread uses for `-c`/interactive statements. Symbol completion (`Symbol.symbolInfo`) is not thread-safe: when the two compilations race, the `_isCompleting` flag misfires and compilation fails with a spurious `Cyclic reference detected while resolving symbol N` error, leaving symbol state corrupted (e.g. `show models` printing nothing).

**Fix:** `runStatement` now joins the warm-up task before compiling. Since `compileSingleUnit` already recompiles all source-path units synchronously, this adds no net latency — the warm-up still overlaps REPL/terminal startup, it just can no longer overlap statement compilation.

Also fixes a related background-thread bug visible in every CI log: `ConnectorCatalog.init` called `tablesInSchemaCache.getAll(...)`, but Caffeine's `getAll` requires a `CacheLoader.loadAll` implementation that the lambda-based loader lacks, so the catalog warm-up thread died with `UnsupportedOperationException` on every REPL start. Keys are now pre-loaded individually.

## Testing

- `cli/testOnly *WvletREPLMainTest` run 6 times: all green, no cyclic-reference errors, no `UnsupportedOperationException` stack traces in the logs (previously appeared on every run)
- `runner/Test/compile`, `connector/Test/compile`, `scalafmtAll` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BdZaoCnzTqCXFNoY74s2cA