### PR TITLE
fix: Execute test-carrying queries once by evaluating trailing tests against the query's own result

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/planner/ExecutionPlanner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/planner/ExecutionPlanner.scala
@@ -26,6 +26,20 @@ object ExecutionPlanner extends Phase("execution-plan"):
       }
       ExecuteQuery(queryWithoutTests)
 
+    // Collect a trailing chain of test relations (in source order) and the tested relation below it
+    def collectTestChain(t: TestRelation): (List[TestRelation], Option[Relation]) =
+      val tests                               = List.newBuilder[TestRelation]
+      def iter(r: Relation): Option[Relation] =
+        r match
+          case tr: TestRelation =>
+            val ret = iter(tr.child)
+            tests += tr
+            ret
+          case other =>
+            Some(other)
+      val nonTestChild = iter(t)
+      (tests.result(), nonTestChild)
+
     def plan(l: LogicalPlan, evalQuery: Boolean): ExecutionPlan =
       l match
         case p: PackageDef =>
@@ -40,37 +54,38 @@ object ExecutionPlanner extends Phase("execution-plan"):
           val debugPlan = plan(d.debugExpr, evalQuery = true)
           ExecuteDebug(d, debugPlan)
         case t: TestRelation =>
-          val plans = List.newBuilder[ExecutionPlan]
-          val tests = List.newBuilder[TestRelation]
-
-          def findNonTestRel(r: Relation): Option[Relation] =
-            r match
-              case tr: TestRelation =>
-                val ret = findNonTestRel(tr.child)
-                tests += tr
-                ret
-              case other =>
-                Some(other)
-          val nonTestChild = findNonTestRel(t.child)
-          tests += t
-
-          // For evaluating the test, need to evaluate the sub query
+          val (tests, nonTestChild) = collectTestChain(t)
+          val plans                 = List.newBuilder[ExecutionPlan]
+          // Execute the tested query only when its result is consumed: this test chain is the
+          // selected execution target, or the tests will read the result in a debug-run.
+          // Otherwise just recurse to plan nested test/debug statements
           nonTestChild.foreach { c =>
-            plans += plan(c, evalQuery = true)
+            plans += plan(c, evalQuery = evalQuery || context.isDebugRun)
           }
           if context.isDebugRun then
-            plans ++= tests.result().map(ExecuteTest(_))
+            plans ++= tests.map(ExecuteTest(_))
           ExecutionPlan(plans.result())
         case save: Save =>
           val queryPlan = plan(save.inputRelation, evalQuery = false)
           ExecuteSave(save, queryPlan)
         case q: Query =>
           val plans = List.newBuilder[ExecutionPlan]
