### PR TITLE
feature: Add Hive dialect variants to the standard library

### DIFF
--- a/website/docs/syntax/stdlib.md
+++ b/website/docs/syntax/stdlib.md
@@ -1,6 +1,6 @@
 # Standard Library Functions
 
-Wvlet ships with a standard library of functions that you call with dot syntax on column values, e.g. `name.upper` or `price.round(2)`. Functions compile to the SQL of the target database engine: when engines differ (e.g. DuckDB and Trino), Wvlet picks the right SQL for the engine you are compiling for, so the same query works across engines.
+Wvlet ships with a standard library of functions that you call with dot syntax on column values, e.g. `name.upper` or `price.round(2)`. Functions compile to the SQL of the target database engine: when engines differ (e.g. DuckDB, Trino, and Hive), Wvlet picks the right SQL for the engine you are compiling for, so the same query works across engines.
 
 ```wvlet
 from orders
@@ -186,5 +186,7 @@ def bit_count(x: long) in duckdb: int = sql"bit_count(${x})"
 -- Selected when compiling for Trino
 def bit_count(x: long) in trino: int = sql"bitwise_bit_count(${x})"
 ```
+
+Supported dialect contexts include `duckdb`, `trino`, and `hive`. Note that pattern strings remain engine-specific even when the function name is mapped: `format` takes a strftime-style pattern on DuckDB (`'%Y-%m-%d'`), a MySQL-style pattern on Trino (`'%Y-%m-%d'` with `%i` for minutes), and a Java SimpleDateFormat pattern on Hive (`'yyyy-MM-dd'`); similarly, Hive's `split` treats the separator as a regular expression.
 
 All DuckDB and Trino engine functions are bundled with the standard library, so calls like `bit_count(x)` type-check offline out of the box and compile to the SQL of the engine you target. For other databases, or engine-specific UDFs, import the engine's function catalog with [`wvlet catalog import`](../usage/catalog-import.md).

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/HiveDialectResolutionTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/HiveDialectResolutionTest.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.compiler.codegen.GenSQL
+
+/**
+  * Standard library functions define `in hive` variants where Hive SQL differs from the other
+  * engines. Hive has no execution backend in this repository, so these tests verify the generated
+  * SQL for the Hive compile target, and that the DuckDB output is unaffected by the Hive variants.
+  */
+class HiveDialectResolutionTest extends UniTest:
+
+  private def generateSQL(wv: String, dbType: DBType = DBType.Hive): String =
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv("."), dbType = dbType))
+    val unit     = CompilationUnit.fromWvletString(wv)
+    val result   = compiler.compileSingleUnit(unit)
+    GenSQL.generateSQL(unit)(using result.context)
+
+  test("select Hive string function variants") {
+    val query =
+      """from [['abc']] as t(s)
+        |select
+        |  s.regexp_like('a.*') as rl,
+        |  s.contains('b') as c,
+        |  s.starts_with('a') as sw,
+        |  s.ends_with('c') as ew,
+        |  s.strpos('b') as sp,
+        |  s.md5 as m,
+        |  s.sha256 as sh,
+        |  s.json_extract_string('$.a') as je,
+        |""".stripMargin
+    val sql = generateSQL(query)
+    sql shouldContain "s rlike 'a.*'"
+    sql shouldContain "instr(s,'b') > 0"
+    sql shouldContain "instr(s,'a') = 1"
+    sql shouldContain "substr(s,-length('c')) = 'c'"
+    sql shouldContain "instr(s,'b')"
+    sql shouldContain "md5(s)"
+    sql shouldContain "sha2(s,256)"
+    sql shouldContain "get_json_object(s,'$.a')"
+  }
+
+  test("select Hive date and timestamp function variants") {
+    val query =
+      """from [['2024-03-15']] as t(ds)
+        |select ds.to_date as d, ds.to_timestamp as tt
+        |select
+        |  d.add_days(1) as ad,
+        |  d.add_months(2) as am,
+        |  d.diff_days('2024-03-25'.to_date) as dd,
+        |  d.day_of_week as dow,
+        |  d.format('yyyy-MM-dd') as f,
+        |  tt.to_unixtime as ut,
+        |""".stripMargin
+    val sql = generateSQL(query)
+    sql shouldContain "date_add(d,1)"
+    sql shouldContain "add_months(d,2)"
+    sql shouldContain "datediff(cast('2024-03-25' as date),d)"
+    sql shouldContain "pmod(dayofweek(d) + 5, 7) + 1"
+    sql shouldContain "date_format(d,'yyyy-MM-dd')"
+    sql shouldContain "cast(unix_timestamp(tt) as bigint)"
+  }
+
+  test("select Hive array and aggregation variants") {
+    val query =
+      """from [[1, 'x']] as t(id, s)
+        |select id, s, [3, 1, 2] as a
+        |select
+        |  a.size as sz,
+        |  a.get(1) as first,
+        |  a.contains(2) as c,
+        |  a.sort.mk_string(',') as st,
+        |""".stripMargin
+    val sql = generateSQL(query)
+    sql shouldContain "size(a)"
+    sql shouldContain "a[1 - 1]"
+    sql shouldContain "array_contains(a,2)"
+    sql shouldContain "concat_ws(',',sort_array(a))"
+  }
+
+  test("select Hive grouped aggregation variants") {
+    val query =
+      """from [[1, 'x', 1.0]] as t(id, s, vv)
+        |select id, s, vv.to_double as v
+        |group by id
+        |agg s.string_agg('-') as sa, v.median as med
+        |""".stripMargin
+    val sql = generateSQL(query)
+    sql shouldContain "concat_ws('-',collect_list(s))"
+    sql shouldContain "percentile_approx(v, 0.5)"
+  }
+
+  test("cast to string instead of varchar for Hive") {
+    val query =
+      """from [[1]] as t(id)
+        |select id.to_string as s
+        |""".stripMargin
+    generateSQL(query) shouldContain "cast(id as string)"
+    generateSQL(query, DBType.DuckDB) shouldContain "cast(id as varchar)"
+  }
+
+  test("keep DuckDB output unaffected by the Hive variants") {
+    val query =
+      """from [['abc']] as t(s)
+        |select s.contains('b') as c, s.md5 as m
+        |""".stripMargin
+    val sql = generateSQL(query, DBType.DuckDB)
+    sql shouldContain "contains(s,'b')"
+    sql shouldContain "md5(s)"
+  }
+
+end HiveDialectResolutionTest

