### PR TITLE
feature: Persistent DuckDB sessions on JVM, Node.js, and Native (cross-platform runner phase 1)

### DIFF
--- a/plans/2026-08-22-cross-platform-runner.md
+++ b/plans/2026-08-22-cross-platform-runner.md
@@ -51,8 +51,9 @@ SQL string and dispatches on a hardcoded `"duckdb" | "trino"` match. Everything
 Both are plain sbt `project`s (`build.sbt:433-485`). Bindings: `java.sql.*`
 (`DBConnector`), caffeine (`ConnectorCatalog`), jline (`QueryResultPrinter` uses
 `org.jline.utils.WCWidth`), arrow-vector, sqlite-jdbc (`SQLiteFlowRunStore`),
-`java.util.concurrent` (scheduler, thread pools). A wholesale crossProject conversion
-is neither feasible nor desirable — flows/scheduler/REPL are legitimately JVM features.
+`java.util.concurrent` (scheduler, thread pools). Flows/scheduler/REPL are
+legitimately JVM features — the crossProject conversion must keep them in
+`.jvm/src`, not port them.
 
 ### G3. No persistent DuckDB session on JS/Native
 `DuckDBCompat.execute` (all three platforms) opens a database, runs one statement
@@ -84,29 +85,39 @@ this design; an `AsyncSqlConnector` mirror is future work.
 
 ## Target architecture
 
-Keep `wvlet-runner` (JVM) as the full-featured runtime; extract its engine-agnostic
-core into a new cross-platform module that both the JVM runner and the thin
-CLIs consume:
+> **Revision (2026-08-22, user feedback):** no separate `wvlet-runner-core` module.
+> `wvlet-runner` itself becomes a `crossProject(JVM, JS, Native)` with
+> `CrossType.Pure` — the same layout `wvlet-lang` uses: shared code stays in
+> `wvlet-runner/src`, and the JVM-only pieces move into `wvlet-runner/.jvm/src`.
+> The JVM platform keeps its `wvlet-connector` dependency via `.jvmConfigure`
+> (per-platform `dependsOn`), so no new artifact and no package renames are needed.
+
+Convert `wvlet-runner` to a crossProject whose shared sources hold the
+engine-agnostic runtime, consumed by both the JVM CLI/server stack and the thin
+Node/Native CLIs:
 
 ```
   wvlet-cli (JVM: REPL, ui, flows)          wvc (Native)      @wvlet/cli (Node)
         │                                          │                │
-  wvlet-runner (JVM-only)                          └───────┬────────┘
-   flows, scheduler, run stores, staging,                  │
-   activation sinks, JDBC connectors,              wvlet-cli-core (X)
-   arrow, ConnectorCatalog                                 │
+        │                                          └───────┬────────┘
+        │                                                  │
+        │                                          wvlet-cli-core (X)
         │                                                  │
         └────────────────┬─────────────────────────────────┘
                          │
-              wvlet-runner-core (NEW, crossProject JVM/JS/Native)
-                PlanExecutor   — ExecutionPlan interpreter over SqlConnector
-                TestEvaluator  — `test` statement evaluation (moved from QueryExecutor)
-                QueryResult ADT + printer (jline-free width handling)
-                SqlConnectorProvider — ConnectorConfig → SqlConnector registry
+              wvlet-runner (converted to crossProject JVM/JS/Native, CrossType.Pure)
+                src/ (shared):
+                  PlanExecutor   — ExecutionPlan interpreter over SqlConnector
+                  TestEvaluator  — `test` statement evaluation (moved from QueryExecutor)
+                  QueryResult ADT + printer (jline-free width handling)
+                  SqlConnectorProvider — ConnectorConfig → SqlConnector registry
+                .jvm/src/ (JVM-only, depends on wvlet-connector via .jvmConfigure):
+                  QueryExecutor (extends PlanExecutor), flows, scheduler, run stores,
+                  staging, activation sinks, arrow, jline REPL support
                          │
               wvlet-lang (X, existing)
                 SqlConnector / QueryHandle / QueryState / QueryStats
-                DuckDB compat (JDBC / koffi / C API) + DuckDBSqlConnector
+                DuckDB compat (JDBC / koffi / C API) + DuckDBSqlConnector + DuckDBSession
                 Trino REST client + TrinoSqlConnector
                 Profile / ConnectorConfig (cross-platform JSONC + env expansion)
 ```
