### PR TITLE
feature: table store substrate — SQL catalog + immutable object files with leased merge and schema escalation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,10 @@ For error reporting, use WvletLangException and StatusCode enum. If necessary er
 ## Development Checklist
 - Before commiting changes, confirm compilation passes for src/main, src/test, and Scala.js
 
+## Architecture Decision Records
+- Non-obvious, durable design decisions are captured in `adr/YYYY-MM-DD-(topic).md`. Check there before reverse-engineering intent from commits.
+- `adr/2026-08-21-table-store-catalog-portability.md`: why the `wvlet-table-store` catalog enforces fencing/retirement with conditional-update row-count assertions (not isolation levels / FOR UPDATE), and how monotonic sequences are emulated portably.
+
 ## Memory
 - For creating temporary files, use target folder, which will be ignored in git
 - `vscode-wvlet` is VS Code plugin folder

--- a/adr/2026-08-21-table-store-catalog-portability.md
+++ b/adr/2026-08-21-table-store-catalog-portability.md
@@ -1,0 +1,50 @@
+# ADR: Table store catalog portability — assertions over isolation levels
+
+Date: 2026-08-21
+PR: wvlet#1959 (`feature/table-store`)
+
+## Context
+
+The table store design note requires the catalog contract to be implementable on Postgres,
+DuckDB, and SQLite with plain SQL (TEXT-JSON only, no arrays/JSONB), and requires that a
+zombie merger can never publish stale state and no file entry ever retires twice. The obvious
+tools for these guarantees — `SELECT … FOR UPDATE` plus `SERIALIZABLE` transactions — are not
+uniformly available or uniformly meaningful across the three drivers (DuckDB's MVCC conflicts,
+SQLite's database-level locking, Postgres's row locks), and leaning on isolation levels would
+make correctness depend on per-backend tuning that tests cannot exercise deterministically.
+
+## Decision
+
+1. **Predicate-based conditional updates with row-count assertions** carry the protocol
+   invariants instead of lock syntax:
+   - Lease fencing inside the commit transaction:
+     `UPDATE leases SET expires_at = ? WHERE name = ? AND fencing_token = ? AND expires_at > now`
+     — commit aborts unless exactly 1 row changes. Tokens come from a monotonic counter, so a
+     zombie's stale token matches zero rows.
+   - Entry retirement:
+     `UPDATE file_entries SET end_snapshot = ? WHERE table_id = ? AND id IN (…) AND end_snapshot IS NULL`
+     — abort via `RetireConflictException` when the affected-row count differs from the source
+     count, so two mergers can never double-fold rows.
+2. **Monotonic sequences are counter-table upserts** executed inside the caller's transaction
+   (`INSERT … ON CONFLICT(scope) DO UPDATE SET next_value = next_value + amount`), returning
+   `[next - amount, next)`. Fresh counters insert `amount + 1` so allocated ids start at 1;
+   0 stays reserved as the "nothing published" sentinel (e.g. `schema_version_head = 0`).
+3. **Embedded drivers serialize through one JDBC connection + monitor**, matching the design's
+   single-process single-writer tradeoff; confidence comes from deterministic fault-injection
+   tests (stale-token commit, double-retire abort, crash-idempotent re-registration) run against
+   both SQLite and DuckDB conformance suites rather than from timing-based concurrency tests.
+
+Worked examples: `JdbcCatalogStore.commitMerge` / `acquireLease` /
+`registerIngest` (wvlet#1959, commit 154901d6); fault-injection expectations in
+`CatalogProtocolTest.scala`.
+
+## Consequences
+
+- Every statement is byte-identical across drivers; adding a backend is a URL + driver class.
+- Correctness does not regress if a deployment runs a weaker isolation level; the conditional
+  updates remain the last line of defense.
+- Cost: wasted fencing tokens when acquisition loses a held lease (harmless — tokens merely
+  increase); retirement of large batches binds one parameter per id (fine at v0 batch sizes; a
+  temp-table join is the future optimization if needed).
+- The Postgres production driver still wants connection pooling; every statement already works
+  unchanged across pooled connections because each transaction is self-contained.

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ val AWS_SDK_VERSION        = "2.20.146"
 val SCALAJS_DOM_VERSION    = "2.8.1"
 val DUCKDB_JDBC_VERSION    = "1.5.5.1"
 val SNOWFLAKE_JDBC_VERSION = "4.3.3"
+val SQLITE_JDBC_VERSION    = "3.53.2.1"
+val POSTGRES_JDBC_VERSION  = "42.7.7"
 val CAFFEINE_VERSION       = "3.2.4"
 
 val SCALA_3 = IO.read(file("SCALA_VERSION")).trim
@@ -103,6 +105,7 @@ lazy val jvmProjects: Seq[ProjectReference] = Seq(
   spec,
   cli,
   cliCore.jvm,
+  tableStore,
   testUtil
 )
 
@@ -445,6 +448,28 @@ lazy val connector = project
       )
   )
   .dependsOn(lang.jvm)
+
+// Portable analytical table store (see plans/2026-08-21-wvlet-table-store.md): a transactional
+// SQL catalog over immutable data files, with leased background merge and lazy schema escalation.
+// Package boundaries mirror the four Uni modules from the design note (object-store / catalog /
+// table-format / table-store) so they can be extracted mechanically later.
+lazy val tableStore = project
+  .in(file("wvlet-table-store"))
+  .settings(
+    buildSettings,
+    name        := "wvlet-table-store",
+    description := "Portable analytical table store: SQL catalog + immutable object-store files",
+    libraryDependencies ++=
+      Seq(
+        // Embedded catalog drivers. Postgres is the production driver; SQLite/DuckDB serve the
+        // embedded profile (single-writer serialized semantics). duckdb_jdbc also produces
+        // Parquet output for merged files through DuckDB's COPY.
+        "org.xerial"     % "sqlite-jdbc" % SQLITE_JDBC_VERSION,
+        "org.duckdb"     % "duckdb_jdbc" % DUCKDB_JDBC_VERSION,
+        "org.postgresql" % "postgresql"  % POSTGRES_JDBC_VERSION
+      )
+  )
+  .dependsOn(api.jvm)
 
 lazy val runner = project
   .in(file("wvlet-runner"))

--- a/plans/2026-08-21-wvlet-table-store.md
+++ b/plans/2026-08-21-wvlet-table-store.md
@@ -1,0 +1,72 @@
+# Wvlet Table Store — portable PlazmaDB successor (substrate v0)
+
+Date: 2026-08-21
+Design source: `/Users/leo/tdx/work/local/default/notes/2026-08-21-wvlet-table-store-portable-plazmadb-successor.md` (rev 2, design-reviewed — treat as pre-approved).
+Worktree: `.worktree/feature-table-store`, branch `feature/table-store`.
+
+## Problem statement
+
+Wvlet lacks its own analytical table store. Today's workloads (LLM Proxy cost tracking, event logs, metering) share one shape: high-frequency structured append → rollups → interactive queries → retention. The design note specifies a portable catalog+format substrate: immutable data files on any object store, a transactional SQL catalog, leased background merge, and lazy schema escalation — re-implementing PlazmaDB's best ideas without its operational lock-in, going where DuckLake doesn't (lease/fencing, raw-ingest tier, hierarchical metadata).
+
+## Scope of THIS PR (agreed with user)
+
+- **Inside wvlet**: new JVM-only sbt module `wvlet-table-store` (id `tableStore`). Package boundaries mirror the four Uni modules so extraction into `org.wvlet.uni` artifacts later is mechanical.
+- **Core substrate + protocols**, no language/compiler changes yet (`CREATE TABLE … USING wvlet` wiring is a fast-follow PR).
+- Deferred (open items in the note): fileset manifests (`kind='fileset'`), predicate rewrite (GDPR erasure) runner, retention runner scheduling, DuckLake projection views, catalog export/import tool, S3/GCS/Azure drivers (interface + FS driver only in v0), struct/array widening rules.
+
+## Architecture (from the note)
+
+Three cleanly separated layers:
+
+1. **Catalog** — transactional SQL DBMS holding snapshots + file_entries (interval-encoded liveness), schema_versions, leases, snapshot_pins, retention policies. Drivers: SQLite (dev/tests), DuckDB (embedded), Postgres (service). Portable contract: TEXT-JSON columns, no arrays/JSONB, UTC-micro timestamps, monotonic per-table sequence emulation.
+2. **Data** — immutable files: `raw/…/<file_id>.jsonl` (pre-issued id + SHA-256 checksum) and `merged/…/<sha256>.parquet` (content-addressed). v0 driver: local filesystem; `ObjectStore` trait leaves S3 open.
+3. **Compute** — engine-agnostic readers; v0 uses DuckDB JDBC for Parquet writing during merge.
+
+## Package layout (`wvlet-table-store/src/main/scala/wvlet/lang/tablestore/`)
+
+- `objectstore/ObjectStore.scala` — checksummed put, streaming get, inventory list; `LocalObjectStore`.
+- `catalog/model.scala` — row types (snapshots, file_entries, file_column_stats, leases, snapshot_pins, schema_versions…).
+- `catalog/CatalogStore.scala` — driver trait: DDL bootstrap, sequence allocation, ingest registration txn, lease acquire/renew/release, retiring-commit txn primitives (conditional retirement + token check), live-entry resolution at pinned snapshot, pruning query joining `file_column_stats`.
+- `catalog/JdbcCatalogStore.scala` — shared JDBC base; `SQLiteCatalogStore`, `DuckDBCatalogStore`, `PostgresCatalogStore`.
+- `format/DataFile.scala` — JSONL reader/writer; Parquet writer via DuckDB COPY; content-addressing.
+- `schema/PromotionLattice.scala` — monotonic lattice `null → long → double → string`; order-independent fold of observed schemas; outlier guardrail (quarantine widenings forced by < 0.1% of rows).
+- `TableStore.scala` — protocol orchestration: `IngestSession` (writer session: pre-issued file-id range, rotating segments, register-on-rotate), `TableReader` (pin snapshot, resolve live entries + cast plan, prune by predicate), `Merger` (leased: select → read once → write Parquet + infer schema → fenced commit), orphan detection helper.
+
+## Protocol invariants to encode (from rev 2 of the note)
+
+- Registered ⇒ immediately readable; there is NO separate live/streaming tier.
+- Visibility: file visible at snapshot S iff `begin_snapshot <= S AND (end_snapshot IS NULL OR end_snapshot > S)`. Snapshot publication is O(files touched).
+- Snapshot ids come from a catalog-side per-table counter incremented inside the registration transaction (sequence emulation, portable).
+- Merge commit txn MUST re-read the lease row under lock and abort unless `fencing_token` equals the merger's token ("stamping is not checking").
+- Retirement is conditional: `UPDATE … SET end_snapshot = :new WHERE id IN (…) AND end_snapshot IS NULL` + assert affected-row count == expected. No entry retires twice; no two mergers fold the same rows.
+- Only the lease holder retires entries / publishes schema versions. Ingest only adds. No optimistic retry paths.
+- Escalation runs only under the merge lease inside the commit txn; lattice fold must be order-independent; outlier guardrail quarantines instead of escalating.
+- Stats are advisory: missing stats ⇒ must-scan. min/max canonical-encoded, tagged with schema_version.
+- Readers pin snapshots via expiring `snapshot_pins` rows; GC never retires files visible at a pinned snapshot.
+- Embedded profile = single-process serialized writes (honest limitation; correctness confidence comes from fault-injection tests).
+
+## Build integration
+
+- `build.sbt`: new `lazy val tableStore = project.in(file("wvlet-table-store"))` JVM project; depends on `api.jvm`; libs: sqlite-jdbc (already in repo), duckdb_jdbc (present), postgresql (add); aggregated into `jvmProjects`; publishable (not noPublish) so future modules can consume it.
+- Tests: uni-test (`UniTest`) under `wvlet-table-store/src/test/scala`.
+
+## Test plan (deterministic, no sleeps where avoidable)
+
+1. Lattice: order-independence (fold permutations), quarantine guardrail thresholds.
+2. Interval visibility: begin/end semantics incl. AS OF reads before/during/after merge.
+3. Ingest: pre-issued ids, crash idempotency (duplicate registration is a no-op), checksum mismatch rejection, immediate readability after registration.
+4. Fencing: zombie merger holding an expired token cannot commit (token asserted in-txn); fresh lease wins; retired-entry double-fold attempt changes 0 rows and fails the assertion.
+5. Pruning: predicate over stats eliminates files; missing stats ⇒ included.
+6. Pins: expired pin does not block retirement; active pinned snapshot blocks it.
+7. Cross-driver conformance: same suite against SQLite and DuckDB catalogs (+ Postgres if available locally; otherwise skipped-by-env).
+8. End-to-end: append N JSONL batches → query (reader) → merge → same results, fewer live entries; schema escalated lazily; new columns appear only post-merge.
+
+## Open questions carried forward (from the note)
+
+Exact struct/array widening rules, predicate-rewrite spec, fileset manifest schema, DuckLake superset-schema decision, export/import tool format, quantified SLO targets.
+
+## Definition of done
+
+- `./sbt tableStore/test` green (plus `scalafmtAll`, `compile`).
+- All protocol invariants above covered by named failing-if-broken tests.
+- Module documented (package README or scaladoc) including honest embedded-profile caveats.

--- a/plans/2026-08-21-wvlet-table-store.md
+++ b/plans/2026-08-21-wvlet-table-store.md
@@ -70,3 +70,36 @@ Exact struct/array widening rules, predicate-rewrite spec, fileset manifest sche
 - `./sbt tableStore/test` green (plus `scalafmtAll`, `compile`).
 - All protocol invariants above covered by named failing-if-broken tests.
 - Module documented (package README or scaladoc) including honest embedded-profile caveats.
+
+## Outcome (2026-08-21 — shipped as wvlet#1959)
+
+All of the above landed; 31/31 tests green locally and in CI (Scala 3 / format / JS / Native jobs).
+
+Deviations and learnings from the original plan:
+
+- **Isolation levels not load-bearing.** Retiring transactions enforce fencing and no-double-retire
+  with predicate-based conditional updates asserted by row count (`UPDATE … WHERE fencing_token = ?
+  AND expires_at > now`, `UPDATE … SET end_snapshot = ? WHERE … AND end_snapshot IS NULL`), so the
+  same statements are correct on SQLite, DuckDB, and Postgres regardless of isolation level.
+- **Sequence emulation detail.** `counters(scope, next_value)` upsert allocates ranges inside the
+  caller's transaction; fresh rows insert `amount + 1` so ids start at 1 (0 would blur "no snapshot
+  yet" sentinels such as `schema_version_head = 0`).
+- **Parquet via DuckDB COPY** with explicit `columns={…}` on `read_json` and aliased CAST
+  projections — DuckDB names projection columns by expression text unless aliased, which initially
+  produced columns literally named `CAST(user_id AS BIGINT)`.
+- **JSONL is compact JSON per line**: uni's `JSON.format` pretty-prints, so encoders use `.toJSON`.
+- **Escalation guardrail semantics settled**: quarantine decisions are per column but applied at
+  file granularity (pass 1 flags outliers, pass 2 refolds over survivors); a brand-new column seen
+  by < threshold of batch rows quarantines its introducing files; escalation never narrows an
+  already-published type.
+- **Embedded concurrency**: one JDBC connection + monitor lock, matching the single-process
+  single-writer contract; correctness confidence comes from the deterministic fault-injection suite
+  run against both embedded backends.
+- Follow-ups unchanged: `CREATE TABLE … USING wvlet` wiring, filesets, retention/erasure runner,
+  DuckLake projection, export/import tool, S3 drivers.
+
+## ADRs
+
+- `adr/2026-08-21-table-store-catalog-portability.md` — why conditional-update assertions instead
+  of isolation levels / FOR UPDATE, and the counter-based sequence emulation.
+

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/ColumnStats.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/ColumnStats.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore
+
+import wvlet.lang.tablestore.catalog.PendingColumnStat
+import wvlet.lang.tablestore.read.Scalar
+import wvlet.lang.tablestore.schema.{ColumnType, TableSchema}
+import wvlet.uni.json.JSON
+
+/**
+  * Collects per-column min/max/null statistics from rows held in memory. Both write paths emit
+  * stats almost for free: the ingest writer has the rows at rotation and the merger reads
+  * everything anyway.
+  *
+  * Stats are advisory pruning metadata: min/max are canonically encoded per type (round-tripping
+  * through [[wvlet.lang.tablestore.read.Pruning.decode]]), and a missing row means "must scan".
+  */
+object ColumnStats:
+
+  /** Compute stats for every column of `schema` over the given rows */
+  def collect(rows: Seq[DataRow], schema: TableSchema): Seq[PendingColumnStat] = schema
+    .columns
+    .map { col =>
+      val values   = rows.flatMap(row => row.get(col.name))
+      val nulls    = rows.count(row => row.get(col.name).forall(_.isInstanceOf[JSON.JSONNull]))
+      val nonNulls = values.filterNot(_.isInstanceOf[JSON.JSONNull])
+      val t        = col.columnType
+
+      val encodedMin: Option[String] =
+        if t == ColumnType.NullType || nonNulls.isEmpty then
+          None
+        else
+          Some(encodeValue(t, minValue(t, nonNulls)))
+      val encodedMax: Option[String] =
+        if t == ColumnType.NullType || nonNulls.isEmpty then
+          None
+        else
+          Some(encodeValue(t, maxValue(t, nonNulls)))
+
+      PendingColumnStat(
+        columnName = col.name,
+        minValue = encodedMin,
+        maxValue = encodedMax,
+        nullCount = nulls.toLong,
+        distinctEstimate = None
+      )
+    }
+
+  private def comparable(t: ColumnType, v: JSON.JSONValue): Comparable[?] =
+    (t, v) match
+      case (ColumnType.LongType, JSON.JSONLong(x)) =>
+        java.lang.Long.valueOf(x)
+      case (ColumnType.DoubleType, JSON.JSONDouble(x)) =>
+        java.lang.Double.valueOf(x)
+      case (ColumnType.StringType, JSON.JSONString(x)) =>
+        x
+      case (_, JSON.JSONString(x)) =>
+        x
+      case (_, JSON.JSONLong(x)) =>
+        java.lang.Long.valueOf(x)
+      case (_, JSON.JSONDouble(x)) =>
+        java.lang.Double.valueOf(x)
+      case _ =>
+        throw TableStoreException(s"Cannot order value ${JSON.format(v)} as ${t}")
+
+  private def minValue(t: ColumnType, vs: Seq[JSON.JSONValue]): JSON.JSONValue = vs.minBy(
+    comparable(t, _).asInstanceOf[Comparable[AnyRef]]
+  )
+
+  private def maxValue(t: ColumnType, vs: Seq[JSON.JSONValue]): JSON.JSONValue = vs.maxBy(
+    comparable(t, _).asInstanceOf[Comparable[AnyRef]]
+  )
+
+  /** Canonical per-type encoding of stat bounds */
+  def encodeValue(t: ColumnType, v: JSON.JSONValue): String =
+    v match
+      case JSON.JSONLong(x) =>
+        x.toString
+      case JSON.JSONDouble(x) =>
+        x.toString
+      case JSON.JSONString(x) =>
+        x
+      case JSON.JSONBoolean(x) =>
+        x.toString
+      case other =>
+        other.toJSON
+
+  /** Build a scalar literal from a typed value, e.g. for predicates over the same column space */
+  def toScalar(t: ColumnType, v: JSON.JSONValue): Option[Scalar] =
+    v match
+      case JSON.JSONLong(x) =>
+        t match
+          case ColumnType.DoubleType =>
+            Some(Scalar.SDouble(x.toDouble))
+          case _ =>
+            Some(Scalar.SLong(x))
+      case JSON.JSONDouble(x) =>
+        Some(Scalar.SDouble(x))
+      case JSON.JSONString(x) =>
+        Some(Scalar.SString(x))
+      case JSON.JSONBoolean(x) =>
+        Some(Scalar.SBoolean(x))
+      case _ =>
+        None
+
+end ColumnStats

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/ColumnStats.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/ColumnStats.scala
@@ -14,7 +14,6 @@
 package wvlet.lang.tablestore
 
 import wvlet.lang.tablestore.catalog.PendingColumnStat
-import wvlet.lang.tablestore.read.Scalar
 import wvlet.lang.tablestore.schema.{ColumnType, TableSchema}
 import wvlet.uni.json.JSON
 
@@ -95,23 +94,5 @@ object ColumnStats:
         x.toString
       case other =>
         other.toJSON