--- a/wvlet-stdlib/module/standard/any.wv
+++ b/wvlet-stdlib/module/standard/any.wv
@@ -36,3 +36,8 @@ type any in duckdb = {
 type any in trino = {
   def to_json: json = sql"cast(${this} as json)"
 }
+
+type any in hive = {
+  -- Hive rejects `varchar` without a length in casts; its string type is `string`
+  def to_string: string = sql"cast(${this} as string)"
+}

--- a/wvlet-stdlib/module/standard/array.wv
+++ b/wvlet-stdlib/module/standard/array.wv
@@ -5,12 +5,17 @@ package wvlet.standard
 type array[A] = {
   def length in duckdb: int = sql"length(${this})"
   def length in trino: int = sql"cardinality(${this})"
+  def length in hive: int = sql"size(${this})"
   def size in duckdb: int = sql"length(${this})"
   def size in trino: int = sql"cardinality(${this})"
+  def size in hive: int = sql"size(${this})"
   def get(index: int): A = sql"${this}[${index}]"
+  -- Hive arrays are 0-indexed, so shift the 1-origin index
+  def get(index: int) in hive: A = sql"${this}[${index} - 1]"
   def count: int = sql"count(*)"
   def count_distinct: int = sql"count(distinct ${this})"
   def count_if(cond:boolean): int = sql"count_if(${cond})"
+  def count_if(cond:boolean) in hive: int = sql"cast(sum(if(${cond},1,0)) as bigint)"
 
   -- Fast and memory-efficient approximate counting of distinct elements
   def count_approx_distinct in trino: int = sql"approx_distinct(${this})"
@@ -26,14 +31,18 @@ type array[A] = {
   def max_by(expr: sql): A = sql"max_by(${this}, ${expr})"
 
   def to_array: array[A] = sql"array_agg(${this})"
+  def to_array in hive: array[A] = sql"collect_list(${this})"
 
   -- Aggregate boolean values of a grouped column
   def bool_and: boolean = sql"bool_and(${this})"
+  def bool_and in hive: boolean = sql"min(${this})"
   def bool_or: boolean = sql"bool_or(${this})"
+  def bool_or in hive: boolean = sql"max(${this})"
 
   -- Concatenate grouped string values with the separator
   def string_agg(separator:string) in duckdb: string = sql"string_agg(${this},${separator})"
   def string_agg(separator:string) in trino: string = sql"array_join(array_agg(${this}),${separator})"
+  def string_agg(separator:string) in hive: string = sql"concat_ws(${separator},collect_list(${this}))"
 
   def exclude(arr: sql) in duckdb: array[A] = sql"array_filter(${this}, x -> NOT array_contains(${arr}, x))"
   def exclude(arr: sql) in trino: array[A] = sql"array_except(${this}, ${arr})"
@@ -43,10 +52,12 @@ type array[A] = {
 
   -- True if the array contains the given element
   def contains(elem:A): boolean = sql"contains(${this},${elem})"
+  def contains(elem:A) in hive: boolean = sql"array_contains(${this},${elem})"
 
   -- Concatenate the array elements into a string with the separator
   def mk_string(separator:string) in duckdb: string = sql"array_to_string(${this},${separator})"
   def mk_string(separator:string) in trino: string = sql"array_join(${this},${separator})"
+  def mk_string(separator:string) in hive: string = sql"concat_ws(${separator},${this})"
 
   -- Remove duplicate elements
   def distinct: array[A] = sql"array_distinct(${this})"
@@ -56,6 +67,7 @@ type array[A] = {
 
   def sort in duckdb: array[A] = sql"list_sort(${this})"
   def sort in trino: array[A] = sql"array_sort(${this})"
+  def sort in hive: array[A] = sql"sort_array(${this})"
 
   def reverse in duckdb: array[A] = sql"list_reverse(${this})"
   def reverse in trino: array[A] = sql"reverse(${this})"
@@ -74,6 +86,7 @@ type array[A of numeric] = {
   def avg: A = sql"avg(${this})"
   def median: A = sql"median(${this})"
   def median in trino: A = sql"approx_percentile(${this}, 0.5)"
+  def median in hive: A = sql"percentile_approx(${this}, 0.5)"
   def variance: A = sql"variance(${this})"
   def stddev: A = sql"stddev(${this})"
   def stddev_pop: A = sql"stddev_pop(${this})"
@@ -83,4 +96,5 @@ type array[A of numeric] = {
 
   def approx_quantile(pos:double) in trino: A = sql"approx_percentile(${this}, ${pos})"
   def approx_quantile(pos:double) in duckdb: A = sql"approx_quantile(${this}, ${pos})"
+  def approx_quantile(pos:double) in hive: A = sql"percentile_approx(${this}, ${pos})"
 }

--- a/wvlet-stdlib/module/standard/boolean.wv
+++ b/wvlet-stdlib/module/standard/boolean.wv
@@ -4,6 +4,7 @@ type boolean = {
   def to_int: int = sql"cast(${this} as bigint)"
   def to_long: long = sql"cast(${this} as bigint)"
   def to_string: string = sql"cast(${this} as varchar)"
+  def to_string in hive: string = sql"cast(${this} as string)"
 
   -- if the value is null, return the given default value
   def or_else(other:boolean): boolean = sql"coalesce(${this},${other})"

--- a/wvlet-stdlib/module/standard/date.wv
+++ b/wvlet-stdlib/module/standard/date.wv
@@ -53,3 +53,29 @@ type date in trino = {
   -- The last day of the month of this date
   def last_day: date = sql"last_day_of_month(${this})"
 }
+
+type date in hive = {
+  def week: int = sql"weekofyear(${this})"
+  def quarter: int = sql"quarter(${this})"
+
+  -- ISO day of week (1 = Monday, 7 = Sunday) and day of year
+  def day_of_week: int = sql"pmod(dayofweek(${this}) + 5, 7) + 1"
+  def day_of_year: int = sql"cast(date_format(${this},'D') as int)"
+
+  -- Truncate with Hive's trunc() unit tokens ('YYYY', 'MM', 'Q')
+  def truncate_to(unit:string): date = sql"cast(trunc(${this},${unit}) as date)"
+
+  def add_days(n:int): date = sql"date_add(${this},${n})"
+  def add_months(n:int): date = sql"cast(add_months(${this},${n}) as date)"
+  def add_years(n:int): date = sql"cast(add_months(${this},${n} * 12) as date)"
+
+  def diff_days(other:date): long = sql"cast(datediff(${other},${this}) as bigint)"
+  def diff_months(other:date): long = sql"cast(months_between(${other},${this}) as bigint)"
+  def diff_years(other:date): long = sql"cast(months_between(${other},${this}) / 12 as bigint)"
+
+  -- Format the date with a Java SimpleDateFormat pattern (e.g. 'yyyy-MM-dd')
+  def format(pattern:string): string = sql"date_format(${this},${pattern})"
+
+  -- The last day of the month of this date
+  def last_day: date = sql"cast(last_day(${this}) as date)"
+}

--- a/wvlet-stdlib/module/standard/decimal.wv
+++ b/wvlet-stdlib/module/standard/decimal.wv
@@ -7,6 +7,7 @@ type decimal = {
   def to_double: double = sql"cast(${this} as double)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
   def to_string: string = sql"cast(${this} as varchar)"
+  def to_string in hive: string = sql"cast(${this} as string)"
 
   def or_else(other:decimal): decimal = sql"coalesce(${this},${other})"
 
@@ -28,6 +29,7 @@ type decimal = {
   -- Drop the fractional part of this value
   def truncate in duckdb: decimal = sql"trunc(${this})"
   def truncate in trino: decimal = sql"truncate(${this})"
+  def truncate in hive: decimal = sql"cast(${this} as bigint)"
 
   def in(v:any*): boolean = sql"${this} in (${v})"
   def not_in(v:any*): boolean = sql"${this} not in (${v})"

--- a/wvlet-stdlib/module/standard/double.wv
+++ b/wvlet-stdlib/module/standard/double.wv
@@ -7,6 +7,7 @@ type double = {
   def to_double: double = sql"cast(${this} as double)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
   def to_string: string = sql"cast(${this} as varchar)"
+  def to_string in hive: string = sql"cast(${this} as string)"
 
   def or_else(other:double): double = sql"coalesce(${this},${other})"
 
@@ -36,6 +37,7 @@ type double = {
   -- Drop the fractional part of this value
   def truncate in duckdb: double = sql"trunc(${this})"
   def truncate in trino: double = sql"truncate(${this})"
+  def truncate in hive: double = sql"cast(cast(${this} as bigint) as double)"
 
   def is_nan in duckdb: boolean = sql"isnan(${this})"
   def is_nan in trino: boolean = sql"is_nan(${this})"

--- a/wvlet-stdlib/module/standard/float.wv
+++ b/wvlet-stdlib/module/standard/float.wv
@@ -7,6 +7,7 @@ type float = {
   def to_double: double = sql"cast(${this} as double)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
   def to_string: string = sql"cast(${this} as varchar)"
+  def to_string in hive: string = sql"cast(${this} as string)"
 
   def or_else(other:float): float = sql"coalesce(${this},${other})"
 
@@ -44,6 +45,7 @@ type real = {
   def to_double: double = sql"cast(${this} as double)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
   def to_string: string = sql"cast(${this} as varchar)"
+  def to_string in hive: string = sql"cast(${this} as string)"
 
   def or_else(other:real): real = sql"coalesce(${this},${other})"
   def round(decimal:int=0): double = sql"round(${this},${decimal})"

--- a/wvlet-stdlib/module/standard/int.wv
+++ b/wvlet-stdlib/module/standard/int.wv
@@ -7,6 +7,7 @@ type int = {
   def to_double: double = sql"cast(${this} as double)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
   def to_string: string = sql"cast(${this} as varchar)"
+  def to_string in hive: string = sql"cast(${this} as string)"
 
   def or_else(other:int): int = sql"coalesce(${this},${other})"
   def round(decimal:int=0): double = sql"round(${this},${decimal})"
@@ -27,6 +28,7 @@ type int = {
   -- Interpret this value as a unix epoch second (in UTC)
   def from_unixtime in duckdb: timestamp = sql"make_timestamp(cast(${this} as bigint) * 1000000)"
   def from_unixtime in trino: timestamp = sql"cast(from_unixtime(${this}) AT TIME ZONE 'UTC' as timestamp)"
+  def from_unixtime in hive: timestamp = sql"cast(from_unixtime(${this}) as timestamp)"
 
   def in(v:any*): boolean = sql"${this} in (${v})"
   def not_in(v:any*): boolean = sql"${this} not in (${v})"

--- a/wvlet-stdlib/module/standard/long.wv
+++ b/wvlet-stdlib/module/standard/long.wv
@@ -7,6 +7,7 @@ type long = {
   def to_double: double = sql"cast(${this} as double)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
   def to_string: string = sql"cast(${this} as varchar)"
+  def to_string in hive: string = sql"cast(${this} as string)"
 
   def or_else(other:long): long = sql"coalesce(${this},${other})"
   def round(decimal:int=0): double = sql"round(${this},${decimal})"
@@ -27,6 +28,7 @@ type long = {
   -- Interpret this value as a unix epoch second (in UTC)
   def from_unixtime in duckdb: timestamp = sql"make_timestamp(cast(${this} as bigint) * 1000000)"
   def from_unixtime in trino: timestamp = sql"cast(from_unixtime(${this}) AT TIME ZONE 'UTC' as timestamp)"
+  def from_unixtime in hive: timestamp = sql"cast(from_unixtime(${this}) as timestamp)"
 
   def in(v:any*): boolean = sql"${this} in (${v})"
   def not_in(v:any*): boolean = sql"${this} not in (${v})"

--- a/wvlet-stdlib/module/standard/map.wv
+++ b/wvlet-stdlib/module/standard/map.wv
@@ -4,14 +4,17 @@ package wvlet.standard
 type map[K,V] = {
   -- Number of entries in the map
   def size: int = sql"cardinality(${this})"
+  def size in hive: int = sql"size(${this})"
 
   def keys: array[K] = sql"map_keys(${this})"
   def values: array[V] = sql"map_values(${this})"
 
   -- True if the map contains the given key
   def contains_key(key:K): boolean = sql"contains(map_keys(${this}),${key})"
+  def contains_key(key:K) in hive: boolean = sql"array_contains(map_keys(${this}),${key})"
 
   -- The value for the given key, or null if the key is absent
   def get(key:K) in duckdb: V = sql"${this}[${key}]"
   def get(key:K) in trino: V = sql"element_at(${this},${key})"
+  def get(key:K) in hive: V = sql"${this}[${key}]"
 }

--- a/wvlet-stdlib/module/standard/null.wv
+++ b/wvlet-stdlib/module/standard/null.wv
@@ -9,4 +9,5 @@ type null = {
   def to_date: date = sql"cast(${this} as date)"
   def to_timestamp: timestamp = sql"cast(${this} as timestamp)"
   def to_string: string = sql"cast(${this} as varchar)"
+  def to_string in hive: string = sql"cast(${this} as string)"
 }

--- a/wvlet-stdlib/module/standard/string.wv
+++ b/wvlet-stdlib/module/standard/string.wv
@@ -87,3 +87,25 @@ type string in trino = {
   def json_extract(path:string): json = sql"json_extract(${this},${path})"
   def json_extract_string(path:string): string = sql"json_extract_scalar(${this},${path})"
 }
+
+type string in hive = {
+  def regexp_like(pattern:string): boolean = sql"${this} rlike ${pattern}"
+  -- Replace every substring matching the regular expression with the replacement
+  def regexp_replace(pattern:string, replacement:string): string = sql"regexp_replace(${this},${pattern},${replacement})"
+  -- 1-origin position of the first occurrence of the substring (0 if not found)
+  def strpos(substr:string): int = sql"instr(${this},${substr})"
+  def contains(substr:string): boolean = sql"instr(${this},${substr}) > 0"
+  def starts_with(prefix:string): boolean = sql"instr(${this},${prefix}) = 1"
+  def ends_with(suffix:string): boolean = sql"substr(${this},-length(${suffix})) = ${suffix}"
+  -- Split the string by the separator into an array of strings. Note: Hive treats the
+  -- separator as a regular expression
+  def split(separator:string): array[string] = sql"split(${this},${separator})"
+  -- Hex-encoded digest strings
+  def md5: string = sql"md5(${this})"
+  def sha256: string = sql"sha2(${this},256)"
+  -- Edit distance between two strings
+  def levenshtein(other:string): int = sql"levenshtein(${this},${other})"
+  -- Extract a JSON value from a string holding JSON text (JSONPath, e.g. '$.a.b')
+  def json_extract(path:string): json = sql"get_json_object(${this},${path})"
+  def json_extract_string(path:string): string = sql"get_json_object(${this},${path})"
+}

--- a/wvlet-stdlib/module/standard/timestamp.wv
+++ b/wvlet-stdlib/module/standard/timestamp.wv
@@ -73,3 +73,23 @@ type timestamp in trino = {
   -- DuckDB's default timestamp rendering instead of Trino's trailing '.000'
   def to_string: string = sql"date_format(${this},'%Y-%m-%d %H:%i:%s')"
 }
+
+type timestamp in hive = {
+  -- ISO day of week (1 = Monday, 7 = Sunday) and day of year
+  def day_of_week: int = sql"pmod(dayofweek(${this}) + 5, 7) + 1"
+  def day_of_year: int = sql"cast(date_format(${this},'D') as int)"
+
+  -- Timestamp arithmetic via unix epoch seconds (Hive has no timestamp interval functions)
+  def add_seconds(n:int): timestamp = sql"cast(from_unixtime(unix_timestamp(${this}) + ${n}) as timestamp)"
+  def add_minutes(n:int): timestamp = sql"cast(from_unixtime(unix_timestamp(${this}) + ${n} * 60) as timestamp)"
+  def add_hours(n:int): timestamp = sql"cast(from_unixtime(unix_timestamp(${this}) + ${n} * 3600) as timestamp)"
+  def add_days(n:int): timestamp = sql"cast(from_unixtime(unix_timestamp(${this}) + ${n} * 86400) as timestamp)"
+
+  -- Format the timestamp with a Java SimpleDateFormat pattern (e.g. 'yyyy-MM-dd HH:mm:ss')
+  def format(pattern:string): string = sql"date_format(${this},${pattern})"
+
+  -- Unix epoch seconds of this timestamp, evaluated in the session time zone
+  def to_unixtime: long = sql"cast(unix_timestamp(${this}) as bigint)"
+
+  def to_string: string = sql"cast(${this} as string)"
+}


### PR DESCRIPTION
## Summary

Extends the stdlib's dialect-aware function resolution (#1966, #1972) to **Hive**. The `type X in hive` machinery already existed (`db_contexts.wv` defines `hive extends db_context`, and `DBType.Hive` maps to the `hive` dialect context); this PR adds the actual `in hive` function variants wherever HiveQL differs from DuckDB/Trino:

- **Strings**: `rlike` regex matching, `instr`-based `strpos`/`contains`/`starts_with`, `sha2(x,256)`, `get_json_object` for JSON extraction, regex-based `split`
- **Dates**: `date_add`/`add_months`/`datediff`/`months_between` arithmetic, `weekofyear`/`quarter`, ISO `day_of_week` via `pmod(dayofweek(d)+5,7)+1`, `trunc()`-based truncation, Java SimpleDateFormat `format`
- **Timestamps**: `unix_timestamp`-based epoch conversion and add_seconds/minutes/hours/days arithmetic (Hive has no timestamp interval functions)
- **Arrays/maps**: `size`, `sort_array`, `array_contains`, `concat_ws` for `mk_string`, 0-indexed `get` shifted from the stdlib's 1-origin convention
- **Aggregations**: `collect_list` for `to_array`/`string_agg`, `percentile_approx` for `median`/`approx_quantile`, `min`/`max` for `bool_and`/`bool_or`, `sum(if(...))` for `count_if`
- **Casts**: `cast(... as string)` — Hive rejects `varchar` without a length, so every type defining its own `to_string` gets a Hive variant

## Verification

Hive has no execution backend in this repo (Hive coverage is parse/codegen-only, cf. `SqlHiveSpec`), so the mappings are verified by generated-SQL assertions in the new `HiveDialectResolutionTest`, which also confirms DuckDB output is unaffected by the added variants.

- `langJVM/testOnly *` — 1887 tests pass (incl. StdLibParseCheck, TyperCoverageCheck ratchet)
- `runnerJVM/testOnly *` — 673 pass (DuckDB specs + Trino execution specs unaffected)
- `projectJS` / `projectNative` test compile clean; scalafmt applied

Docs: `website/docs/syntax/stdlib.md` now lists Hive as a supported dialect and notes the engine-specific pattern-string caveats (`format` patterns, regex `split`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDVq4Etzaj8C8XCUm2iJiP