@@ -140,7 +151,7 @@ single-query calls.
 
 ### C2. Cross-platform `SqlConnectorProvider` (partial G1, enables profiles)
 
-In `wvlet-runner-core`: resolve a `ConnectorConfig` (from the cross-platform
+In shared `wvlet-runner` sources: resolve a `ConnectorConfig` (from the cross-platform
 `Profile`) to a `SqlConnector`:
 
 | `type` | Connector | Availability |
@@ -158,7 +169,7 @@ equality (same key rule as the JVM provider, decision D5 of
 
 Split `QueryExecutor` along the `SqlConnector` seam:
 
-- **Moves to `wvlet-runner-core`** (verified platform-clean):
+- **Moves to shared `wvlet-runner/src`** (verified platform-clean):
   - The `ExecutionPlan` walk (`execute`/`process`/`report`,
     QueryExecutor.scala:254-351) for `ExecuteQuery`, `ExecuteStatement` lists,
     `ExecuteTest`, `ExecuteValDef`, `ExecuteCommand` subset (`ExecuteExpr`,
@@ -177,7 +188,7 @@ Split `QueryExecutor` along the `SqlConnector` seam:
   (`runEmbeddedFlows`/`runEmbeddedToolCalls`), source-table staging across
   connectors, `DBConnector`/JDBC result paths, arrow export, catalog registration.
 
-Shape: `class PlanExecutor(connectorProvider, profile)` in runner-core with
+Shape: `class PlanExecutor(connectorProvider, profile)` in shared runner sources with
 `protected def executeUnsupported(plan): QueryResult` hooks;
 `QueryExecutor extends PlanExecutor` overrides them with the JVM implementations.
 `wvlet-cli-core`'s `run` switches from "generate one SQL string" to
@@ -198,7 +209,7 @@ Server side:
 Client side:
 4. Add `NativePlatform` to the `wvlet-client` crossProject — it depends only on
    `wvlet-api` + uni RPC, both of which already cross-build to Native.
-5. New `WvletServerSqlConnector extends SqlConnector` in runner-core: `submit` →
+5. New `WvletServerSqlConnector extends SqlConnector` in shared runner sources: `submit` →
    `FrontendApi.submitQuery`, `await` → poll `getQueryInfo` + drain pages, `cancel` →
    `cancelQuery`. Registered as connector `type: "wvlet"` with
    `host`/`port`/`useHttps` from `ConnectorConfig`.
@@ -230,10 +241,12 @@ client sends `Authorization: Basic …` (password requires `useHttps`) or
 1. **PR1 — DuckDB sessions (C1)**: `DuckDBSession` on all three platforms +
    session-backed `DuckDBSqlConnector` + cross-platform tests (temp table survives
    across `execute` calls; gated on `DuckDB.canExecute` like `DuckDBExecuteTest`).
-2. **PR2 — runner-core skeleton + provider (C2)**: new
-   `crossProject wvlet-runner-core`; move the runner `QueryResult` ADT + a
-   jline-free printer; `SqlConnectorProvider`; route `WvletCli.run` through it
-   (profile-driven backend selection preserved, `-t` still wins).
+2. **PR2 — runner crossProject conversion + provider (C2)**: convert
+   `wvlet-runner` to `crossProject(JVM, JS, Native)` with `CrossType.Pure`,
+   moving the JVM-only sources into `.jvm/src` (mechanical, no package changes);
+   keep the runner `QueryResult` ADT + a jline-free printer in shared sources;
+   add `SqlConnectorProvider`; route `WvletCli.run` through it (profile-driven
+   backend selection preserved, `-t` still wins).
 3. **PR3 — PlanExecutor extraction (C3)**: the big refactor. `QueryExecutor` keeps
    its public surface; JVM `runner/test`, RunnerSpec suites, and TyperCoverageCheck
    guard the move. cliCore `run` executes plans; add native/Node smoke specs for
@@ -255,7 +268,7 @@ PR2+ the three-platform smoke (`cliCoreJVM/run`, `node sdks/cli-node/bin/wvlet.j
 - **QueryExecutor entanglement**: `Context`/catalog access inside the interpreter may
   drag JVM-only catalog types; the seam must pass capabilities in, not reach out
   (mitigation: PR3 lands behind the existing JVM test suites, which are extensive).
-- **New published artifact** (`wvlet-runner-core` ×3 platforms): release automation
+- **`wvlet-runner` published for 3 platforms** (was JVM-only): release automation
   aggregates `projectJVM/JS/Native`, so inclusion is automatic, but npm/native binary
   size will grow — watch `wvc` link time and `@wvlet/cli` bundle size.
 - **uni `HttpSyncClient` thread-safety** — single-threaded on Node/Native; the

--- a/wvlet-lang/.js/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
+++ b/wvlet-lang/.js/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
@@ -67,21 +67,51 @@ trait DuckDBCompat:
         executeWith(api, sql)
 
   private def executeWith(api: DuckDBApi, sql: String): QueryResult =
-    val dbBox = js.Array[js.Any](null)
-    if asInt(api.duckdb_open.call(null, null, dbBox)) != 0 then
+    val session = openSession(api, None)
+    try session.execute(sql)
+    finally session.close()
+
+  /**
+    * Open a persistent session holding one koffi database + connection handle pair; every
+    * `session.execute(sql)` runs on that connection, so in-memory tables and other session state
+    * survive across calls. `path` opens a file-backed database; `None` opens an in-memory one.
+    */
+  def newSession(path: Option[String] = None): DuckDBSession =
+    DuckDBApi.instance match
+      case None =>
+        throw new UnsupportedOperationException(
+          "libduckdb is not available; set WVLET_LIBDUCKDB to its absolute path or install it via your platform package manager"
+        )
+      case Some(api) =>
+        openSession(api, path)
+
+  private def openSession(api: DuckDBApi, path: Option[String]): DuckDBSession =
+    val dbBox         = js.Array[js.Any](null)
+    val cPath: js.Any = path.map(js.Any.fromString).getOrElse(null)
+    if asInt(api.duckdb_open.call(null, cPath, dbBox)) != 0 then
       throw StatusCode.NOT_IMPLEMENTED.newException("duckdb_open failed")
-    val db = dbBox(0)
-    try
-      val conBox = js.Array[js.Any](null)
-      if asInt(api.duckdb_connect.call(null, db, conBox)) != 0 then
-        throw StatusCode.NOT_IMPLEMENTED.newException("duckdb_connect failed")
-      val con = conBox(0)
-      try runQuery(api, con, sql)
-      finally api.duckdb_disconnect.call(null, js.Array[js.Any](con))
-    finally
+    val db     = dbBox(0)
+    val conBox = js.Array[js.Any](null)
+    if asInt(api.duckdb_connect.call(null, db, conBox)) != 0 then
       api.duckdb_close.call(null, js.Array[js.Any](db))
-    end try
-  end executeWith
+      throw StatusCode.NOT_IMPLEMENTED.newException("duckdb_connect failed")
+    val con = conBox(0)
+
+    new DuckDBSession:
+      private var closed = false
+
+      override def execute(sql: String): QueryResult =
+        if closed then
+          throw new IllegalStateException("DuckDB session is already closed")
+        runQuery(api, con, sql)
+
+      override def close(): Unit =
+        if !closed then
+          closed = true
+          api.duckdb_disconnect.call(null, js.Array[js.Any](con))
+          api.duckdb_close.call(null, js.Array[js.Any](db))
+
+  end openSession
 
   private def runQuery(api: DuckDBApi, con: js.Any, sql: String): QueryResult =
     val result = js.Object()

--- a/wvlet-lang/.jvm/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
+++ b/wvlet-lang/.jvm/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
@@ -103,11 +103,35 @@ trait DuckDBCompat:
       rows += QueryResultRow(values)
     QueryResult(columns, rows.result())
 
-  private def withConnection[U](f: DuckDBConnection => U): U =
+  /**
+    * Open a persistent session — a single long-lived JDBC connection that every
+    * `session.execute(sql)` runs on, so in-memory tables and other session state survive across
+    * calls. `path` opens a file-backed database; `None` opens an in-memory one.
+    */
+  def newSession(path: Option[String] = None): DuckDBSession =
+    val conn = openConnection(path)
+    new DuckDBSession:
+      private var closed = false
+
+      override def execute(sql: String): QueryResult =
+        if closed then
+          throw new IllegalStateException("DuckDB session is already closed")
+        withResource(conn.createStatement()) { stmt =>
+          executeStatement(stmt, sql)
+        }
+
+      override def close(): Unit =
+        if !closed then
+          closed = true
+          conn.close()
+
+  private def withConnection[U](f: DuckDBConnection => U): U = withResource(openConnection(None))(f)
+
+  private def openConnection(path: Option[String]): DuckDBConnection =
     Class.forName("org.duckdb.DuckDBDriver")
-    DriverManager.getConnection("jdbc:duckdb:") match
+    DriverManager.getConnection(s"jdbc:duckdb:${path.getOrElse("")}") match
       case conn: DuckDBConnection =>
-        withResource(conn)(f)
+        conn
       case _ =>
         throw StatusCode.NOT_IMPLEMENTED.newException("duckdb connection is unavailable")
 

--- a/wvlet-lang/.native/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
+++ b/wvlet-lang/.native/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
@@ -90,20 +90,54 @@ trait DuckDBCompat:
     * small C wrapper `wvlet_duckdb_fetch_chunk(duckdb_result *)` from `wvlet_duckdb_helpers.c` to
     * forward by-value internally on the C side.
     */
-  def execute(sql: String): QueryResult = Zone {
-    val db  = stackalloc[DuckDBApi.duckdb_database]()
-    val con = stackalloc[DuckDBApi.duckdb_connection]()
-    if DuckDBApi.duckdb_open(null, db) != 0 then
+  def execute(sql: String): QueryResult =
+    val session = newSession(None)
+    try session.execute(sql)
+    finally session.close()
+
+  /**
+    * Open a persistent session holding one `duckdb_database` + `duckdb_connection` pair; every
+    * `session.execute(sql)` runs on that connection, so in-memory tables and other session state
+    * survive across calls. `path` opens a file-backed database; `None` opens an in-memory one.
+    *
+    * The opaque C handles are plain pointer values, so they can outlive the `stackalloc`ed out-
+    * parameter slots used here; `close()` writes them back into fresh slots for `duckdb_disconnect`
+    * / `duckdb_close`.
+    */
+  def newSession(path: Option[String] = None): DuckDBSession = Zone {
+    val db    = stackalloc[DuckDBApi.duckdb_database]()
+    val con   = stackalloc[DuckDBApi.duckdb_connection]()
+    val cPath = path.map(p => toCString(p)).getOrElse(null)
+    if DuckDBApi.duckdb_open(cPath, db) != 0 then
       throw StatusCode.NOT_IMPLEMENTED.newException("duckdb_open failed")
-    try
-      if DuckDBApi.duckdb_connect(!db, con) != 0 then
-        throw StatusCode.NOT_IMPLEMENTED.newException("duckdb_connect failed")
-      try runQuery(!con, sql)
-      finally DuckDBApi.duckdb_disconnect(con)
-    finally
+    if DuckDBApi.duckdb_connect(!db, con) != 0 then
       DuckDBApi.duckdb_close(db)
-    end try
+      throw StatusCode.NOT_IMPLEMENTED.newException("duckdb_connect failed")
+    NativeDuckDBSession(!db, !con)
   }
+
+  private class NativeDuckDBSession(db: DuckDBApi.duckdb_database, con: DuckDBApi.duckdb_connection)
+      extends DuckDBSession:
+    private var closed = false
+
+    override def execute(sql: String): QueryResult =
+      if closed then
+        throw new IllegalStateException("DuckDB session is already closed")
+      Zone {
+        runQuery(con, sql)
+      }
+
+    override def close(): Unit =
+      if !closed then
+        closed = true
+        val conSlot = stackalloc[DuckDBApi.duckdb_connection]()
+        !conSlot = con
+        DuckDBApi.duckdb_disconnect(conSlot)
+        val dbSlot = stackalloc[DuckDBApi.duckdb_database]()
+        !dbSlot = db
+        DuckDBApi.duckdb_close(dbSlot)
+
+  end NativeDuckDBSession
 
   private def runQuery(con: DuckDBApi.duckdb_connection, sql: String)(using Zone): QueryResult =
     val result = stackalloc[DuckDBApi.duckdb_result]()

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSession.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSession.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer.duckdb
+
+import wvlet.lang.compiler.connector.QueryResult
+
+/**
+  * A persistent DuckDB session: every [[execute]] runs on the SAME database connection, so
+  * in-memory tables, temp views, and other session state survive across calls — unlike
+  * [[DuckDB.execute]], which opens a fresh in-memory database per invocation.
+  *
+  * Obtain one via [[DuckDB.newSession]] (in-memory by default, file-backed when a path is given).
+  * Sessions are single-threaded, must be closed by the caller, and throw `IllegalStateException` on
+  * use after close. Each platform backs the session with its long-lived native handle: a JDBC
+  * `DuckDBConnection` on JVM, koffi FFI handles on Node.js, and `duckdb_database` /
+  * `duckdb_connection` C-API handles on Scala Native.
+  */
+trait DuckDBSession extends AutoCloseable:
+  /** Run `sql` on this session's connection and materialize the result as strings. */
+  def execute(sql: String): QueryResult
+
+  /** Close the underlying connection (and database handle where applicable). Idempotent. */
+  override def close(): Unit

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSqlConnector.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSqlConnector.scala
@@ -32,23 +32,34 @@ import wvlet.lang.compiler.query.QueryProgressMonitor
   * (JDBC on JVM, libduckdb on Native, koffi on JS) don't surface per-batch stats today, but the
   * monitor is reserved for the same role when they do.
   *
-  * Each `submit` invokes `DuckDB.execute(sql)`, which on JVM opens a fresh in-memory `jdbc:duckdb:`
-  * connection per call; in-memory tables don't persist across calls. The runner's JVM
-  * `DuckDBConnector` exposes a stateful `asSqlConnector` view over its long-lived connection for
-  * session-preserving execution; this cross-platform `SqlConnector` is the right tool for one-shot
-  * CLI queries against ephemeral DuckDB instances.
+  * Without a session, each `submit` invokes `DuckDB.execute(sql)`, which opens a fresh in-memory
+  * database per call — in-memory tables don't persist across calls; that mode is the right tool for
+  * one-shot CLI queries. Pass a [[DuckDBSession]] (from [[DuckDB.newSession]]) to run every
+  * statement on the same connection so temp tables, models, and multi-statement scripts work; the
+  * connector then owns the session and closes it in `close()`. The runner's JVM `DuckDBConnector`
+  * exposes an equivalent stateful `asSqlConnector` view over its long-lived JDBC connection.
   */
-class DuckDBSqlConnector extends SqlConnector:
+class DuckDBSqlConnector(session: Option[DuckDBSession] = None) extends SqlConnector:
 
   override def submit(sql: String)(using QueryProgressMonitor): QueryHandle =
-    val result = DuckDB.execute(sql)
+    val result =
+      session match
+        case Some(s) =>
+          s.execute(sql)
+        case None =>
+          DuckDB.execute(sql)
     DuckDBSqlConnector.completedHandle(result)
 
-  override def close(): Unit = ()
+  override def close(): Unit = session.foreach(_.close())
 
 end DuckDBSqlConnector
 
 object DuckDBSqlConnector:
+
+  /** A connector over a fresh persistent session (in-memory, or file-backed when `path` is set). */
+  def withNewSession(path: Option[String] = None): DuckDBSqlConnector = DuckDBSqlConnector(
+    Some(DuckDB.newSession(path))
+  )
 
   /**
     * Build a [[QueryHandle]] that wraps an already-materialized [[QueryResult]]. Used for backends

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSessionTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBSessionTest.scala
@@ -1,0 +1,104 @@
+package wvlet.lang.compiler.analyzer.duckdb
+
+import wvlet.lang.compiler.query.QueryProgressMonitor
+import wvlet.uni.test.UniTest
+
+/**
+  * Cross-platform tests for [[DuckDB.newSession]] — the persistent-connection counterpart to the
+  * one-shot `DuckDB.execute`. The same session semantics must hold on all three platforms (JDBC on
+  * JVM, koffi-FFI on JS, C API on Native): state created by one `execute` is visible to the next.
+  *
+  * Auto-skips on Scala.js if libduckdb isn't loadable. `DuckDB.canExecute` gates the run.
+  */
+class DuckDBSessionTest extends UniTest:
+
+  private def skipIfUnavailable(): Unit =
+    if !DuckDB.canExecute then
+      ignore("DuckDB.execute not yet wired on this platform")
+
+  test("session preserves tables across execute calls") {
+    skipIfUnavailable()
+    val session = DuckDB.newSession()
+    try
+      session.execute("create table t(id integer, msg varchar)")
+      session.execute("insert into t values (1, 'hello'), (2, 'session')")
+      val r = session.execute("select * from t order by id")
+      r.rowCount shouldBe 2
+      r.rows.map(_.values) shouldBe
+        List(List(Some("1"), Some("hello")), List(Some("2"), Some("session")))
+    finally
+      session.close()
+  }
+
+  test("separate sessions are isolated") {
+    skipIfUnavailable()
+    val s1 = DuckDB.newSession()
+    val s2 = DuckDB.newSession()
+    try
+      s1.execute("create table only_in_s1(id integer)")
+      val err = intercept[Exception] {
+        s2.execute("select * from only_in_s1")
+      }
+      err.getMessage shouldContain "only_in_s1"
+    finally
+      s1.close()
+      s2.close()
+  }
+
+  test("session rejects execute after close") {
+    skipIfUnavailable()
+    val session = DuckDB.newSession()
+    session.execute("select 1")
+    session.close()
+    // close() must be idempotent
+    session.close()
+    intercept[IllegalStateException] {
+      session.execute("select 1")
+    }
+  }
+
+  test("file-backed session persists data across sessions") {
+    skipIfUnavailable()
+    val path = s"target/duckdb-session-test-${System.currentTimeMillis()}.db"
+    val s1   = DuckDB.newSession(Some(path))
+    try
+      s1.execute("create table persisted(id integer)")
+      s1.execute("insert into persisted values (42)")
+    finally
+      s1.close()
+    val s2 = DuckDB.newSession(Some(path))
+    try
+      val r = s2.execute("select id from persisted")
+      r.rows.map(_.values.head) shouldBe List(Some("42"))
+    finally
+      s2.close()
+  }
+
+  test("session-backed DuckDBSqlConnector keeps state across submits") {
+    skipIfUnavailable()
+    given QueryProgressMonitor = QueryProgressMonitor.noOp
+    val connector              = DuckDBSqlConnector.withNewSession()
+    try
+      connector.execute("create table c(id integer)")
+      connector.execute("insert into c values (7)")
+      val r = connector.execute("select id from c")
+      r.rows.map(_.values.head) shouldBe List(Some("7"))
+    finally
+      connector.close()
+  }
+
+  test("sessionless DuckDBSqlConnector stays one-shot") {
+    skipIfUnavailable()
+    given QueryProgressMonitor = QueryProgressMonitor.noOp
+    val connector              = DuckDBSqlConnector()
+    try
+      connector.execute("create table gone(id integer)")
+      val err = intercept[Exception] {
+        connector.execute("select * from gone")
+      }
+      err.getMessage shouldContain "gone"
+    finally
+      connector.close()
+  }
+
+end DuckDBSessionTest


### PR DESCRIPTION
## Summary

Phase 1 of `plans/2026-08-22-cross-platform-runner.md`: a persistent DuckDB session API so repeated `execute` calls share one connection — the prerequisite for temp tables, models, and multi-statement scripts in the cross-platform runner.

- **`DuckDB.newSession(path)`** on all three platforms (in-memory by default, file-backed with a path):
  - JVM: one long-lived JDBC `DuckDBConnection`
  - Native: `duckdb_database`/`duckdb_connection` C-API handles held across calls
  - Node.js: koffi FFI handles held across calls
- **`DuckDBSqlConnector`** gains a session-backed mode (`DuckDBSqlConnector.withNewSession()` or pass a session); it owns and closes the session. The stateless one-shot mode stays the default.
- The per-call open/close bodies on JS and Native collapse into short-lived sessions, removing duplicated FFI setup.
- **Design revision** (review feedback): `wvlet-runner` will be converted to a `crossProject` with `.jvm/.js/.native` folders (CrossType.Pure, like `wvlet-lang`) instead of extracting a separate `wvlet-runner-core` module.

## Tests

New cross-platform `DuckDBSessionTest` (6 tests) passing on **JVM, Scala.js/Node, and Scala Native**: state persists across executes, session isolation, use-after-close rejection, file-backed persistence across sessions, session-backed vs one-shot connector behavior.

- `langJVM/testOnly *DuckDB*`: 22/22
- `langJS/testOnly *DuckDBSessionTest*`: 6/6 (with `WVLET_LIBDUCKDB`)
- `langNative/testOnly *DuckDBSessionTest*`: 6/6
- `runner/testOnly *DuckDBConnector*`: 8/8
- `projectJVM/JS/Native Test/compile` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49