### PR TITLE
fix: Parse operators with standard precedence; remove spurious type-mismatch warnings

### DIFF
--- a/spec/basic/string-concat.wv
+++ b/spec/basic/string-concat.wv
@@ -41,7 +41,7 @@ test _.output should be """
 select "hello" + " wvlet" + " and airframe!"
 test _.output should be """
 ┌─────────────────────────────────────────────────────┐
-│ concat('hello', concat(' wvlet', ' and airframe!')) │
+│ concat(concat('hello', ' wvlet'), ' and airframe!') │
 │                       string                        │
 ├─────────────────────────────────────────────────────┤
 │ hello wvlet and airframe!                           │

--- a/spec/tpcds/q72.wv
+++ b/spec/tpcds/q72.wv
@@ -18,10 +18,10 @@ left join promotion
 left join catalog_returns
   on (cr_item_sk = cs_item_sk and cr_order_number = cs_order_number)
 where 
+  -- SQL Server: DATEADD(day, 5, d1.d_date)
   d1.d_week_seq = d2.d_week_seq
   and inv_quantity_on_hand < cs_quantity
-  and -- SQL Server: DATEADD(day, 5, d1.d_date)
-  d3.d_date > d1.d_date + 5
+  and d3.d_date > d1.d_date + 5
   and hd_buy_potential = '>10000'
   and d1.d_year = 1999
   and cd_marital_status = 'D'

--- a/spec/tpcds/q75.wv
+++ b/spec/tpcds/q75.wv
@@ -71,7 +71,7 @@ where
   and curr_yr.i_manufact_id = prev_yr.i_manufact_id
   and curr_yr.d_year = 2002
   and prev_yr.d_year = 2002 - 1
-  and curr_yr.sales_cnt::DECIMAL[17,2] / prev_yr.sales_cnt::DECIMAL[17,2] < 0.9
+  and curr_yr.sales_cnt::decimal[17,2] / prev_yr.sales_cnt::decimal[17,2] < 0.9
 select 
   prev_yr.d_year as prev_year,
   curr_yr.d_year as year_,

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/DataTypeParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/DataTypeParser.scala
@@ -55,9 +55,11 @@ object DataTypeParser extends LogSupport:
     .newException(msg)
 
   private def toDataType(typeName: String, params: List[DataType]): DataType =
-    typeName match
+    // SQL type names are case-insensitive: CAST(x AS DECIMAL(17,2)) must produce the same
+    // DecimalType as decimal(17,2), not fall through to an opaque GenericType
+    typeName.toLowerCase match
       case p if params.isEmpty && DataType.isPrimitiveTypeName(p) =>
-        DataType.getPrimitiveType(typeName)
+        DataType.getPrimitiveType(p)
       case "varchar" if params.size <= 1 =>
         if params.isEmpty then
           DataType.getPrimitiveType("varchar")

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/SqlParser.scala
@@ -1992,69 +1992,55 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
 
   def expression(): Expression = booleanExpression()
 
+  // Boolean and arithmetic operators parse with standard SQL precedence, each level
+  // left-associative: OR < AND < NOT < comparison/IS/IN/LIKE/BETWEEN < +,- < *,/,% < unary +/-
   def booleanExpression(): Expression =
-    def booleanExpressionRest(expr: Expression): Expression =
+    var expr     = andExpression()
+    var continue = true
+    while continue do
+      val t = scanner.lookAhead()
+      t.token match
+        case SqlToken.OR =>
+          consume(SqlToken.OR)
+          expr = Or(expr, andExpression(), spanFrom(t))
+        case _ =>
+          continue = false
+    expr
+
+  private def andExpression(): Expression =
+    var expr     = notExpression()
+    var continue = true
+    while continue do
       val t = scanner.lookAhead()
       t.token match
         case SqlToken.AND =>
           consume(SqlToken.AND)
-          val right = booleanExpression()
-          And(expr, right, spanFrom(t))
-        case SqlToken.OR =>
-          consume(SqlToken.OR)
-          val right = booleanExpression()
-          Or(expr, right, spanFrom(t))
+          expr = And(expr, notExpression(), spanFrom(t))
         case _ =>
-          expr
+          continue = false
+    expr
 
+  private def notExpression(): Expression =
     val t = scanner.lookAhead()
     t.token match
       case SqlToken.EXCLAMATION | SqlToken.NOT =>
         consume(t.token)
-        val e = valueExpression()
-        booleanExpressionRest(Not(e, spanFrom(t)))
+        Not(valueExpression(), spanFrom(t))
       case _ =>