-          if evalQuery then
-            plans += queryExecutePlan(q)
-
-          // Evaluate inner query, debug, and test expressions
-          plans += plan(q.child, false)
+          q.child match
+            case t: TestRelation if evalQuery && context.isDebugRun =>
+              // Trailing tests read this query's own result: plan nested test/debug statements
+              // first, run the (test-stripped) query once, then evaluate the trailing tests
+              // against that result — instead of executing the same query a second time
+              val (tests, nonTestChild) = collectTestChain(t)
+              nonTestChild.foreach { c =>
+                plans += plan(c, evalQuery = false)
+              }
+              plans += queryExecutePlan(q)
+              plans ++= tests.map(ExecuteTest(_))
+            case _ =>
+              if evalQuery then
+                plans += queryExecutePlan(q)
+              // Evaluate inner query, debug, and test expressions
+              plans += plan(q.child, false)
           ExecutionPlan(plans.result())
         case r: Relation =>
           val plans = List.newBuilder[ExecutionPlan]

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/planner/ExecutionPlannerTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/planner/ExecutionPlannerTest.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.planner
+
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.Symbol
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.model.plan.*
+import wvlet.uni.log.LogLevel
+import wvlet.uni.test.UniTest
+
+/**
+  * Verifies the shape of generated execution plans, especially that queries carrying `test`
+  * statements execute exactly once: trailing tests are evaluated against the query's own result
+  * instead of re-running the (test-stripped) query a second time.
+  */
+class ExecutionPlannerTest extends UniTest:
+
+  private def plan(query: String, debugRun: Boolean): ExecutionPlan =
+    val workEnv       = WorkEnv(".", logLevel = LogLevel.WARN)
+    val compiler      = Compiler(CompilerOptions(sourceFolders = List("."), workEnv = workEnv))
+    val unit          = CompilationUnit.fromWvletString(query)
+    val compileResult = compiler.compileSingleUnit(unit)
+    compileResult.reportAllErrors
+    val ctx = compileResult
+      .context
+      .withCompilationUnit(unit)
+      .withDebugRun(debugRun)
+      .newContext(Symbol.NoSymbol)
+    ExecutionPlanner.plan(unit, ctx)
+
+  /** Flatten the plan tree into evaluation order */
+  private def flatten(p: ExecutionPlan): List[ExecutionPlan] =
+    val buf                          = List.newBuilder[ExecutionPlan]
+    def iter(x: ExecutionPlan): Unit =
+      buf += x
+      x match
+        case ExecuteTasks(tasks) =>
+          tasks.foreach(iter)
+        case ExecuteSave(_, queryPlan) =>
+          iter(queryPlan)
+        case ExecuteDebug(_, debugPlan) =>
+          iter(debugPlan)
+        case _ =>
+    iter(p)
+    buf.result()
+
+  private def queriesAndTests(p: ExecutionPlan): List[ExecutionPlan] = flatten(p).filter {
+    case _: ExecuteQuery | _: ExecuteTest =>
+      true
+    case _ =>
+      false
+  }
+
+  test("should execute a query without tests exactly once") {
+    val steps = queriesAndTests(plan("from [[1], [2]] as t(a) select a", debugRun = true))
+    steps.count(_.isInstanceOf[ExecuteQuery]) shouldBe 1
+    steps.count(_.isInstanceOf[ExecuteTest]) shouldBe 0
+  }
+
+  test("should run a query with trailing tests only once in a debug-run") {
+    val steps = queriesAndTests(
+      plan(
+        """from [[1], [2]] as t(a)
+          |select a
+          |test _.size should be 2
+          |test _.columns should contain 'a'""".stripMargin,
+        debugRun = true
+      )
+    )
+    steps.count(_.isInstanceOf[ExecuteQuery]) shouldBe 1
+    steps.count(_.isInstanceOf[ExecuteTest]) shouldBe 2
+    // Tests are evaluated after the query result is materialized
+    steps.head.isInstanceOf[ExecuteQuery] shouldBe true
+  }
+
+  test("should not execute test inputs when tests are skipped (non-debug run)") {
+    val steps = queriesAndTests(
+      plan(
+        """from [[1], [2]] as t(a)
+          |select a
+          |test _.size should be 2""".stripMargin,
+        debugRun = false
+      )
+    )
+    steps.count(_.isInstanceOf[ExecuteQuery]) shouldBe 1
+    steps.count(_.isInstanceOf[ExecuteTest]) shouldBe 0
+  }
+
+  test("should still execute intermediate stages for mid-query tests") {
+    val steps = queriesAndTests(
+      plan(
+        """from [[1], [2]] as t(a)
+          |test _.size should be 2
+          |where a > 1
+          |select a
+          |test _.size should be 1""".stripMargin,
+        debugRun = true
+      )
+    )
+    // The intermediate stage runs for its own test; the full query runs once for the
+    // trailing test
+    steps.count(_.isInstanceOf[ExecuteQuery]) shouldBe 2
+    steps.count(_.isInstanceOf[ExecuteTest]) shouldBe 2
+    steps
+      .map {
+        case _: ExecuteQuery =>
+          "query"
+        case _ =>
+          "test"
+      }
+      .shouldBe(List("query", "test", "query", "test"))
+  }
+
+  test("should plan one execution per statement in multi-statement scripts") {
+    val steps = queriesAndTests(
+      plan(
+        """select 10 as x;
+          |select 20 as y
+          |test _.size should be 1""".stripMargin,
+        debugRun = true
+      )
+    )
+    steps.count(_.isInstanceOf[ExecuteQuery]) shouldBe 2
+    steps.count(_.isInstanceOf[ExecuteTest]) shouldBe 1
+  }
+
+end ExecutionPlannerTest

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/PlanExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/PlanExecutorTest.scala
@@ -75,6 +75,10 @@ class PlanExecutorTest extends UniTest:
       t
     }.size shouldBe 1
     passing.hasError shouldBe false
+    // The tested query runs exactly once; the trailing test reads its result directly
+    collect(passing) { case t: TableRows =>
+      t
+    }.size shouldBe 1
 
     val failing = run("""from [[1]] as t(a) select a
                         |test _.size should be 5""".stripMargin)


### PR DESCRIPTION
## Summary

Fixes the double execution of queries that carry `test` statements (the follow-up noted in #1967).

Previously, for a query ending with tests, `ExecutionPlanner` emitted **two** `ExecuteQuery` nodes:
1. the top-level (test-stripped) query execution, and
2. a second execution of the same query planned by the `TestRelation` case, solely to produce a "last result" for the tests to read.

This ran every test-carrying query twice against the engine in debug-runs (REPL, CLI `run`, spec runner). Non-debug runs paid the second execution too, even though tests never evaluate there.

## Changes

- `ExecutionPlanner`: a trailing test chain directly under a `Query` is now evaluated against the query's own single execution — nested/mid-query tests are planned first, then the test-stripped query runs once, then the trailing tests read its result.
- The `TestRelation` case only executes the tested input when its result is actually consumed (it is the selected execution target, or tests will run in a debug-run); otherwise it just recurses to plan nested test/debug statements.
- Mid-query tests are unchanged: their intermediate stage still executes, since its result differs from the final query's.

## Tests

- New `ExecutionPlannerTest` (langJVM, cross-platform source) pinning the plan shape: single `ExecuteQuery` for trailing tests, no test-input execution in non-debug runs, intermediate stages still planned for mid-query tests, per-statement executions in multi-statement scripts.
- `PlanExecutorTest` now asserts a test-carrying query materializes exactly one `TableRows`.
- Verified: `langJVM/test` (944), `runnerJVM/testOnly *RunnerSpec*` (471 incl. TPC-DS), full `runnerJVM/test`, and `langJS`/`runnerJS`/`runnerNative` test compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49