### PR TITLE
feature: Complete the wvlet-server query API as a REST backend (cross-platform runner phase 4)

### DIFF
--- a/wvlet-api/src/main/scala/wvlet/lang/api/v1/frontend/FrontendApi.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/v1/frontend/FrontendApi.scala
@@ -42,11 +42,20 @@ trait FrontendApi:
     */
   def getQueryInfo(request: QueryInfoRequest): QueryInfo
 
+  /**
+    * Cancel a running (or queued) query. Best-effort: the terminal status transitions to CANCELED
+    * immediately and any later completion of the underlying statement is discarded. Cancelling an
+    * already-finished query is a no-op returning its final state.
+    */
+  def cancelQuery(request: QueryCancelRequest): QueryInfo
+
 object FrontendApi extends RxRouterProvider:
   override def router = RxRouter.of[FrontendApi]
 
   case class ServerStatus(version: String = BuildInfo.version, upTime: ElapsedTime)
 
   case class QueryInfoRequest(queryId: ULID, pageToken: String)
+
+  case class QueryCancelRequest(queryId: ULID)
 
   case class QueryResponse(queryId: ULID, requestId: ULID)

--- a/wvlet-client/src/main/scala/wvlet/lang/api/v1/frontend/client/FrontendApiClient.scala
+++ b/wvlet-client/src/main/scala/wvlet/lang/api/v1/frontend/client/FrontendApiClient.scala
@@ -14,7 +14,12 @@
 package wvlet.lang.api.v1.frontend.client
 
 import wvlet.lang.api.v1.frontend.FrontendApi
-import wvlet.lang.api.v1.frontend.FrontendApi.{QueryInfoRequest, QueryResponse, ServerStatus}
+import wvlet.lang.api.v1.frontend.FrontendApi.{
+  QueryCancelRequest,
+  QueryInfoRequest,
+  QueryResponse,
+  ServerStatus
+}
 import wvlet.lang.api.v1.query.{QueryInfo, QueryRequest}
 import wvlet.uni.http.*
 import wvlet.uni.http.rpc.RPCClient
@@ -25,6 +30,7 @@ import wvlet.uni.surface.Surface
   * Hand-written RPC client for [[FrontendApi]]. Mirrors the shape of
   * `wvlet.uni.http.codegen.client.RPCClientGenerator` output so it can be regenerated later by
   * uni's codegen without affecting consumers. Replaces the previous airframe-codegen'd FrontendRPC.
+  * Covers status/submitQuery/getQueryInfo/cancelQuery.
   */
 object FrontendApiClient:
   private val rpc = RPCClient.build(Surface.of[FrontendApi], Surface.methodsOf[FrontendApi])
@@ -43,6 +49,12 @@ object FrontendApiClient:
       Seq(request)
     )
 
+    def cancelQuery(request: QueryCancelRequest): QueryInfo = rpc.callSync(
+      client,
+      "cancelQuery",
+      Seq(request)
+    )
+
   end SyncClient
 
   class AsyncClient(client: HttpAsyncClient):