-        val expr = valueExpression()
-        booleanExpressionRest(expr)
+        valueExpression()
 
   def valueExpression(): Expression =
     def valueExpressionRest(expr: Expression): Expression =
       val t = scanner.lookAhead()
       t.token match
-        case SqlToken.PLUS =>
-          consume(SqlToken.PLUS)
-          val right = valueExpression()
-          ArithmeticBinaryExpr(BinaryExprType.Add, expr, right, spanFrom(t))
-        case SqlToken.MINUS =>
-          consume(SqlToken.MINUS)
-          val right = valueExpression()
-          ArithmeticBinaryExpr(BinaryExprType.Subtract, expr, right, spanFrom(t))
-        case SqlToken.STAR =>
-          consume(SqlToken.STAR)
-          val right = valueExpression()
-          ArithmeticBinaryExpr(BinaryExprType.Multiply, expr, right, spanFrom(t))
-        case SqlToken.DIV =>
-          consume(SqlToken.DIV)
-          val right = valueExpression()
-          ArithmeticBinaryExpr(BinaryExprType.Divide, expr, right, spanFrom(t))
-        case SqlToken.MOD =>
-          consume(SqlToken.MOD)
-          val right = valueExpression()
-          ArithmeticBinaryExpr(BinaryExprType.Modulus, expr, right, spanFrom(t))
-        case token
-            if token == SqlToken.DIV_INT || (token.isIdentifier && t.str.toUpperCase == "DIV") =>
-          // Support DIV keyword (Hive/MySQL) and // operator (DuckDB) for integer division
-          consumeToken()
-          val right = valueExpression()
-          ArithmeticBinaryExpr(BinaryExprType.DivideInt, expr, right, spanFrom(t))
         case SqlToken.EQ =>
           consume(SqlToken.EQ)
-          val right = valueExpression()
-          Eq(expr, right, spanFrom(t))
+          val right = additiveExpression()
+          valueExpressionRest(Eq(expr, right, spanFrom(t)))
         case SqlToken.NEQ | SqlToken.NEQ2 =>
           consumeToken()
-          val right = valueExpression()
-          NotEq(expr, right, spanFrom(t))
+          val right = additiveExpression()
+          valueExpressionRest(NotEq(expr, right, spanFrom(t)))
         case SqlToken.IS =>
           consume(SqlToken.IS)
           scanner.lookAhead().token match
@@ -2063,103 +2049,157 @@ class SqlParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends L
               scanner.lookAhead().token match
                 case SqlToken.NULL =>
                   consume(SqlToken.NULL)
-                  IsNotNull(expr, spanFrom(t))
+                  valueExpressionRest(IsNotNull(expr, spanFrom(t)))
                 case SqlToken.DISTINCT =>
                   consume(SqlToken.DISTINCT)
                   consume(SqlToken.FROM)
-                  val right = valueExpression()
-                  NotDistinctFrom(expr, right, spanFrom(t))
+                  val right = additiveExpression()
+                  valueExpressionRest(NotDistinctFrom(expr, right, spanFrom(t)))
                 case _ =>
-                  val right = valueExpression()
-                  NotEq(expr, right, spanFrom(t))
+                  val right = additiveExpression()
+                  valueExpressionRest(NotEq(expr, right, spanFrom(t)))
             case SqlToken.NULL =>
               consume(SqlToken.NULL)
-              IsNull(expr, spanFrom(t))
+              valueExpressionRest(IsNull(expr, spanFrom(t)))
             case SqlToken.DISTINCT =>
               consume(SqlToken.DISTINCT)
               consume(SqlToken.FROM)
-              val right = valueExpression()
-              DistinctFrom(expr, right, spanFrom(t))
+              val right = additiveExpression()
+              valueExpressionRest(DistinctFrom(expr, right, spanFrom(t)))
             case _ =>
-              val right = valueExpression()
-              Eq(expr, right, spanFrom(t))
+              val right = additiveExpression()
+              valueExpressionRest(Eq(expr, right, spanFrom(t)))
         case SqlToken.LT =>
           consume(SqlToken.LT)
-          val right = valueExpression()
-          LessThan(expr, right, spanFrom(t))
+          val right = additiveExpression()
+          valueExpressionRest(LessThan(expr, right, spanFrom(t)))
         case SqlToken.GT =>
           consume(SqlToken.GT)