-
-  /** Build a scalar literal from a typed value, e.g. for predicates over the same column space */
-  def toScalar(t: ColumnType, v: JSON.JSONValue): Option[Scalar] =
-    v match
-      case JSON.JSONLong(x) =>
-        t match
-          case ColumnType.DoubleType =>
-            Some(Scalar.SDouble(x.toDouble))
-          case _ =>
-            Some(Scalar.SLong(x))
-      case JSON.JSONDouble(x) =>
-        Some(Scalar.SDouble(x))
-      case JSON.JSONString(x) =>
-        Some(Scalar.SString(x))
-      case JSON.JSONBoolean(x) =>
-        Some(Scalar.SBoolean(x))
-      case _ =>
-        None
 
 end ColumnStats

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/IngestSession.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/IngestSession.scala
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore
+
+import wvlet.lang.tablestore.catalog.{CatalogStore, PendingColumnStat, PendingFileEntry}
+import wvlet.lang.tablestore.format.JsonlFile
+import wvlet.lang.tablestore.objectstore.Checksum
+import wvlet.lang.tablestore.schema.{ColumnDesc, ObservedSchema, TableSchema}
+import wvlet.uni.json.JSON
+import wvlet.uni.log.LogSupport
+
+import scala.collection.mutable.ArrayBuffer
+
+case class IngestConfig(
+    /** Rotate the local segment after this many rows */
+    maxRowsPerFile: Long = 100_000L,
+    /** Rotate the local segment after this many buffered bytes */
+    maxBytesPerFile: Long = 32L * 1024 * 1024,
+    /** File ids are pre-issued from the catalog in batches of this size */
+    fileIdBatchSize: Int = 16
+)
+
+/**
+  * A high-frequency append session for one table.
+  *
+  * Rows buffer in a rotating local segment; on rotation the writer uploads `raw/.../<fileId>.jsonl`
+  * and registers it in one catalog transaction — the snapshot id is allocated inside that
+  * transaction from a catalog counter, so concurrent ingest writers never contend on a CAS, and
+  * ingest costs one transaction per file batch, never per row. The data is readable as soon as
+  * registration returns: there is no separate live/streaming tier; freshness is bounded by segment
+  * rotation cadence.
+  *
+  * File ids are pre-issued in batches, so a crashed session's retries are no-ops: registering an
+  * already-registered id again changes nothing (crash idempotency).
+  */
+class IngestSession(
+    store: TableStore,
+    table: CatalogTable,
+    writerId: String,
+    config: IngestConfig = IngestConfig()
+) extends AutoCloseable
+    with LogSupport:
+
+  private val buffer        = ArrayBuffer[DataRow]()
+  private var bufferedBytes = 0L
+  private val idPool        = ArrayBuffer.empty[EntryId]
+  private val snapshotIds   = ArrayBuffer.empty[SnapshotId]
+  private val entryIds      = ArrayBuffer.empty[EntryId]
+  private var totalRows     = 0L
+  private var totalBytes    = 0L
+
+  private def catalog: CatalogStore = store.catalog
+
+  /** Append one row (a JSON object). Rotates the segment when it reaches the configured bounds */
+  def add(row: DataRow): Unit = synchronized {
+    buffer += row
+    bufferedBytes += row.toJSON.length.toLong + 1L
+    totalRows += 1
+    if buffer.size.toLong >= config.maxRowsPerFile || bufferedBytes >= config.maxBytesPerFile then
+      rotate()
+  }
+
+  def addAll(rows: Seq[DataRow]): Unit = rows.foreach(add)
+
+  /** Upload and register whatever is currently buffered */
+  def flush(): Option[SnapshotId] = synchronized {
+    rotate()
+    snapshotIds.lastOption
+  }
+
+  def ingestedEntryIds: Seq[EntryId]      = entryIds.toList
+  def flushedSnapshotIds: Seq[SnapshotId] = snapshotIds.toList
+  def rowCount: Long                      = totalRows
+  def byteSize: Long                      = totalBytes
+
+  /**
+    * Flush and stop. Sessions are cheap; open one per writer loop rather than reusing across
+    * processes.
+    */
+  override def close(): Unit = flush()
+
+  private def rotate(): Unit =
+    if buffer.isEmpty then
+      ()
+    else
+      val entryId = nextEntryId()
+      val format  = DataFormat.Jsonl
+      val bytes   = JsonlFile.encode(buffer.toSeq)
+      val key     = TableStore.rawKey(table.id, entryId, format)
+      val put     = store.objects.put(key, bytes)
+      // Catalog-verified checksums: registration records exactly what was written
+      if put.checksum != Checksum.sha256Hex(bytes) then
+        throw TableStoreException(s"Object store corrupted the ingest write of ${key}")
+
+      val observed = ObservedSchema.fromRows(buffer.toSeq)
+      val stats    = ColumnStats.collect(
+        buffer.toSeq,
+        TableSchema(0L, observed.columns.map((n, t) => ColumnDesc(n, t)))
+      )
+      val (minTs, maxTs) = eventTimeBounds()
+
+      val result = catalog.registerIngest(
+        table.id,
+        writerId,
+        Seq(
+          PendingFileEntry(
+            entryId = entryId,
+            s3Key = key,
+            format = format,
+            checksum = Checksum.sha256Hex(bytes),
+            rowCount = buffer.size.toLong,
+            byteSize = bytes.length.toLong,
+            minEventTs = minTs,
+            maxEventTs = maxTs,
+            observedSchemaJson = observed.schemaJson,
+            stats = stats
+          )
+        )
+      )
+      result.snapshotId.foreach(snapshotIds += _)
+      result.registeredEntryIds.foreach(entryIds += _)
+      totalBytes += bytes.length.toLong
+      buffer.clear()
+      bufferedBytes = 0L
+      debug(s"Registered ${key} with ${bytes.length} bytes at snapshot ${result.snapshotId}")
+  end rotate
+
+  private def nextEntryId(): EntryId = synchronized {
+    if idPool.isEmpty then
+      idPool ++= catalog.allocateFileIds(table.id, config.fileIdBatchSize)
+    val id = idPool.remove(idPool.size - 1)
+    id
+  }
+
+  private def eventTimeBounds(): (Option[Long], Option[Long]) =
+    table.options.eventTimeColumn match
+      case None =>
+        (None, None)
+      case Some(col) =>
+        val ts = buffer.flatMap(
+          _.get(col)
+            .collect { case JSON.JSONLong(v) =>
+              v
+            }
+        )
+        if ts.isEmpty then
+          (None, None)
+        else
+          (Some(ts.min), Some(ts.max))
+
+end IngestSession

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/TableStore.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/TableStore.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore
+
+import wvlet.lang.tablestore.catalog.{CatalogDrivers, CatalogStore}
+import wvlet.lang.tablestore.objectstore.ObjectStore
+import wvlet.lang.tablestore.schema.ColumnDesc
+
+/**
+  * The table store facade: a transactional catalog plus an immutable object store holding the data
+  * files. Ingestion registers files directly into the catalog — a registered file is immediately
+  * readable; background merge only makes scans faster.
+  *
+  * Object layout:
+  *   - raw ingest: `raw/table=<id>/<fileId>.<ext>` — pre-issued id + catalog checksum
+  *   - merged output: `merged/table=<id>/<sha256>.parquet` — content-addressed
+  */
+case class TableStore(catalog: CatalogStore, objects: ObjectStore):
+  def initialize(): Unit = catalog.initialize()
+
+  def createDatabase(name: String): wvlet.lang.tablestore.catalog.Database = catalog.createDatabase(
+    name
+  )
+
+  def createTable(
+      databaseName: String,
+      name: String,
+      options: TableOptions = TableOptions.default,
+      initialColumns: Seq[ColumnDesc] = Nil
+  ): CatalogTable = catalog.createTable(databaseName, name, options, initialColumns)
+
+  def findTable(databaseName: String, name: String): Option[CatalogTable] = catalog.findTable(
+    databaseName,
+    name
+  )
+
+  def newIngestSession(table: CatalogTable, writerId: String): IngestSession = IngestSession(
+    this,
+    table,
+    writerId
+  )
+
+  def reader: read.TableReader = read.TableReader(catalog, objects)
+
+  def merger(writerId: String): merge.Merger = merge.Merger(store = this, writerId = writerId)
+
+  /** Object keys referenced by the catalog are subtracted from the store inventory */
+  def orphanCandidates(tableId: Long): Seq[objectstore.ObjectSummary] =
+    val referenced = catalog.referencedKeys(tableId)
+    val inventory  =
+      objects.list(s"raw/table=${tableId}/") ++ objects.list(s"merged/table=${tableId}/")
+    inventory.filterNot(s => referenced.contains(s.key))
+
+end TableStore
+
+object TableStore:
+  /** Embedded profile: SQLite catalog + local filesystem store under one root directory */
+  def embedded(rootPath: String): TableStore =
+    val store = TableStore(
+      CatalogDrivers.sqlite(s"${rootPath}/catalog.db"),
+      ObjectStore.local(s"${rootPath}/objects")
+    )
+    store.initialize()
+    store
+
+  /** Raw data file key for a pre-issued entry id */
+  private[tablestore] def rawKey(tableId: Long, entryId: EntryId, format: DataFormat): String =
+    s"raw/table=${tableId}/${entryId}.${
+        if format == DataFormat.Jsonl then
+          "jsonl"
+        else
+          "parquet"
+      }"
+
+  /** Content-addressed key of a merged Parquet file */
+  private[tablestore] def mergedKey(tableId: Long, sha256: String): String =
+    s"merged/table=${tableId}/${sha256}.parquet"
+
+end TableStore

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/catalog/CatalogDrivers.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/catalog/CatalogDrivers.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.catalog
+
+import java.util.Properties
+
+/**
+  * Catalog driver factory. All three backends run the same portable SQL through
+  * [[JdbcCatalogStore]]; only connectivity differs.
+  */
+object CatalogDrivers:
+
+  /** JDBC 4 auto-discovery does not always survive test classloaders; load drivers explicitly */
+  private def loadDriver(className: String): Unit =
+    try
+      Class.forName(className)
+    catch
+      case e: ClassNotFoundException =>
+        throw wvlet.lang.tablestore.TableStoreException(s"JDBC driver not found: ${className}", e)
+
+  /** SQLite catalog — the dev/test backend of the embedded profile */
+  def sqlite(path: String): JdbcCatalogStore =
+    loadDriver("org.sqlite.JDBC")
+    val props = new Properties()
+    props.setProperty("busy_timeout", "10000")
+    props.setProperty("journal_mode", "WAL")
+    new JdbcCatalogStore(s"jdbc:sqlite:${path}", user = None, password = None)
+
+  def inMemorySqlite(): JdbcCatalogStore = sqlite(":memory:")
+
+  /** DuckDB catalog — the embedded profile backend sharing the engine with the reader */
+  def duckdb(path: String): JdbcCatalogStore =
+    loadDriver("org.duckdb.DuckDBDriver")
+    new JdbcCatalogStore(
+      if path.isEmpty || path == ":memory:" then
+        "jdbc:duckdb:"
+      else
+        s"jdbc:duckdb:${path}"
+    )
+
+  def inMemoryDuckDB(): JdbcCatalogStore = duckdb(":memory:")
+
+  /** Postgres catalog — the production single-tenant / multi-tenant service backend */
+  def postgres(
+      host: String,
+      port: Int,
+      database: String,
+      user: String,
+      password: String
+  ): JdbcCatalogStore =
+    loadDriver("org.postgresql.Driver")
+    new JdbcCatalogStore(
+      s"jdbc:postgresql://${host}:${port}/${database}",
+      user = Some(user),
+      password = Some(password)
+    )
+
+end CatalogDrivers

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/catalog/CatalogStore.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/catalog/CatalogStore.scala
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.catalog
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.tablestore.schema.ColumnDesc
+import wvlet.lang.tablestore.{
+  CatalogTable,
+  ColumnStat,
+  DataFormat,
+  EntryId,
+  FileEntry,
+  Lease,
+  SchemaVersion,
+  SchemaVersionId,
+  Snapshot,
+  SnapshotId,
+  SnapshotKind,
+  SnapshotPin,
+  TableOptions,
+  TableStoreException
+}
+
+/** A database (namespace) of tables */
+case class Database(id: Long, name: String, createdAt: Long)
+
+/**
+  * A file prepared for registration. `entryId` comes from [[CatalogStore.allocateFileIds]] and
+  * names the object in the store before registration, making retries after a crash no-ops.
+  */
+case class PendingFileEntry(
+    entryId: EntryId,
+    s3Key: String,
+    format: DataFormat,
+    checksum: String,
+    rowCount: Long,
+    byteSize: Long,
+    minEventTs: Option[Long],
+    maxEventTs: Option[Long],
+    observedSchemaJson: String,
+    stats: Seq[PendingColumnStat]
+)
+
+/** Advisory per-column statistics registered together with their file */
+case class PendingColumnStat(
+    columnName: String,
+    minValue: Option[String],
+    maxValue: Option[String],
+    nullCount: Long,
+    distinctEstimate: Option[Long]
+)
+
+case class IngestResult(
+    /** The snapshot carrying the new entries; None when everything was already registered */
+    snapshotId: Option[SnapshotId],
+    registeredEntryIds: Seq[EntryId],
+    skippedEntryIds: Seq[EntryId]
+)
+
+/**
+  * One atomic merge commit: fence-check the lease, retire sources conditionally, register the
+  * merged file, escalate the schema if widened, and publish the snapshot — all in one transaction.
+  */
+case class MergeCommit(
+    leaseName: String,
+    fencingToken: Long,
+    tableId: Long,
+    sourceEntryIds: Seq[EntryId],
+    mergedEntry: PendingFileEntry,
+    /** Some(schema) publishes a new schema version inside the same transaction */
+    escalatedSchema: Option[wvlet.lang.tablestore.schema.TableSchema],
+    writer: String
+)
+
+case class MergeCommitResult(
+    snapshotId: SnapshotId,
+    mergedEntryId: EntryId,
+    newSchemaVersion: Option[SchemaVersionId],
+    retiredEntryIds: Seq[EntryId]
+)
+
+class LeaseHeldException(leaseName: String, holder: String)
+    extends TableStoreException(s"Lease '${leaseName}' is currently held by '${holder}'")
+
+/** Thrown when the commit transaction finds the fencing token stale — the zombie loses */
+class LeaseLostException(leaseName: String, fencingToken: Long)
+    extends TableStoreException(
+      s"Fencing token ${fencingToken} no longer matches lease '${leaseName}'"
+    )
+
+class RetireConflictException(expected: Int, actual: Int)
+    extends TableStoreException(
+      s"Conditional retirement touched ${actual} rows, expected ${expected}; aborting to avoid double-folding"
+    )
+
+/**
+  * The transactional catalog of the table store: table metadata, the snapshot/file-entry inventory,
+  * leases, pins, and stats. Implementations must provide serializable (or equivalent single-writer)
+  * isolation for retiring transactions, monotonic per-table sequences, and TEXT-JSON metadata
+  * columns only — no arrays, no JSONB (see the portability constraints in the design note).
+  */
+trait CatalogStore extends AutoCloseable:
+
+  /** Create catalog tables if missing */
+  def initialize(): Unit
+
+  // ---- Databases and tables ----
+  def createDatabase(name: String): Database
+  def findDatabase(name: String): Option[Database]
+
+  /**
+    * Register a table and its schema head in one transaction. Declared `initialColumns` publish as
+    * schema version 1; an empty declaration leaves version 0 (no published columns) until the first
+    * merge escalates the schema from observed data.
+    */
+  def createTable(
+      databaseName: String,
+      name: String,
+      options: TableOptions = TableOptions.default,
+      initialColumns: Seq[ColumnDesc] = Nil
+  ): CatalogTable
+
+  def findTable(databaseName: String, name: String): Option[CatalogTable]
+  def getTable(tableId: Long): CatalogTable
+
+  // ---- Sequences ----
+
+  /**
+    * Pre-issue `count` monotonically increasing file ids for a writer session. Ids survive crashes:
+    * registering a previously issued id again is a no-op.
+    */
+  def allocateFileIds(tableId: Long, count: Int): Seq[EntryId]
+
+  // ---- Ingest ----
+
+  /**
+    * Register uploaded files in one transaction: allocate a snapshot id, insert the snapshot row
+    * and the file entries with `begin_snapshot` = that id. Data is readable immediately after this
+    * returns. Re-registering an already known entry id skips that entry (crash idempotency).
+    */
+  def registerIngest(tableId: Long, writer: String, entries: Seq[PendingFileEntry]): IngestResult
+
+  // ---- Reads ----
+
+  def latestSnapshot(tableId: Long): Option[Snapshot]
+  def snapshotOf(tableId: Long, snapshotId: SnapshotId): Option[Snapshot]
+  def snapshotsOf(tableId: Long): Seq[Snapshot]
+  def schemaVersionsOf(tableId: Long): Seq[SchemaVersion]
+
+  /** Entries visible at `snapshotId` under the interval predicate */
+  def liveEntries(tableId: Long, snapshotId: SnapshotId): Seq[FileEntry]
+  def entry(entryId: EntryId): Option[FileEntry]
+
+  /** Stats for the given entries — advisory pruning input */
+  def statsFor(fileIds: Seq[EntryId]): Seq[ColumnStat]
+
+  // ---- Leases ----
+
+  /**
+    * Acquire the named lease, taking over expired ones. Each acquisition mints a fresh,
+    * monotonically increasing fencing token.
+    */
+  def acquireLease(name: String, tableId: Option[Long], holder: String, ttlMillis: Long): Lease
+
+  /** Extend a held lease; fails with [[LeaseLostException]] if the token is stale */
+  def renewLease(name: String, holder: String, fencingToken: Long, ttlMillis: Long): Lease
+
+  def releaseLease(name: String, holder: String, fencingToken: Long): Unit
+  def leaseOf(name: String): Option[Lease]
+
+  // ---- Merge commit ----
+
+  /**
+    * Execute a [[MergeCommit]] atomically. The fencing token is verified inside the transaction; a
+    * stale token throws [[LeaseLostException]]. Source retirement is conditional on
+    * `end_snapshot IS NULL` and asserted by row count, so no entry ever retires twice.
+    */
+  def commitMerge(commit: MergeCommit): MergeCommitResult
+
+  // ---- Snapshot pins ----
+
+  def pinSnapshot(tableId: Long, snapshotId: SnapshotId, holder: String, ttlMillis: Long): Unit
+  def renewPin(tableId: Long, holder: String, ttlMillis: Long): Unit
+  def releasePin(tableId: Long, holder: String): Unit
+  def activePins(tableId: Long): Seq[SnapshotPin]
+
+  // ---- GC helpers ----
+
+  /** All keys referenced by the catalog — orphan detection subtracts them from a store inventory */
+  def referencedKeys(tableId: Long): Set[String]
+
+  /**
+    * Retired entries whose files no active pin can see anymore — safe to delete from the store
+    * (after checking no other table references them).
+    */
+  def deletableEntries(tableId: Long): Seq[FileEntry]
+
+end CatalogStore

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/catalog/JdbcCatalogStore.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/catalog/JdbcCatalogStore.scala
@@ -1,0 +1,975 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.catalog
+
+import wvlet.lang.tablestore.{
+  CatalogTable,
+  ColumnStat,
+  DataFormat,
+  EntryId,
+  EntryKind,
+  FileEntry,
+  Lease,
+  nowMicros,
+  SchemaVersion,
+  SchemaVersionId,
+  Snapshot,
+  SnapshotId,
+  SnapshotKind,
+  SnapshotPin,
+  TableOptions,
+  TableStoreException
+}
+import wvlet.lang.tablestore.schema.{ColumnDesc, TableSchema}
+import wvlet.uni.json.JSON
+import wvlet.uni.log.LogSupport
+
+import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet}
+
+/**
+  * A portable JDBC implementation of [[CatalogStore]] shared by SQLite, DuckDB, and Postgres.
+  *
+  * The catalog contract is honored with plain SQL only: TEXT-JSON metadata, no array columns, and
+  * monotonic counters emulated with a CAS-style upsert. Correctness of retiring transactions does
+  * not lean on isolation levels — fencing and retirement are enforced by conditional updates with
+  * row-count assertions inside one transaction.
+  *
+  * Concurrency note: this implementation serializes access through a single connection, matching
+  * the embedded profile's single-process single-writer semantics. A pooled variant for Postgres can
+  * reuse every statement unchanged.
+  */
+class JdbcCatalogStore(
+    url: String,
+    user: Option[String] = None,
+    password: Option[String] = None,
+    /** TTL applied when a successful merge commit renews its lease */
+    val leaseTtlMillis: Long = 60_000L
+) extends CatalogStore
+    with LogSupport:
+
+  private val conn: Connection =
+    (user, password) match
+      case (Some(u), Some(p)) =>
+        DriverManager.getConnection(url, u, p)
+      case _ =>
+        DriverManager.getConnection(url)
+
+  private val lock = new Object
+
+  override def close(): Unit = lock.synchronized(conn.close())
+
+  // ---- Low-level helpers ----
+
+  private def update(sql: String, bind: PreparedStatement => Unit): Int = lock.synchronized {
+    val st = conn.prepareStatement(sql)
+    try
+      bind(st)
+      st.executeUpdate()
+    finally
+      st.close()
+  }
+
+  private def query[A](sql: String, bind: PreparedStatement => Unit)(mapRs: ResultSet => A): A =
+    lock.synchronized {
+      val st = conn.prepareStatement(sql)
+      try
+        bind(st)
+        val rs = st.executeQuery()
+        try mapRs(rs)
+        finally rs.close()
+      finally
+        st.close()
+    }
+
+  private def queryOne[A](sql: String, bind: PreparedStatement => Unit)(
+      mapRs: ResultSet => A
+  ): Option[A] =
+    query(sql, bind) { rs =>
+      if rs.next() then
+        Some(mapRs(rs))
+      else
+        None
+    }
+
+  private def queryList[A](sql: String, bind: PreparedStatement => Unit)(
+      mapRs: ResultSet => A
+  ): Seq[A] =
+    query(sql, bind) { rs =>
+      val b = Seq.newBuilder[A]
+      while rs.next() do
+        b += mapRs(rs)
+      b.result()
+    }
+
+  private def tx[A](body: => A): A = lock.synchronized {
+    val prevAutoCommit = conn.getAutoCommit
+    conn.setAutoCommit(false)
+    try
+      val result = body
+      conn.commit()
+      result
+    catch
+      case e: Throwable =>
+        conn.rollback()
+        throw e
+    finally
+      conn.setAutoCommit(prevAutoCommit)
+  }
+
+  private def exec(sql: String): Unit = lock.synchronized {
+    val st = conn.createStatement()
+    try st.execute(sql)
+    finally st.close()
+  }
+
+  // ---- DDL ----
+
+  override def initialize(): Unit = lock.synchronized {
+    val ddl = Seq(
+      """CREATE TABLE IF NOT EXISTS databases(
+        |  id BIGINT PRIMARY KEY,
+        |  name VARCHAR NOT NULL UNIQUE,
+        |  created_at BIGINT NOT NULL
+        |)""".stripMargin,
+      """CREATE TABLE IF NOT EXISTS tables(
+        |  id BIGINT PRIMARY KEY,
+        |  db_id BIGINT NOT NULL,
+        |  name VARCHAR NOT NULL,
+        |  schema_version_head BIGINT NOT NULL DEFAULT 0,
+        |  partition_spec_json TEXT NOT NULL DEFAULT '{}',
+        |  options_json TEXT NOT NULL DEFAULT '{}',
+        |  created_at BIGINT NOT NULL,
+        |  UNIQUE(db_id, name)
+        |)""".stripMargin,
+      """CREATE TABLE IF NOT EXISTS schema_versions(
+        |  table_id BIGINT NOT NULL,
+        |  version BIGINT NOT NULL,
+        |  schema_json TEXT NOT NULL,
+        |  published_at BIGINT NOT NULL,
+        |  published_by_snapshot BIGINT NOT NULL,
+        |  PRIMARY KEY (table_id, version)
+        |)""".stripMargin,
+      """CREATE TABLE IF NOT EXISTS snapshots(
+        |  table_id BIGINT NOT NULL,
+        |  id BIGINT NOT NULL,
+        |  kind VARCHAR NOT NULL,
+        |  schema_version BIGINT NOT NULL,
+        |  published_at BIGINT NOT NULL,
+        |  published_by VARCHAR NOT NULL,
+        |  fencing_token VARCHAR,
+        |  PRIMARY KEY (table_id, id)
+        |)""".stripMargin,
+      """CREATE TABLE IF NOT EXISTS file_entries(
+        |  id BIGINT PRIMARY KEY,
+        |  table_id BIGINT NOT NULL,
+        |  kind VARCHAR NOT NULL,
+        |  s3_key VARCHAR NOT NULL,
+        |  format VARCHAR NOT NULL,
+        |  checksum VARCHAR NOT NULL,
+        |  row_count BIGINT NOT NULL,
+        |  byte_size BIGINT NOT NULL,
+        |  min_event_ts BIGINT,
+        |  max_event_ts BIGINT,
+        |  observed_schema_json TEXT NOT NULL,
+        |  begin_snapshot BIGINT NOT NULL,
+        |  end_snapshot BIGINT,
+        |  merged_from_json TEXT,
+        |  written_by VARCHAR NOT NULL,
+        |  created_at BIGINT NOT NULL
+        |)""".stripMargin,
+      """CREATE INDEX IF NOT EXISTS idx_file_entries_liveness
+        |  ON file_entries(table_id, begin_snapshot, end_snapshot)""".stripMargin,
+      """CREATE TABLE IF NOT EXISTS file_column_stats(
+        |  file_id BIGINT NOT NULL,
+        |  table_id BIGINT NOT NULL,
+        |  column_name VARCHAR NOT NULL,
+        |  schema_version BIGINT NOT NULL,
+        |  min_value VARCHAR,
+        |  max_value VARCHAR,
+        |  null_count BIGINT NOT NULL,
+        |  distinct_estimate BIGINT,
+        |  PRIMARY KEY (file_id, column_name)
+        |)""".stripMargin,
+      """CREATE TABLE IF NOT EXISTS snapshot_pins(
+        |  table_id BIGINT NOT NULL,
+        |  snapshot_id BIGINT NOT NULL,
+        |  holder VARCHAR NOT NULL,
+        |  expires_at BIGINT NOT NULL,
+        |  PRIMARY KEY (table_id, holder)
+        |)""".stripMargin,
+      """CREATE TABLE IF NOT EXISTS leases(
+        |  name VARCHAR PRIMARY KEY,
+        |  table_id BIGINT,
+        |  holder VARCHAR NOT NULL,
+        |  fencing_token BIGINT NOT NULL,
+        |  acquired_at BIGINT NOT NULL,
+        |  expires_at BIGINT NOT NULL
+        |)""".stripMargin,
+      """CREATE TABLE IF NOT EXISTS retention_policies(
+        |  table_id BIGINT NOT NULL,
+        |  kind VARCHAR NOT NULL,
+        |  horizon_days INT NOT NULL,
+        |  PRIMARY KEY (table_id, kind)
+        |)""".stripMargin,
+      // Monotonic sequence emulation: each scope holds the next unallocated value
+      """CREATE TABLE IF NOT EXISTS counters(
+        |  scope VARCHAR PRIMARY KEY,
+        |  next_value BIGINT NOT NULL
+        |)""".stripMargin
+    )
+    ddl.foreach(exec)
+  }
+
+  // ---- Counters (monotonic sequences) ----
+
+  /**
+    * Reserve `amount` monotonic values from the scope's counter: ids are 1-based and never repeat.
+    * The CAS-style upsert allocates inside the caller's transaction, so concurrent writers
+    * serialize on the counter row without a separate round trip.
+    */
+  private def reserve(scope: String, amount: Long): (Long, Long) =
+    update(
+      """INSERT INTO counters(scope, next_value) VALUES(?, ?)
+        |ON CONFLICT(scope) DO UPDATE SET next_value = next_value + ?""".stripMargin,
+      st =>
+        st.setString(1, scope)
+        // Fresh counters start just past the first allocation so ids begin at 1
+        st.setLong(2, amount + 1)
+        st.setLong(3, amount)
+    )
+    val next =
+      queryOne("SELECT next_value FROM counters WHERE scope = ?", st => st.setString(1, scope))(
+        rs => rs.getLong(1)
+      ).get
+    (next - amount, next)
+
+  private def tableSnapshotScope(tableId: Long) = s"table:${tableId}:snapshot"
+  private def tableFileScope(tableId: Long)     = s"table:${tableId}:file"
+
+  override def allocateFileIds(tableId: Long, count: Int): Seq[EntryId] = tx {
+    val (start, end) = reserve(tableFileScope(tableId), count)
+    (start until end)
+  }
+
+  // ---- Databases and tables ----
+
+  override def createDatabase(name: String): Database = tx {
+    findDatabase(name) match
+      case Some(db) =>
+        db
+      case None =>
+        val id = reserve("database-id", 1)._1
+        update(
+          "INSERT INTO databases(id, name, created_at) VALUES (?, ?, ?)",
+          st =>
+            st.setLong(1, id)
+            st.setString(2, name)
+            st.setLong(3, nowMicros)
+        )
+        Database(id, name, nowMicros)
+  }
+
+  override def findDatabase(name: String): Option[Database] =
+    queryOne(
+      "SELECT id, name, created_at FROM databases WHERE name = ?",
+      st => st.setString(1, name)
+    )(rs => Database(rs.getLong(1), rs.getString(2), rs.getLong(3)))
+
+  override def createTable(
+      databaseName: String,
+      name: String,
+      options: TableOptions = TableOptions.default,
+      initialColumns: Seq[ColumnDesc] = Nil
+  ): CatalogTable = tx {
+    val db = findDatabase(databaseName).getOrElse {
+      throw wvlet
+        .lang
+        .api
+        .StatusCode
+        .CATALOG_NOT_FOUND
+        .newException(s"Database '${databaseName}' does not exist")
+    }
+    findTable(databaseName, name).foreach { t =>
+      throw wvlet
+        .lang
+        .api
+        .StatusCode
+        .TABLE_ALREADY_EXISTS
+        .newException(s"Table '${databaseName}.${name}' already exists as id ${t.id}")
+    }
+    val id = reserve("table-id", 1)._1
+    update(
+      """INSERT INTO tables(id, db_id, name, schema_version_head, partition_spec_json, options_json, created_at)
+        |VALUES (?, ?, ?, 0, '{}', ?, ?)""".stripMargin,
+      st =>
+        st.setLong(1, id)
+        st.setLong(2, db.id)
+        st.setString(3, name)
+        st.setString(4, options.toJson)
+        st.setLong(5, nowMicros)
+    )
+    if initialColumns.nonEmpty then
+      // The declared schema head: version 1, published by table creation (snapshot 0)
+      publishSchemaVersion(id, TableSchema(1, initialColumns), bySnapshot = 0L)
+    CatalogTable(
+      id,
+      databaseName,
+      name,
+      if initialColumns.nonEmpty then
+        1
+      else
+        0
+      ,
+      options.toJson,
+      nowMicros
+    )
+  }
+
+  override def findTable(databaseName: String, name: String): Option[CatalogTable] =
+    queryOne(
+      """SELECT t.id, d.name, t.name, t.schema_version_head, t.options_json, t.created_at
+        |FROM tables t JOIN databases d ON t.db_id = d.id
+        |WHERE d.name = ? AND t.name = ?""".stripMargin,
+      st =>
+        st.setString(1, databaseName)
+        st.setString(2, name)
+    ) { rs =>
+      CatalogTable(
+        rs.getLong(1),
+        rs.getString(2),
+        rs.getString(3),
+        rs.getLong(4),
+        rs.getString(5),
+        rs.getLong(6)
+      )
+    }
+
+  override def getTable(tableId: Long): CatalogTable = queryOne(
+    """SELECT t.id, d.name, t.name, t.schema_version_head, t.options_json, t.created_at
+        |FROM tables t JOIN databases d ON t.db_id = d.id
+        |WHERE t.id = ?""".stripMargin,
+    st => st.setLong(1, tableId)
+  ) { rs =>
+    CatalogTable(
+      rs.getLong(1),
+      rs.getString(2),
+      rs.getString(3),
+      rs.getLong(4),
+      rs.getString(5),
+      rs.getLong(6)
+    )
+  }.getOrElse {
+    throw wvlet.lang.api.StatusCode.TABLE_NOT_FOUND.newException(s"Table id ${tableId}")
+  }
+
+  private def schemaHead(tableId: Long): SchemaVersionId = queryOne(
+    "SELECT schema_version_head FROM tables WHERE id = ?",
+    st => st.setLong(1, tableId)
+  )(rs => rs.getLong(1)).getOrElse(0L)
+
+  // ---- Ingest registration ----
+
+  override def registerIngest(
+      tableId: Long,
+      writer: String,
+      entries: Seq[PendingFileEntry]
+  ): IngestResult = tx {
+    require(entries.forall(e => e.entryId >= 0), "entry ids must be pre-issued")
+    val knownIds = entries.map(_.entryId).filter(entryExists)
+    val fresh    = entries.filterNot(e => knownIds.contains(e.entryId))
+
+    if fresh.isEmpty then
+      IngestResult(None, Nil, knownIds)
+    else
+      val snapId = reserve(tableSnapshotScope(tableId), 1)._1
+      val head   = schemaHead(tableId)
+      insertSnapshot(Snapshot(tableId, snapId, SnapshotKind.Ingest, head, nowMicros, writer, None))
+      fresh.foreach { e =>
+        insertFileEntry(
+          FileEntry(
+            id = e.entryId,
+            tableId = tableId,
+            kind = EntryKind.File,
+            s3Key = e.s3Key,
+            format = e.format,
+            checksum = e.checksum,
+            rowCount = e.rowCount,
+            byteSize = e.byteSize,
+            minEventTs = e.minEventTs,
+            maxEventTs = e.maxEventTs,
+            observedSchemaJson = e.observedSchemaJson,
+            beginSnapshot = snapId,
+            endSnapshot = None,
+            mergedFrom = Nil,
+            writtenBy = writer,
+            createdAt = nowMicros
+          ),
+          e.stats,
+          head
+        )
+      }
+      IngestResult(Some(snapId), fresh.map(_.entryId), knownIds)
+    end if
+  }
+
+  private def entryExists(entryId: EntryId): Boolean =
+    queryOne("SELECT id FROM file_entries WHERE id = ?", st => st.setLong(1, entryId))(rs =>
+      rs.getLong(1)
+    ).isDefined
+
+  private def insertSnapshot(snapshot: Snapshot): Unit = update(
+    """INSERT INTO snapshots(table_id, id, kind, schema_version, published_at, published_by, fencing_token)
+        |VALUES (?, ?, ?, ?, ?, ?, ?)""".stripMargin,
+    st =>
+      st.setLong(1, snapshot.tableId)
+      st.setLong(2, snapshot.id)
+      st.setString(3, snapshot.kind.toString.toLowerCase)
+      st.setLong(4, snapshot.schemaVersion)
+      st.setLong(5, snapshot.publishedAt)
+      st.setString(6, snapshot.publishedBy)
+      snapshot.fencingToken.foreach(t => st.setString(7, t))
+      if snapshot.fencingToken.isEmpty then
+        st.setNull(7, java.sql.Types.VARCHAR)
+  )
+
+  private def insertFileEntry(
+      entry: FileEntry,
+      stats: Seq[PendingColumnStat],
+      statsSchemaVersion: SchemaVersionId
+  ): Unit =
+    update(
+      """INSERT INTO file_entries(
+        |  id, table_id, kind, s3_key, format, checksum, row_count, byte_size,
+        |  min_event_ts, max_event_ts, observed_schema_json, begin_snapshot, end_snapshot,
+        |  merged_from_json, written_by, created_at)
+        |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        |ON CONFLICT (id) DO NOTHING""".stripMargin,
+      st =>
+        var i = 1
+        st.setLong(i, entry.id);
+        i += 1
+        st.setLong(i, entry.tableId);
+        i += 1
+        st.setString(i, entry.kind.toString.toLowerCase);
+        i += 1
+        st.setString(i, entry.s3Key);
+        i += 1
+        st.setString(i, entry.format.toString.toLowerCase);
+        i += 1
+        st.setString(i, entry.checksum);
+        i += 1
+        st.setLong(i, entry.rowCount);
+        i += 1
+        st.setLong(i, entry.byteSize);
+        i += 1
+        setOptionalLong(st, i, entry.minEventTs);
+        i += 1
+        setOptionalLong(st, i, entry.maxEventTs);
+        i += 1
+        st.setString(i, entry.observedSchemaJson);
+        i += 1
+        st.setLong(i, entry.beginSnapshot);
+        i += 1
+        entry.endSnapshot.foreach(x => st.setLong(i, x))
+        if entry.endSnapshot.isEmpty then
+          st.setNull(i, java.sql.Types.BIGINT)
+        i += 1
+        st.setString(i, encodeMergedFrom(entry.mergedFrom));
+        i += 1
+        st.setString(i, entry.writtenBy);
+        i += 1
+        st.setLong(i, entry.createdAt)
+    )
+    stats.foreach { stat =>
+      update(
+        """INSERT INTO file_column_stats(file_id, table_id, column_name, schema_version, min_value, max_value, null_count, distinct_estimate)
+          |VALUES (?, ?, ?, ?, ?, ?, ?, ?)""".stripMargin,
+        st =>
+          var i = 1
+          st.setLong(i, entry.id);
+          i += 1
+          st.setLong(i, entry.tableId);
+          i += 1
+          st.setString(i, stat.columnName);
+          i += 1
+          st.setLong(i, statsSchemaVersion);
+          i += 1
+          setOptionalString(st, i, stat.minValue);
+          i += 1
+          setOptionalString(st, i, stat.maxValue);
+          i += 1
+          st.setLong(i, stat.nullCount);
+          i += 1
+          setOptionalLong(st, i, stat.distinctEstimate)
+      )
+    }
+  end insertFileEntry
+
+  private def encodeMergedFrom(ids: List[EntryId]): String = JSON.format(
+    JSON.JSONArray(ids.map(id => JSON.JSONLong(id)).toIndexedSeq)
+  )
+
+  private def decodeMergedFrom(json: String): List[EntryId] =
+    if json == null then
+      Nil
+    else
+      JSON.parse(json) match
+        case JSON.JSONArray(items) =>
+          items
+            .collect { case JSON.JSONLong(v) =>
+              v
+            }
+            .toList
+        case _ =>
+          Nil
+
+  private def setOptionalLong(st: PreparedStatement, index: Int, v: Option[Long]): Unit =
+    v match
+      case Some(x) =>
+        st.setLong(index, x)
+      case None =>
+        st.setNull(index, java.sql.Types.BIGINT)
+
+  private def setOptionalString(st: PreparedStatement, index: Int, v: Option[String]): Unit =
+    v match
+      case Some(x) =>
+        st.setString(index, x)
+      case None =>
+        st.setNull(index, java.sql.Types.VARCHAR)
+
+  // ---- Row mapping ----
+
+  private def mapEntry(rs: ResultSet): FileEntry = FileEntry(
+    id = rs.getLong("id"),
+    tableId = rs.getLong("table_id"),
+    kind = enumFromName(EntryKind.values, rs.getString("kind"), EntryKind.File),
+    s3Key = rs.getString("s3_key"),
+    format = enumFromName(DataFormat.values, rs.getString("format"), DataFormat.Jsonl),
+    checksum = rs.getString("checksum"),
+    rowCount = rs.getLong("row_count"),
+    byteSize = rs.getLong("byte_size"),
+    minEventTs = optLong(rs, "min_event_ts"),
+    maxEventTs = optLong(rs, "max_event_ts"),
+    observedSchemaJson = rs.getString("observed_schema_json"),
+    beginSnapshot = rs.getLong("begin_snapshot"),
+    endSnapshot = optLong(rs, "end_snapshot"),
+    mergedFrom = decodeMergedFrom(rs.getString("merged_from_json")),
+    writtenBy = rs.getString("written_by"),
+    createdAt = rs.getLong("created_at")
+  )
+
+  private def mapSnapshot(rs: ResultSet): Snapshot = Snapshot(
+    tableId = rs.getLong("table_id"),
+    id = rs.getLong("id"),
+    kind = enumFromName(SnapshotKind.values, rs.getString("kind"), SnapshotKind.Ingest),
+    schemaVersion = rs.getLong("schema_version"),
+    publishedAt = rs.getLong("published_at"),
+    publishedBy = rs.getString("published_by"),
+    fencingToken =
+      val t = rs.getString("fencing_token")
+      if rs.wasNull then
+        None
+      else
+        Some(t)
+  )
+
+  private def enumFromName[E](values: Array[E], raw: String, default: E): E = values
+    .find(_.toString.toLowerCase == raw)
+    .getOrElse(default)
+
+  private def optLong(rs: ResultSet, col: String): Option[Long] =
+    val v = rs.getLong(col)
+    if rs.wasNull then
+      None
+    else
+      Some(v)
+
+  private def optLongAt(rs: ResultSet, col: Int): Option[Long] =
+    val v = rs.getLong(col)
+    if rs.wasNull then
+      None
+    else
+      Some(v)
+
+  // ---- Reads ----
+
+  override def latestSnapshot(tableId: Long): Option[Snapshot] =
+    queryOne(
+      "SELECT * FROM snapshots WHERE table_id = ? ORDER BY id DESC LIMIT 1",
+      st => st.setLong(1, tableId)
+    )(mapSnapshot)
+
+  override def snapshotOf(tableId: Long, snapshotId: SnapshotId): Option[Snapshot] =
+    queryOne(
+      "SELECT * FROM snapshots WHERE table_id = ? AND id = ?",
+      st =>
+        st.setLong(1, tableId)
+        st.setLong(2, snapshotId)
+    )(mapSnapshot)
+
+  override def snapshotsOf(tableId: Long): Seq[Snapshot] =
+    queryList(
+      "SELECT * FROM snapshots WHERE table_id = ? ORDER BY id",
+      st => st.setLong(1, tableId)
+    )(mapSnapshot)
+
+  override def schemaVersionsOf(tableId: Long): Seq[SchemaVersion] =
+    queryList(
+      """SELECT version, schema_json, published_at, published_by_snapshot
+        |FROM schema_versions WHERE table_id = ? ORDER BY version""".stripMargin,
+      st => st.setLong(1, tableId)
+    ) { rs =>
+      SchemaVersion(tableId, rs.getLong(1), rs.getString(2), rs.getLong(3), rs.getLong(4))
+    }
+
+  /**
+    * The interval predicate `begin_snapshot <= S AND (end_snapshot IS NULL OR end_snapshot > S)` —
+    * the single definition of file liveness in the system.
+    */
+  private val livePredicateSql =
+    "begin_snapshot <= ? AND (end_snapshot IS NULL OR end_snapshot > ?)"
+
+  override def liveEntries(tableId: Long, snapshotId: SnapshotId): Seq[FileEntry] =
+    queryList(
+      s"""SELECT * FROM file_entries WHERE table_id = ? AND $livePredicateSql ORDER BY id"""
+        .stripMargin,
+      st =>
+        st.setLong(1, tableId)
+        st.setLong(2, snapshotId)
+        st.setLong(3, snapshotId)
+    )(mapEntry)
+
+  override def entry(entryId: EntryId): Option[FileEntry] =
+    queryOne("SELECT * FROM file_entries WHERE id = ?", st => st.setLong(1, entryId))(mapEntry)
+
+  override def statsFor(fileIds: Seq[EntryId]): Seq[ColumnStat] =
+    if fileIds.isEmpty then
+      Nil
+    else
+      val placeholders = fileIds.map(_ => "?").mkString(", ")
+      queryList(
+        s"""SELECT file_id, column_name, schema_version, min_value, max_value, null_count, distinct_estimate
+           |FROM file_column_stats WHERE file_id IN ($placeholders) ORDER BY file_id, column_name"""
+          .stripMargin,
+        st =>
+          var i = 1
+          fileIds.foreach { id =>
+            st.setLong(i, id)
+            i += 1
+          }
+      ) { rs =>
+        ColumnStat(
+          fileId = rs.getLong(1),
+          columnName = rs.getString(2),
+          schemaVersion = rs.getLong(3),
+          minValue = optString(rs, 4),
+          maxValue = optString(rs, 5),
+          nullCount = rs.getLong(6),
+          distinctEstimate = optLongAt(rs, 7)
+        )
+      }
+
+  private def optString(rs: ResultSet, col: Int): Option[String] =
+    val v = rs.getString(col)
+    if rs.wasNull then
+      None
+    else
+      Some(v)
+
+  // ---- Leases ----
+
+  private def leaseTokenScope(name: String) = s"lease-token:${name}"
+
+  override def acquireLease(
+      name: String,
+      tableId: Option[Long],
+      holder: String,
+      ttlMillis: Long
+  ): Lease = tx {
+    val now             = nowMicros
+    val expiresAtMicros = now + ttlMillis * 1000L
+    // Mint a fresh fencing token for every acquisition attempt. Tokens only ever increase, so a
+    // zombie holding an old token can never pass an in-transaction check against the new one.
+    val token = reserve(leaseTokenScope(name), 1)._1
+    update(
+      """INSERT INTO leases(name, table_id, holder, fencing_token, acquired_at, expires_at)
+        |VALUES (?, ?, ?, ?, ?, ?)
+        |ON CONFLICT(name) DO UPDATE SET
+        |  holder = excluded.holder,
+        |  fencing_token = excluded.fencing_token,
+        |  acquired_at = excluded.acquired_at,
+        |  expires_at = excluded.expires_at
+        |WHERE leases.expires_at <= ?
+        |   OR leases.holder = excluded.holder""".stripMargin,
+      st =>
+        st.setString(1, name)
+        setOptionalLong(st, 2, tableId)
+        st.setString(3, holder)
+        st.setLong(4, token)
+        st.setLong(5, now)
+        st.setLong(6, expiresAtMicros)
+        st.setLong(7, now)
+    )
+    leaseOf(name) match
+      case Some(l) if l.holder == holder && l.fencingToken == token =>
+        l
+      case Some(other) =>
+        throw LeaseHeldException(name, other.holder)
+      case None =>
+        throw TableStoreException(s"Lease row '${name}' disappeared during acquisition")
+  }
+
+  override def renewLease(
+      name: String,
+      holder: String,
+      fencingToken: Long,
+      ttlMillis: Long
+  ): Lease = tx {
+    val updated = update(
+      """UPDATE leases SET expires_at = ? WHERE name = ? AND holder = ? AND fencing_token = ? AND expires_at > ?"""
+        .stripMargin,
+      st =>
+        st.setLong(1, nowMicros + ttlMillis * 1000L)
+        st.setString(2, name)
+        st.setString(3, holder)
+        st.setLong(4, fencingToken)
+        st.setLong(5, nowMicros)
+    )
+    if updated != 1 then
+      throw LeaseLostException(name, fencingToken)
+    leaseOf(name).get
+  }
+
+  override def releaseLease(name: String, holder: String, fencingToken: Long): Unit = tx {
+    update(
+      "DELETE FROM leases WHERE name = ? AND holder = ? AND fencing_token = ?",
+      st =>
+        st.setString(1, name)
+        st.setString(2, holder)
+        st.setLong(3, fencingToken)
+    )
+    ()
+  }
+
+  override def leaseOf(name: String): Option[Lease] =
+    queryOne(
+      "SELECT name, table_id, holder, fencing_token, acquired_at, expires_at FROM leases WHERE name = ?",
+      st => st.setString(1, name)
+    ) { rs =>
+      Lease(
+        rs.getString(1),
+        optLongAt(rs, 2),
+        rs.getString(3),
+        rs.getLong(4),
+        rs.getLong(5),
+        rs.getLong(6)
+      )
+    }
+
+  // ---- Merge commit ----
+
+  override def commitMerge(commit: MergeCommit): MergeCommitResult = tx {
+    // 1. Fencing: re-read the lease inside this transaction and abort unless our token matches.
+    //    Stamping is not checking — this conditional update is what excludes a zombie merger.
+    val fenced = update(
+      """UPDATE leases SET expires_at = ? WHERE name = ? AND fencing_token = ? AND expires_at > ?"""
+        .stripMargin,
+      st =>
+        st.setLong(1, nowMicros + leaseTtlMillis * 1000L)
+        st.setString(2, commit.leaseName)
+        st.setLong(3, commit.fencingToken)
+        st.setLong(4, nowMicros)
+    )
+    if fenced != 1 then
+      throw LeaseLostException(commit.leaseName, commit.fencingToken)
+
+    val snapId = reserve(tableSnapshotScope(commit.tableId), 1)._1
+
+    // 2. Retire sources conditionally and assert the affected-row count so two mergers can never
+    //    double-fold the same rows. (An empty source list retires nothing.)
+    val retired =
+      if commit.sourceEntryIds.isEmpty then
+        0
+      else
+        val placeholders = commit.sourceEntryIds.map(_ => "?").mkString(", ")
+        update(
+          s"""UPDATE file_entries SET end_snapshot = ?
+             |WHERE table_id = ? AND id IN ($placeholders) AND end_snapshot IS NULL""".stripMargin,
+          st =>
+            st.setLong(1, snapId)
+            st.setLong(2, commit.tableId)
+            var i = 3
+            commit
+              .sourceEntryIds
+              .foreach { id =>
+                st.setLong(i, id)
+                i += 1
+              }
+        )
+    if retired != commit.sourceEntryIds.size then
+      throw RetireConflictException(commit.sourceEntryIds.size, retired)
+
+    // 3. Schema escalation publishes a new version under the same transaction
+    val headBefore                          = schemaHead(commit.tableId)
+    val newVersion: Option[SchemaVersionId] = commit
+      .escalatedSchema
+      .map { schema =>
+        publishSchemaVersion(commit.tableId, schema, snapId)
+        schema.version
+      }
+    val effectiveHead = newVersion.getOrElse(headBefore)
+
+    // 4. Register the merged file; it is immediately visible at the new snapshot
+    insertFileEntry(
+      FileEntry(
+        id = commit.mergedEntry.entryId,
+        tableId = commit.tableId,
+        kind = EntryKind.File,
+        s3Key = commit.mergedEntry.s3Key,
+        format = commit.mergedEntry.format,
+        checksum = commit.mergedEntry.checksum,
+        rowCount = commit.mergedEntry.rowCount,
+        byteSize = commit.mergedEntry.byteSize,
+        minEventTs = commit.mergedEntry.minEventTs,
+        maxEventTs = commit.mergedEntry.maxEventTs,
+        observedSchemaJson = commit.mergedEntry.observedSchemaJson,
+        beginSnapshot = snapId,
+        endSnapshot = None,
+        mergedFrom = commit.sourceEntryIds.toList,
+        writtenBy = commit.writer,
+        createdAt = nowMicros
+      ),
+      commit.mergedEntry.stats,
+      effectiveHead
+    )
+
+    // 5. Publish the retiring snapshot with the verified token stamped on it
+    insertSnapshot(
+      Snapshot(
+        commit.tableId,
+        snapId,
+        SnapshotKind.Merge,
+        effectiveHead,
+        nowMicros,
+        commit.writer,
+        Some(commit.fencingToken.toString)
+      )
+    )
+
+    MergeCommitResult(snapId, commit.mergedEntry.entryId, newVersion, commit.sourceEntryIds)
+  }
+
+  private def publishSchemaVersion(
+      tableId: Long,
+      schema: TableSchema,
+      bySnapshot: SnapshotId
+  ): Unit =
+    update(
+      """INSERT INTO schema_versions(table_id, version, schema_json, published_at, published_by_snapshot)
+        |VALUES (?, ?, ?, ?, ?)""".stripMargin,
+      st =>
+        st.setLong(1, tableId)
+        st.setLong(2, schema.version)
+        st.setString(3, schema.schemaJson)
+        st.setLong(4, nowMicros)
+        st.setLong(5, bySnapshot)
+    )
+    update(
+      "UPDATE tables SET schema_version_head = ? WHERE id = ?",
+      st =>
+        st.setLong(1, schema.version)
+        st.setLong(2, tableId)
+    )
+
+  // ---- Snapshot pins ----
+
+  override def pinSnapshot(
+      tableId: Long,
+      snapshotId: SnapshotId,
+      holder: String,
+      ttlMillis: Long
+  ): Unit = tx {
+    update(
+      """INSERT INTO snapshot_pins(table_id, snapshot_id, holder, expires_at)
+        |VALUES (?, ?, ?, ?)
+        |ON CONFLICT(table_id, holder) DO UPDATE SET
+        |  snapshot_id = excluded.snapshot_id,
+        |  expires_at = excluded.expires_at""".stripMargin,
+      st =>
+        st.setLong(1, tableId)
+        st.setLong(2, snapshotId)
+        st.setString(3, holder)
+        st.setLong(4, nowMicros + ttlMillis * 1000L)
+    )
+    ()
+  }
+
+  override def renewPin(tableId: Long, holder: String, ttlMillis: Long): Unit = tx {
+    val updated = update(
+      "UPDATE snapshot_pins SET expires_at = ? WHERE table_id = ? AND holder = ?",
+      st =>
+        st.setLong(1, nowMicros + ttlMillis * 1000L)
+        st.setLong(2, tableId)
+        st.setString(3, holder)
+    )
+    if updated != 1 then
+      throw TableStoreException(s"No active pin for holder '${holder}' on table ${tableId}")
+  }
+
+  override def releasePin(tableId: Long, holder: String): Unit = tx {
+    update(
+      "DELETE FROM snapshot_pins WHERE table_id = ? AND holder = ?",
+      st =>
+        st.setLong(1, tableId)
+        st.setString(2, holder)
+    )
+    ()
+  }
+
+  override def activePins(tableId: Long): Seq[SnapshotPin] =
+    queryList(
+      "SELECT table_id, snapshot_id, holder, expires_at FROM snapshot_pins WHERE table_id = ? AND expires_at > ?",
+      st =>
+        st.setLong(1, tableId)
+        st.setLong(2, nowMicros)
+    ) { rs =>
+      SnapshotPin(rs.getLong(1), rs.getLong(2), rs.getString(3), rs.getLong(4))
+    }
+
+  // ---- GC helpers ----
+
+  override def referencedKeys(tableId: Long): Set[String] =
+    queryList(
+      "SELECT DISTINCT s3_key FROM file_entries WHERE table_id = ?",
+      st => st.setLong(1, tableId)
+    )(rs => rs.getString(1)).toSet
+
+  override def deletableEntries(tableId: Long): Seq[FileEntry] =
+    // A retired entry's file may be deleted once no active pin holds any snapshot that still
+    // sees it: NOT EXISTS pin p where begin <= p.snapshot < end
+    queryList(
+      """SELECT e.* FROM file_entries e
+        |WHERE e.table_id = ? AND e.end_snapshot IS NOT NULL
+        |AND NOT EXISTS (
+        |  SELECT 1 FROM snapshot_pins p
+        |  WHERE p.table_id = e.table_id AND p.expires_at > ?
+        |    AND p.snapshot_id >= e.begin_snapshot AND p.snapshot_id < e.end_snapshot
+        |)
+        |ORDER BY e.id""".stripMargin,
+      st =>
+        st.setLong(1, tableId)
+        st.setLong(2, nowMicros)
+    )(mapEntry)
+
+end JdbcCatalogStore

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/format/DataFile.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/format/DataFile.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.format
+
+import wvlet.lang.tablestore.{DataRow, TableStoreException}
+import wvlet.uni.io.IO
+import wvlet.uni.json.{JSON, JSONParseException}
+import wvlet.uni.json.JSON.JSONObject
+
+/** newline-delimited JSON — the raw ingest format */
+object JsonlFile:
+  def encode(rows: Seq[DataRow]): Array[Byte] =
+    val sb = new StringBuilder
+    rows.foreach { row =>
+      // Compact form — pretty-printed values would span multiple lines and break the format
+      sb.append(row.toJSON)
+      sb.append('\n')
+    }
+    sb.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+
+  /** Parse JSONL content into rows; blank lines are skipped */
+  def decode(bytes: Array[Byte]): Seq[DataRow] =
+    val text = new String(bytes, java.nio.charset.StandardCharsets.UTF_8)
+    text
+      .linesIterator
+      .zipWithIndex
+      .flatMap { (line, idx) =>
+        if line.trim.isEmpty then
+          None
+        else
+          try
+            JSON.parse(line) match
+              case obj: JSONObject =>
+                Some(obj)
+              case other =>
+                throw TableStoreException(
+                  s"Expected a JSON object per line, got ${JSON.format(other)} at line ${idx + 1}"
+                )
+          catch
+            case e: JSONParseException =>
+              throw TableStoreException(s"Malformed JSONL at line ${idx + 1}: ${line.take(100)}", e)
+      }
+      .toSeq
+
+  def read(path: String): Seq[DataRow] = decode(IO.readBytes(path))
+
+  def write(path: String, rows: Seq[DataRow]): Unit = IO.writeBytes(path, encode(rows))
+end JsonlFile

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/format/ParquetFile.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/format/ParquetFile.scala
@@ -1,0 +1,210 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.format
+
+import wvlet.lang.tablestore.{DataRow, TableStoreException}
+import wvlet.lang.tablestore.schema.{ColumnType, TableSchema}
+import wvlet.uni.json.JSON
+
+import java.sql.DriverManager
+
+/**
+  * Produces read-optimized Parquet files for merged entries. Column types are cast explicitly from
+  * the escalated schema — production writers never rely on engine-side schema inference.
+  */
+object ParquetFile:
+
+  // JDBC 4 auto-discovery does not always survive test classloaders
+  private lazy val driverLoaded = Class.forName("org.duckdb.DuckDBDriver")
+
+  private def newConnection: java.sql.Connection =
+    driverLoaded
+    DriverManager.getConnection("jdbc:duckdb:")
+
+  private def duckDbType(t: ColumnType): String =
+    t match
+      case ColumnType.NullType =>
+        "VARCHAR" // all-null columns stay nullable strings
+      case ColumnType.BooleanType =>
+        "BOOLEAN"
+      case ColumnType.LongType =>
+        "BIGINT"
+      case ColumnType.DoubleType =>
+        "DOUBLE"
+      case ColumnType.StringType =>
+        "VARCHAR"
+
+  /**
+    * Write rows as a Parquet file with exactly the columns of `schema`. Rows may carry extra or
+    * missing columns; extras are dropped and missing ones become NULL.
+    */
+  def write(rows: Seq[DataRow], schema: TableSchema, outputPath: String): Unit =
+    if schema.columns.isEmpty then
+      throw TableStoreException("Refusing to write a Parquet file with no columns")
+    val normalized = normalize(rows, schema)
+    val tmpJsonl   = java.nio.file.Files.createTempFile("wvlet-merge-", ".jsonl")
+    try
+      JsonlFile.write(tmpJsonl.toString, normalized)
+      val conn = newConnection
+      try
+        val st = conn.createStatement()
+        try
+          val colDefs = schema
+            .columns
+            .map(c => s"'${escapeSql(c.name)}': '${duckDbType(c.columnType)}'")
+            .mkString(", ")
+          // Explicit column spec — no engine-side inference
+          st.execute(
+            s"""CREATE TABLE merged AS SELECT ${selectList(schema)} FROM read_json('${escapeSql(
+                tmpJsonl.toString
+              )}', columns={${colDefs}})"""
+          )
+          st.execute(s"COPY merged TO '${escapeSql(outputPath)}' (FORMAT PARQUET)")
+        finally
+          st.close()
+      finally
+        conn.close()
+    finally
+      java.nio.file.Files.deleteIfExists(tmpJsonl)
+  end write
+
+  private def selectList(schema: TableSchema): String = schema
+    .columns
+    .map { c =>
+      c.columnType match
+        case ColumnType.LongType =>
+          s"""CAST("${quote(c.name)}" AS BIGINT) AS "${quote(c.name)}""""
+        case ColumnType.DoubleType =>
+          s"""CAST("${quote(c.name)}" AS DOUBLE) AS "${quote(c.name)}""""
+        case ColumnType.StringType =>
+          s"""CAST("${quote(c.name)}" AS VARCHAR) AS "${quote(c.name)}""""
+        case ColumnType.BooleanType =>
+          s"""CAST("${quote(c.name)}" AS BOOLEAN) AS "${quote(c.name)}""""
+        case ColumnType.NullType =>
+          s"""CAST(NULL AS VARCHAR) AS "${quote(c.name)}""""
+    }
+    .mkString(", ")
+
+  /** Cast one row to the target schema, filling missing columns with null */
+  def normalizeRow(row: DataRow, schema: TableSchema): DataRow = JSON.JSONObject(
+    schema
+      .columns
+      .map { col =>
+        val v: JSON.JSONValue =
+          row.get(col.name) match
+            case None | Some(_: JSON.JSONNull) =>
+              JSON.JSONNull()
+            case Some(raw) =>
+              (col.columnType, raw) match
+                case (ColumnType.NullType, _) =>
+                  raw
+                case (ColumnType.LongType, l: JSON.JSONLong) =>
+                  l
+                case (ColumnType.LongType, d: JSON.JSONDouble) =>
+                  JSON.JSONLong(d.v.toLong)
+                case (ColumnType.LongType, JSON.JSONString(s)) =>
+                  JSON.JSONLong(s.toLong)
+                case (ColumnType.DoubleType, d: JSON.JSONDouble) =>
+                  d
+                case (ColumnType.DoubleType, l: JSON.JSONLong) =>
+                  JSON.JSONDouble(l.v.toDouble)
+                case (ColumnType.DoubleType, JSON.JSONString(s)) =>
+                  JSON.JSONDouble(s.toDouble)
+                case (ColumnType.StringType, s: JSON.JSONString) =>
+                  s
+                case (ColumnType.StringType, structured: (JSON.JSONArray | JSON.JSONObject)) =>
+                  JSON.JSONString(structured.toJSON)
+                case (ColumnType.StringType, other) =>
+                  JSON.JSONString(otherValueString(other))
+                case (ColumnType.BooleanType, b: JSON.JSONBoolean) =>
+                  b
+                case (ColumnType.BooleanType, _) =>
+                  throw TableStoreException(s"Cannot coerce value to boolean: ${JSON.format(raw)}")
+        col.name -> v
+      }
+  )
+
+  private def normalize(rows: Seq[DataRow], schema: TableSchema): Seq[DataRow] = rows.map(
+    normalizeRow(_, schema)
+  )
+
+  private def otherValueString(v: JSON.JSONValue): String =
+    v match
+      case JSON.JSONBoolean(b) =>
+        b.toString
+      case n: JSON.JSONNumber =>
+        JSON.format(n)
+      case other =>
+        JSON.format(other)
+
+  private def escapeSql(s: String): String = s.replace("'", "\\'")
+
+  private def quote(s: String): String = s.replace("\"", "\\\"")
+
+  /** Read a Parquet file into typed JSON rows (JSONLong / JSONDouble / JSONString / JSONBoolean) */
+  def read(path: String): Seq[DataRow] =
+    val conn = newConnection
+    try
+      val st = conn.createStatement()
+      try
+        val rs = st.executeQuery(s"SELECT * FROM read_parquet('${escapeSql(path)}')")
+        try
+          val meta  = rs.getMetaData
+          val n     = meta.getColumnCount
+          val names = (1 to n).map(meta.getColumnLabel)
+          val b     = Seq.newBuilder[DataRow]
+          while rs.next() do
+            b +=
+              JSON.JSONObject(
+                (names.zipWithIndex).map { (name, i) =>
+                  name -> valueAt(rs, i + 1, meta.getColumnType(i + 1))
+                }
+              )
+          b.result()
+        finally
+          rs.close()
+      finally
+        st.close()
+    finally
+      conn.close()
+
+  private def valueAt(rs: java.sql.ResultSet, index: Int, sqlType: Int): JSON.JSONValue =
+    import java.sql.Types.*
+    sqlType match
+      case TINYINT | SMALLINT | INTEGER | BIGINT =>
+        val v = rs.getLong(index)
+        if rs.wasNull then
+          JSON.JSONNull()
+        else
+          JSON.JSONLong(v)
+      case FLOAT | DOUBLE | REAL | DECIMAL | NUMERIC =>
+        val v = rs.getDouble(index)
+        if rs.wasNull then
+          JSON.JSONNull()
+        else
+          JSON.JSONDouble(v)
+      case BOOLEAN =>
+        val v = rs.getBoolean(index)
+        if rs.wasNull then
+          JSON.JSONNull()
+        else
+          JSON.JSONBoolean(v)
+      case _ =>
+        val v = rs.getString(index)
+        if rs.wasNull then
+          JSON.JSONNull()
+        else
+          JSON.JSONString(v)
+
+end ParquetFile

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/merge/Merger.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/merge/Merger.scala
@@ -1,0 +1,222 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.merge
+
+import wvlet.lang.tablestore.catalog.{MergeCommit, PendingFileEntry}
+import wvlet.lang.tablestore.{
+  CatalogTable,
+  ColumnStats,
+  DataRow,
+  DataFormat,
+  EntryId,
+  SnapshotId,
+  TableStore,
+  TableStoreException
+}
+import wvlet.lang.tablestore.format.{JsonlFile, ParquetFile}
+import wvlet.lang.tablestore.objectstore.Checksum
+import wvlet.lang.tablestore.schema.{ObservedSchema, SchemaEscalation}
+import wvlet.uni.log.LogSupport
+
+case class MergePolicy(
+    /** Merge at most this many live small entries per run */
+    maxSourceFiles: Int = 64,
+    /** Entries with at most this many rows count as "small" (merge candidates) */
+    smallEntryRows: Long = 50_000L,
+    /** Skip merging when fewer than this many candidate entries are live */
+    minSourceFiles: Int = 2,
+    /** Quarantine threshold forwarded to schema escalation */
+    outlierThreshold: Double = SchemaEscalation.defaultOutlierThreshold
+)
+
+sealed trait MergeOutcome
+case object NothingToMerge extends MergeOutcome
+
+case class Merged(
+    snapshotId: SnapshotId,
+    mergedEntryId: EntryId,
+    sourceEntryIds: Seq[EntryId],
+    newSchemaVersion: Option[Long],
+    quarantinedEntryIds: Seq[EntryId],
+    rowCount: Long
+) extends MergeOutcome
+
+/**
+  * The leased background merger: rewrites many small entries into one read-optimized Parquet file
+  * and escalates the table schema from the same observed contents — one pass, two purposes.
+  *
+  * The merge lease is the only writer that retires entries or publishes schema versions; ingest
+  * only adds. The fencing token is verified inside the commit transaction, so a stalled merger
+  * whose lease was taken over can never publish stale state.
+  */
+case class Merger(store: TableStore, writerId: String) extends LogSupport:
+
+  /**
+    * Run one merge round over a partition range of the table. `leaseName` scopes exclusivity, e.g.
+    * `merge:<tableId>:<time-range>` — leasing per range lets large tables merge in parallel.
+    */
+  def mergeOnce(
+      table: CatalogTable,
+      leaseName: String,
+      policy: MergePolicy = MergePolicy(),
+      leaseTtlMillis: Long = 60_000L
+  ): MergeOutcome =
+    val catalog = store.catalog
+
+    val lease = catalog.acquireLease(leaseName, Some(table.id), writerId, leaseTtlMillis)
+    try
+      val latest = catalog
+        .latestSnapshot(table.id)
+        .getOrElse {
+          return NothingToMerge
+        }
+      val candidates = catalog
+        .liveEntries(table.id, latest.id)
+        .filter(e => e.format == DataFormat.Jsonl && e.rowCount <= policy.smallEntryRows)
+        .sortBy(e => (e.rowCount, e.id))
+        .take(policy.maxSourceFiles)
+      if candidates.size < policy.minSourceFiles then
+        return NothingToMerge
+
+      // Escalate from catalog metadata alone: no data read needed to know the target schema
+      val currentSchema = currentPublishedSchema(table)
+      val escalation    = SchemaEscalation.escalate(
+        currentSchema,
+        nextVersion = math.max(currentSchema.version, table.schemaVersionHead) + 1,
+        files = candidates.map(e =>
+          (e.id, e.rowCount, ObservedSchema.fromJson(e.observedSchemaJson))
+        ),
+        outlierThreshold = policy.outlierThreshold
+      )
+      if escalation.quarantinedFiles.nonEmpty then
+        warn(
+          s"Quarantining ${escalation.quarantinedFiles.size} file(s) of table '${table
+              .name}' for review: ${escalation.quarantinedFiles}"
+        )
+
+      val sources = candidates.filterNot(e => escalation.quarantinedFiles.contains(e.id))
+      if sources.isEmpty then
+        warn(s"All merge candidates of '${table.name}' were quarantined; skipping")
+        return NothingToMerge
+
+      // Read every surviving source — the only full read of the raw data
+      val rows = sources.flatMap { entry =>
+        val bytes    = store.objects.get(entry.s3Key)
+        val checksum = Checksum.sha256Hex(bytes)
+        if checksum != entry.checksum then
+          throw TableStoreException(
+            s"Checksum mismatch on ${entry.s3Key}: expected ${entry.checksum}, got ${checksum}"
+          )
+        JsonlFile.decode(bytes)
+      }
+
+      val targetSchema = escalation.escalatedSchema.getOrElse(currentSchema)
+
+      // Write merged Parquet content-addressed by SHA-256
+      val tmpFile            = java.nio.file.Files.createTempFile("wvlet-merged-", ".parquet")
+      val bytes: Array[Byte] =
+        try
+          ParquetFile.write(rows, targetSchema, tmpFile.toString)
+          java.nio.file.Files.readAllBytes(tmpFile)
+        finally
+          java.nio.file.Files.deleteIfExists(tmpFile)
+      val sha256 = Checksum.sha256Hex(bytes)
+      val key    = TableStore.mergedKey(table.id, sha256)
+      val put    = store.objects.put(key, bytes)
+      if put.checksum != sha256 then
+        throw TableStoreException(s"Object store corrupted the merged write of ${key}")
+
+      val eventTsBounds      = boundsOf(rows, table.options.eventTimeColumn)
+      val stats              = ColumnStats.collect(rows, targetSchema)
+      val pendingMergedEntry = PendingFileEntry(
+        entryId = reserveOneEntryId(table.id),
+        s3Key = key,
+        format = DataFormat.Parquet,
+        checksum = sha256,
+        rowCount = rows.size.toLong,
+        byteSize = bytes.length.toLong,
+        minEventTs = eventTsBounds._1,
+        maxEventTs = eventTsBounds._2,
+        observedSchemaJson = targetSchema.schemaJson,
+        stats = stats
+      )
+
+      val result = catalog.commitMerge(
+        MergeCommit(
+          leaseName = leaseName,
+          fencingToken = lease.fencingToken,
+          tableId = table.id,
+          sourceEntryIds = sources.map(_.id),
+          mergedEntry = pendingMergedEntry,
+          escalatedSchema = escalation.escalatedSchema,
+          writer = writerId
+        )
+      )
+      debug(
+        s"Merged ${sources.size} entries into ${key} at snapshot ${result.snapshotId}" +
+          escalation
+            .escalatedSchema
+            .map(schema => s", published schema v${schema.version}")
+            .getOrElse("")
+      )
+      Merged(
+        result.snapshotId,
+        result.mergedEntryId,
+        result.retiredEntryIds,
+        result.newSchemaVersion,
+        escalation.quarantinedFiles,
+        rows.size.toLong
+      )
+    finally
+      catalog.releaseLease(leaseName, writerId, lease.fencingToken)
+    end try
+  end mergeOnce
+
+  private def currentPublishedSchema(
+      table: CatalogTable
+  ): wvlet.lang.tablestore.schema.TableSchema =
+    if table.schemaVersionHead == 0 then
+      wvlet.lang.tablestore.schema.TableSchema.empty
+    else
+      store.catalog.schemaVersionsOf(table.id).find(_.version == table.schemaVersionHead) match
+        case Some(v) =>
+          wvlet.lang.tablestore.schema.TableSchema.fromJson(v.version, v.schemaJson)
+        case None =>
+          throw TableStoreException(
+            s"Schema version ${table.schemaVersionHead} of table '${table.name}' is missing"
+          )
+
+  private def reserveOneEntryId(tableId: EntryId): EntryId =
+    store.catalog.allocateFileIds(tableId, 1).head
+
+  private def boundsOf(
+      rows: Seq[DataRow],
+      eventTimeColumn: Option[String]
+  ): (Option[Long], Option[Long]) =
+    eventTimeColumn match
+      case None =>
+        (None, None)
+      case Some(col) =>
+        val ts = rows.flatMap(
+          _.get(col)
+            .collect { case wvlet.uni.json.JSON.JSONLong(v) =>
+              v
+            }
+        )
+        if ts.isEmpty then
+          (None, None)
+        else
+          (Some(ts.min), Some(ts.max))
+
+end Merger

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/model.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/model.scala
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore
+
+import wvlet.uni.json.JSON
+
+type SnapshotId      = Long
+type EntryId         = Long
+type SchemaVersionId = Long
+
+/** One row of a data file: a JSON object with typed leaf values */
+type DataRow = JSON.JSONObject
+
+/** UTC microseconds since epoch — the canonical timestamp representation of the catalog contract */
+def nowMicros: Long = java.time.Instant.now().toEpochMilli * 1000L
+
+enum SnapshotKind:
+  case Ingest
+  case Merge
+  case Rewrite
+  case Retention
+
+enum EntryKind:
+  case File
+  case FileSet
+
+enum DataFormat:
+  case Jsonl
+  case Parquet
+
+/**
+  * A table registered in the catalog. `schemaVersionHead` points at the latest published
+  * [[SchemaVersion]]; new columns stay pending until merge-time escalation bumps it.
+  */
+case class CatalogTable(
+    id: Long,
+    databaseName: String,
+    name: String,
+    schemaVersionHead: SchemaVersionId,
+    /** Optional table options as JSON text (e.g. event-time column name) */
+    optionsJson: String,
+    createdAt: Long
+):
+  def options: TableOptions = TableOptions.fromJson(optionsJson)
+
+case class TableOptions(
+    /** Column interpreted as the event time for pruning and retention. None = no event time */
+    eventTimeColumn: Option[String]
+):
+  def toJson: String =
+    val entries = Seq(eventTimeColumn.map(v => "event_time" -> JSON.JSONString(v))).flatten
+    (JSON.JSONObject(entries)).toJSON
+
+object TableOptions:
+  val default: TableOptions                = TableOptions(eventTimeColumn = None)
+  def fromJson(json: String): TableOptions =
+    if json == null || json.isEmpty then
+      default
+    else
+      JSON.parse(json) match
+        case obj: JSON.JSONObject =>
+          TableOptions(eventTimeColumn =
+            obj
+              .get("event_time")
+              .collect { case JSON.JSONString(v) =>
+                v
+              }
+          )
+        case _ =>
+          default
+
+/** A published schema version of a table. Publishing happens only through ingest registration or */
+/** under the merge lease */
+case class SchemaVersion(
+    tableId: Long,
+    version: SchemaVersionId,
+    /** Ordered column definitions encoded as JSON: [{"name":..., "type":"long"}, ...] */
+    schemaJson: String,
+    publishedAt: Long,
+    /** Snapshot that first carried this schema version */
+    publishedBySnapshot: SnapshotId
+)
+
+case class Snapshot(
+    tableId: Long,
+    id: SnapshotId,
+    kind: SnapshotKind,
+    schemaVersion: SchemaVersionId,
+    publishedAt: Long,
+    publishedBy: String,
+    /** Lease fencing token for retiring snapshots (merge/rewrite/retention); None for ingest */
+    fencingToken: Option[String]
+)
+
+/**
+  * One registered data file (or file set manifest). A file is visible at snapshot S iff
+  * `beginSnapshot <= S && (endSnapshot.isEmpty || endSnapshot.get > S)` — interval-encoded
+  * liveness, so publication costs O(files touched), never O(files live).
+  */
+case class FileEntry(
+    id: EntryId,
+    tableId: Long,
+    kind: EntryKind,
+    s3Key: String,
+    format: DataFormat,
+    checksum: String,
+    rowCount: Long,
+    byteSize: Long,
+    minEventTs: Option[Long],
+    maxEventTs: Option[Long],
+    /** Schema observed in this file at registration, as JSON {"columns":[{"name","type"}]} */
+    observedSchemaJson: String,
+    beginSnapshot: SnapshotId,
+    endSnapshot: Option[SnapshotId],
+    mergedFrom: List[EntryId],
+    writtenBy: String,
+    createdAt: Long
+):
+  def isVisibleAt(snapshotId: SnapshotId): Boolean =
+    beginSnapshot <= snapshotId && endSnapshot.forall(_ > snapshotId)
+
+  def isLive: Boolean = endSnapshot.isEmpty
+
+/** Per-column min/max statistics of one file — advisory pruning metadata */
+case class ColumnStat(
+    fileId: EntryId,
+    columnName: String,
+    schemaVersion: SchemaVersionId,
+    minValue: Option[String],
+    maxValue: Option[String],
+    nullCount: Long,
+    distinctEstimate: Option[Long]
+)
+
+case class SnapshotPin(tableId: Long, snapshotId: SnapshotId, holder: String, expiresAt: Long)
+
+/** Named exclusive lease with a monotonically increasing fencing token */
+case class Lease(
+    name: String,
+    tableId: Option[Long],
+    holder: String,
+    fencingToken: Long,
+    acquiredAt: Long,
+    expiresAt: Long
+):
+  def isExpired(nowMicros: Long): Boolean = expiresAt <= nowMicros
+
+case class RetentionPolicy(tableId: Long, kind: String, horizonDays: Int)
+
+class TableStoreException(message: String, cause: Throwable | Null = null)
+    extends RuntimeException(message, cause)

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/objectstore/Checksum.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/objectstore/Checksum.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.objectstore
+
+import java.security.MessageDigest
+
+/** SHA-256 content checksums used for raw-file verification and merged-file addressing */
+object Checksum:
+  def sha256Hex(bytes: Array[Byte]): String =
+    val d = MessageDigest.getInstance("SHA-256").digest(bytes)
+    d.map(b => f"${b & 0xff}02x").mkString
+
+  def sha256Hex(stream: java.io.InputStream): String =
+    val md   = MessageDigest.getInstance("SHA-256")
+    val buf  = new Array[Byte](8192)
+    var read = 0
+    while
+      read = stream.read(buf)
+      read != -1
+    do
+      md.update(buf, 0, read)
+    md.digest().map(b => f"${b & 0xff}02x").mkString
+
+end Checksum

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/objectstore/ObjectStore.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/objectstore/ObjectStore.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.objectstore
+
+import wvlet.uni.io.IO
+import java.io.InputStream
+
+case class ObjectSummary(key: String, byteSize: Long)
+
+/** Result of a verified put */
+case class PutResult(key: String, checksum: String, byteSize: Long)
+
+/**
+  * Immutable object storage for data files: checksummed puts, streaming gets, and inventory list.
+  * Implementations cover local filesystems today; S3/GCS/Azure drivers slot in behind this trait
+  * without protocol changes (encryption etc. is deployment configuration, not protocol).
+  */
+trait ObjectStore extends AutoCloseable:
+
+  /** Store bytes at `key`, verifying integrity with the SHA-256 checksum of the payload */
+  def put(key: String, bytes: Array[Byte]): PutResult
+
+  def get(key: String): Array[Byte] = withStream(key)(readAll)
+
+  /** Stream the object content. The stream must not be used after the method returns */
+  def withStream[A](key: String)(f: InputStream => A): A
+
+  /**
+    * Run `f` against a local file holding the object content. Local stores hand out the real file
+    * (treat it as read-only); remote stores stage a temporary copy.
+    */
+  def withLocalFile[A](key: String)(f: java.io.File => A): A
+
+  def exists(key: String): Boolean
+
+  /** List objects under a key prefix — used by orphan detection, never as a routine write path */
+  def list(prefix: String): Seq[ObjectSummary]
+
+  def delete(key: String): Unit
+
+  private def readAll(in: InputStream): Array[Byte] =
+    val out = new java.io.ByteArrayOutputStream()
+    val buf = new Array[Byte](8192)
+    var n   = 0
+    while
+      n = in.read(buf)
+      n != -1
+    do
+      out.write(buf, 0, n)
+    out.toByteArray
+
+end ObjectStore
+
+object ObjectStore:
+  def local(rootPath: String): LocalObjectStore = LocalObjectStore(rootPath)
+
+/**
+  * Filesystem-backed [[ObjectStore]]. Keys are slash-separated relative paths resolved under the
+  * root directory; path traversal outside the root is rejected.
+  */
+class LocalObjectStore(rootPath: String) extends ObjectStore:
+  import java.io.File
+
+  // Canonicalize once so symlinked roots (e.g. macOS /tmp -> /private/tmp) don't false-positive
+  // the containment check
+  private val root: File =
+    val dir = File(rootPath)
+    IO.createDirectoryIfNotExists(dir.getPath)
+    dir.getCanonicalFile
+
+  private def pathOf(key: String): File =
+    val f = File(root, key).getCanonicalFile
+    if !f.getPath.startsWith(root.getPath) then
+      throw new IllegalArgumentException(s"Object key escapes the store root: ${key}")
+    f.getParentFile match
+      case p if p != null =>
+        IO.createDirectoryIfNotExists(p.getPath)
+      case _ =>
+    f
+
+  override def put(key: String, bytes: Array[Byte]): PutResult =
+    val f        = pathOf(key)
+    val checksum = Checksum.sha256Hex(bytes)
+    // Write to a temp file first so a crashed writer never leaves a partial object at `key`
+    val tmp = File(f.getParentFile, s".${f.getName}.tmp-${java.util.UUID.randomUUID()}")
+    try
+      IO.writeBytes(tmp.getPath, bytes)
+      if !tmp.renameTo(f) then
+        // Cross-device or platform quirks: fall back to copy + delete
+        IO.copy(tmp.getPath, f.getPath)
+        tmp.delete()
+    finally
+      tmp.delete()
+    PutResult(key, checksum, bytes.length)
+
+  override def withStream[A](key: String)(f: InputStream => A): A =
+    val in = new java.io.BufferedInputStream(new java.io.FileInputStream(pathOf(key)))
+    try f(in)
+    finally in.close()
+
+  override def withLocalFile[A](key: String)(f: java.io.File => A): A = f(pathOf(key))
+
+  override def exists(key: String): Boolean = pathOf(key).isFile
+
+  override def list(prefix: String): Seq[ObjectSummary] =
+    val dir = File(root, prefix)
+    if !dir.isDirectory then
+      Nil
+    else
+      IO.list(dir.getPath)
+        .flatMap { entry =>
+          val childKey = s"${prefix.stripSuffix("/")}/${entry.fileName}"
+          if IO.info(entry.path).fileType == wvlet.uni.io.FileType.Directory then
+            list(childKey)
+          else
+            Seq(ObjectSummary(childKey, IO.info(entry).size))
+        }
+        .toSeq
+
+  override def delete(key: String): Unit =
+    val f = pathOf(key)
+    if f.exists() then
+      IO.deleteIfExists(f.getPath)
+
+  override def close(): Unit = {}
+end LocalObjectStore

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/read/Pruning.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/read/Pruning.scala
@@ -107,18 +107,6 @@ object Pruning:
       case _ =>
         encoded
 