@@ -56,6 +68,12 @@ object FrontendApiClient:
     def getQueryInfo(request: QueryInfoRequest): Rx[QueryInfo] = rpc.callAsync(
       client,
       "getQueryInfo",
+      Seq(request)
+    )
+
+    def cancelQuery(request: QueryCancelRequest): Rx[QueryInfo] = rpc.callAsync(
+      client,
+      "cancelQuery",
       Seq(request)
     )
 

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
@@ -184,7 +184,9 @@ class WvletScriptRunner(
           .withQueryProgressMonitor(queryProgressMonitor)
 
         val queryResult = queryExecutor
-          .setRowLimit(resultRowLimits)
+          // A request-level maxRows (e.g. remote clients fetching structured results)
+          // overrides the runner's interactive row limit
+          .setRowLimit(request.maxRows.getOrElse(resultRowLimits))
           .executeSelectedStatement(newUnit, request.querySelection, request.linePosition, ctx)
         queryResult
       else

--- a/wvlet-server/src/main/scala/wvlet/lang/server/FrontendApiImpl.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/FrontendApiImpl.scala
@@ -25,4 +25,8 @@ class FrontendApiImpl(queryService: QueryService, workEnv: WorkEnv)
     debug(request)
     queryService.fetchNext(request)
 
+  override def cancelQuery(request: QueryCancelRequest): QueryInfo =
+    debug(request)
+    queryService.cancel(request.queryId)
+
 end FrontendApiImpl

--- a/wvlet-server/src/main/scala/wvlet/lang/server/QueryService.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/QueryService.scala
@@ -5,14 +5,18 @@ import wvlet.lang.api.StatusCode
 import wvlet.lang.api.WvletLangException
 import wvlet.lang.api.v1.frontend.FrontendApi.QueryInfoRequest
 import wvlet.lang.api.v1.frontend.FrontendApi.QueryResponse
+import wvlet.lang.api.v1.query.Column
 import wvlet.lang.api.v1.query.QueryError
 import wvlet.lang.api.v1.query.QueryInfo
 import wvlet.lang.api.v1.query.QueryRequest
-import wvlet.lang.api.v1.query.QueryResult
+import wvlet.lang.api.v1.query.QueryResult as ApiQueryResult
 import wvlet.lang.api.v1.query.QueryStatus
 import wvlet.lang.api.v1.query.QueryStatus.QUEUED
-import wvlet.lang.api.v1.query.QueryStatus.RUNNING
 import wvlet.lang.compiler.query.QueryProgressMonitor
+import wvlet.lang.runner.PlanResult
+import wvlet.lang.runner.QueryResult
+import wvlet.lang.runner.QueryResultList
+import wvlet.lang.runner.TableRows
 import wvlet.uni.log.LogSupport
 import wvlet.uni.util.ThreadUtil
 import wvlet.uni.util.ULID
@@ -28,7 +32,8 @@ class QueryService(sessions: ScriptRunnerSessions) extends LogSupport with AutoC
     ThreadUtil.newDaemonThreadFactory("wvlet-query-service")
   )
 
-  private val queryMap = ConcurrentHashMap[ULID, QueryInfo]().asScala
+  private val queryMap       = ConcurrentHashMap[ULID, QueryInfo]().asScala
+  private val runningQueries = ConcurrentHashMap[ULID, java.util.concurrent.Future[?]]().asScala
 
   override def close(): Unit =
     // Close the query service
@@ -45,10 +50,13 @@ class QueryService(sessions: ScriptRunnerSessions) extends LogSupport with AutoC
       createdAt = Instant.now()
     )
     queryMap += queryId -> firstQueryInfo
-    threadManager.submit(
+    val future = threadManager.submit(
       new Runnable:
-        override def run: Unit = runQuery(queryId, request)
+        override def run: Unit =
+          try runQuery(queryId, request)
+          finally runningQueries -= queryId
     )
+    runningQueries += queryId -> future
     QueryResponse(queryId = queryId, requestId = request.requestId)
 
   def fetchNext(request: QueryInfoRequest): QueryInfo =
@@ -60,31 +68,77 @@ class QueryService(sessions: ScriptRunnerSessions) extends LogSupport with AutoC
         throw StatusCode.INVALID_ARGUMENT.newException(s"Query not found: ${request.queryId}")
       }
 