-          val right = valueExpression()
-          GreaterThan(expr, right, spanFrom(t))
+          val right = additiveExpression()
+          valueExpressionRest(GreaterThan(expr, right, spanFrom(t)))
         case SqlToken.LTEQ =>
           consume(SqlToken.LTEQ)
-          val right = valueExpression()
-          LessThanOrEq(expr, right, spanFrom(t))
+          val right = additiveExpression()
+          valueExpressionRest(LessThanOrEq(expr, right, spanFrom(t)))
         case SqlToken.GTEQ =>
           consume(SqlToken.GTEQ)
-          val right = valueExpression()
-          GreaterThanOrEq(expr, right, spanFrom(t))
+          val right = additiveExpression()
+          valueExpressionRest(GreaterThanOrEq(expr, right, spanFrom(t)))
         case SqlToken.IN =>
           consume(SqlToken.IN)
           val values = inExprList()
-          In(expr, values, spanFrom(t))
+          valueExpressionRest(In(expr, values, spanFrom(t)))
         case SqlToken.LIKE =>
           consume(SqlToken.LIKE)
-          val right  = valueExpression()
+          val right  = additiveExpression()
           val escape = parseEscapeClause()
-          Like(expr, right, escape, spanFrom(t))
+          valueExpressionRest(Like(expr, right, escape, spanFrom(t)))
         case SqlToken.RLIKE =>
           consume(SqlToken.RLIKE)
-          val right = valueExpression()
-          RLike(expr, right, spanFrom(t))
+          val right = additiveExpression()
+          valueExpressionRest(RLike(expr, right, spanFrom(t)))
         case SqlToken.NOT =>
           consume(SqlToken.NOT)
           val t2 = scanner.lookAhead()
           t2.token match
             case SqlToken.LIKE =>
               consume(SqlToken.LIKE)
-              val right  = valueExpression()
+              val right  = additiveExpression()
               val escape = parseEscapeClause()
-              NotLike(expr, right, escape, spanFrom(t))
+              valueExpressionRest(NotLike(expr, right, escape, spanFrom(t)))
             case SqlToken.RLIKE =>
               consume(SqlToken.RLIKE)
-              val right = valueExpression()
-              NotRLike(expr, right, spanFrom(t))
+              val right = additiveExpression()
+              valueExpressionRest(NotRLike(expr, right, spanFrom(t)))
             case SqlToken.IN =>
               consume(SqlToken.IN)
               val values = inExprList()
-              NotIn(expr, values, spanFrom(t))
+              valueExpressionRest(NotIn(expr, values, spanFrom(t)))
             case _ =>
               unexpected(t2)
         case SqlToken.BETWEEN =>
           consume(SqlToken.BETWEEN)
-          val start = valueExpression()
+          val start = additiveExpression()
           consume(SqlToken.AND)
-          val end = valueExpression()
-          Between(expr, start, end, spanFrom(t))
+          val end = additiveExpression()
+          valueExpressionRest(Between(expr, start, end, spanFrom(t)))
         case _ =>
           expr
       end match
     end valueExpressionRest
 
-    val t    = scanner.lookAhead()
-    val expr =
+    valueExpressionRest(additiveExpression())
+
+  end valueExpression
+
+  private def additiveExpression(): Expression =
+    var expr     = multiplicativeExpression()
+    var continue = true
+    while continue do
+      val t = scanner.lookAhead()
       t.token match
         case SqlToken.PLUS =>
           consume(SqlToken.PLUS)
-          val v = valueExpression()
-          ArithmeticUnaryExpr(Sign.Positive, v, spanFrom(t))
+          expr = ArithmeticBinaryExpr(
+            BinaryExprType.Add,
+            expr,
+            multiplicativeExpression(),
+            spanFrom(t)
+          )
         case SqlToken.MINUS =>
           consume(SqlToken.MINUS)
-          val v = valueExpression()
-          ArithmeticUnaryExpr(Sign.Negative, v, spanFrom(t))
-        case SqlToken.QUESTION | SqlToken.DOLLAR =>
-          queryParameter()
+          expr = ArithmeticBinaryExpr(
+            BinaryExprType.Subtract,
+            expr,
+            multiplicativeExpression(),
+            spanFrom(t)
+          )
         case _ =>
-          primaryExpression()
-    valueExpressionRest(expr)
+          continue = false
+    expr
 