-  /** Canonical encoding of stat values — must round-trip through [[decode]] */
-  def encode(t: ColumnType, s: Scalar): Option[String] =
-    s match
-      case Scalar.SLong(v) =>
-        Some(v.toString)
-      case Scalar.SDouble(v) =>
-        Some(v.toString)
-      case Scalar.SString(v) =>
-        Some(v)
-      case Scalar.SBoolean(v) =>
-        Some(v.toString)
-
   private def asComparable(s: Scalar, t: ColumnType): Comparable[?] =
     (t, s) match
       case (_, Scalar.SBoolean(v)) =>

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/read/Pruning.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/read/Pruning.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.read
+
+import wvlet.lang.tablestore.ColumnStat
+import wvlet.lang.tablestore.schema.ColumnType
+
+enum Scalar:
+  case SLong(v: Long)
+  case SDouble(v: Double)
+  case SString(v: String)
+  case SBoolean(v: Boolean)
+
+/** A conjunctive predicate over table columns, used for catalog-side pruning */
+enum Predicate:
+  case Eq(column: String, value: Scalar)
+  case Lt(column: String, value: Scalar)
+  case Lte(column: String, value: Scalar)
+  case Gt(column: String, value: Scalar)
+  case Gte(column: String, value: Scalar)
+  case And(parts: List[Predicate])
+
+/**
+  * Catalog-side pruning: a file survives when its min/max stat ranges can still satisfy the
+  * predicate. Statistics are advisory — a missing stats row (or missing bound) means "must scan",
+  * never "can skip".
+  */
+object Pruning:
+
+  /**
+    * @param stats
+    *   the file's column statistics keyed by column name
+    * @param typeOf
+    *   resolves the type used to decode canonical stat values for a column
+    */
+  def canMatch(stats: Map[String, ColumnStat], typeOf: String => ColumnType): Predicate => Boolean =
+
+    def apply(predicate: Predicate): Boolean =
+      predicate match
+        case Predicate.And(parts) =>
+          parts.forall(apply)
+        case pred =>
+          val col = columnName(pred)
+          stats.get(col) match
+            case None =>
+              true // no stats -> must scan
+            case Some(stat) =>
+              val t   = typeOf(col)
+              val min = stat.minValue.map(decode(t, _))
+              val max = stat.maxValue.map(decode(t, _))
+              pred match
+                case Predicate.Eq(_, v) =>
+                  val c = asComparable(v, t)
+                  min.forall(m => compare(m, c) <= 0) && max.forall(m => compare(m, c) >= 0)
+                case Predicate.Lt(_, v) =>
+                  max.forall(m => compare(m, asComparable(v, t)) > 0)
+                case Predicate.Lte(_, v) =>
+                  max.forall(m => compare(m, asComparable(v, t)) >= 0)
+                case Predicate.Gt(_, v) =>
+                  min.forall(m => compare(m, asComparable(v, t)) < 0)
+                case Predicate.Gte(_, v) =>
+                  min.forall(m => compare(m, asComparable(v, t)) <= 0)
+                case Predicate.And(_) =>
+                  true // handled recursively above
+
+    apply
+  end canMatch
+
+  private def columnName(p: Predicate): String =
+    p match
+      case Predicate.Eq(c, _) =>
+        c
+      case Predicate.Lt(c, _) =>
+        c
+      case Predicate.Lte(c, _) =>
+        c
+      case Predicate.Gt(c, _) =>
+        c
+      case Predicate.Gte(c, _) =>
+        c
+      case Predicate.And(_) =>
+        throw new IllegalStateException("And is handled recursively")
+
+  /**
+    * Canonical stat strings round-trip through the column's type so comparisons follow type
+    * semantics, not text collation.
+    */
+  def decode(t: ColumnType, encoded: String): Comparable[?] =
+    t match
+      case ColumnType.LongType =>
+        encoded.toLong
+      case ColumnType.DoubleType =>
+        encoded.toDouble
+      case ColumnType.BooleanType =>
+        java.lang.Boolean.parseBoolean(encoded)
+      case _ =>
+        encoded
+
+  /** Canonical encoding of stat values — must round-trip through [[decode]] */
+  def encode(t: ColumnType, s: Scalar): Option[String] =
+    s match
+      case Scalar.SLong(v) =>
+        Some(v.toString)
+      case Scalar.SDouble(v) =>
+        Some(v.toString)
+      case Scalar.SString(v) =>
+        Some(v)
+      case Scalar.SBoolean(v) =>
+        Some(v.toString)
+
+  private def asComparable(s: Scalar, t: ColumnType): Comparable[?] =
+    (t, s) match
+      case (_, Scalar.SBoolean(v)) =>
+        java.lang.Boolean.valueOf(v)
+      case (_, Scalar.SString(v)) =>
+        v
+      case (ColumnType.DoubleType, Scalar.SLong(v)) =>
+        java.lang.Double.valueOf(v.toDouble)
+      case (ColumnType.StringType, Scalar.SLong(v)) =>
+        v.toString
+      case (ColumnType.StringType, Scalar.SDouble(v)) =>
+        v.toString
+      case (_, Scalar.SLong(v)) =>
+        java.lang.Long.valueOf(v)
+      case (_, Scalar.SDouble(v)) =>
+        java.lang.Double.valueOf(v)
+
+  @SuppressWarnings(Array("unchecked"))
+  private def compare(a: Comparable[?], b: Comparable[?]): Int = a
+    .asInstanceOf[Comparable[AnyRef]]
+    .compareTo(b.asInstanceOf[AnyRef])
+
+end Pruning

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/read/TableReader.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/read/TableReader.scala
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.read
+
+import wvlet.lang.tablestore.{
+  CatalogTable,
+  DataRow,
+  DataFormat,
+  FileEntry,
+  SnapshotId,
+  TableStoreException
+}
+import wvlet.lang.tablestore.catalog.CatalogStore
+import wvlet.lang.tablestore.format.{JsonlFile, ParquetFile}
+import wvlet.lang.tablestore.objectstore.ObjectStore
+import wvlet.lang.tablestore.schema.{ColumnType, ObservedSchema, TableSchema}
+import wvlet.uni.log.LogSupport
+
+import java.sql.DriverManager
+
+/** One planned cast of a file column toward the published schema */
+case class CastSpec(
+    column: String,
+    targetType: ColumnType,
+    /** None when the file lacks the column entirely — the scan fills NULL */
+    sourceType: Option[ColumnType]
+):
+  def isFillNull: Boolean = sourceType.isEmpty
+
+/** A file selected for scanning together with its cast plan */
+case class PlannedFile(entry: FileEntry, casts: Seq[CastSpec])
+
+/**
+  * Everything a reader needs: the pinned snapshot, the published schema in effect there, and the
+  * surviving (pruned) files with their cast plans. The scan itself holds no catalog locks.
+  */
+case class ScanPlan(
+    table: CatalogTable,
+    snapshotId: SnapshotId,
+    snapshotPublishedAtMicros: Long,
+    schema: TableSchema,
+    files: Seq[PlannedFile],
+    /** Entries eliminated by catalog-side pruning (stats said they cannot match) */
+    prunedEntryCount: Int
+)
+
+/**
+  * Resolves scans against the catalog and materializes rows. Production engines can replace
+  * [[scan]] with their own readers driven by [[ScanPlan]]: union un-merged JSONL beside merged
+  * Parquet and cast every file to the published schema — no engine-side schema inference anywhere.
+  */
+class TableReader(catalog: CatalogStore, objects: ObjectStore) extends LogSupport:
+
+  /**
+    * Pin the latest snapshot (or an explicit AS OF one) and resolve the files worth scanning. The
+    * scan itself holds no catalog locks; long scans renew their pin until done so that retention
+    * never retires files visible at a pinned snapshot.
+    */
+  def plan(
+      table: CatalogTable,
+      asOf: Option[SnapshotId] = None,
+      predicate: Option[Predicate] = None,
+      /** When set, registers an expiring pin for this read */
+      pinHolder: Option[String] = None,
+      pinTtlMillis: Long = 60_000L
+  ): ScanPlan =
+    val snapshot =
+      asOf match
+        case Some(id) =>
+          catalog
+            .snapshotOf(table.id, id)
+            .getOrElse {
+              throw TableStoreException(s"Snapshot ${id} of table '${table.name}' does not exist")
+            }
+        case None =>
+          catalog
+            .latestSnapshot(table.id)
+            .getOrElse {
+              throw TableStoreException(s"Table '${table.name}' has no snapshots yet")
+            }
+
+    pinHolder.foreach { holder =>
+      catalog.pinSnapshot(table.id, snapshot.id, holder, pinTtlMillis)
+    }
+
+    val candidates                   = catalog.liveEntries(table.id, snapshot.id)
+    val schema                       = schemaAt(table, snapshot.schemaVersion)
+    val typeOf: String => ColumnType =
+      col => schema.column(col).map(_.columnType).getOrElse(ColumnType.NullType)
+
+    // Predicate pushdown into the catalog scan: file_entries ⋈ file_column_stats. One catalog
+    // round trip returns exactly the files worth scanning — no data I/O for pruned files.
+    val statsByEntry = catalog
+      .statsFor(candidates.map(_.id))
+      .groupBy(_.fileId)
+      .map { case (fid, stats) =>
+        fid -> stats.map(s => s.columnName -> s).toMap
+      }
+    val surviving =
+      predicate match
+        case None =>
+          candidates
+        case Some(p) =>
+          candidates.filter { e =>
+            Pruning.canMatch(statsByEntry.getOrElse(e.id, Map.empty), typeOf)(p)
+          }
+    val prunedCount = candidates.size - surviving.size
+
+    val files = surviving.map { entry =>
+      PlannedFile(entry, castPlan(entry, schema))
+    }
+    ScanPlan(table, snapshot.id, snapshot.publishedAt, schema, files, prunedCount)
+  end plan
+
+  /** Materialize the rows of a plan by scanning every surviving file and casting to the schema */
+  def scan(plan: ScanPlan): Seq[DataRow] =
+    val rows = Seq.newBuilder[DataRow]
+    plan
+      .files
+      .foreach { planned =>
+        val bytes  = objects.get(planned.entry.s3Key)
+        val actual = wvlet.lang.tablestore.objectstore.Checksum.sha256Hex(bytes)
+        if actual != planned.entry.checksum then
+          throw TableStoreException(
+            s"Checksum mismatch for ${planned.entry.s3Key}: expected ${planned
+                .entry
+                .checksum}, got ${actual}"
+          )
+        val decoded: Seq[DataRow] =
+          planned.entry.format match
+            case DataFormat.Jsonl =>
+              JsonlFile.decode(bytes)
+            case DataFormat.Parquet =>
+              objects.withLocalFile(planned.entry.s3Key) { f =>
+                ParquetFile.read(f.getPath)
+              }
+        decoded.foreach(row => rows += ParquetFile.normalizeRow(row, plan.schema))
+      }
+    rows.result()
+  end scan
+
+  private def castPlan(entry: FileEntry, schema: TableSchema): Seq[CastSpec] =
+    if schema.columns.isEmpty then
+      Nil
+    else
+      val observed = ObservedSchema.fromJson(entry.observedSchemaJson)
+      schema
+        .columns
+        .flatMap { col =>
+          observed.columnType(col.name) match
+            case None =>
+              // The file predates this column: fill NULL during the scan
+              Some(CastSpec(col.name, col.columnType, None))
+            case Some(src) if src != col.columnType =>
+              Some(CastSpec(col.name, col.columnType, Some(src)))
+            case Some(_) =>
+              None
+        }
+
+  /** The published schema in effect at a snapshot (version 0 = nothing published yet) */
+  def schemaAt(table: CatalogTable, version: Long): TableSchema =
+    if version == 0 then
+      TableSchema.empty
+    else
+      catalog.schemaVersionsOf(table.id).find(_.version == version) match
+        case Some(v) =>
+          TableSchema.fromJson(v.version, v.schemaJson)
+        case None =>
+          throw TableStoreException(
+            s"Schema version ${version} of table '${table.name}' is missing from the catalog"
+          )
+
+end TableReader

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/read/TableReader.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/read/TableReader.scala
@@ -27,16 +27,13 @@ import wvlet.lang.tablestore.objectstore.ObjectStore
 import wvlet.lang.tablestore.schema.{ColumnType, ObservedSchema, TableSchema}
 import wvlet.uni.log.LogSupport
 