+  /**
+    * Best-effort cancellation: the query's terminal status becomes CANCELED right away (later
+    * completion of the underlying statement is discarded by [[completeQuery]]'s guard) and the
+    * worker thread is interrupted. Cancelling an already-finished query returns its final state
+    * unchanged.
+    */
+  def cancel(queryId: ULID): QueryInfo =
+    val info = queryMap
+      .get(queryId)
+      .getOrElse {
+        throw StatusCode.INVALID_ARGUMENT.newException(s"Query not found: ${queryId}")
+      }
+    if info.status.isFinished then
+      info
+    else
+      val canceled = info.copy(
+        pageToken = "2",
+        status = QueryStatus.CANCELED,
+        completedAt = Some(Instant.now())
+      )
+      queryMap += queryId -> canceled
+      runningQueries.get(queryId).foreach(_.cancel(true))
+      canceled
+
+  /**
+    * Record the terminal state of a query unless it was already cancelled — a cancelled query's
+    * CANCELED status must survive the racing completion of its worker thread
+    */
+  private def completeQuery(queryId: ULID, f: QueryInfo => QueryInfo): Unit = queryMap
+    .get(queryId)
+    .foreach { current =>
+      if current.status != QueryStatus.CANCELED then
+        queryMap += queryId -> f(current)
+    }
+
   private def runQuery(queryId: ULID, request: QueryRequest)(using
       queryProgressMonitor: QueryProgressMonitor = QueryProgressMonitor.noOp
   ): Unit =
