### PR TITLE
feature: Remote wvlet-server execution backend for thin clients (cross-platform runner phase 5)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,6 +120,7 @@ lazy val jsProjects: Seq[ProjectReference] = Seq(
 
 lazy val nativeProjects: Seq[ProjectReference] = Seq(
   api.native,
+  client.native,
   lang.native,
   runner.native,
   cliCore.native,
@@ -499,7 +500,8 @@ lazy val runner = crossProject(JVMPlatform, JSPlatform, NativePlatform)
         //        ) cross (CrossVersion.for3Use2_13)
       )
   )
-  .dependsOn(lang)
+  // `client` provides the RPC client for the remote wvlet-server backend (WvletServerClient)
+  .dependsOn(lang, client)
   .jvmConfigure(_.dependsOn(connector, testUtil % Test))
 
 lazy val spec = project
@@ -621,12 +623,15 @@ lazy val server = project
   )
   .dependsOn(api.jvm, client.jvm, runner.jvm, httpServer, testUtil % Test)
 
-// Hand-written uni-RPC clients live in wvlet-client/{shared,jvm,js}/src/main/scala. The
-// FrontendRPC shim aggregates the per-service clients so consumers see a single surface.
-lazy val client = crossProject(JVMPlatform, JSPlatform)
+// Hand-written uni-RPC clients live in wvlet-client/src/main/scala. The FrontendRPC shim
+// aggregates the per-service clients so consumers see a single surface. Cross-builds for all
+// three platforms so the runner's remote wvlet-server backend works from wvc and the Node CLI.
+lazy val client = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
   .in(file("wvlet-client"))
   .settings(buildSettings)
   .jsSettings(libraryDependencies += scalajsJavaSecureRandom)
+  .nativeSettings(uniNativeCurlLinking)
   .dependsOn(api)
 
 import org.scalajs.linker.interface.OutputPatterns

--- a/plans/2026-08-22-cross-platform-runner.md
+++ b/plans/2026-08-22-cross-platform-runner.md
@@ -209,10 +209,15 @@ Server side:
 Client side:
 4. Add `NativePlatform` to the `wvlet-client` crossProject — it depends only on
    `wvlet-api` + uni RPC, both of which already cross-build to Native.
-5. New `WvletServerSqlConnector extends SqlConnector` in shared runner sources: `submit` →
-   `FrontendApi.submitQuery`, `await` → poll `getQueryInfo` + drain pages, `cancel` →
-   `cancelQuery`. Registered as connector `type: "wvlet"` with
-   `host`/`port`/`useHttps` from `ConnectorConfig`.
+5. New `WvletServerClient` in shared runner sources: submit → poll `getQueryInfo` →
+   adapt the structured result; cancel → `cancelQuery`. `-t wvlet` on the CLI
+   sends the **original wvlet text** and skips local compilation entirely.
+   > **Revision (phase-5 implementation):** not a `SqlConnector`. Wrapping the
+   > server in `SqlConnector.submit(sql)` and routing through `PlanExecutor`
+   > would compile locally, generate SQL, and have the server re-compile that
+   > text — double compilation with mismatched contexts. The server owns the
+   > compilation (its profiles, catalogs, credentials), so the client stays a
+   > raw-text remote runner with one server session per client instance.
 
 This gives thin native/Node clients a REST path to every engine the JVM server
 supports (including Snowflake JDBC and multi-connector staging) without porting any

--- a/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
+++ b/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
@@ -37,7 +37,9 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
   @command(description = "Convert SQL to wvlet flow-style query")
   def to_wvlet(opt: WvletCliCompileOption): Unit = println(WvletCliCompiler(opt).generateWvlet)
 
-  @command(description = "Compile and execute a wvlet query against DuckDB, Trino, or a remote wvlet server")
+  @command(description =
+    "Compile and execute a wvlet query against DuckDB, Trino, or a remote wvlet server"
+  )
   def run(opt: WvletCliRunOption): Unit =
     val result = executeAgainst(opt)
     val output =
@@ -162,10 +164,8 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
       // The server resolves this name in ITS profiles.json; unset runs on the server default
       profile = engine.flatMap(_.properties.get("remoteProfile")).map(_.toString)
     )
-    try
-      client.runQuery(query)
-    finally
-      client.close()
+    try client.runQuery(query)
+    finally client.close()
 
   end executeOnRemoteServer
 