-import java.sql.DriverManager
-
 /** One planned cast of a file column toward the published schema */
 case class CastSpec(
     column: String,
     targetType: ColumnType,
     /** None when the file lacks the column entirely — the scan fills NULL */
     sourceType: Option[ColumnType]
-):
-  def isFillNull: Boolean = sourceType.isEmpty
+)
 
 /** A file selected for scanning together with its cast plan */
 case class PlannedFile(entry: FileEntry, casts: Seq[CastSpec])

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/schema/PromotionLattice.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/schema/PromotionLattice.scala
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.schema
+
+import wvlet.lang.tablestore.TableStoreException
+import wvlet.uni.json.JSON
+
+/**
+  * The monotonic promotion lattice for schema escalation: `null -> long -> double -> string`, with
+  * boolean as a leaf that widens to string (it has no numeric supertype). Escalation is
+  * irreversible, so widening follows this lattice only — never narrowing.
+  */
+enum ColumnType:
+  case NullType
+  case BooleanType
+  case LongType
+  case DoubleType
+  case StringType
+
+object ColumnType:
+  private val order: Map[ColumnType, Int] = Map(
+    NullType    -> 0,
+    BooleanType -> 1,
+    LongType    -> 2,
+    DoubleType  -> 3,
+    StringType  -> 4
+  )
+
+  /** The least upper bound in the promotion lattice. Commutative and associative */
+  def lub(a: ColumnType, b: ColumnType): ColumnType =
+    if a == b then
+      a
+    else
+      (a, b) match
+        case (NullType, other) =>
+          other
+        case (other, NullType) =>
+          other
+        // Boolean and numerics are incomparable; both widen to string
+        case (BooleanType, _) =>
+          StringType
+        case (_, BooleanType) =>
+          StringType
+        case (x, y) =>
+          if order(x) < order(y) then
+            y
+          else
+            x
+
+  def fold(types: Seq[ColumnType]): ColumnType = types.foldLeft(NullType: ColumnType)(lub)
+
+  def parse(s: String): ColumnType =
+    s match
+      case "null" =>
+        NullType
+      case "boolean" =>
+        BooleanType
+      case "long" =>
+        LongType
+      case "double" =>
+        DoubleType
+      case "string" =>
+        StringType
+      case other =>
+        throw TableStoreException(s"Unknown column type in observed schema: ${other}")
+
+end ColumnType
+
+/**
+  * The schema observed inside one data file at registration time. Columns are kept sorted by name
+  * so that encoding — and therefore checksums and equality tests — is deterministic.
+  */
+case class ObservedSchema(columns: Seq[(String, ColumnType)]):
+  def columnType(name: String): Option[ColumnType] = columns.collectFirst {
+    case (n, t) if n == name =>
+      t
+  }
+
+  def schemaJson: String = ObservedSchema.toJson(this)
+
+object ObservedSchema:
+  val empty: ObservedSchema = ObservedSchema(Nil)
+
+  def apply(pairs: Seq[(String, ColumnType)]): ObservedSchema =
+    // Deduplicate by column keeping the lub of duplicates, then sort by name
+    val merged = pairs
+      .groupBy(_._1)
+      .view
+      .mapValues(vs => ColumnType.fold(vs.map(_._2)))
+      .toSeq
+      .sortBy(_._1)
+    new ObservedSchema(merged)
+
+  /** Infer an observed schema from one JSONL row. Order-independent by construction */
+  def fromRow(row: JSON.JSONObject): ObservedSchema = ObservedSchema(
+    row.v.map((name, value) => name -> typeOf(value))
+  )
+
+  /** Fold row schemas into the schema of a whole file */
+  def fromRows(rows: Seq[JSON.JSONObject]): ObservedSchema = ObservedSchema(
+    rows
+      .flatMap(_.v)
+      .groupBy(_._1)
+      .map((name, values) => name -> ColumnType.fold(values.map(v => typeOf(v._2))))
+      .toSeq
+  )
+
+  def fromJson(json: String): ObservedSchema =
+    if json == null || json.isEmpty then
+      empty
+    else
+      JSON.parse(json) match
+        case obj: JSON.JSONObject =>
+          obj.get("columns") match
+            case Some(JSON.JSONArray(items)) =>
+              ObservedSchema(
+                items.collect { case col: JSON.JSONObject =>
+                  val name = col
+                    .get("name")
+                    .collect { case JSON.JSONString(v) =>
+                      v
+                    }
+                  val typ = col
+                    .get("type")
+                    .collect { case JSON.JSONString(v) =>
+                      v
+                    }
+                  (name, typ) match
+                    case (Some(n), Some(t)) =>
+                      n -> ColumnType.parse(t)
+                    case _ =>
+                      throw TableStoreException(
+                        s"Malformed observed schema entry: ${JSON.format(col)}"
+                      )
+                }
+              )
+            case _ =>
+              empty
+        case _ =>
+          throw wvlet.lang.tablestore.TableStoreException(s"Malformed observed schema: ${json}")
+
+  def toJson(observed: ObservedSchema): String =
+    val cols = observed
+      .columns
+      .map { (name, typ) =>
+        JSON.JSONObject(
+          Seq("name" -> JSON.JSONString(name), "type" -> JSON.JSONString(typeName(typ)))
+        )
+      }
+    (JSON.JSONObject(Seq("columns" -> JSON.JSONArray(cols.toIndexedSeq)))).toJSON
+
+  def typeName(t: ColumnType): String =
+    t match
+      case ColumnType.NullType =>
+        "null"
+      case ColumnType.BooleanType =>
+        "boolean"
+      case ColumnType.LongType =>
+        "long"
+      case ColumnType.DoubleType =>
+        "double"
+      case ColumnType.StringType =>
+        "string"
+
+  private def typeOf(value: JSON.JSONValue): ColumnType =
+    value match
+      case _: JSON.JSONNull =>
+        ColumnType.NullType
+      case _: JSON.JSONLong =>
+        ColumnType.LongType
+      case _: JSON.JSONDouble =>
+        ColumnType.DoubleType
+      case _: JSON.JSONBoolean =>
+        ColumnType.BooleanType
+      case _: JSON.JSONString =>
+        ColumnType.StringType
+      // Structured values are encoded as canonical JSON text until their widening rules are
+      // specified by the promotion-lattice spec
+      case _: JSON.JSONArray =>
+        ColumnType.StringType
+      case _: JSON.JSONObject =>
+        ColumnType.StringType
+
+end ObservedSchema