-    var lastInfo = queryMap(queryId)
-    lastInfo = lastInfo.copy(
-      pageToken = "1",
-      status = QueryStatus.RUNNING,
-      startedAt = Some(Instant.now())
+    // A query cancelled while still queued must not start (and the guarded transition keeps
+    // the CANCELED status from being overwritten by this RUNNING update)
+    if queryMap.get(queryId).exists(_.status == QueryStatus.CANCELED) then
+      return
+    completeQuery(
+      queryId,
+      _.copy(pageToken = "1", status = QueryStatus.RUNNING, startedAt = Some(Instant.now()))
     )
-    queryMap += queryId -> lastInfo
 
-    // Route the query to the runner owning the client's session, so `use` statements switch
-    // the engine/catalog only for that session
-    val queryResult = sessions.runnerFor(request.sessionId).runStatement(request)
+    // Route the query to the runner owning the client's session (and requested profile), so
+    // `use` statements switch the engine/catalog only for that session. Statements of ONE
+    // session are serialized on its runner: the compiler inside is not thread-safe, and two
+    // concurrent statements in the same session used to race it (queries of different
+    // sessions still run in parallel)
+    val runner      = sessions.runnerFor(request.sessionId, request.profile)
+    val queryResult = runner.synchronized {
+      runner.runStatement(request)
+    }
     if queryResult.isSuccess then
-      // TODO Support pagination
-      // TODO Return the query result
       val preview = queryResult.toPrettyBox()
-      queryMap += queryId ->
-        lastInfo.copy(
+      // The final tabular result (row count already bounded by the runner's row limit /
+      // request.maxRows); test and command outcomes have no tabular shape
+      val result = lastTableRows(queryResult).map(toApiResult)
+      completeQuery(
+        queryId,
+        _.copy(
           pageToken = "2",
           status = QueryStatus.FINISHED,
           completedAt = Some(Instant.now()),
+          result = result,
           preview = Some(preview)
         )
+      )
     else
       val errors: Seq[Throwable]        = queryResult.getAllErrors
       val errorReport: List[QueryError] =
@@ -102,16 +156,37 @@ class QueryService(sessions: ScriptRunnerSessions) extends LogSupport with AutoC
           }
           .toList
 
-      queryMap += queryId ->
-        lastInfo.copy(
+      completeQuery(
+        queryId,
+        _.copy(
           pageToken = "2",
           status = QueryStatus.FAILED,
           statusCode = errorReport.head.statusCode,
           completedAt = Some(Instant.now()),
           errors = errorReport
         )
+      )
     end if
 
   end runQuery
+
+  private def lastTableRows(r: QueryResult): Option[TableRows] =
+    r match
+      case t: TableRows =>
+        Some(t)
+      case l: QueryResultList =>
+        l.list.reverseIterator.flatMap(x => lastTableRows(x)).nextOption()
+      case p: PlanResult =>
+        lastTableRows(p.result)
+      case _ =>
+        None
+
+  private def toApiResult(t: TableRows): ApiQueryResult =
+    val fields = t.schema.fields
+    ApiQueryResult(
+      schema = fields.map(f => Column(f.name.name, f.dataType.typeDescription)).toSeq,
+      rows = t.rows.map(row => fields.map(f => row.getOrElse(f.name.name, null)).toSeq).toSeq,
+      actualTotalRows = Some(t.totalRows)
+    )
 
 end QueryService

--- a/wvlet-server/src/main/scala/wvlet/lang/server/ScriptRunnerSessions.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/ScriptRunnerSessions.scala
@@ -13,6 +13,8 @@
  */
 package wvlet.lang.server
 
+import wvlet.lang.api.StatusCode
+import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.runner.QueryExecutor
 import wvlet.lang.runner.ThreadManager
@@ -59,11 +61,24 @@ class ScriptRunnerSessions(
 
   /**
     * The runner of the given session, creating it on first use. Requests without a session id share
-    * the default session
+    * the default session. A request naming a profile other than the server's default gets a runner
+    * bound to that profile, isolated under a profile-qualified session key.
     */
-  def runnerFor(sessionId: Option[String]): WvletScriptRunner =
+  def runnerFor(sessionId: Option[String], profileName: Option[String] = None): WvletScriptRunner =
     evictIdleSessions()
-    val key = sessionId.getOrElse(ScriptRunnerSessions.DefaultSessionKey)
+    val requestedProfile = profileName.filter(_ != config.profile.name)
+    val profile          =
+      requestedProfile match
+        case None =>
+          config.profile
+        case Some(name) =>
+          Profile
+            .getProfile(name)
+            .getOrElse {
+              throw StatusCode.INVALID_ARGUMENT.newException(s"Unknown profile: ${name}")
+            }
+    val baseKey = sessionId.getOrElse(ScriptRunnerSessions.DefaultSessionKey)
+    val key     = requestedProfile.map(p => s"${baseKey}@${p}").getOrElse(baseKey)
     // Create-or-touch atomically: compute and the eviction's computeIfPresent serialize on the
     // same key, so an entry can never be touched after eviction closed it
     val entry = sessions.compute(
@@ -71,7 +86,7 @@ class ScriptRunnerSessions(
       (k, existing) =>
         if existing == null then
           debug(s"Creating a new script-runner session: ${k}")
-          Entry(newRunner())
+          Entry(newRunner(profile))
         else
           existing.touch()
           existing
@@ -81,14 +96,26 @@ class ScriptRunnerSessions(
   /** The number of live sessions (for monitoring and tests) */
   def sessionCount: Int = sessions.size()
 
-  private def newRunner(): WvletScriptRunner = WvletScriptRunner(
-    workEnv,
-    // Session runners are created on demand by the first request, so a background source
-    // pre-compilation would race that request's own compilation within one compiler
-    config.copy(precompileSourcePaths = false),
-    QueryExecutor(connectorProvider, config.profile, workEnv),
-    threadManager
-  )
+  private def newRunner(profile: Profile): WvletScriptRunner =
+    val sessionConfig =
+      if profile eq config.profile then
+        // Session runners are created on demand by the first request, so a background source
+        // pre-compilation would race that request's own compilation within one compiler
+        config.copy(precompileSourcePaths = false)
+      else
+        // A request-selected profile also drives the runner's default catalog/schema
+        config.copy(
+          precompileSourcePaths = false,
+          profile = profile,
+          catalog = profile.defaultEngine.catalog,
+          schema = profile.defaultEngine.schema
+        )
+    WvletScriptRunner(
+      workEnv,
+      sessionConfig,
+      QueryExecutor(connectorProvider, profile, workEnv),
+      threadManager
+    )
 
   private def evictIdleSessions(): Unit =
     val cutoff = System.currentTimeMillis() - idleTimeout.toMillis

--- a/wvlet-server/src/test/scala/wvlet/lang/server/QueryInfoWeaverTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/QueryInfoWeaverTest.scala
@@ -1,0 +1,50 @@
+package wvlet.lang.server
+
+import wvlet.uni.test.UniTest
+import wvlet.uni.weaver.Weaver
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.v1.query.{QueryResult as ApiQueryResult, Column, QueryInfo, QueryStatus}
+import wvlet.uni.util.ULID
+import java.time.Instant
+
+/**
+  * Guards the Weaver round-trip of the structured query result: `QueryInfo.result.rows` is
+  * `Seq[Seq[Any]]`, which must survive JSON encode/decode (via uni's AnyWeaver) for RPC clients to
+  * receive rows (#1963 phase 4)
+  */
+class QueryInfoWeaverTest extends UniTest:
+  test("weave ApiQueryResult with Any rows") {
+    val r = ApiQueryResult(
+      schema = Seq(Column("x", "int"), Column("s", "string")),
+      rows = Seq(Seq(1, "hello"), Seq(2, null)),
+      actualTotalRows = Some(2)
+    )
+    val codec = Weaver.of[ApiQueryResult]
+    val back  = codec.fromJson(codec.toJson(r))
+    back.rows.size shouldBe 2
+    back.rows.head.map(v => Option(v).map(_.toString).orNull) shouldBe List("1", "hello")
+    back.rows(1)(1) shouldBe null
+  }
+
+  test("weave QueryInfo with a structured result") {
+    val q = QueryInfo(
+      queryId = ULID.newULID,
+      pageToken = "2",
+      status = QueryStatus.FINISHED,
+      statusCode = StatusCode.OK,
+      createdAt = Instant.now(),
+      result = Some(
+        ApiQueryResult(
+          schema = Seq(Column("x", "int")),
+          rows = Seq(Seq(42)),
+          actualTotalRows = Some(1)
+        )
+      )
+    )
+    val codec = Weaver.of[QueryInfo]
+    val back  = codec.fromJson(codec.toJson(q))
+    back.result.isDefined shouldBe true
+    back.result.get.rows.head.head.toString shouldBe "42"
+  }
+
+end QueryInfoWeaverTest

--- a/wvlet-server/src/test/scala/wvlet/lang/server/QueryServiceTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/QueryServiceTest.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.server
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
+import wvlet.lang.api.v1.frontend.FrontendApi.QueryInfoRequest
+import wvlet.lang.api.v1.query.QueryInfo
+import wvlet.lang.api.v1.query.QueryRequest
+import wvlet.lang.api.v1.query.QueryStatus
+import wvlet.lang.catalog.ConnectorConfig
+import wvlet.lang.catalog.Profile
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.runner.ThreadManager
+import wvlet.lang.runner.WvletScriptRunnerConfig
+import wvlet.lang.runner.connector.ConnectorProvider
+import wvlet.uni.test.UniTest
+import wvlet.uni.util.ULID
+
+/**
+  * Query lifecycle over [[QueryService]]: structured results with row limits, and best-effort
+  * cancellation with its status guard (#1963 phase 4)
+  */
+class QueryServiceTest extends UniTest:
+
+  private val workDir = new java.io.File("target/query-service-test")
+  workDir.mkdirs()
+  private val workEnv = WorkEnv(path = workDir.getPath)
+
+  private val engine = ConnectorConfig(
+    name = "duckdb",
+    `type` = "duckdb",
+    default = true,
+    catalog = Some("memory"),
+    schema = Some("main")
+  )
+
+  private val profile = Profile(name = "test", connectors = Seq(engine))
+
+  private val provider      = ConnectorProvider(workEnv)
+  private val threadManager = ThreadManager()
+  private val sessions      = ScriptRunnerSessions(
+    workEnv,
+    WvletScriptRunnerConfig(
+      interactive = false,
+      profile = profile,
+      catalog = engine.catalog,
+      schema = engine.schema
+    ),
+    provider,
+    threadManager,
+    ScriptRunnerSessions.DefaultIdleTimeout
+  )
+
+  private val service = QueryService(sessions)
+
+  override def afterAll: Unit =
+    service.close()
+    sessions.close()
+    threadManager.close()
+    provider.close()
+
+  private def awaitCompletion(queryId: ULID, timeoutMillis: Long = 30000): QueryInfo =
+    val deadline = System.currentTimeMillis() + timeoutMillis
+    var info     = service.fetchNext(QueryInfoRequest(queryId, pageToken = "0"))
+    while !info.status.isFinished && System.currentTimeMillis() < deadline do
+      Thread.sleep(50)
+      info = service.fetchNext(QueryInfoRequest(queryId, pageToken = info.pageToken))
+    info.status.isFinished shouldBe true
+    info
+
+  test("return structured rows along with the preview") {
+    val response = service.enqueue(QueryRequest(query = "select 1 as x, 'hello' as s"))
+    val info     = awaitCompletion(response.queryId)
+    info.status shouldBe QueryStatus.FINISHED
+    info.preview.isDefined shouldBe true
+    val result = info.result.getOrElse(fail("result was not populated"))
+    result.schema.map(_.name) shouldBe List("x", "s")
+    result.rows.size shouldBe 1
+    result.rows.head.map(v => Option(v).map(_.toString).orNull) shouldBe List("1", "hello")
+  }
+
+  test("bound structured rows by request.maxRows and report the total") {
+    val response = service.enqueue(
+      QueryRequest(
+        query = "from [[1], [2], [3], [4], [5]] as t(a) select a order by a",
+        maxRows = Some(2)
+      )
+    )
+    val info   = awaitCompletion(response.queryId)
+    val result = info.result.getOrElse(fail("result was not populated"))
+    result.rows.size shouldBe 2
+    result.actualTotalRows shouldBe Some(5)
+  }
+
+  test("report failures with error details and no result") {
+    val response = service.enqueue(QueryRequest(query = "from table_that_does_not_exist_xyz"))
+    val info     = awaitCompletion(response.queryId)
+    info.status shouldBe QueryStatus.FAILED
+    info.errors.nonEmpty shouldBe true
+    info.result shouldBe None
+  }
+
+  test("reject cancellation of an unknown query") {
+    intercept[WvletLangException] {
+      service.cancel(ULID.newULID)
+    }.statusCode shouldBe StatusCode.INVALID_ARGUMENT
+  }
+
+  test("keep the final state when cancelling an already-finished query") {
+    val response = service.enqueue(QueryRequest(query = "select 1"))
+    awaitCompletion(response.queryId)
+    val info = service.cancel(response.queryId)
+    info.status shouldBe QueryStatus.FINISHED
+  }
+
+  test("cancellation is terminal — a racing completion never overwrites it") {
+    // A fresh session id forces runner creation + first compilation, so the query is still in
+    // flight when cancel lands; if it happens to finish first, cancel reports FINISHED instead.
+    // Either way the state cancel returned must be the state that sticks.
+    val response = service.enqueue(
+      QueryRequest(query = "select 42", sessionId = Some(s"cancel-${ULID.newULIDString}"))
+    )
+    val onCancel = service.cancel(response.queryId)
+    Thread.sleep(2000) // let the worker thread run to completion
+    val finalInfo = service.fetchNext(QueryInfoRequest(response.queryId, pageToken = "2"))
+    finalInfo.status shouldBe onCancel.status
+    if onCancel.status == QueryStatus.CANCELED then
+      finalInfo.result shouldBe None
+  }
+
+end QueryServiceTest

--- a/wvlet-server/src/test/scala/wvlet/lang/server/UlidRpcRoundTripTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/UlidRpcRoundTripTest.scala
@@ -1,6 +1,9 @@
 package wvlet.lang.server
 
+import wvlet.lang.api.v1.frontend.FrontendApi.QueryCancelRequest
+import wvlet.lang.api.v1.frontend.FrontendApi.QueryInfoRequest
 import wvlet.lang.api.v1.frontend.FrontendRPC
+import wvlet.lang.api.v1.query.QueryInfo
 import wvlet.lang.api.v1.query.QueryRequest
 import wvlet.lang.test.WvletDITest
 import wvlet.uni.util.ULID
@@ -25,6 +28,37 @@ class UlidRpcRoundTripTest extends WvletDITest:
 
     response.requestId shouldBe request.requestId
     ULID.isValid(response.queryId.toString) shouldBe true
+  }
+
+  test("getQueryInfo serves structured result rows over RPC") {
+    val client   = dep[FrontendRPC.RPCSyncClient]
+    val response = client
+      .FrontendApi
+      .submitQuery(QueryRequest(query = "select 42 as answer, 'rpc' as via"))
+
+    val deadline        = System.currentTimeMillis() + 30000
+    var info: QueryInfo = client
+      .FrontendApi
+      .getQueryInfo(QueryInfoRequest(response.queryId, pageToken = "0"))
+    while !info.status.isFinished && System.currentTimeMillis() < deadline do
+      Thread.sleep(50)
+      info = client
+        .FrontendApi
+        .getQueryInfo(QueryInfoRequest(response.queryId, pageToken = info.pageToken))
+    info.status.isFailed shouldBe false
+
+    // The Seq[Seq[Any]] rows must survive the Weaver round-trip over the wire
+    val result = info.result.getOrElse(throw new AssertionError("result was not populated"))
+    result.schema.map(_.name) shouldBe List("answer", "via")
+    result.rows.size shouldBe 1
+    result.rows.head.map(v => Option(v).map(_.toString).orNull) shouldBe List("42", "rpc")
+  }
+
+  test("cancelQuery is exposed over RPC") {
+    val client   = dep[FrontendRPC.RPCSyncClient]
+    val response = client.FrontendApi.submitQuery(QueryRequest(query = "select 1"))
+    val info     = client.FrontendApi.cancelQuery(QueryCancelRequest(response.queryId))
+    info.status.isFinished shouldBe true
   }
 
 end UlidRpcRoundTripTest


### PR DESCRIPTION
## Summary

Phase 4 of `plans/2026-08-22-cross-platform-runner.md`: make the wvlet-server RPC surface usable as a query backend for remote clients (prerequisite for the `WvletServerSqlConnector` in phase 5).

- **Structured results**: `getQueryInfo` now populates `QueryInfo.result` (schema + rows + actual total) alongside the pretty-box preview. `QueryRequest.maxRows` overrides the runner's interactive row limit, so remote clients control result size.
- **`FrontendApi.cancelQuery`** (new endpoint + hand-written RPC client methods): best-effort cancellation. The CANCELED status is terminal — guarded state transitions ensure a racing worker-thread completion never overwrites it, and a query cancelled while queued never starts.
- **`QueryRequest.profile` honored**: a request naming a profile other than the server default gets a runner bound to that profile under a profile-qualified session key (previously the field was silently ignored).
- **Per-session statement serialization**: the compiler inside a session runner is not thread-safe; two concurrent statements in one session raced it and intermittently produced empty results (reproduced via the RPC round-trip test). Statements now serialize per runner; different sessions still run in parallel.

## Tests

- New `QueryServiceTest` (6): structured rows + preview, maxRows bounding with actual totals, failure reporting, cancel of unknown/finished queries, and the cancel-vs-completion race guard.
- New `QueryInfoWeaverTest`: guards the `Seq[Seq[Any]]` rows' Weaver JSON round-trip (uni AnyWeaver) that RPC transport relies on.
- `UlidRpcRoundTripTest` extended: structured rows and cancelQuery exercised over real RPC (Netty server + uni HTTP client).
- `server/test`: 18/18; `projectJVM/JS/Native Test/compile` green.

## Notes

- Dev gotcha (repo-known pattern): `RPCRouter.of`/`Surface.methodsOf` macro expansions are not re-expanded by incremental compilation when only the RPC trait changes — a stale server expansion made `cancelQuery` invisible until `server/clean`. Same class of issue as the documented `Launcher.of` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49