-  end valueExpression
+  private def multiplicativeExpression(): Expression =
+    var expr     = unaryExpression()
+    var continue = true
+    while continue do
+      val t = scanner.lookAhead()
+      t.token match
+        case SqlToken.STAR =>
+          consume(SqlToken.STAR)
+          expr = ArithmeticBinaryExpr(BinaryExprType.Multiply, expr, unaryExpression(), spanFrom(t))
+        case SqlToken.DIV =>
+          consume(SqlToken.DIV)
+          expr = ArithmeticBinaryExpr(BinaryExprType.Divide, expr, unaryExpression(), spanFrom(t))
+        case SqlToken.MOD =>
+          consume(SqlToken.MOD)
+          expr = ArithmeticBinaryExpr(BinaryExprType.Modulus, expr, unaryExpression(), spanFrom(t))
+        case token
+            if token == SqlToken.DIV_INT || (token.isIdentifier && t.str.toUpperCase == "DIV") =>
+          // Support DIV keyword (Hive/MySQL) and // operator (DuckDB) for integer division
+          consumeToken()
+          expr = ArithmeticBinaryExpr(
+            BinaryExprType.DivideInt,
+            expr,
+            unaryExpression(),
+            spanFrom(t)
+          )
+        case _ =>
+          continue = false
+    expr
+
+  private def unaryExpression(): Expression =
+    val t = scanner.lookAhead()
+    t.token match
+      case SqlToken.PLUS =>
+        consume(SqlToken.PLUS)
+        ArithmeticUnaryExpr(Sign.Positive, unaryExpression(), spanFrom(t))
+      case SqlToken.MINUS =>
+        consume(SqlToken.MINUS)
+        ArithmeticUnaryExpr(Sign.Negative, unaryExpression(), spanFrom(t))
+      case SqlToken.QUESTION | SqlToken.DOLLAR =>
+        queryParameter()
+      case _ =>
+        primaryExpression()
 
   def inExprList(): List[Expression] =
     @tailrec

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -2551,150 +2551,193 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     booleanExpression()
   }
 
+  // Boolean and arithmetic operators parse with standard precedence, each level
+  // left-associative: OR < AND < NOT < comparison/IS/IN/LIKE/BETWEEN < +,- < *,/,% < unary +/-
   def booleanExpression(): Expression = node {
+    var expr     = andExpression()
+    var continue = true
+    while continue do
+      val t = scanner.lookAhead()
+      t.token match
+        case WvletToken.OR =>
+          consume(WvletToken.OR)
+          expr = Or(expr, andExpression(), spanFrom(t))
+        case _ =>
+          continue = false
+    expr
+  }
+
+  private def andExpression(): Expression = node {
+    var expr     = notExpression()
+    var continue = true
+    while continue do
+      val t = scanner.lookAhead()
+      t.token match
+        case WvletToken.AND =>
+          consume(WvletToken.AND)
+          expr = And(expr, notExpression(), spanFrom(t))
+        case _ =>
+          continue = false
+    expr
+  }
+
+  private def notExpression(): Expression = node {
     val t = scanner.lookAhead()
     t.token match
       case WvletToken.EXCLAMATION | WvletToken.NOT =>
         consume(t.token)
-        val expr = valueExpression()
-        booleanExpressionRest(Not(expr, spanFrom(t)))
+        Not(valueExpression(), spanFrom(t))
       case _ =>
-        val expr = valueExpression()
-        booleanExpressionRest(expr)
-  }
-
-  def booleanExpressionRest(expression: Expression): Expression = node {
-    val t = scanner.lookAhead()
-    t.token match
-      case WvletToken.AND =>
-        consume(WvletToken.AND)
-        val right = booleanExpression()
-        And(expression, right, spanFrom(t))
-      case WvletToken.OR =>
-        consume(WvletToken.OR)
-        val right = booleanExpression()
-        Or(expression, right, spanFrom(t))
-      case _ =>
-        expression
+        valueExpression()
   }
 
   def valueExpression(): Expression = node {
-    val t    = scanner.lookAhead()
-    val expr =
+    valueExpressionRest(additiveExpression())
+  }
+
+  private def additiveExpression(): Expression = node {
+    var expr     = multiplicativeExpression()
+    var continue = true
+    while continue do
+      val t = scanner.lookAhead()
       t.token match
         case WvletToken.PLUS =>
           consume(WvletToken.PLUS)
-          val right = valueExpression()
-          ArithmeticUnaryExpr(Sign.Positive, right, spanFrom(t))
+          expr = ArithmeticBinaryExpr(
+            BinaryExprType.Add,
+            expr,
+            multiplicativeExpression(),
+            spanFrom(t)
+          )
         case WvletToken.MINUS =>
           consume(WvletToken.MINUS)
-          val right = valueExpression()
-          ArithmeticUnaryExpr(Sign.Negative, right, spanFrom(t))
+          expr = ArithmeticBinaryExpr(
+            BinaryExprType.Subtract,
+            expr,
+            multiplicativeExpression(),
+            spanFrom(t)
+          )
         case _ =>
-          primaryExpression()
+          continue = false
+    expr
+  }
 