--- a/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/schema/SchemaEscalation.scala
+++ b/wvlet-table-store/src/main/scala/wvlet/lang/tablestore/schema/SchemaEscalation.scala
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.schema
+
+import wvlet.lang.tablestore.{EntryId, SchemaVersionId, TableStoreException}
+import wvlet.uni.json.JSON
+
+/** One column of a published (escalated) schema */
+case class ColumnDesc(name: String, columnType: ColumnType):
+  def schemaJson: String =
+    (
+      JSON.JSONObject(
+        Seq(
+          "name" -> JSON.JSONString(name),
+          "type" -> JSON.JSONString(ObservedSchema.typeName(columnType))
+        )
+      )
+    ).toJSON
+
+object ColumnDesc:
+  def fromJson(v: JSON.JSONObject): ColumnDesc =
+    val name = v
+      .get("name")
+      .collect { case JSON.JSONString(s) =>
+        s
+      }
+    val typ = v
+      .get("type")
+      .collect { case JSON.JSONString(s) =>
+        s
+      }
+    (name, typ) match
+      case (Some(n), Some(t)) =>
+        ColumnDesc(n, ColumnType.parse(t))
+      case _ =>
+        throw TableStoreException(s"Malformed column descriptor: ${v.toJSON}")
+
+/** A published table schema: deterministic, name-sorted column definitions */
+case class TableSchema(version: SchemaVersionId, columns: Seq[ColumnDesc]):
+  def column(name: String): Option[ColumnDesc] = columns.find(_.name == name)
+  def schemaJson: String                       =
+    val cols = columns.map { c =>
+      JSON.JSONObject(
+        Seq(
+          "name" -> JSON.JSONString(c.name),
+          "type" -> JSON.JSONString(ObservedSchema.typeName(c.columnType))
+        )
+      )
+    }
+    (JSON.JSONObject(Seq("columns" -> JSON.JSONArray(cols.toIndexedSeq)))).toJSON
+
+object TableSchema:
+  val empty: TableSchema = TableSchema(0L, Nil)
+
+  def fromJson(version: SchemaVersionId, json: String): TableSchema =
+    if json == null || json.isEmpty then
+      TableSchema(version, Nil)
+    else
+      JSON.parse(json) match
+        case obj: JSON.JSONObject =>
+          obj.get("columns") match
+            case Some(JSON.JSONArray(items)) =>
+              TableSchema(
+                version,
+                items.collect { case c: JSON.JSONObject =>
+                  ColumnDesc.fromJson(c)
+                }
+              )
+            case _ =>
+              TableSchema(version, Nil)
+        case _ =>
+          throw TableStoreException("Malformed table schema JSON")
+
+/**
+  * Result of escalating one table's schema over a batch of files.
+  *
+  * @param escalatedSchema
+  *   the new published schema if any column widened or files were quarantined; None when the schema
+  *   head already covers everything observed
+  * @param quarantinedFiles
+  *   files excluded by the outlier guardrail. They remain registered and readable; their columns
+  *   re-enter escalation only after review
+  */
+case class EscalationResult(
+    currentSchema: TableSchema,
+    escalatedSchema: Option[TableSchema],
+    quarantinedFiles: Seq[EntryId]
+)
+
+/**
+  * Merge-time schema escalation following PlazmaDB's lazy escalation, made deterministic:
+  *   - folding observed schemas is order-independent ([[ColumnType.lub]] is a join-semilattice);
+  *   - the outlier guardrail quarantines a widening forced by fewer than the threshold fraction of
+  *     rows instead of irreversibly escalating.
+  *
+  * The guardrail runs per column in pass one; every file flagged for any column is then excluded
+  * entirely and the fold recomputes over the survivors in pass two.
+  */
+object SchemaEscalation:
+
+  /** A widening forced by less than this fraction of rows quarantines the offending file */
+  val defaultOutlierThreshold: Double = 0.001
+
+  /**
+    * @param files
+    *   (file id, row count, observed schema) triples of the entries being merged
+    * @return
+    *   the escalated schema and the files quarantined by the guardrail
+    */
+  def escalate(
+      currentSchema: TableSchema,
+      nextVersion: SchemaVersionId,
+      files: Seq[(EntryId, Long, ObservedSchema)],
+      outlierThreshold: Double = defaultOutlierThreshold
+  ): EscalationResult =
+    val outliers = detectOutliers(currentSchema, files, outlierThreshold)
+    val kept     = files.filterNot((id, _, _) => outliers(id))
+
+    val allColumns = (currentSchema.columns.map(_.name) ++ kept.flatMap(_._3.columns.map(_._1)))
+      .distinct
+      .sorted
+
+    val newColumns = allColumns.map { col =>
+      val contributors = kept.flatMap { (id, rows, observed) =>
+        observed.columnType(col).map(t => (id, rows, t))
+      }
+      val totalRows = contributors.map(_._2).sum
+      val folded    =
+        totalRows match
+          case 0L =>
+            // Only the published schema mentions this column (or nothing at all)
+            currentSchema.column(col).map(_.columnType).getOrElse(ColumnType.NullType)
+          case _ =>
+            ColumnType.fold(contributors.map(_._3))
+      // Escalation never narrows: keep the published type when observations folded lower
+      val resolvedType =
+        currentSchema.column(col).map(_.columnType) match
+          case Some(published) =>
+            ColumnType.lub(published, folded)
+          case None =>
+            folded
+      ColumnDesc(col, resolvedType)
+    }
+
+    val widened = newColumns.exists { col =>
+      currentSchema.column(col.name) match
+        // A brand-new column with an observed type widens the schema
+        case None =>
+          col.columnType != ColumnType.NullType
+        case Some(prev) =>
+          ColumnType.lub(prev.columnType, col.columnType) != prev.columnType
+    }
+
+    val escalated =
+      if widened then
+        Some(TableSchema(nextVersion, newColumns))
+      else
+        None
+
+    EscalationResult(currentSchema, escalated, outliers.toSeq.sorted)
+  end escalate
+
+  /**
+    * Files whose removal would avoid a widening while dropping fewer than `outlierThreshold` of the
+    * batch's rows. Two rules, both evaluated per column:
+    *   - minority introduction: a column carried by fewer than the threshold of all batch rows
+    *     quarantines every file that introduces it (a widening out of null is still irreversible);
+    *   - single-file forcing: if dropping one file lowers the union type, and its rows are under
+    *     the threshold, quarantine it.
+    *
+    * Deterministic: folds are order-independent and files are visited in id order.
+    */
+  private def detectOutliers(
+      currentSchema: TableSchema,
+      files: Seq[(EntryId, Long, ObservedSchema)],
+      outlierThreshold: Double
+  ): Set[EntryId] =
+    val batchRows = files.map(_._2).sum.toDouble
+    val columns   = files.flatMap(_._3.columns.map(_._1)).distinct.sorted
+
+    val flagged =
+      for
+        col          <- columns
+        contributors <- Seq(files.flatMap(f => f._3.columnType(col).map(t => (f._1, f._2, t))))
+        contributorRows = contributors.map(_._2).sum
+        unionType       = ColumnType.fold(contributors.map(_._3))
+        published       = currentSchema.column(col).map(_.columnType)
+        // No guardrail when the fold matches what is already published — republishing needs no
+        // justification. A column absent from the catalog has no widening to protect either.
+        if !published.contains(unionType) && unionType != ColumnType.NullType && batchRows > 0
+        candidate <-
+          if contributorRows.toDouble / batchRows < outlierThreshold then
+            // Rule 1: the whole introducing minority goes to review
+            contributors
+          else
+            // Rule 2: drop one file at a time and see whether the union drops with it
+            for
+              c <- contributors
+              remaining = contributors.filterNot(_._1 == c._1)
+              if remaining.nonEmpty
+              keptType = ColumnType.fold(remaining.map(_._3))
+              // Only consider removals that actually lower the union type
+              if keptType != unionType && ColumnType.lub(keptType, unionType) == unionType
+              droppedFraction = c._2.toDouble / batchRows.toDouble
+              if droppedFraction < outlierThreshold
+            yield c
+      yield candidate._1
+
+    flagged.toSet
+  end detectOutliers
+
+end SchemaEscalation