@@ -217,7 +217,10 @@ case class WvletCliRunOption(
     query: Option[String] = None,
     @option(prefix = "-p,--profile", description = "Profile name from ~/.wvlet/profiles.json")
     profile: Option[String] = None,
-    @option(prefix = "-t,--target", description = "Backend: duckdb (default), trino, or wvlet (remote server)")
+    @option(
+      prefix = "-t,--target",
+      description = "Backend: duckdb (default), trino, or wvlet (remote server)"
+    )
     targetDBType: Option[String] = None,
     @option(prefix = "--format", description = "Output format: box (default), csv")
     format: String = "box",

--- a/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
+++ b/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
@@ -13,6 +13,7 @@ import wvlet.lang.runner.QueryResult
 import wvlet.lang.runner.QueryResultList
 import wvlet.lang.runner.TableRows
 import wvlet.lang.runner.connector.SqlConnectorProvider
+import wvlet.lang.runner.connector.WvletServerClient
 import wvlet.uni.cli.launcher.argument
 import wvlet.uni.cli.launcher.command
 import wvlet.uni.cli.launcher.option
@@ -36,7 +37,7 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
   @command(description = "Convert SQL to wvlet flow-style query")
   def to_wvlet(opt: WvletCliCompileOption): Unit = println(WvletCliCompiler(opt).generateWvlet)
 
-  @command(description = "Compile and execute a wvlet query against DuckDB or Trino")
+  @command(description = "Compile and execute a wvlet query against DuckDB, Trino, or a remote wvlet server")
   def run(opt: WvletCliRunOption): Unit =
     val result = executeAgainst(opt)
     val output =
@@ -61,6 +62,10 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
       .orElse(engine.map(_.`type`))
       .map(_.toLowerCase)
       .getOrElse("duckdb")
+    if backend == "wvlet" then
+      // Remote execution: the server compiles and runs the ORIGINAL wvlet text with its own
+      // profile, catalogs, and credentials — no local engine or compilation involved
+      return executeOnRemoteServer(opt, engine)
     // CLI flags override the matching profile field. `--https` (a Boolean flag) can't
     // distinguish "user passed false" from "user didn't pass it", so the profile setting only
     // applies when the flag was left at the default `false`.
@@ -108,6 +113,58 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
       provider.close()
 
   end executeAgainst
+
+  private def executeOnRemoteServer(
+      opt: WvletCliRunOption,
+      engine: Option[ConnectorConfig]
+  ): QueryResult =
+    val host = opt
+      .host
+      .orElse(engine.flatMap(_.host))
+      .getOrElse(
+        throw new IllegalArgumentException(
+          "wvlet server host is required — pass --host or set 'host' on the profile"
+        )
+      )
+    val useHttps =
+      if opt.useHttps then
+        true
+      else
+        engine.flatMap(_.useHttps).getOrElse(false)
+    val port = opt
+      .port
+      .orElse(engine.flatMap(_.port))
+      .getOrElse(
+        if useHttps then
+          443
+        else
+          // The wvlet server's default port
+          9090
+      )
+    val scheme =
+      if useHttps then
+        "https"
+      else
+        "http"
+    val query =
+      (opt.file, opt.query) match
+        case (Some(f), None) =>
+          wvlet.lang.compiler.SourceIO.readAsString(s"${opt.workFolder}/${f}".stripPrefix("./"))
+        case (None, Some(q)) =>
+          q
+        case _ =>
+          throw new IllegalArgumentException("Specify either --file or a query argument")
+    val client = WvletServerClient(
+      baseUri = s"${scheme}://${host}:${port}",
+      // The server resolves this name in ITS profiles.json; unset runs on the server default
+      profile = engine.flatMap(_.properties.get("remoteProfile")).map(_.toString)
+    )
+    try
+      client.runQuery(query)
+    finally
+      client.close()
+
+  end executeOnRemoteServer
 
   private def lastTableRows(r: QueryResult): Option[TableRows] =
     r match
@@ -157,7 +214,7 @@ case class WvletCliRunOption(
     query: Option[String] = None,
     @option(prefix = "-p,--profile", description = "Profile name from ~/.wvlet/profiles.json")
     profile: Option[String] = None,
-    @option(prefix = "-t,--target", description = "Backend: duckdb (default) or trino")
+    @option(prefix = "-t,--target", description = "Backend: duckdb (default), trino, or wvlet (remote server)")
     targetDBType: Option[String] = None,
     @option(prefix = "--format", description = "Output format: box (default), csv")
     format: String = "box",

--- a/wvlet-runner/.js/src/main/scala/wvlet/lang/runner/compat/SleepCompatImpl.scala
+++ b/wvlet-runner/.js/src/main/scala/wvlet/lang/runner/compat/SleepCompatImpl.scala
@@ -1,0 +1,20 @@
+package wvlet.lang.runner.compat
+
+import scala.scalajs.js
+
+private[runner] trait SleepCompatImpl:
+  /**
+    * Node.js has no `Thread.sleep`; block on `Atomics.wait` against a throwaway
+    * `SharedArrayBuffer` (the primitive uni's Node sync HTTP channel is built on). Falls back to
+    * a busy wait where `SharedArrayBuffer` is unavailable.
+    */
+  def sleepMillis(millis: Long): Unit =
+    try
+      val sab = js.Dynamic.newInstance(js.Dynamic.global.SharedArrayBuffer)(4)
+      val arr = js.Dynamic.newInstance(js.Dynamic.global.Int32Array)(sab)
+      js.Dynamic.global.Atomics.applyDynamic("wait")(arr, 0, 0, millis.toDouble)
+      ()
+    catch
+      case _: Throwable =>
+        val deadline = System.currentTimeMillis() + millis
+        while System.currentTimeMillis() < deadline do ()

--- a/wvlet-runner/.js/src/main/scala/wvlet/lang/runner/compat/SleepCompatImpl.scala
+++ b/wvlet-runner/.js/src/main/scala/wvlet/lang/runner/compat/SleepCompatImpl.scala
@@ -4,9 +4,9 @@ import scala.scalajs.js
 
 private[runner] trait SleepCompatImpl:
   /**
-    * Node.js has no `Thread.sleep`; block on `Atomics.wait` against a throwaway
-    * `SharedArrayBuffer` (the primitive uni's Node sync HTTP channel is built on). Falls back to
-    * a busy wait where `SharedArrayBuffer` is unavailable.
+    * Node.js has no `Thread.sleep`; block on `Atomics.wait` against a throwaway `SharedArrayBuffer`
+    * (the primitive uni's Node sync HTTP channel is built on). Falls back to a busy wait where
+    * `SharedArrayBuffer` is unavailable.
     */
   def sleepMillis(millis: Long): Unit =
     try
@@ -17,4 +17,6 @@ private[runner] trait SleepCompatImpl:
     catch
       case _: Throwable =>
         val deadline = System.currentTimeMillis() + millis
-        while System.currentTimeMillis() < deadline do ()
+        while System.currentTimeMillis() < deadline do
+          (
+        )

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/compat/SleepCompatImpl.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/compat/SleepCompatImpl.scala
@@ -1,0 +1,4 @@
+package wvlet.lang.runner.compat
+
+private[runner] trait SleepCompatImpl:
+  def sleepMillis(millis: Long): Unit = Thread.sleep(millis)

--- a/wvlet-runner/.native/src/main/scala/wvlet/lang/runner/compat/SleepCompatImpl.scala
+++ b/wvlet-runner/.native/src/main/scala/wvlet/lang/runner/compat/SleepCompatImpl.scala
@@ -1,0 +1,4 @@
+package wvlet.lang.runner.compat
+
+private[runner] trait SleepCompatImpl:
+  def sleepMillis(millis: Long): Unit = Thread.sleep(millis)

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/compat/Sleep.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/compat/Sleep.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner.compat
+
+/**
+  * Cross-platform synchronous sleep, used by polling loops (e.g. the remote wvlet-server client).
+  * JVM and Native use `Thread.sleep`; Node.js has no thread sleep, so its impl blocks on
+  * `Atomics.wait` (the same primitive uni's Node sync HTTP channel relies on).
+  */
+private[runner] object Sleep extends SleepCompatImpl

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/WvletServerClient.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/WvletServerClient.scala
@@ -37,10 +37,10 @@ import scala.collection.immutable.ListMap
 import scala.util.Try
 
 /**
-  * Remote execution against a wvlet server: submits the ORIGINAL wvlet query text over the
-  * server's RPC API, polls until a terminal state, and adapts the structured result into the
-  * runner's [[QueryResult]] shape. The server compiles and runs the query with its own profile,
-  * catalogs, and credentials — thin clients (wvc, the Node CLI) need no local engine at all.
+  * Remote execution against a wvlet server: submits the ORIGINAL wvlet query text over the server's
+  * RPC API, polls until a terminal state, and adapts the structured result into the runner's
+  * [[QueryResult]] shape. The server compiles and runs the query with its own profile, catalogs,
+  * and credentials — thin clients (wvc, the Node CLI) need no local engine at all.
   *
   * One server-side session is held per client instance (a fresh ULID session id), so `use`
   * statements and temp tables persist across [[runQuery]] calls. Built purely on uni's sync HTTP
@@ -74,18 +74,19 @@ class WvletServerClient(
   def runQuery(wvletQuery: String): QueryResult = toQueryResult(awaitCompletion(submit(wvletQuery)))
 
   /** Submit a wvlet query and return its server-side query id without waiting. */
-  def submit(wvletQuery: String): ULID = rpc
-    .FrontendApi
-    .submitQuery(
-      QueryRequest(
-        query = wvletQuery,
-        querySelection = QuerySelection.All,
-        profile = profile,
-        maxRows = Some(maxRows),
-        sessionId = Some(sessionId)
+  def submit(wvletQuery: String): ULID =
+    rpc
+      .FrontendApi
+      .submitQuery(
+        QueryRequest(
+          query = wvletQuery,
+          querySelection = QuerySelection.All,
+          profile = profile,
+          maxRows = Some(maxRows),
+          sessionId = Some(sessionId)
+        )
       )
-    )
-    .queryId
+      .queryId
 
   /** Poll the server until the query reaches a terminal state. */
   def awaitCompletion(queryId: ULID): QueryInfo =
@@ -104,15 +105,15 @@ class WvletServerClient(
         info
           .result
           .map { r =>
-            val fields = r
-              .schema
-              .map { c =>
-                NamedType(
-                  Name.termName(c.name),
-                  Try(DataType.parse(c.typeName)).getOrElse(DataType.AnyType)
-                )
-              }
-              .toList
+            val fields =
+              r.schema
+                .map { c =>
+                  NamedType(
+                    Name.termName(c.name),
+                    Try(DataType.parse(c.typeName)).getOrElse(DataType.AnyType)
+                  )
+                }
+                .toList
             val names = fields.map(_.name.name)
             val rows  = r.rows.map(row => ListMap.from(names.zip(row))).toList
             TableRows(

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/WvletServerClient.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/WvletServerClient.scala
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner.connector
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.api.v1.frontend.FrontendApi.QueryCancelRequest
+import wvlet.lang.api.v1.frontend.FrontendApi.QueryInfoRequest
+import wvlet.lang.api.v1.frontend.FrontendRPC
+import wvlet.lang.api.v1.query.QueryInfo
+import wvlet.lang.api.v1.query.QueryRequest
+import wvlet.lang.api.v1.query.QuerySelection
+import wvlet.lang.api.v1.query.QueryStatus
+import wvlet.lang.compiler.Name
+import wvlet.lang.model.DataType
+import wvlet.lang.model.DataType.NamedType
+import wvlet.lang.model.DataType.SchemaType
+import wvlet.lang.runner.ErrorResult
+import wvlet.lang.runner.QueryResult
+import wvlet.lang.runner.TableRows
+import wvlet.lang.runner.compat.Sleep
+import wvlet.uni.http.Http
+import wvlet.uni.log.LogSupport
+import wvlet.uni.util.ULID
+
+import scala.collection.immutable.ListMap
+import scala.util.Try
+
+/**
+  * Remote execution against a wvlet server: submits the ORIGINAL wvlet query text over the
+  * server's RPC API, polls until a terminal state, and adapts the structured result into the
+  * runner's [[QueryResult]] shape. The server compiles and runs the query with its own profile,
+  * catalogs, and credentials — thin clients (wvc, the Node CLI) need no local engine at all.
+  *
+  * One server-side session is held per client instance (a fresh ULID session id), so `use`
+  * statements and temp tables persist across [[runQuery]] calls. Built purely on uni's sync HTTP
+  * client, so it runs unchanged on JVM, Node.js, and Native.
+  */
+class WvletServerClient(
+    baseUri: String,
+    // Server-side profile to run under; None uses the server's default profile
+    profile: Option[String] = None,
+    maxRows: Int = WvletServerClient.DefaultMaxRows,
+    pollIntervalMillis: Long = 100
+) extends AutoCloseable
+    with LogSupport:
+
+  private val rpc = FrontendRPC.newRPCSyncClient(
+    Http
+      .client
+      .withBaseUri(baseUri)
+      // The Native (libcurl) channel does not transparently decompress gzip responses the way
+      // the JVM client does; ask the server for identity encoding so all platforms decode alike
+      .withRequestFilter(req => req.setHeader("Accept-Encoding", "identity"))
+      .newSyncClient
+  )
+
+  // One server-side session per client so engine/schema switches survive across statements
+  private val sessionId = ULID.newULIDString
+
+  override def close(): Unit = rpc.close()
+
+  /** Submit a wvlet query, wait for completion, and adapt the result. */
+  def runQuery(wvletQuery: String): QueryResult = toQueryResult(awaitCompletion(submit(wvletQuery)))
+
+  /** Submit a wvlet query and return its server-side query id without waiting. */
+  def submit(wvletQuery: String): ULID = rpc
+    .FrontendApi
+    .submitQuery(
+      QueryRequest(
+        query = wvletQuery,
+        querySelection = QuerySelection.All,
+        profile = profile,
+        maxRows = Some(maxRows),
+        sessionId = Some(sessionId)
+      )
+    )
+    .queryId
+
+  /** Poll the server until the query reaches a terminal state. */
+  def awaitCompletion(queryId: ULID): QueryInfo =
+    var info = rpc.FrontendApi.getQueryInfo(QueryInfoRequest(queryId, pageToken = "0"))
+    while !info.status.isFinished do
+      Sleep.sleepMillis(pollIntervalMillis)
+      info = rpc.FrontendApi.getQueryInfo(QueryInfoRequest(queryId, pageToken = info.pageToken))
+    info
+
+  /** Best-effort server-side cancellation. */
+  def cancel(queryId: ULID): QueryInfo = rpc.FrontendApi.cancelQuery(QueryCancelRequest(queryId))
+
+  private def toQueryResult(info: QueryInfo): QueryResult =
+    info.status match
+      case QueryStatus.FINISHED =>
+        info
+          .result
+          .map { r =>
+            val fields = r
+              .schema
+              .map { c =>
+                NamedType(
+                  Name.termName(c.name),
+                  Try(DataType.parse(c.typeName)).getOrElse(DataType.AnyType)
+                )
+              }
+              .toList
+            val names = fields.map(_.name.name)
+            val rows  = r.rows.map(row => ListMap.from(names.zip(row))).toList
+            TableRows(
+              SchemaType(None, Name.NoTypeName, fields),
+              rows,
+              r.actualTotalRows.getOrElse(rows.size)
+            )
+          }
+          .getOrElse(QueryResult.empty)
+      case QueryStatus.CANCELED =>
+        ErrorResult(
+          StatusCode
+            .QUERY_EXECUTION_FAILURE
+            .newException(s"Query ${info.queryId} was canceled on the server")
+        )
+      case _ =>
+        val error = info
+          .errors
+          .headOption
+          .map(e => e.statusCode.newException(info.errors.map(_.message).mkString("; ")))
+          .getOrElse(
+            StatusCode
+              .QUERY_EXECUTION_FAILURE
+              .newException(s"Query ${info.queryId} failed with status ${info.status}")
+          )
+        ErrorResult(error)
+
+end WvletServerClient
+
+object WvletServerClient:
+  /** Default bound for structured rows fetched from the server */
+  val DefaultMaxRows: Int = 10000

--- a/wvlet-server/src/test/scala/wvlet/lang/server/WvletServerClientTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/WvletServerClientTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.server
+
+import wvlet.lang.runner.ErrorResult
+import wvlet.lang.runner.TableRows
+import wvlet.lang.runner.connector.WvletServerClient
+import wvlet.lang.test.WvletDITest
+import wvlet.uni.http.netty.NettyHttpServer
+
+/**
+  * End-to-end tests for [[WvletServerClient]] — the remote wvlet-server execution backend used by
+  * `wvc run -t wvlet` and the Node CLI — against a live in-process server (#1963 phase 5)
+  */
+class WvletServerClientTest extends WvletDITest:
+
+  initDesign:
+    _.add(WvletServer.testDesign)
+
+  private def withClient[U](body: WvletServerClient => U): U =
+    val server = dep[NettyHttpServer]
+    val client = WvletServerClient(s"http://localhost:${server.localPort}")
+    try body(client)
+    finally client.close()
+
+  test("run a wvlet query remotely and adapt structured rows") {
+    withClient { client =>
+      val result = client.runQuery("from [[1, 'a'], [2, 'b']] as t(id, name) select id, name")
+      result match
+        case t: TableRows =>
+          t.schema.fields.map(_.name.name) shouldBe List("id", "name")
+          t.totalRows shouldBe 2
+          t.rows.map(_.values.map(v => Option(v).map(_.toString).orNull).toList) shouldBe
+            List(List("1", "a"), List("2", "b"))
+        case other =>
+          fail(s"Expected TableRows, got: ${other}")
+    }
+  }
+
+  test("preserve session state across statements of one client") {
+    withClient { client =>
+      client.runQuery("execute sql\"create table remote_nums(n integer)\"")
+      client.runQuery("execute sql\"insert into remote_nums values (1), (2), (3)\"")
+      val result = client.runQuery("from remote_nums select count(*) as cnt")
+      result match
+        case t: TableRows =>
+          t.rows.head.values.head.toString shouldBe "3"
+        case other =>
+          fail(s"Expected TableRows, got: ${other}")
+    }
+  }
+
+  test("evaluate test statements server-side") {
+    withClient { client =>
+      val result = client.runQuery("""from [[1], [2]] as t(a) select a
+                                     |test _.size should be 2""".stripMargin)
+      result.hasError shouldBe false
+    }
+  }
+
+  test("surface remote failures as errors") {
+    withClient { client =>
+      val result = client.runQuery("from table_that_does_not_exist_on_server")
+      result match
+        case e: ErrorResult =>
+          Option(e.e.getMessage).getOrElse("") shouldContain "table_that_does_not_exist_on_server"
+        case other =>
+          fail(s"Expected ErrorResult, got: ${other}")
+    }
+  }
+
+end WvletServerClientTest


### PR DESCRIPTION
## Summary

Phase 5 — the final phase — of `plans/2026-08-22-cross-platform-runner.md`: `wvc` and the Node CLI can now run queries through a central wvlet server that holds the profiles, catalogs, and credentials.

- **`WvletServerClient`** (shared `wvlet-runner` sources): submits the **original wvlet text** over the server's RPC API, polls to completion, adapts the structured result into the runner's `QueryResult`, and exposes best-effort `cancel`. One server-side session per client instance, so `use` switches and temp tables persist across statements.
- **`wvlet-client` cross-builds for Native** (it only needs `wvlet-api` + uni RPC); `wvlet-runner` now depends on it.
- **CLI: `run -t wvlet --host … [--port …]`** skips local compilation entirely — the server compiles with its own context. *Design revision (recorded in the plan doc): not a `SqlConnector` wrapper — routing locally generated SQL through `PlanExecutor` would double-compile with mismatched contexts.*
- Cross-platform `Sleep` compat for the poll loop (Node.js blocks on `Atomics.wait`; JVM/Native use `Thread.sleep`).
- `Accept-Encoding: identity` is pinned on the RPC client — the Native libcurl channel does not transparently gunzip like the JVM client (found via a live-server smoke from the native binary).

## Tests

- New `WvletServerClientTest` (4) against a live in-process Netty server: structured-row adaptation, cross-statement session persistence, server-side test-statement evaluation, error surfacing.
- E2E smokes against a real `WvletServerMain` on port 19091: **`wvc run -t wvlet`** (native binary) and **`node sdks/cli-node/bin/wvlet.js run -t wvlet`** both return correct box-rendered results, exit code 0.
- `server/test` green; `projectJVM/JS/Native Test/compile` green (includes the new `client.native`).

With this, all six phases of the cross-platform runner plan are implemented: DuckDB sessions (#1964), runner crossProject + provider (#1965), plan interpreter (#1967), server REST completion (#1968), Trino auth (#1969), and the remote wvlet backend (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49