-    valueExpressionRest(expr)
+  private def multiplicativeExpression(): Expression = node {
+    var expr     = unaryExpression()
+    var continue = true
+    while continue do
+      val t = scanner.lookAhead()
+      t.token match
+        case WvletToken.STAR =>
+          consume(WvletToken.STAR)
+          expr = ArithmeticBinaryExpr(BinaryExprType.Multiply, expr, unaryExpression(), spanFrom(t))
+        case WvletToken.DIV =>
+          consume(WvletToken.DIV)
+          expr = ArithmeticBinaryExpr(BinaryExprType.Divide, expr, unaryExpression(), spanFrom(t))
+        case WvletToken.MOD =>
+          consume(WvletToken.MOD)
+          expr = ArithmeticBinaryExpr(BinaryExprType.Modulus, expr, unaryExpression(), spanFrom(t))
+        case _ =>
+          continue = false
+    expr
+  }
+
+  private def unaryExpression(): Expression = node {
+    val t = scanner.lookAhead()
+    t.token match
+      case WvletToken.PLUS =>
+        consume(WvletToken.PLUS)
+        ArithmeticUnaryExpr(Sign.Positive, unaryExpression(), spanFrom(t))
+      case WvletToken.MINUS =>
+        consume(WvletToken.MINUS)
+        ArithmeticUnaryExpr(Sign.Negative, unaryExpression(), spanFrom(t))
+      case _ =>
+        primaryExpression()
   }
 
   def valueExpressionRest(expr: Expression): Expression = node {
     val t = scanner.lookAhead()
     t.token match
-      case WvletToken.PLUS =>
-        consume(WvletToken.PLUS)
-        val right = valueExpression()
-        ArithmeticBinaryExpr(BinaryExprType.Add, expr, right, spanFrom(t))
-      case WvletToken.MINUS =>
-        consume(WvletToken.MINUS)
-        val right = valueExpression()
-        ArithmeticBinaryExpr(BinaryExprType.Subtract, expr, right, spanFrom(t))
-      case WvletToken.STAR =>
-        consume(WvletToken.STAR)
-        val right = valueExpression()
-        ArithmeticBinaryExpr(BinaryExprType.Multiply, expr, right, spanFrom(t))
-      case WvletToken.DIV =>
-        consume(WvletToken.DIV)
-        val right = valueExpression()
-        ArithmeticBinaryExpr(BinaryExprType.Divide, expr, right, spanFrom(t))
-      case WvletToken.MOD =>
-        consume(WvletToken.MOD)
-        val right = valueExpression()
-        ArithmeticBinaryExpr(BinaryExprType.Modulus, expr, right, spanFrom(t))
       case WvletToken.EQ =>
         consume(WvletToken.EQ)
         scanner.lookAhead().token match
           case WvletToken.EQ =>
             consume(WvletToken.EQ)
           case _ =>
-        val right = valueExpression()
-        Eq(expr, right, spanFrom(t))
+        val right = additiveExpression()
+        valueExpressionRest(Eq(expr, right, spanFrom(t)))
       case WvletToken.NEQ =>
         consume(WvletToken.NEQ)
-        val right = valueExpression()
-        NotEq(expr, right, spanFrom(t))
+        val right = additiveExpression()
+        valueExpressionRest(NotEq(expr, right, spanFrom(t)))
       case WvletToken.IS =>
         consume(WvletToken.IS)
         scanner.lookAhead().token match
           case WvletToken.NOT =>
             consume(WvletToken.NOT)
-            val right = valueExpression()
-            NotEq(expr, right, spanFrom(t))
+            val right = additiveExpression()
+            valueExpressionRest(NotEq(expr, right, spanFrom(t)))
           case _ =>
-            val right = valueExpression()
-            Eq(expr, right, spanFrom(t))
+            val right = additiveExpression()
+            valueExpressionRest(Eq(expr, right, spanFrom(t)))
       case WvletToken.LT =>
         consume(WvletToken.LT)
-        val right = valueExpression()
-        LessThan(expr, right, spanFrom(t))
+        val right = additiveExpression()
+        valueExpressionRest(LessThan(expr, right, spanFrom(t)))
       case WvletToken.GT =>
         consume(WvletToken.GT)
-        val right = valueExpression()
-        GreaterThan(expr, right, spanFrom(t))
+        val right = additiveExpression()
+        valueExpressionRest(GreaterThan(expr, right, spanFrom(t)))
       case WvletToken.LTEQ =>
         consume(WvletToken.LTEQ)
-        val right = valueExpression()
-        LessThanOrEq(expr, right, spanFrom(t))
+        val right = additiveExpression()
+        valueExpressionRest(LessThanOrEq(expr, right, spanFrom(t)))
       case WvletToken.GTEQ =>
         consume(WvletToken.GTEQ)
-        val right = valueExpression()
-        GreaterThanOrEq(expr, right, spanFrom(t))
+        val right = additiveExpression()
+        valueExpressionRest(GreaterThanOrEq(expr, right, spanFrom(t)))
       case WvletToken.IN =>
         consume(WvletToken.IN)
         val valueList = inExprList()
-        expr match
-          case RowConstructor(_, _) =>
-            TupleIn(expr, valueList, spanFrom(t))
-          case _ =>
-            In(expr, valueList, spanFrom(t))
+        val in        =
+          expr match
+            case RowConstructor(_, _) =>
+              TupleIn(expr, valueList, spanFrom(t))
+            case _ =>
+              In(expr, valueList, spanFrom(t))
+        valueExpressionRest(in)
       case WvletToken.LIKE =>
         consume(WvletToken.LIKE)
-        val right  = valueExpression()
+        val right  = additiveExpression()
         val escape = parseEscapeClause()
-        Like(expr, right, escape, spanFrom(t))
+        valueExpressionRest(Like(expr, right, escape, spanFrom(t)))
       case WvletToken.NOT =>
         consume(WvletToken.NOT)
         val t2 = scanner.lookAhead()
         t2.token match
           case WvletToken.LIKE =>
             consume(WvletToken.LIKE)
-            val right  = valueExpression()
+            val right  = additiveExpression()
             val escape = parseEscapeClause()
-            NotLike(expr, right, escape, spanFrom(t))
+            valueExpressionRest(NotLike(expr, right, escape, spanFrom(t)))
           case WvletToken.IN =>
             consume(WvletToken.IN)
             val valueList = inExprList()
-            expr match
-              case RowConstructor(_, _) =>
-                TupleNotIn(expr, valueList, spanFrom(t))
-              case _ =>
-                NotIn(expr, valueList, spanFrom(t))
+            val notIn     =
+              expr match
+                case RowConstructor(_, _) =>
+                  TupleNotIn(expr, valueList, spanFrom(t))
+                case _ =>
+                  NotIn(expr, valueList, spanFrom(t))
+            valueExpressionRest(notIn)
           case other =>
             unexpected(t2)
       case WvletToken.BETWEEN =>
         consume(WvletToken.BETWEEN)
-        val left = valueExpression()
+        val left = additiveExpression()
         consume(WvletToken.AND)
-        val right = valueExpression()
-        Between(expr, left, right, spanFrom(t))
+        val right = additiveExpression()
+        valueExpressionRest(Between(expr, left, right, spanFrom(t)))
       case WvletToken.SHOULD =>
         consume(WvletToken.SHOULD)
         val not =

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -148,12 +148,19 @@ object Typer extends Phase("typer") with LogSupport:
     * is an ErrorType while both operand types are concrete scalars is a genuine user error; error
     * results over unresolved or virtual operand types are deferred states, not diagnostics
     */
-  private def collectTypeMismatches(plan: LogicalPlan)(using ctx: Context): Unit = plan
-    .traverseExpressions {
-      case op: ArithmeticBinaryExpr if op.tpe.isInstanceOf[Type.ErrorType] =>
+  private def collectTypeMismatches(plan: LogicalPlan)(using ctx: Context): Unit =
+    // An ErrorType inherited from an operand is a propagated state, not a new mismatch: only
+    // the node where the error originated reports a diagnostic. Without this check, a single
+    // mismatch under an AND-chain reports once per enclosing conjunct, each time with the
+    // boolean operand types of the AND ("expected boolean, got boolean")
+    def isErrorOrigin(op: Expression): Boolean =
+      !op.children.exists(_.tpe.isInstanceOf[Type.ErrorType])
+
+    plan.traverseExpressions {
+      case op: ArithmeticBinaryExpr if op.tpe.isInstanceOf[Type.ErrorType] && isErrorOrigin(op) =>
         if isConcreteScalar(op.left.dataType) && isConcreteScalar(op.right.dataType) then
           ctx.addTyperError(TypeMismatch(op.left.dataType, op.right.dataType, op))
-      case op: ConditionalExpression if op.tpe.isInstanceOf[Type.ErrorType] =>
+      case op: ConditionalExpression if op.tpe.isInstanceOf[Type.ErrorType] && isErrorOrigin(op) =>
         val types = op.children.map(_.dataType).toList
         if types.nonEmpty && types.forall(isConcreteScalar) then
           ctx.addTyperError(

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/ExpressionPrecedenceTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/ExpressionPrecedenceTest.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.parser
+
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.model.expr.*
+import wvlet.uni.test.UniTest
+
+/**
+  * Operator precedence tests for both parsers: OR < AND < NOT < comparison < additive <
+  * multiplicative < unary, with binary operators associating to the left
+  */
+class ExpressionPrecedenceTest extends UniTest:
+
+  private def sqlExpr(s: String): Expression = SqlParser(CompilationUnit.fromSqlString(s))
+    .expression()
+
+  private def wvExpr(s: String): Expression = WvletParser(CompilationUnit.fromWvletString(s))
+    .expression()
+
+  private def checkPrecedence(parse: String => Expression): Unit =
+    // multiplicative binds tighter than additive
+    parse("a + b * c") shouldMatch {
+      case ArithmeticBinaryExpr(
+            BinaryExprType.Add,
+            _,
+            ArithmeticBinaryExpr(BinaryExprType.Multiply, _, _, _),
+            _
+          ) =>
+    }
+    parse("a * b + c") shouldMatch {
+      case ArithmeticBinaryExpr(
+            BinaryExprType.Add,
+            ArithmeticBinaryExpr(BinaryExprType.Multiply, _, _, _),
+            _,
+            _
+          ) =>
+    }
+    // additive is left-associative: a - b + c = (a - b) + c
+    parse("a - b + c") shouldMatch {
+      case ArithmeticBinaryExpr(
+            BinaryExprType.Add,
+            ArithmeticBinaryExpr(BinaryExprType.Subtract, _, _, _),
+            _,
+            _
+          ) =>
+    }
+    // arithmetic binds tighter than comparison: a / b < c = (a / b) < c
+    parse("a / b < c") shouldMatch {
+      case LessThan(ArithmeticBinaryExpr(BinaryExprType.Divide, _, _, _), _, _) =>
+    }
+    parse("a < b + c") shouldMatch {
+      case LessThan(_, ArithmeticBinaryExpr(BinaryExprType.Add, _, _, _), _) =>
+    }
+    // AND binds tighter than OR: a and b or c = (a and b) or c
+    parse("a and b or c") shouldMatch { case Or(And(_, _, _), _, _) =>
+    }
+    parse("a or b and c") shouldMatch { case Or(_, And(_, _, _), _) =>
+    }
+    // comparison binds tighter than AND: a < b and c = (a < b) and c
+    parse("a < b and c > d") shouldMatch { case And(LessThan(_, _, _), GreaterThan(_, _, _), _) =>
+    }
+    // NOT binds tighter than AND: not a and b = (not a) and b
+    parse("not a and b") shouldMatch { case And(Not(_, _), _, _) =>
+    }
+    // unary minus binds tighter than multiplication: -a * b = (-a) * b
+    parse("-a * b") shouldMatch {
+      case ArithmeticBinaryExpr(
+            BinaryExprType.Multiply,
+            ArithmeticUnaryExpr(Sign.Negative, _, _),
+            _,
+            _
+          ) =>
+    }
+    // between operands stop at the additive level
+    parse("a between b + 1 and c + 2") shouldMatch {
+      case Between(
+            _,
+            ArithmeticBinaryExpr(BinaryExprType.Add, _, _, _),
+            ArithmeticBinaryExpr(BinaryExprType.Add, _, _, _),
+            _
+          ) =>
+    }
+  end checkPrecedence
+
+  test("should parse SQL operators with standard precedence") {
+    checkPrecedence(sqlExpr)
+  }
+
+  test("should parse Wvlet operators with standard precedence") {
+    checkPrecedence(wvExpr)
+  }
+
+end ExpressionPrecedenceTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperDiagnosticsTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/TyperDiagnosticsTest.scala
@@ -28,6 +28,12 @@ class TyperDiagnosticsTest extends UniTest:
     compiler.compileSingleUnit(unit)
     unit.typerErrors
 
+  private def compileSqlErrors(sql: String): List[TyperError] =
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv(".")))
+    val unit     = CompilationUnit.fromSqlString(sql)
+    compiler.compileSingleUnit(unit)
+    unit.typerErrors
+
   test("report a mismatch between resolved incompatible operand types") {
     val errors = compileErrors("select 1 - 'a' as v")
     errors.exists {
@@ -66,6 +72,30 @@ class TyperDiagnosticsTest extends UniTest:
     mismatches.foreach { m =>
       m.severity shouldBe TyperError.Severity.Error
     }
+  }
+
+  test("report a genuine mismatch only at its origin, not at enclosing conjuncts") {
+    // The inner comparison is the only origin; the surrounding AND chain propagates its
+    // ErrorType and must not add duplicate "expected boolean, got boolean" diagnostics
+    val errors = compileErrors("select (1 < 'a') and true and true as v")
+    errors
+      .collect { case t: TypeMismatch =>
+        t
+      }
+      .size shouldBe 1
+  }
+
+  test("not report mismatches for case-insensitive parameterized cast types (TPC-DS q75)") {
+    // CAST(x AS DECIMAL(17,2)) must type as decimal(17,2); a case-sensitive type lookup turned
+    // it into an opaque generic type, making every comparison against it a false mismatch
+    val errors = compileSqlErrors("""SELECT 1 AS v
+        |FROM t1 curr_yr, t1 prev_yr
+        |WHERE curr_yr.a = prev_yr.a
+        |  AND CAST(curr_yr.b AS DECIMAL(17,2)) / CAST(prev_yr.b AS DECIMAL(17,2)) < 0.9
+        |""".stripMargin)
+    errors.collect { case t: TypeMismatch =>
+      t
+    } shouldBe Nil
   }
 
   test("fail the compilation on type errors when failOnTypeErrors is set") {


### PR DESCRIPTION
## Summary

Follow-up to #1960: eliminates the spurious `Type mismatch: expected boolean, got boolean` Typer warnings seen on TPC-DS q04/q75/q78. Investigating the diagnostics uncovered three compounding bugs:

### 1. No operator precedence in either parser (the deep one)

Both `SqlParser` and `WvletParser` parsed all binary operators in a single flat, right-recursive level, so:
- `a / b < 0.9` parsed as `a / (b < 0.9)`
- `a - b + c` parsed as `a - (b + c)`
- `a and b or c` parsed as `a and (b or c)`

This was invisible in execution because the SQL/Wvlet generators print expressions back in source token order without parentheses, so DuckDB re-parsed the text with correct precedence — but the AST itself was wrong, and the Typer saw impossible operand pairings (e.g. a comparison nested under a division), producing `ErrorType`s. Both parsers now use standard precedence climbing — `OR < AND < NOT < comparison/IS/IN/LIKE/BETWEEN < +,- < *,/,% < unary ±` — with left-associative levels. A new `ExpressionPrecedenceTest` locks the tree shapes in for both parsers.

### 2. Case-sensitive type-name lookup

`CAST(x AS DECIMAL(17,2))` fell through to an opaque `GenericType("DECIMAL")` instead of `decimal(17,2)` because `DataTypeParser.toDataType` matched type names case-sensitively (only the parameterized path was affected). Comparisons against such casts then looked like mismatches. Parameterized type names now resolve case-insensitively; unknown types keep their original spelling.

### 3. Propagated errors re-reported per conjunct

`collectTypeMismatches` reported a single propagated `ErrorType` once per enclosing `AND`, each time printing the AND's boolean operand types (hence "expected boolean, got boolean"). Only the origin node — whose own operands caused the error — reports now.

## Testing

- New `ExpressionPrecedenceTest` (SQL + Wvlet precedence/associativity tree shapes)
- New `TyperDiagnosticsTest` cases: single origin report under an AND chain; q75-style uppercase parameterized cast produces no mismatches
- `langJVM/test`, `runner/test` (all spec suites incl. TPC-DS SQL + Wvlet): green, with **zero** type-mismatch warnings in the logs (previously q04/q75/q78 warned)
- `projectJS/Test/compile`, `projectNative/Test/compile`, `scalafmtCheck`: green
- Regenerated `spec/tpcds`: only benign diffs (`DECIMAL[17,2]` → `decimal[17,2]`, one comment repositioned)

Note: generators still print expressions in token order without structure-derived parentheses; expressions constructed programmatically by rewrites rely on this. With the parser now producing correctly-shaped trees, a future improvement could parenthesize by precedence in the generators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RURVxYnBzFMEyQf2HX5j6r