--- a/wvlet-table-store/src/test/scala/wvlet/lang/tablestore/TableStoreEndToEndTest.scala
+++ b/wvlet-table-store/src/test/scala/wvlet/lang/tablestore/TableStoreEndToEndTest.scala
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore
+
+import wvlet.lang.tablestore.catalog.CatalogDrivers
+import wvlet.lang.tablestore.merge.Merged
+import wvlet.lang.tablestore.objectstore.ObjectStore
+import wvlet.lang.tablestore.read.{Predicate, Scalar}
+import wvlet.lang.tablestore.schema.ColumnDesc
+import wvlet.lang.tablestore.schema.ColumnType
+import wvlet.uni.json.JSON
+import wvlet.uni.test.UniTest
+import wvlet.uni.test.empty
+
+import java.nio.file.Files
+
+class TableStoreEndToEndTest extends UniTest:
+
+  private def tempStore(): TableStore =
+    val dir   = Files.createTempDirectory("wvlet-table-store-test")
+    val store = TableStore(
+      CatalogDrivers.sqlite(s"${dir}/catalog.db"),
+      ObjectStore.local(s"${dir}/objects")
+    )
+    store.initialize()
+    store
+
+  private def row(pairs: (String, JSON.JSONValue)*): DataRow = JSON.JSONObject(pairs)
+
+  test("ingested data is readable immediately; merge keeps results identical") {
+    val store = tempStore()
+    try
+      store.createDatabase("main")
+      val table = store.createTable("main", "usage")
+
+      // Two ingest sessions append rows in separate small files
+      val session1 = store.newIngestSession(table, "writer-1")
+      session1.addAll(
+        Seq(
+          row(
+            "user_id" -> JSON.JSONLong(1),
+            "model"   -> JSON.JSONString("gpt"),
+            "tokens"  -> JSON.JSONLong(120)
+          ),
+          row(
+            "user_id" -> JSON.JSONLong(2),
+            "model"   -> JSON.JSONString("claude"),
+            "tokens"  -> JSON.JSONLong(80)
+          )
+        )
+      )
+      session1.close()
+
+      val session2 = store.newIngestSession(table, "writer-2")
+      session2.addAll(
+        Seq(
+          row(
+            "user_id" -> JSON.JSONLong(3),
+            "model"   -> JSON.JSONString("gpt"),
+            "tokens"  -> JSON.JSONLong(20)
+          )
+        )
+      )
+      session2.close()
+      val rawEntryIds = session1.ingestedEntryIds ++ session2.ingestedEntryIds
+
+      val beforeMerge = store.reader.plan(table)
+      beforeMerge.files.size shouldBe 2
+      val rowsBefore = store.reader.scan(beforeMerge)
+      rowsBefore.size shouldBe 3
+
+      // Merge: both raw entries become one Parquet entry; same rows come back
+      val merged =
+        store.merger("merger-1").mergeOnce(table, leaseName = s"merge:${table.id}:all") match
+          case m: Merged =>
+            m
+          case other =>
+            sys.error(s"Expected a merge to happen, got ${other}")
+      merged.sourceEntryIds.toSet shouldBe rawEntryIds.toSet
+      merged.rowCount shouldBe 3L
+      merged.quarantinedEntryIds shouldBe empty
+
+      val plan = store.reader.plan(table)
+      // Only the merged entry is live at the new snapshot
+      plan.files.size shouldBe 1
+      plan.files.head.entry.format shouldBe DataFormat.Parquet
+      val rowsAfter = store.reader.scan(plan)
+      rowsAfter.size shouldBe 3
+      rowsAfter.map(_.get("user_id")).toSet shouldBe
+        Set(Some(JSON.JSONLong(1)), Some(JSON.JSONLong(2)), Some(JSON.JSONLong(3)))
+      // AS OF the first ingest snapshot still returns only the original raw file
+      val asOfPlan = store.reader.plan(table, asOf = session1.flushedSnapshotIds.headOption)
+      asOfPlan.files.map(f => (f.entry.format, f.entry.id)) shouldBe
+        Seq((DataFormat.Jsonl, session1.ingestedEntryIds.head))
+    finally
+      store.catalog.close()
+    end try
+  }
+
+  test("declared schema heads make fresh tables readable and casts fill nulls") {
+    val store = tempStore()
+    try
+      store.createDatabase("main")
+      val table = store.createTable(
+        "main",
+        "events",
+        initialColumns = Seq(ColumnDesc("id", ColumnType.LongType))
+      )
+      val session = store.newIngestSession(table, "writer-1")
+      session.add(row("id" -> JSON.JSONLong(7)))
+      session.close()
+
+      val rows = store.reader.scan(store.reader.plan(table))
+      rows.size shouldBe 1
+      rows.head.get("id") shouldBe Some(JSON.JSONLong(7))
+
+      // A file carrying a pending column stays castable to the published one-column schema
+      val session2 = store.newIngestSession(table, "writer-2")
+      session2.add(row("id" -> JSON.JSONLong(8), "pending_col" -> JSON.JSONString("later")))
+      session2.close()
+      val rows2 = store.reader.scan(store.reader.plan(table))
+      rows2.size shouldBe 2
+      rows2.foreach(_.get("pending_col") shouldBe None)
+    finally
+      store.catalog.close()
+  }
+
+  test("catalog-side pruning skips files that cannot match the predicate") {
+    val store = tempStore()
+    try
+      store.createDatabase("main")
+      val table = store.createTable(
+        "main",
+        "metering",
+        options = TableOptions(eventTimeColumn = Some("ts")),
+        initialColumns = Seq(
+          ColumnDesc("user", ColumnType.StringType),
+          ColumnDesc("ts", ColumnType.LongType)
+        )
+      )
+      val s = store.newIngestSession(table, "writer-1")
+      // File A: user alice only; File B: user bob only — stats allow exact pruning on user
+      s.addAll(Seq(row("user" -> JSON.JSONString("alice"), "ts" -> JSON.JSONLong(100))))
+      s.flush()
+      s.addAll(Seq(row("user" -> JSON.JSONString("bob"), "ts" -> JSON.JSONLong(200))))
+      s.close()
+
+      val predicate = Predicate.And(List(Predicate.Eq("user", Scalar.SString("alice"))))
+      val plan      = store.reader.plan(table, predicate = Some(predicate))
+      plan.prunedEntryCount shouldBe 1
+      plan.files.size shouldBe 1
+      val scanned = store.reader.scan(plan)
+      scanned.size shouldBe 1
+      scanned.head.get("user") shouldBe Some(JSON.JSONString("alice"))
+    finally
+      store.catalog.close()
+  }
+
+  test("merge escalates the schema lazily from observed data") {
+    val store = tempStore()
+    try
+      store.createDatabase("main")
+      val table = store.createTable("main", "logs")
+      val s     = store.newIngestSession(table, "writer-1")
+      s.addAll(Seq(row("msg" -> JSON.JSONString("a")), row("msg" -> JSON.JSONString("b"))))
+      s.flush()
+      // New column appears in later data — invisible until escalation
+      s.addAll(Seq(row("msg" -> JSON.JSONString("c"), "level" -> JSON.JSONString("warn"))))
+      s.close()
+
+      // Before merge: only msg is visible (no published columns yet, so scans yield empty rows)
+      val preSchema = store.reader.plan(table).schema
+      preSchema.columns shouldBe empty
+
+      val outcome =
+        store.merger("merger-1").mergeOnce(table, s"merge:${table.id}:all") match
+          case m: Merged =>
+            m
+          case other =>
+            sys.error(s"Expected a merge, got ${other}")
+      outcome.newSchemaVersion shouldBe Some(1)
+
+      val postPlan = store.reader.plan(table)
+      postPlan.schema.column("msg").get.columnType shouldBe ColumnType.StringType
+      postPlan.schema.column("level").get.columnType shouldBe ColumnType.StringType
+      val rows = store.reader.scan(postPlan)
+      rows.size shouldBe 3
+      // The escalated column is visible; rows predating it scan as explicit NULLs
+      rows.map(_.get("level")).toSet shouldBe
+        Set(Some(JSON.JSONString("warn")), Some(JSON.JSONNull()))
+    finally
+      store.catalog.close()
+    end try
+  }
+
+  test("orphan detection subtracts catalog references from the store inventory") {
+    val store = tempStore()
+    try
+      store.createDatabase("main")
+      val table   = store.createTable("main", "t")
+      val session = store.newIngestSession(table, "writer-1")
+      session.add(row("x" -> JSON.JSONLong(1)))
+      session.close()
+
+      // An upload that never got registered (e.g. crash between upload and registration)
+      store.objects.put(TableStore.rawKey(table.id, 9999, DataFormat.Jsonl), Array[Byte]())
+
+      val orphans = store.orphanCandidates(table.id)
+      orphans.map(_.key) shouldBe Seq(TableStore.rawKey(table.id, 9999, DataFormat.Jsonl))
+    finally
+      store.catalog.close()
+  }
+
+end TableStoreEndToEndTest

