### PR TITLE
feature: Trino password and bearer-token authentication (cross-platform runner phase 6)

### DIFF
--- a/website/docs/usage/trino.md
+++ b/website/docs/usage/trino.md
@@ -33,6 +33,37 @@ $ wv --profile trino
 wv>
 ```
 
+## Authentication
+
+Two authentication methods are supported. Values support `${ENV_VAR}` interpolation, so secrets can stay out of `profiles.json`:
+
+- **Password (basic auth)** — set `"password"` on the connector. Requires `"useHttps": true`; Trino coordinators reject password credentials over insecure connections.
+- **Bearer token (JWT / OAuth2)** — set a `"token"` property. Takes the place of a password (setting both is rejected).
+
+```jsonc title='~/.wvlet/profiles.json'
+{
+  "profiles": [
+    {
+      "name": "trino-jwt",
+      "connectors": [
+        {
+          "name": "trino",
+          "type": "trino",
+          "host": "trino.example.com",
+          "useHttps": true,
+          "catalog": "hive",
+          "schema": "default",
+          "properties": {
+            "token": "${TRINO_ACCESS_TOKEN}"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+The `Authorization` header is sent on every request of the query lifecycle (initial submission, result pagination, and cancellation), so gateways that authenticate each request work out of the box.
 
 ## Connecting to Trino at Treasure Data 
 

--- a/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
+++ b/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
@@ -59,6 +59,9 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
       name = backend,
       `type` = backend,
       user = opt.user.orElse(engine.flatMap(_.user)),
+      // Credentials come from the profile only (with ${ENV} interpolation) — never CLI flags
+      password = engine.flatMap(_.password),
+      properties = engine.map(_.properties).getOrElse(Map.empty),
       host = opt.host.orElse(engine.flatMap(_.host)),
       port = opt.port.orElse(engine.flatMap(_.port)),
       catalog = opt.catalog.orElse(engine.flatMap(_.catalog)),

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/analyzer/trino/TrinoTest.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/analyzer/trino/TrinoTest.scala
@@ -84,6 +84,34 @@ class TrinoTest extends UniTest:
     }
   }
 
+  test("send the bearer token on the initial POST and every follow-up GET") {
+    val page1 =
+      """{
+      |  "id": "q9",
+      |  "columns": [{"name": "x", "type": "integer"}],
+      |  "data": [[1]],
+      |  "nextUri": "__SERVER__/v1/statement/q9/2",
+      |  "stats": {"state": "RUNNING"}
+      |}""".stripMargin
+    val page2 =
+      """{
+      |  "id": "q9",
+      |  "data": [[2]],
+      |  "stats": {"state": "FINISHED"}
+      |}""".stripMargin
+    withFakeTrino(Seq(page1, page2)) { (port, calls) =>
+      val cfg = TrinoConfig(host = "localhost", port = port, user = "u").withToken("jwt-xyz")
+      val r   = Trino.execute("select x from t", cfg)
+      r.rows.map(_.values.head) shouldBe List(Some("1"), Some("2"))
+      val recorded = calls()
+      recorded.map(_.method) shouldBe List("POST", "GET")
+      // Gateways authenticate every request, so the token must ride follow-up GETs too
+      recorded.foreach { r =>
+        r.headers.get("authorization") shouldBe Some("Bearer jwt-xyz")
+      }
+    }
+  }
+
   test("execute falls back to any for compound / unknown column types") {
     val body =
       """{

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/trino/Trino.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/trino/Trino.scala
@@ -93,7 +93,40 @@ object Trino extends LogSupport:
   private[trino] def withTrinoHeaders(req: Request, config: TrinoConfig): Request =
     val base = req.setHeader("X-Trino-User", config.user).setHeader("X-Trino-Source", config.source)
     val withCatalog = config.catalog.foldLeft(base)((r, c) => r.setHeader("X-Trino-Catalog", c))
-    config.schema.foldLeft(withCatalog)((r, s) => r.setHeader("X-Trino-Schema", s))
+    val withSchema = config.schema.foldLeft(withCatalog)((r, s) => r.setHeader("X-Trino-Schema", s))
+    authorizationHeader(config).foldLeft(withSchema)((r, v) => r.setHeader("Authorization", v))
+
+  /**
+    * The `Authorization` header for the configured credentials: `Bearer <token>` for token auth,
+    * `Basic <base64(user:password)>` for password auth. Password credentials require HTTPS — Trino
+    * coordinators reject them over insecure connections, so failing here gives a clearer error than
+    * the server's would. Setting both is ambiguous and rejected.
+    */
+  private[trino] def authorizationHeader(config: TrinoConfig): Option[String] =
+    (config.token, config.password) match
+      case (Some(_), Some(_)) =>
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(
+            "Trino auth accepts either a bearer token or a password, not both — unset one"
+          )
+      case (Some(token), None) =>
+        Some(s"Bearer ${token}")
+      case (None, Some(password)) =>
+        if !config.useHttps then
+          throw StatusCode
+            .INVALID_ARGUMENT
+            .newException(
+              "Trino password authentication requires HTTPS — set useHttps on the connection"
+            )
+        val credential = java
+          .util
+          .Base64
+          .getEncoder
+          .encodeToString(s"${config.user}:${password}".getBytes("UTF-8"))
+        Some(s"Basic ${credential}")
+      case (None, None) =>
+        None
 
   /**
     * Send `req` and surface non-2xx responses as exceptions. `HttpSyncClient` already throws on

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/trino/TrinoConfig.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/trino/TrinoConfig.scala
@@ -13,7 +13,12 @@ case class TrinoConfig(
     catalog: Option[String] = None,
     schema: Option[String] = None,
     useHttps: Boolean = false,
-    source: String = "wvlet"
+    source: String = "wvlet",
+    // Basic authentication (user + password). Requires useHttps — Trino coordinators reject
+    // password credentials over insecure connections
+    password: Option[String] = None,
+    // Bearer-token authentication (JWT / OAuth2 access token). Mutually exclusive with password
+    token: Option[String] = None
 ):
   def withHost(host: String): TrinoConfig            = copy(host = host)
   def withPort(port: Int): TrinoConfig               = copy(port = port)
@@ -24,6 +29,10 @@ case class TrinoConfig(
   def noSchema(): TrinoConfig                        = copy(schema = None)
   def withHttps(enable: Boolean = true): TrinoConfig = copy(useHttps = enable)
   def withSource(source: String): TrinoConfig        = copy(source = source)
+  def withPassword(password: String): TrinoConfig    = copy(password = Some(password))
+  def noPassword(): TrinoConfig                      = copy(password = None)
+  def withToken(token: String): TrinoConfig          = copy(token = Some(token))
+  def noToken(): TrinoConfig                         = copy(token = None)
 
   def baseUri: String =
     val scheme =

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/trino/TrinoAuthTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/trino/TrinoAuthTest.scala
@@ -1,0 +1,43 @@
+package wvlet.lang.compiler.analyzer.trino
+
+import wvlet.lang.api.WvletLangException
+import wvlet.uni.test.UniTest
+
+/**
+  * Cross-platform tests for the Trino `Authorization` header: bearer tokens, HTTPS-gated basic
+  * auth, and the token/password exclusivity rule. Pure header construction — no server needed, so
+  * the same behavior is verified on JVM, JS, and Native.
+  */
+class TrinoAuthTest extends UniTest:
+
+  private val base = TrinoConfig(host = "localhost", user = "alice")
+
+  test("send no Authorization header without credentials") {
+    Trino.authorizationHeader(base) shouldBe None
+  }
+
+  test("send a bearer token as Authorization: Bearer") {
+    Trino.authorizationHeader(base.withToken("jwt-abc")) shouldBe Some("Bearer jwt-abc")
+  }
+
+  test("encode password auth as Authorization: Basic over HTTPS") {
+    val header = Trino.authorizationHeader(base.withHttps().withPassword("secret"))
+    // base64("alice:secret")
+    header shouldBe Some("Basic YWxpY2U6c2VjcmV0")
+  }
+
+  test("reject password auth over insecure connections") {
+    val err = intercept[WvletLangException] {
+      Trino.authorizationHeader(base.withPassword("secret"))
+    }
+    err.getMessage shouldContain "HTTPS"
+  }
+
+  test("reject setting both token and password") {
+    val err = intercept[WvletLangException] {
+      Trino.authorizationHeader(base.withHttps().withPassword("secret").withToken("jwt"))
+    }
+    err.getMessage shouldContain "not both"
+  }
+
+end TrinoAuthTest

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/SqlConnectorProvider.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/SqlConnectorProvider.scala
@@ -90,7 +90,12 @@ class SqlConnectorProvider(profile: Profile = Profile.defaultDuckDBProfile)
             user = config.user.getOrElse("wvlet"),
             catalog = config.catalog,
             schema = config.schema,
-            useHttps = useHttps
+            useHttps = useHttps,
+            // Basic auth from the standard password field; bearer tokens (JWT / OAuth2) from
+            // the `token` property. Profile values support ${ENV} interpolation, so secrets
+            // stay out of profiles.json itself
+            password = config.password,
+            token = config.properties.get("token").map(_.toString)
           )
         )
       case other =>


### PR DESCRIPTION
## Summary

Phase 6 of `plans/2026-08-22-cross-platform-runner.md`: the cross-platform Trino client previously sent only `X-Trino-User`, so authenticated production coordinators were unreachable from any platform.

- **`TrinoConfig.password`** — basic auth (`Authorization: Basic base64(user:password)`). Requires `useHttps`; rejected client-side with a clear error otherwise (Trino coordinators refuse password credentials over insecure connections anyway).
- **`TrinoConfig.token`** — bearer token (JWT / OAuth2). Mutually exclusive with password; setting both is rejected as ambiguous.
- The `Authorization` header rides **every request** of the query lifecycle — initial `POST /v1/statement`, pagination `GET`s, and the cancellation `DELETE` — matching the existing per-request `X-Trino-*` header behavior gateways rely on.
- Profiles feed credentials via the standard `password` field and a `token` property (both `${ENV}`-interpolated); `SqlConnectorProvider` and the cross-platform CLI thread them through. Credentials never come from CLI flags.
- User docs: new Authentication section in `website/docs/usage/trino.md`.

## Tests

- New cross-platform `TrinoAuthTest` (5 tests — header construction, HTTPS gating, exclusivity) passing on **JVM, Scala.js, and Scala Native**.
- `TrinoTest` fake-coordinator suite extended: the bearer token is asserted on the initial POST and every follow-up GET (14/14).
- `projectJVM/JS/Native Test/compile` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49