--- a/wvlet-table-store/src/test/scala/wvlet/lang/tablestore/catalog/CatalogProtocolTest.scala
+++ b/wvlet-table-store/src/test/scala/wvlet/lang/tablestore/catalog/CatalogProtocolTest.scala
@@ -1,0 +1,355 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.catalog
+
+import wvlet.lang.tablestore.catalog.{PendingColumnStat, PendingFileEntry}
+import wvlet.lang.tablestore.{DataFormat, EntryKind, SnapshotKind, TableOptions}
+import wvlet.lang.tablestore.schema.{ColumnDesc, ColumnType}
+import wvlet.uni.test.UniTest
+import wvlet.uni.test.empty
+
+/**
+  * Deterministic protocol conformance suite shared by every catalog driver. The embedded profile
+  * never exercises lease contention by accident — its correctness confidence must come from these
+  * fault-injection tests (zombie mergers, double retirement, crash idempotency).
+  */
+trait CatalogProtocolSpec extends UniTest:
+  protected def newCatalog: CatalogStore
+
+  /** A catalog with a fresh 'main' database */
+  protected def freshCatalog: CatalogStore =
+    val c = newCatalog
+    c.initialize()
+    c.createDatabase("main")
+    c
+
+  private def pending(
+      id: Long,
+      rows: Long = 10L,
+      schemaJson: String = """{"columns":[{"name":"id","type":"long"}]}"""
+  ): PendingFileEntry = PendingFileEntry(
+    entryId = id,
+    s3Key = s"raw/table=1/${id}.jsonl",
+    format = DataFormat.Jsonl,
+    checksum = f"checksum-${id}%04d",
+    rowCount = rows,
+    byteSize = rows * 20L,
+    minEventTs = None,
+    maxEventTs = None,
+    observedSchemaJson = schemaJson,
+    stats = Seq(PendingColumnStat("id", Some("0"), Some(rows.toString), 0, None))
+  )
+
+  test("allocate monotonic file id ranges") {
+    val catalog = freshCatalog
+    try
+      val table = catalog.createTable("main", "ids", TableOptions.default)
+      val ids1  = catalog.allocateFileIds(table.id, 3)
+      val ids2  = catalog.allocateFileIds(table.id, 2)
+      ids1 shouldBe Seq(ids1.head, ids1.head + 1, ids1.head + 2)
+      (ids2.toSet & ids1.toSet) shouldBe empty
+      (ids2.max > ids1.max) shouldBe true
+    finally
+      catalog.close()
+  }
+
+  test("register ingest atomically and expose entries immediately") {
+    val catalog = freshCatalog
+    try
+      val table  = catalog.createTable("main", "events", TableOptions.default)
+      val ids    = catalog.allocateFileIds(table.id, 2)
+      val result = catalog.registerIngest(table.id, "writer-1", ids.map(id => pending(id)))
+      result.snapshotId.isDefined shouldBe true
+      result.registeredEntryIds shouldBe ids
+      result.skippedEntryIds shouldBe empty
+
+      val snapId = result.snapshotId.get
+      val live   = catalog.liveEntries(table.id, snapId)
+      live.map(_.id) shouldBe ids
+      live.foreach(e =>
+        e.isVisibleAt(snapId) shouldBe true
+        e.endSnapshot shouldBe None
+        e.kind shouldBe EntryKind.File
+      )
+      // Stats registered in the same transaction
+      catalog.statsFor(ids).size shouldBe 2
+    finally
+      catalog.close()
+  }
+
+  test("re-registering issued ids is a no-op (crash idempotency)") {
+    val catalog = freshCatalog
+    try
+      val table = catalog.createTable("main", "events", TableOptions.default)
+      val ids   = catalog.allocateFileIds(table.id, 1)
+      val first = catalog.registerIngest(table.id, "writer-1", Seq(pending(ids.head)))
+      // Simulate a retry after a crash before the writer received the ack
+      val retry = catalog.registerIngest(table.id, "writer-1", Seq(pending(ids.head)))
+      retry.snapshotId shouldBe None
+      retry.skippedEntryIds shouldBe Seq(ids.head)
+      retry.registeredEntryIds shouldBe empty
+      catalog.snapshotsOf(table.id).size shouldBe 1
+    finally
+      catalog.close()
+  }
+
+  test("interval-encoded liveness resolves AS OF reads") {
+    val catalog = freshCatalog
+    try
+      val table             = catalog.createTable("main", "events", TableOptions.default)
+      val idA :: idB :: Nil = catalog.allocateFileIds(table.id, 2).toList: @unchecked
+      val s1 = catalog.registerIngest(table.id, "w", Seq(pending(idA))).snapshotId.get
+      val s2 = catalog.registerIngest(table.id, "w", Seq(pending(idB))).snapshotId.get
+
+      catalog.liveEntries(table.id, s1).map(_.id) shouldBe Seq(idA)
+      catalog.liveEntries(table.id, s2).map(_.id).toSet shouldBe Set(idA, idB)
+
+      // Retire A at snapshot s3 (folding A into a merged file) and check both sides of the interval
+      val lease    = catalog.acquireLease("test-retire:all", Some(table.id), "retirer", 60000)
+      val mergedId = catalog.allocateFileIds(table.id, 1).head
+      val s3       =
+        catalog
+          .commitMerge(
+            MergeCommit(
+              leaseName = "test-retire:all",
+              fencingToken = lease.fencingToken,
+              tableId = table.id,
+              sourceEntryIds = Seq(idA),
+              mergedEntry = pending(mergedId),
+              escalatedSchema = None,
+              writer = "retirer"
+            )
+          )
+          .snapshotId
+      catalog.releaseLease("test-retire:all", "retirer", lease.fencingToken)
+
+      catalog.liveEntries(table.id, s1).map(_.id) shouldBe Seq(idA)
+      catalog.liveEntries(table.id, s2).map(_.id).toSet shouldBe Set(idA, idB)
+      // At s3 both B and the new merged entry are live; A is retired
+      catalog.liveEntries(table.id, s3).map(_.id).toSet shouldBe Set(idB, mergedId)
+    finally
+      catalog.close()
+    end try
+  }
+
+  test("fencing tokens increase monotonically and stale tokens cannot commit") {
+    val catalog = freshCatalog
+    try
+      val table = catalog.createTable("main", "events", TableOptions.default)
+
+      val l1 = catalog.acquireLease("merge:t1:r1", Some(table.id), "merger-1", ttlMillis = 60000)
+      // A second acquirer cannot take a held lease
+      intercept[LeaseHeldException] {
+        catalog.acquireLease("merge:t1:r1", Some(table.id), "merger-2", ttlMillis = 60000)
+      }
+      catalog.releaseLease("merge:t1:r1", "merger-1", l1.fencingToken)
+
+      // Take over with a strictly higher token — the zombie's token is now stale forever
+      val l2 = catalog.acquireLease("merge:t1:r1", Some(table.id), "merger-2", ttlMillis = 60000)
+      (l2.fencingToken > l1.fencingToken) shouldBe true
+
+      // Zombie merger tries to commit with the stale token: rejected inside the transaction
+      val zombieIds = catalog.allocateFileIds(table.id, 1)
+      val zReg      = catalog.registerIngest(table.id, "zombie", Seq(pending(zombieIds.head)))
+      intercept[LeaseLostException] {
+        catalog.commitMerge(
+          mergeCommit(
+            table.id,
+            "merge:t1:r1",
+            l1.fencingToken,
+            sources = Seq.empty,
+            mergedEntryId = catalog.allocateFileIds(table.id, 1).head,
+            afterSnapshot = zReg.snapshotId.getOrElse(0L)
+          )
+        )
+      }
+    finally
+      catalog.close()
+    end try
+  }
+
+  test("conditional retirement asserts row counts so no entry retires twice") {
+    val catalog = freshCatalog
+    try
+      val table             = catalog.createTable("main", "events", TableOptions.default)
+      val idA :: idB :: Nil = catalog.allocateFileIds(table.id, 2).toList: @unchecked
+      catalog.registerIngest(table.id, "w", Seq(pending(idA), pending(idB)))
+      val lease = catalog.acquireLease("merge:t1:all", Some(table.id), "m1", 60000)
+
+      val mergedId = catalog.allocateFileIds(table.id, 1).head
+      val commit   = MergeCommit(
+        leaseName = "merge:t1:all",
+        fencingToken = lease.fencingToken,
+        tableId = table.id,
+        sourceEntryIds = Seq(idA),
+        mergedEntry = pending(mergedId),
+        escalatedSchema = None,
+        writer = "m1"
+      )
+      val result = catalog.commitMerge(commit)
+      result.retiredEntryIds shouldBe Seq(idA)
+      catalog.entry(idA).get.endSnapshot.isDefined shouldBe true
+
+      // Retiring A again within one more merge of [A, B] must abort: A is already retired, so the
+      // conditional UPDATE touches fewer rows than asserted
+      val secondMergedId = catalog.allocateFileIds(table.id, 1).head
+      intercept[RetireConflictException] {
+        catalog.commitMerge(
+          commit.copy(sourceEntryIds = Seq(idA, idB), mergedEntry = pending(secondMergedId))
+        )
+      }
+      // Nothing from the aborted transaction leaked
+      catalog.entry(secondMergedId) shouldBe None
+    finally
+      catalog.close()
+    end try
+  }
+
+  test("commit verifies the token even when sources are empty") {
+    val catalog = freshCatalog
+    try
+      val table = catalog.createTable("main", "events", TableOptions.default)
+      val lease = catalog.acquireLease("merge:t1:x", Some(table.id), "m1", 60000)
+      val ok    = catalog.commitMerge(
+        MergeCommit(
+          leaseName = "merge:t1:x",
+          fencingToken = lease.fencingToken,
+          tableId = table.id,
+          sourceEntryIds = Seq.empty,
+          mergedEntry = pending(catalog.allocateFileIds(table.id, 1).head),
+          escalatedSchema = None,
+          writer = "m1"
+        )
+      )
+      (ok.snapshotId > 0L) shouldBe true
+    finally
+      catalog.close()
+  }
+
+  test("pins expire and only active pins block retirement of visible files") {
+    val catalog = freshCatalog
+    try
+      val table = catalog.createTable("main", "events", TableOptions.default)
+      val idA   = catalog.allocateFileIds(table.id, 1).head
+      val s1    = catalog.registerIngest(table.id, "w", Seq(pending(idA))).snapshotId.get
+
+      catalog.pinSnapshot(table.id, s1, "reader-1", ttlMillis = -1) // already expired
+      val expiredPinDeletion = catalog.deletableEntries(table.id).filter(_.id == idA)
+      // Not retired yet, so still not deletable
+      expiredPinDeletion shouldBe empty
+
+      val s2 = retire(catalog, table.id, Seq(idA))
+      // With no pin, the retired file is deletable...
+      catalog.deletableEntries(table.id).map(_.id) shouldBe Seq(idA)
+
+      // ...but a fresh pin holding s1 (which still sees A) protects it
+      catalog.pinSnapshot(table.id, s1, "reader-2", ttlMillis = 60_000)
+      catalog.deletableEntries(table.id).map(_.id) shouldBe empty
+
+      // A pin at s2 (where A is invisible) does not protect it
+      catalog.releasePin(table.id, "reader-2")
+      catalog.pinSnapshot(table.id, s2, "reader-3", ttlMillis = 60_000)
+      catalog.deletableEntries(table.id).map(_.id) shouldBe Seq(idA)
+    finally
+      catalog.close()
+  }
+
+  test("schema versions publish through commits") {
+    val catalog = freshCatalog
+    try
+      val table = catalog.createTable(
+        "main",
+        "events",
+        TableOptions.default,
+        initialColumns = Seq(ColumnDesc("id", ColumnType.LongType))
+      )
+      table.schemaVersionHead shouldBe 1
+      catalog.schemaVersionsOf(table.id).map(_.version) shouldBe Seq(1)
+
+      val lease    = catalog.acquireLease("merge:t1:s", Some(table.id), "m1", 60000)
+      val mergedId = catalog.allocateFileIds(table.id, 1).head
+      val widened  = wvlet
+        .lang
+        .tablestore
+        .schema
+        .TableSchema(
+          2,
+          Seq(ColumnDesc("id", ColumnType.LongType), ColumnDesc("extra", ColumnType.StringType))
+        )
+      val commit = MergeCommit(
+        leaseName = "merge:t1:s",
+        fencingToken = lease.fencingToken,
+        tableId = table.id,
+        sourceEntryIds = Seq.empty,
+        mergedEntry = pending(mergedId),
+        escalatedSchema = Some(widened),
+        writer = "m1"
+      )
+      val result = catalog.commitMerge(commit)
+      result.newSchemaVersion shouldBe Some(2)
+      catalog.getTable(table.id).schemaVersionHead shouldBe 2
+      catalog.schemaVersionsOf(table.id).map(_.version) shouldBe Seq(1, 2)
+    finally
+      catalog.close()
+    end try
+  }
+
+  /** Retire `entryIds` under a fresh lease, returning the publishing snapshot id */
+  private def retire(catalog: CatalogStore, tableId: Long, entryIds: Seq[Long]): Long =
+    val leaseName = s"test-retire:${tableId}:${entryIds.mkString("-")}"
+    val lease     = catalog.acquireLease(leaseName, Some(tableId), "retirer", 60000)
+    try
+      val mergedId = catalog.allocateFileIds(tableId, 1).head
+      val latest   = catalog.latestSnapshot(tableId)
+      catalog
+        .commitMerge(
+          mergeCommit(
+            tableId,
+            leaseName,
+            lease.fencingToken,
+            entryIds,
+            mergedId,
+            latest.fold(0L)(_.id)
+          )
+        )
+        .snapshotId
+    finally
+      catalog.releaseLease(leaseName, "retirer", lease.fencingToken)
+
+  private def mergeCommit(
+      tableId: Long,
+      leaseName: String,
+      token: Long,
+      sources: Seq[Long],
+      mergedEntryId: Long,
+      afterSnapshot: Long
+  ): MergeCommit = MergeCommit(
+    leaseName = leaseName,
+    fencingToken = token,
+    tableId = tableId,
+    sourceEntryIds = sources,
+    mergedEntry = pending(mergedEntryId),
+    escalatedSchema = None,
+    writer = "test-writer"
+  )
+
+end CatalogProtocolSpec
+
+/** Conformance run on SQLite — the dev/test backend of the embedded profile */
+class SQLiteCatalogProtocolTest extends CatalogProtocolSpec:
+  override protected def newCatalog: CatalogStore = CatalogDrivers.inMemorySqlite()
+
+/** Conformance run on DuckDB — the embedded-profile engine backend */
+class DuckDBCatalogProtocolTest extends CatalogProtocolSpec:
+  override protected def newCatalog: CatalogStore = CatalogDrivers.inMemoryDuckDB()

--- a/wvlet-table-store/src/test/scala/wvlet/lang/tablestore/schema/PromotionLatticeTest.scala
+++ b/wvlet-table-store/src/test/scala/wvlet/lang/tablestore/schema/PromotionLatticeTest.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.tablestore.schema
+
+import wvlet.uni.json.JSON
+import wvlet.uni.json.JSON.JSONDouble
+import wvlet.uni.json.JSON.JSONLong
+import wvlet.uni.json.JSON.JSONString
+import wvlet.uni.test.UniTest
+import wvlet.uni.test.empty
+
+class PromotionLatticeTest extends UniTest:
+
+  import ColumnType.*
+
+  test("lub follows the promotion lattice") {
+    lub(NullType, LongType) shouldBe LongType
+    lub(LongType, NullType) shouldBe LongType
+    lub(LongType, DoubleType) shouldBe DoubleType
+    lub(DoubleType, StringType) shouldBe StringType
+    lub(StringType, LongType) shouldBe StringType
+  }
+
+  test("boolean and numerics are incomparable; both widen to string") {
+    lub(BooleanType, LongType) shouldBe StringType
+    lub(LongType, BooleanType) shouldBe StringType
+    lub(BooleanType, DoubleType) shouldBe StringType
+    lub(BooleanType, BooleanType) shouldBe BooleanType
+  }
+
+  test("folding observed schemas is order-independent") {
+    val types  = Seq[ColumnType](LongType, DoubleType, NullType, LongType, StringType)
+    val folded = types.permutations.map(permutation => ColumnType.fold(permutation)).toSet
+    folded.size shouldBe 1
+    folded.head shouldBe StringType
+  }
+
+  test("fold of a homogeneous set keeps the type") {
+    ColumnType.fold(Seq(LongType, LongType, LongType)) shouldBe LongType
+    ColumnType.fold(Nil) shouldBe NullType
+  }
+
+  test("escalation folds file schemas in any order") {
+    val current = TableSchema.empty
+    val files   = Seq(
+      (1L, 100L, ObservedSchema.fromRow(row("a" -> JSONLong(1), "b" -> JSONString("x")))),
+      (2L, 200L, ObservedSchema.fromRow(row("b" -> JSONString("y"), "c" -> JSONDouble(2.5)))),
+      (3L, 300L, ObservedSchema.fromRow(row("c" -> JSONString("z"))))
+    )
+    val results =
+      files
+        .permutations
+        .map(permutation =>
+          SchemaEscalation.escalate(current, nextVersion = 1L, files = permutation)
+        )
+        .toSeq
+    results.toSet.size shouldBe 1
+    val result = results.head
+    result.quarantinedFiles shouldBe empty
+    val schema = result.escalatedSchema.get
+    schema.column("a").get.columnType shouldBe LongType
+    schema.column("b").get.columnType shouldBe StringType
+    schema.column("c").get.columnType shouldBe StringType
+  }
+
+  test("the outlier guardrail quarantines a widening forced by a tiny minority") {
+    // One small file forces long -> string; it must be quarantined instead of escalating
+    val current  = TableSchema(1, Seq(ColumnDesc("user_id", LongType)))
+    val bigFiles = (1L to 5L).map { id =>
+      (id, 10_000L, ObservedSchema.fromRow(row("user_id" -> JSONLong(id))))
+    }
+    val oddFile = (99L, 5L, ObservedSchema.fromRow(row("user_id" -> JSONString("garbage"))))
+
+    val result = SchemaEscalation.escalate(current, nextVersion = 2L, files = bigFiles :+ oddFile)
+    result.quarantinedFiles shouldBe Seq(99L)
+    // The published type stays long: no irreversible widening happened, and since nothing widened
+    // there may be no new schema version at all
+    val effectiveType =
+      result.escalatedSchema match
+        case Some(schema) =>
+          schema.column("user_id").get.columnType
+        case None =>
+          LongType
+    effectiveType shouldBe LongType
+  }
+
+  test("a widening backed by enough rows escalates normally") {
+    val current = TableSchema(1, Seq(ColumnDesc("user_id", LongType)))
+    val files   = (1L to 4L).map { id =>
+      (id, 10_000L, ObservedSchema.fromRow(row("user_id" -> JSONString(s"user-${id}"))))
+    }
+    val result = SchemaEscalation.escalate(current, nextVersion = 2L, files = files)
+    result.quarantinedFiles shouldBe empty
+    result.escalatedSchema.get.column("user_id").get.columnType shouldBe StringType
+  }
+
+  test("escalation never narrows the published type") {
+    val current       = TableSchema(2, Seq(ColumnDesc("v", StringType)))
+    val files         = Seq((1L, 100L, ObservedSchema.fromRow(row("v" -> JSONLong(42)))))
+    val result        = SchemaEscalation.escalate(current, nextVersion = 3L, files = files)
+    val effectiveType =
+      result.escalatedSchema match
+        case Some(schema) =>
+          schema.column("v").get.columnType
+        case None =>
+          StringType
+    effectiveType shouldBe StringType
+    result.quarantinedFiles shouldBe empty
+  }
+
+  private def row(pairs: (String, wvlet.uni.json.JSON.JSONValue)*): wvlet.uni.json.JSON.JSONObject =
+    wvlet.uni.json.JSON.JSONObject(pairs)
+
+end PromotionLatticeTest


### PR DESCRIPTION
## Summary

Implements the core substrate of the Wvlet Table Store design (portable PlazmaDB successor, design note rev 2, 2026-08-21): a portable, high-throughput analytical table store that runs identically on a laptop (embedded) and against a service. The full plan is captured in `plans/2026-08-21-wvlet-table-store.md` in this PR.

This PR adds a new JVM module `wvlet-table-store` whose package boundaries mirror the four Uni modules from the design (`objectstore` / `catalog` / `format` / `tablestore` protocols), so extraction into separate `org.wvlet.uni` artifacts later stays mechanical. Language-level integration (`CREATE TABLE ... USING wvlet`, flow sinks) is intentionally out of scope and will follow once the substrate is settled.

## What's implemented

**Catalog** (`catalog/`)
- One portable JDBC implementation over SQLite (dev/tests), DuckDB (embedded engine profile), and Postgres (service profile) — plain SQL only: TEXT-JSON metadata, no arrays/JSONB, UTC-micros timestamps
- Monotonic per-table snapshot/file sequences via CAS-style counter upserts allocated *inside* registration transactions — concurrent ingest writers never contend on a CAS
- Interval-encoded file liveness: an entry is visible at snapshot S iff `begin_snapshot <= S AND (end_snapshot IS NULL OR end_snapshot > S)`; publication is O(files touched)
- Named leases with monotonically increasing fencing tokens; expiring ref-counted snapshot pins

**Protocols**
- **Ingest**: writer sessions buffer rotating JSONL segments keyed by pre-issued file ids; one catalog transaction per rotation registers the file (+ observed schema + column stats) — data is readable immediately on return; re-registering an issued id is a no-op (crash idempotency)
- **Merge**: leased merger selects small live entries, reads them once, writes content-addressed Parquet (explicit casts from the escalated schema — no engine-side inference) and commits atomically:
  - fencing token re-checked inside the commit transaction (stamping is not checking)
  - sources retired conditionally (`AND end_snapshot IS NULL`) with row-count assertion — no double-folding
  - schema escalation published in the same transaction under the merge lease only
- **Schema escalation**: monotonic promotion lattice (`null → boolean/long → double → string`), order-independent fold (join-semilattice), outlier guardrail quarantining widenings forced by <0.1% of rows instead of escalating irreversibly; escalation never narrows
- **Read**: pinned snapshots (AS OF supported), cast plans derived from catalog metadata, catalog-side pruning joining `file_entries ⋈ file_column_stats` (stats advisory: missing ⇒ must-scan)

**Object store** (`objectstore/`): checksummed puts, streaming gets, inventory list for orphan anti-joins; local filesystem driver behind the trait (S3/GCS/Azure slot in without protocol changes)

## Tests (31, all passing)

- Protocol conformance suite runs against **both embedded backends** (SQLite + DuckDB): monotonic id allocation, immediate readability, crash idempotency, interval AS OF semantics, zombie-merger fencing rejection, conditional-retirement conflict abort, pin expiry protecting/not-protecting retired files, schema publishing
- Deterministic fault-injection rather than timing-based tests, per the design's honest note that the embedded profile never exercises lease contention by accident
- End-to-end: ingest → read → merge → identical results via Parquet; lazy escalation makes new columns appear only after merge; pruning eliminates provably-non-matching files; orphan detection by anti-join

## Design decisions worth reviewing

- Correctness of retiring transactions does not lean on isolation levels: token check + retirement are predicate-based conditional updates asserted by row count (portable across drivers)
- Embedded profile serializes access through one connection (documented tradeoff from the design); a pooled Postgres variant can reuse every statement unchanged
- Merged Parquet is produced through DuckDB `COPY` with explicit column specs; production readers cast to the published schema and never auto-infer

## Out of scope (follow-ups)

`CREATE TABLE ... USING wvlet` wiring, fileset manifests (`kind='fileset'`), retention runner + predicate rewrite (erasure), DuckLake read-projection, catalog export/import tool, S3/GCS drivers.

Fixes part of the storage roadmap described in the design note.