### PR TITLE
feature: Add Snowflake and BigQuery dialect variants to the standard library

### DIFF
--- a/website/docs/syntax/stdlib.md
+++ b/website/docs/syntax/stdlib.md
@@ -1,6 +1,6 @@
 # Standard Library Functions
 
-Wvlet ships with a standard library of functions that you call with dot syntax on column values, e.g. `name.upper` or `price.round(2)`. Functions compile to the SQL of the target database engine: when engines differ (e.g. DuckDB, Trino, and Hive), Wvlet picks the right SQL for the engine you are compiling for, so the same query works across engines.
+Wvlet ships with a standard library of functions that you call with dot syntax on column values, e.g. `name.upper` or `price.round(2)`. Functions compile to the SQL of the target database engine: when engines differ (e.g. DuckDB, Trino, Hive, Snowflake, and BigQuery), Wvlet picks the right SQL for the engine you are compiling for, so the same query works across engines.
 
 ```wvlet
 from orders
@@ -187,6 +187,6 @@ def bit_count(x: long) in duckdb: int = sql"bit_count(${x})"
 def bit_count(x: long) in trino: int = sql"bitwise_bit_count(${x})"
 ```
 
-Supported dialect contexts include `duckdb`, `trino`, and `hive`. Note that pattern strings remain engine-specific even when the function name is mapped: `format` takes a strftime-style pattern on DuckDB (`'%Y-%m-%d'`), a MySQL-style pattern on Trino (`'%Y-%m-%d'` with `%i` for minutes), and a Java SimpleDateFormat pattern on Hive (`'yyyy-MM-dd'`); similarly, Hive's `split` treats the separator as a regular expression.
+Supported dialect contexts include `duckdb`, `trino`, `hive`, `snowflake`, and `bigquery`. Note that pattern strings remain engine-specific even when the function name is mapped: `format` takes a strftime-style pattern on DuckDB and BigQuery (`'%Y-%m-%d'`), a MySQL-style pattern on Trino (`'%Y-%m-%d'` with `%i` for minutes), a Java SimpleDateFormat pattern on Hive (`'yyyy-MM-dd'`), and a SQL format model on Snowflake (`'YYYY-MM-DD'`). Similarly, Hive's `split` treats the separator as a regular expression, and Snowflake's JSON paths omit the leading `$.`.
 
 All DuckDB and Trino engine functions are bundled with the standard library, so calls like `bit_count(x)` type-check offline out of the box and compile to the SQL of the engine you target. For other databases, or engine-specific UDFs, import the engine's function catalog with [`wvlet catalog import`](../usage/catalog-import.md).

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/SnowflakeBigQueryDialectResolutionTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/SnowflakeBigQueryDialectResolutionTest.scala
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.compiler.codegen.GenSQL
+
+/**
+  * Standard library functions define `in snowflake` and `in bigquery` variants where those engines
+  * differ from the others. Neither engine has an execution backend in this repository, so these
+  * tests verify the generated SQL for each compile target, and that the DuckDB output is unaffected
+  * by the added variants.
+  */
+class SnowflakeBigQueryDialectResolutionTest extends UniTest:
+
+  private def generateSQL(wv: String, dbType: DBType): String =
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv("."), dbType = dbType))
+    val unit     = CompilationUnit.fromWvletString(wv)
+    val result   = compiler.compileSingleUnit(unit)
+    GenSQL.generateSQL(unit)(using result.context)
+
+  private val stringQuery =
+    """from [['abc']] as t(s)
+      |select
+      |  s.regexp_like('a.*') as rl,
+      |  s.contains('b') as c,
+      |  s.starts_with('a') as sw,
+      |  s.ends_with('c') as ew,
+      |  s.md5 as m,
+      |  s.sha256 as sh,
+      |  s.levenshtein('abd') as lv,
+      |  s.json_extract_string('$.a') as je,
+      |""".stripMargin
+
+  test("select Snowflake string function variants") {
+    val sql = generateSQL(stringQuery, DBType.Snowflake)
+    sql shouldContain "regexp_instr(s,'a.*') > 0"
+    sql shouldContain "contains(s,'b')"
+    sql shouldContain "startswith(s,'a')"
+    sql shouldContain "endswith(s,'c')"
+    sql shouldContain "md5(s)"
+    sql shouldContain "sha2(s,256)"
+    sql shouldContain "editdistance(s,'abd')"
+    sql shouldContain "json_extract_path_text(s,'$.a')"
+  }
+
+  test("select BigQuery string function variants") {
+    val sql = generateSQL(stringQuery, DBType.BigQuery)
+    sql shouldContain "regexp_contains(s,'a.*')"
+    sql shouldContain "strpos(s,'b') > 0"
+    sql shouldContain "starts_with(s,'a')"
+    sql shouldContain "ends_with(s,'c')"
+    sql shouldContain "lower(to_hex(md5(s)))"
+    sql shouldContain "lower(to_hex(sha256(s)))"
+    sql shouldContain "edit_distance(s,'abd')"
+    sql shouldContain "json_extract_scalar(s,'$.a')"
+  }
+
+  private val dateQuery =
+    """from [['2024-03-15']] as t(ds)
+      |select ds.to_date as d, ds.to_timestamp as tt
+      |select
+      |  d.add_days(1) as ad,
+      |  d.diff_days('2024-03-25'.to_date) as dd,
+      |  d.day_of_week as dow,
+      |  tt.add_hours(3) as ah,
+      |  tt.to_unixtime as ut,
+      |""".stripMargin
+
+  test("select Snowflake date and timestamp function variants") {
+    val sql = generateSQL(dateQuery, DBType.Snowflake)
+    sql shouldContain "dateadd('day',1,d)"
+    sql shouldContain "datediff('day',d,cast('2024-03-25' as date))"
+    sql shouldContain "dayofweekiso(d)"
+    sql shouldContain "dateadd('hour',3,tt)"
+    sql shouldContain "cast(date_part('epoch_second',tt) as bigint)"
+  }
+
+  test("select BigQuery date and timestamp function variants") {
+    val sql = generateSQL(dateQuery, DBType.BigQuery)
+    sql shouldContain "date_add(d, interval (1) day)"
+    sql shouldContain "date_diff(cast('2024-03-25' as date),d,day)"
+    sql shouldContain "mod(extract(dayofweek from d) + 5, 7) + 1"
+    sql shouldContain "timestamp_add(tt, interval (3) hour)"
+    sql shouldContain "unix_seconds(tt)"
+  }
+
+  private val arrayQuery =
+    """from [[1]] as t(id)
+      |select id, [3, 1, 2] as a
+      |select
+      |  a.size as sz,
+      |  a.get(1) as first,
+      |  a.contains(2) as c,
+      |  a.mk_string(',') as st,
+      |""".stripMargin
+
+  test("select Snowflake array function variants") {
+    val sql = generateSQL(arrayQuery, DBType.Snowflake)
+    sql shouldContain "array_size(a)"
+    sql shouldContain "get(a,1 - 1)"
+    sql shouldContain "array_contains(to_variant(2),a)"
+    sql shouldContain "array_to_string(a,',')"
+  }
+
+  test("select BigQuery array function variants") {
+    val sql = generateSQL(arrayQuery, DBType.BigQuery)
+    sql shouldContain "array_length(a)"
+    sql shouldContain "a[ordinal(1)]"
+    sql shouldContain "2 in unnest(a)"
+    sql shouldContain "array_to_string(a,',')"
+  }
+
+  private val aggQuery =
+    """from [[1, 'x', 1.0]] as t(id, s, vv)
+      |select id, s, vv.to_double as v
+      |group by id
+      |agg s.string_agg('-') as sa, v.median as med
+      |""".stripMargin
+
+  test("select Snowflake aggregation variants") {
+    val sql = generateSQL(aggQuery, DBType.Snowflake)
+    sql shouldContain "listagg(s,'-')"
+    sql shouldContain "median(v)"
+  }
+
+  test("select BigQuery aggregation variants") {
+    val sql = generateSQL(aggQuery, DBType.BigQuery)
+    sql shouldContain "string_agg(s,'-')"
+    sql shouldContain "approx_quantiles(v, 2)[offset(1)]"
+  }
+
+  test("use BigQuery cast type names") {
+    val query =
+      """from [['1']] as t(s)
+        |select s.to_long as l, s.to_double as d, 1.to_string as ss
+        |""".stripMargin
+    val sql = generateSQL(query, DBType.BigQuery)
+    sql shouldContain "cast(s as int64)"
+    sql shouldContain "cast(s as float64)"
+    sql shouldContain "cast(1 as string)"
+  }
+
+  test("keep DuckDB output unaffected by the new variants") {
+    val sql = generateSQL(stringQuery, DBType.DuckDB)
+    sql shouldContain "contains(s,'b')"
+    sql shouldContain "md5(s)"
+    sql shouldContain "starts_with(s,'a')"
+  }
+
+end SnowflakeBigQueryDialectResolutionTest

--- a/wvlet-stdlib/module/standard/any.wv
+++ b/wvlet-stdlib/module/standard/any.wv
@@ -3,10 +3,15 @@ package wvlet.standard
 type any = {
   def to_string: string = sql"cast(${this} as varchar)"
   def to_int: int = sql"cast(${this} as bigint)"
+  def to_int in bigquery: int = sql"cast(${this} as int64)"
   def to_long: long = sql"cast(${this} as bigint)"
+  def to_long in bigquery: long = sql"cast(${this} as int64)"
   def to_float: float = sql"cast(${this} as double)"
+  def to_float in bigquery: float = sql"cast(${this} as float64)"
   def to_double: double = sql"cast(${this} as double)"
+  def to_double in bigquery: double = sql"cast(${this} as float64)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
+  def to_boolean in bigquery: boolean = sql"cast(${this} as bool)"
 
   -- SQL types
   def to_date: date = sql"cast(${this} as date)"
@@ -39,5 +44,10 @@ type any in trino = {
 
 type any in hive = {
   -- Hive rejects `varchar` without a length in casts; its string type is `string`
+  def to_string: string = sql"cast(${this} as string)"
+}
+
+type any in bigquery = {
+  -- BigQuery's string type is `string`, not `varchar`
   def to_string: string = sql"cast(${this} as string)"
 }

--- a/wvlet-stdlib/module/standard/array.wv
+++ b/wvlet-stdlib/module/standard/array.wv
@@ -6,23 +6,36 @@ type array[A] = {
   def length in duckdb: int = sql"length(${this})"
   def length in trino: int = sql"cardinality(${this})"
   def length in hive: int = sql"size(${this})"
+  def length in snowflake: int = sql"array_size(${this})"
+  def length in bigquery: int = sql"array_length(${this})"
   def size in duckdb: int = sql"length(${this})"
   def size in trino: int = sql"cardinality(${this})"
   def size in hive: int = sql"size(${this})"
+  def size in snowflake: int = sql"array_size(${this})"
+  def size in bigquery: int = sql"array_length(${this})"
   def get(index: int): A = sql"${this}[${index}]"
-  -- Hive arrays are 0-indexed, so shift the 1-origin index
+  -- Hive and Snowflake arrays are 0-indexed, so shift the 1-origin index
   def get(index: int) in hive: A = sql"${this}[${index} - 1]"
+  def get(index: int) in snowflake: A = sql"get(${this},${index} - 1)"
+  def get(index: int) in bigquery: A = sql"${this}[ordinal(${index})]"
   def count: int = sql"count(*)"
   def count_distinct: int = sql"count(distinct ${this})"
   def count_if(cond:boolean): int = sql"count_if(${cond})"
   def count_if(cond:boolean) in hive: int = sql"cast(sum(if(${cond},1,0)) as bigint)"
+  def count_if(cond:boolean) in bigquery: int = sql"countif(${cond})"
 
   -- Fast and memory-efficient approximate counting of distinct elements
   def count_approx_distinct in trino: int = sql"approx_distinct(${this})"
   def count_approx_distinct in duckdb: int = sql"approx_count_distinct(${this})"
+  def count_approx_distinct in snowflake: int = sql"approx_count_distinct(${this})"
+  def count_approx_distinct in bigquery: int = sql"approx_count_distinct(${this})"
 
   def arbitrary: A = sql"arbitrary(${this})"
+  def arbitrary in snowflake: A = sql"any_value(${this})"
+  def arbitrary in bigquery: A = sql"any_value(${this})"
   def any: A = sql"arbitrary(${this})"
+  def any in snowflake: A = sql"any_value(${this})"
+  def any in bigquery: A = sql"any_value(${this})"
 
   def min: A = sql"min(${this})"
   def max: A = sql"max(${this})"
@@ -36,13 +49,19 @@ type array[A] = {
   -- Aggregate boolean values of a grouped column
   def bool_and: boolean = sql"bool_and(${this})"
   def bool_and in hive: boolean = sql"min(${this})"
+  def bool_and in snowflake: boolean = sql"booland_agg(${this})"
+  def bool_and in bigquery: boolean = sql"logical_and(${this})"
   def bool_or: boolean = sql"bool_or(${this})"
   def bool_or in hive: boolean = sql"max(${this})"
+  def bool_or in snowflake: boolean = sql"boolor_agg(${this})"
+  def bool_or in bigquery: boolean = sql"logical_or(${this})"
 
   -- Concatenate grouped string values with the separator
   def string_agg(separator:string) in duckdb: string = sql"string_agg(${this},${separator})"
   def string_agg(separator:string) in trino: string = sql"array_join(array_agg(${this}),${separator})"
   def string_agg(separator:string) in hive: string = sql"concat_ws(${separator},collect_list(${this}))"
+  def string_agg(separator:string) in snowflake: string = sql"listagg(${this},${separator})"
+  def string_agg(separator:string) in bigquery: string = sql"string_agg(${this},${separator})"
 
   def exclude(arr: sql) in duckdb: array[A] = sql"array_filter(${this}, x -> NOT array_contains(${arr}, x))"
   def exclude(arr: sql) in trino: array[A] = sql"array_except(${this}, ${arr})"
@@ -53,11 +72,15 @@ type array[A] = {
   -- True if the array contains the given element
   def contains(elem:A): boolean = sql"contains(${this},${elem})"
   def contains(elem:A) in hive: boolean = sql"array_contains(${this},${elem})"
+  def contains(elem:A) in snowflake: boolean = sql"array_contains(to_variant(${elem}),${this})"
+  def contains(elem:A) in bigquery: boolean = sql"${elem} in unnest(${this})"
 
   -- Concatenate the array elements into a string with the separator
   def mk_string(separator:string) in duckdb: string = sql"array_to_string(${this},${separator})"
   def mk_string(separator:string) in trino: string = sql"array_join(${this},${separator})"
   def mk_string(separator:string) in hive: string = sql"concat_ws(${separator},${this})"
+  def mk_string(separator:string) in snowflake: string = sql"array_to_string(${this},${separator})"
+  def mk_string(separator:string) in bigquery: string = sql"array_to_string(${this},${separator})"
 
   -- Remove duplicate elements
   def distinct: array[A] = sql"array_distinct(${this})"
@@ -68,16 +91,22 @@ type array[A] = {
   def sort in duckdb: array[A] = sql"list_sort(${this})"
   def sort in trino: array[A] = sql"array_sort(${this})"
   def sort in hive: array[A] = sql"sort_array(${this})"
+  def sort in snowflake: array[A] = sql"array_sort(${this})"
 
   def reverse in duckdb: array[A] = sql"list_reverse(${this})"
   def reverse in trino: array[A] = sql"reverse(${this})"
+  def reverse in snowflake: array[A] = sql"array_reverse(${this})"
+  def reverse in bigquery: array[A] = sql"array_reverse(${this})"
 
   -- 1-origin position of the first occurrence of the element (0 if not found)
   def index_of(elem:A) in duckdb: int = sql"coalesce(list_position(${this},${elem}), 0)"
   def index_of(elem:A) in trino: int = sql"array_position(${this},${elem})"
+  def index_of(elem:A) in snowflake: int = sql"coalesce(array_position(to_variant(${elem}),${this}) + 1, 0)"
 
   def concat(other:any) in duckdb: array[A] = sql"list_concat(${this},${other})"
   def concat(other:any) in trino: array[A] = sql"concat(${this},${other})"
+  def concat(other:any) in snowflake: array[A] = sql"array_cat(${this},${other})"
+  def concat(other:any) in bigquery: array[A] = sql"array_concat(${this},${other})"
 }
 
 -- array functions specific to numeric elements
@@ -87,6 +116,7 @@ type array[A of numeric] = {
   def median: A = sql"median(${this})"
   def median in trino: A = sql"approx_percentile(${this}, 0.5)"
   def median in hive: A = sql"percentile_approx(${this}, 0.5)"
+  def median in bigquery: A = sql"approx_quantiles(${this}, 2)[offset(1)]"
   def variance: A = sql"variance(${this})"
   def stddev: A = sql"stddev(${this})"
   def stddev_pop: A = sql"stddev_pop(${this})"
@@ -97,4 +127,6 @@ type array[A of numeric] = {
   def approx_quantile(pos:double) in trino: A = sql"approx_percentile(${this}, ${pos})"
   def approx_quantile(pos:double) in duckdb: A = sql"approx_quantile(${this}, ${pos})"
   def approx_quantile(pos:double) in hive: A = sql"percentile_approx(${this}, ${pos})"
+  def approx_quantile(pos:double) in snowflake: A = sql"approx_percentile(${this}, ${pos})"
+  def approx_quantile(pos:double) in bigquery: A = sql"approx_quantiles(${this}, 100)[offset(cast(${pos} * 100 as int64))]"
 }

--- a/wvlet-stdlib/module/standard/boolean.wv
+++ b/wvlet-stdlib/module/standard/boolean.wv
@@ -2,9 +2,12 @@ package wvlet.standard
 
 type boolean = {
   def to_int: int = sql"cast(${this} as bigint)"
+  def to_int in bigquery: int = sql"cast(${this} as int64)"
   def to_long: long = sql"cast(${this} as bigint)"
+  def to_long in bigquery: long = sql"cast(${this} as int64)"
   def to_string: string = sql"cast(${this} as varchar)"
   def to_string in hive: string = sql"cast(${this} as string)"
+  def to_string in bigquery: string = sql"cast(${this} as string)"
 
   -- if the value is null, return the given default value
   def or_else(other:boolean): boolean = sql"coalesce(${this},${other})"

--- a/wvlet-stdlib/module/standard/date.wv
+++ b/wvlet-stdlib/module/standard/date.wv
@@ -79,3 +79,43 @@ type date in hive = {
   -- The last day of the month of this date
   def last_day: date = sql"cast(last_day(${this}) as date)"
 }
+
+type date in snowflake = {
+  -- ISO day of week (1 = Monday, 7 = Sunday) and day of year
+  def day_of_week: int = sql"dayofweekiso(${this})"
+  def day_of_year: int = sql"dayofyear(${this})"
+
+  def add_days(n:int): date = sql"dateadd('day',${n},${this})"
+  def add_months(n:int): date = sql"dateadd('month',${n},${this})"
+  def add_years(n:int): date = sql"dateadd('year',${n},${this})"
+
+  def diff_days(other:date): long = sql"datediff('day',${this},${other})"
+  def diff_months(other:date): long = sql"datediff('month',${this},${other})"
+  def diff_years(other:date): long = sql"datediff('year',${this},${other})"
+
+  -- Format the date with a SQL format model (e.g. 'YYYY-MM-DD')
+  def format(pattern:string): string = sql"to_char(${this},${pattern})"
+
+  -- The last day of the month of this date
+  def last_day: date = sql"last_day(${this})"
+}
+
+type date in bigquery = {
+  -- ISO day of week (1 = Monday, 7 = Sunday; BigQuery's DAYOFWEEK starts at 1 = Sunday)
+  def day_of_week: int = sql"mod(extract(dayofweek from ${this}) + 5, 7) + 1"
+  def day_of_year: int = sql"extract(dayofyear from ${this})"
+
+  def add_days(n:int): date = sql"date_add(${this}, interval (${n}) day)"
+  def add_months(n:int): date = sql"date_add(${this}, interval (${n}) month)"
+  def add_years(n:int): date = sql"date_add(${this}, interval (${n}) year)"
+
+  def diff_days(other:date): long = sql"date_diff(${other},${this},day)"
+  def diff_months(other:date): long = sql"date_diff(${other},${this},month)"
+  def diff_years(other:date): long = sql"date_diff(${other},${this},year)"
+
+  -- Format the date with a strftime-style pattern (e.g. '%Y-%m-%d')
+  def format(pattern:string): string = sql"format_date(${pattern},${this})"
+
+  -- The last day of the month of this date
+  def last_day: date = sql"last_day(${this})"
+}

--- a/wvlet-stdlib/module/standard/db_contexts.wv
+++ b/wvlet-stdlib/module/standard/db_contexts.wv
@@ -8,6 +8,10 @@ type trino extends db_context
 
 type hive extends db_context
 
+type snowflake extends db_context
+
+type bigquery extends db_context
+
 -- Contexts for defining Treasure Data specific Trino/Hive dialects.
 -- It can also use extensions for standard Trino/Hive
 type td_trino extends trino

--- a/wvlet-stdlib/module/standard/decimal.wv
+++ b/wvlet-stdlib/module/standard/decimal.wv
@@ -2,12 +2,18 @@ package wvlet.standard
 
 type decimal = {
   def to_int: int = sql"cast(${this} as bigint)"
+  def to_int in bigquery: int = sql"cast(${this} as int64)"
   def to_long: long = sql"cast(${this} as bigint)"
+  def to_long in bigquery: long = sql"cast(${this} as int64)"
   def to_float: float = sql"cast(${this} as double)"
+  def to_float in bigquery: float = sql"cast(${this} as float64)"
   def to_double: double = sql"cast(${this} as double)"
+  def to_double in bigquery: double = sql"cast(${this} as float64)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
+  def to_boolean in bigquery: boolean = sql"cast(${this} as bool)"
   def to_string: string = sql"cast(${this} as varchar)"
   def to_string in hive: string = sql"cast(${this} as string)"
+  def to_string in bigquery: string = sql"cast(${this} as string)"
 
   def or_else(other:decimal): decimal = sql"coalesce(${this},${other})"
 
@@ -21,7 +27,10 @@ type decimal = {
   def exp: double = sql"exp(${this})"
   def ln: double = sql"ln(${this})"
   def log10: double = sql"log10(${this})"
+  def log10 in snowflake: double = sql"log(10,${this})"
   def log2: double = sql"log2(${this})"
+  def log2 in snowflake: double = sql"log(2,${this})"
+  def log2 in bigquery: double = sql"log(${this}, 2)"
   def power(exponent:double): double = sql"power(${this},${exponent})"
   def mod(divisor:decimal): decimal = sql"mod(${this},${divisor})"
   def sign: int = sql"sign(${this})"
@@ -30,6 +39,8 @@ type decimal = {
   def truncate in duckdb: decimal = sql"trunc(${this})"
   def truncate in trino: decimal = sql"truncate(${this})"
   def truncate in hive: decimal = sql"cast(${this} as bigint)"
+  def truncate in snowflake: decimal = sql"trunc(${this})"
+  def truncate in bigquery: decimal = sql"trunc(${this})"
 
   def in(v:any*): boolean = sql"${this} in (${v})"
   def not_in(v:any*): boolean = sql"${this} not in (${v})"

--- a/wvlet-stdlib/module/standard/double.wv
+++ b/wvlet-stdlib/module/standard/double.wv
@@ -2,12 +2,18 @@ package wvlet.standard
 
 type double = {
   def to_int: int = sql"cast(${this} as bigint)"
+  def to_int in bigquery: int = sql"cast(${this} as int64)"
   def to_long: long = sql"cast(${this} as bigint)"
+  def to_long in bigquery: long = sql"cast(${this} as int64)"
   def to_float: float = sql"cast(${this} as double)"
+  def to_float in bigquery: float = sql"cast(${this} as float64)"
   def to_double: double = sql"cast(${this} as double)"
+  def to_double in bigquery: double = sql"cast(${this} as float64)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
+  def to_boolean in bigquery: boolean = sql"cast(${this} as bool)"
   def to_string: string = sql"cast(${this} as varchar)"
   def to_string in hive: string = sql"cast(${this} as string)"
+  def to_string in bigquery: string = sql"cast(${this} as string)"
 
   def or_else(other:double): double = sql"coalesce(${this},${other})"
 
@@ -21,7 +27,10 @@ type double = {
   def exp: double = sql"exp(${this})"
   def ln: double = sql"ln(${this})"
   def log10: double = sql"log10(${this})"
+  def log10 in snowflake: double = sql"log(10,${this})"
   def log2: double = sql"log2(${this})"
+  def log2 in snowflake: double = sql"log(2,${this})"
+  def log2 in bigquery: double = sql"log(${this}, 2)"
   def power(exponent:double): double = sql"power(${this},${exponent})"
   def sign: int = sql"sign(${this})"
 
@@ -38,13 +47,18 @@ type double = {
   def truncate in duckdb: double = sql"trunc(${this})"
   def truncate in trino: double = sql"truncate(${this})"
   def truncate in hive: double = sql"cast(cast(${this} as bigint) as double)"
+  def truncate in snowflake: double = sql"trunc(${this})"
+  def truncate in bigquery: double = sql"trunc(${this})"
 
   def is_nan in duckdb: boolean = sql"isnan(${this})"
   def is_nan in trino: boolean = sql"is_nan(${this})"
+  def is_nan in bigquery: boolean = sql"is_nan(${this})"
   def is_finite in duckdb: boolean = sql"isfinite(${this})"
   def is_finite in trino: boolean = sql"is_finite(${this})"
+  def is_finite in bigquery: boolean = sql"(not is_nan(${this}) and not is_inf(${this}))"
   def is_infinite in duckdb: boolean = sql"isinf(${this})"
   def is_infinite in trino: boolean = sql"is_infinite(${this})"
+  def is_infinite in bigquery: boolean = sql"is_inf(${this})"
 
   def in(v:any*): boolean = sql"${this} in (${v})"
   def not_in(v:any*): boolean = sql"${this} not in (${v})"

--- a/wvlet-stdlib/module/standard/float.wv
+++ b/wvlet-stdlib/module/standard/float.wv
@@ -2,12 +2,18 @@ package wvlet.standard
 
 type float = {
   def to_int: int = sql"cast(${this} as bigint)"
+  def to_int in bigquery: int = sql"cast(${this} as int64)"
   def to_long: long = sql"cast(${this} as bigint)"
+  def to_long in bigquery: long = sql"cast(${this} as int64)"
   def to_float: float = sql"cast(${this} as double)"
+  def to_float in bigquery: float = sql"cast(${this} as float64)"
   def to_double: double = sql"cast(${this} as double)"
+  def to_double in bigquery: double = sql"cast(${this} as float64)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
+  def to_boolean in bigquery: boolean = sql"cast(${this} as bool)"
   def to_string: string = sql"cast(${this} as varchar)"
   def to_string in hive: string = sql"cast(${this} as string)"
+  def to_string in bigquery: string = sql"cast(${this} as string)"
 
   def or_else(other:float): float = sql"coalesce(${this},${other})"
 
@@ -20,16 +26,22 @@ type float = {
   def exp: double = sql"exp(${this})"
   def ln: double = sql"ln(${this})"
   def log10: double = sql"log10(${this})"
+  def log10 in snowflake: double = sql"log(10,${this})"
   def log2: double = sql"log2(${this})"
+  def log2 in snowflake: double = sql"log(2,${this})"
+  def log2 in bigquery: double = sql"log(${this}, 2)"
   def power(exponent:double): double = sql"power(${this},${exponent})"
   def sign: int = sql"sign(${this})"
 
   def is_nan in duckdb: boolean = sql"isnan(${this})"
   def is_nan in trino: boolean = sql"is_nan(${this})"
+  def is_nan in bigquery: boolean = sql"is_nan(${this})"
   def is_finite in duckdb: boolean = sql"isfinite(${this})"
   def is_finite in trino: boolean = sql"is_finite(${this})"
+  def is_finite in bigquery: boolean = sql"(not is_nan(${this}) and not is_inf(${this}))"
   def is_infinite in duckdb: boolean = sql"isinf(${this})"
   def is_infinite in trino: boolean = sql"is_infinite(${this})"
+  def is_infinite in bigquery: boolean = sql"is_inf(${this})"
 
   def in(v:any*): boolean = sql"${this} in (${v})"
   def not_in(v:any*): boolean = sql"${this} not in (${v})"
@@ -40,12 +52,18 @@ type float = {
 -- `real` is a distinct primitive type (e.g. 4-byte floating point columns)
 type real = {
   def to_int: int = sql"cast(${this} as bigint)"
+  def to_int in bigquery: int = sql"cast(${this} as int64)"
   def to_long: long = sql"cast(${this} as bigint)"
+  def to_long in bigquery: long = sql"cast(${this} as int64)"
   def to_float: float = sql"cast(${this} as double)"
+  def to_float in bigquery: float = sql"cast(${this} as float64)"
   def to_double: double = sql"cast(${this} as double)"
+  def to_double in bigquery: double = sql"cast(${this} as float64)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
+  def to_boolean in bigquery: boolean = sql"cast(${this} as bool)"
   def to_string: string = sql"cast(${this} as varchar)"
   def to_string in hive: string = sql"cast(${this} as string)"
+  def to_string in bigquery: string = sql"cast(${this} as string)"
 
   def or_else(other:real): real = sql"coalesce(${this},${other})"
   def round(decimal:int=0): double = sql"round(${this},${decimal})"

--- a/wvlet-stdlib/module/standard/int.wv
+++ b/wvlet-stdlib/module/standard/int.wv
@@ -2,12 +2,18 @@ package wvlet.standard
 
 type int = {
   def to_int: int = sql"cast(${this} as bigint)"
+  def to_int in bigquery: int = sql"cast(${this} as int64)"
   def to_long: long = sql"cast(${this} as bigint)"
+  def to_long in bigquery: long = sql"cast(${this} as int64)"
   def to_float: float = sql"cast(${this} as double)"
+  def to_float in bigquery: float = sql"cast(${this} as float64)"
   def to_double: double = sql"cast(${this} as double)"
+  def to_double in bigquery: double = sql"cast(${this} as float64)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
+  def to_boolean in bigquery: boolean = sql"cast(${this} as bool)"
   def to_string: string = sql"cast(${this} as varchar)"
   def to_string in hive: string = sql"cast(${this} as string)"
+  def to_string in bigquery: string = sql"cast(${this} as string)"
 
   def or_else(other:int): int = sql"coalesce(${this},${other})"
   def round(decimal:int=0): double = sql"round(${this},${decimal})"
@@ -20,7 +26,10 @@ type int = {
   def exp: double = sql"exp(${this})"
   def ln: double = sql"ln(${this})"
   def log10: double = sql"log10(${this})"
+  def log10 in snowflake: double = sql"log(10,${this})"
   def log2: double = sql"log2(${this})"
+  def log2 in snowflake: double = sql"log(2,${this})"
+  def log2 in bigquery: double = sql"log(${this}, 2)"
   def power(exponent:double): double = sql"power(${this},${exponent})"
   def mod(divisor:int): int = sql"mod(${this},${divisor})"
   def sign: int = sql"sign(${this})"
@@ -29,6 +38,8 @@ type int = {
   def from_unixtime in duckdb: timestamp = sql"make_timestamp(cast(${this} as bigint) * 1000000)"
   def from_unixtime in trino: timestamp = sql"cast(from_unixtime(${this}) AT TIME ZONE 'UTC' as timestamp)"
   def from_unixtime in hive: timestamp = sql"cast(from_unixtime(${this}) as timestamp)"
+  def from_unixtime in snowflake: timestamp = sql"to_timestamp_ntz(${this})"
+  def from_unixtime in bigquery: timestamp = sql"timestamp_seconds(${this})"
 
   def in(v:any*): boolean = sql"${this} in (${v})"
   def not_in(v:any*): boolean = sql"${this} not in (${v})"

--- a/wvlet-stdlib/module/standard/long.wv
+++ b/wvlet-stdlib/module/standard/long.wv
@@ -2,12 +2,18 @@ package wvlet.standard
 
 type long = {
   def to_int: int = sql"cast(${this} as bigint)"
+  def to_int in bigquery: int = sql"cast(${this} as int64)"
   def to_long: long = sql"cast(${this} as bigint)"
+  def to_long in bigquery: long = sql"cast(${this} as int64)"
   def to_float: float = sql"cast(${this} as double)"
+  def to_float in bigquery: float = sql"cast(${this} as float64)"
   def to_double: double = sql"cast(${this} as double)"
+  def to_double in bigquery: double = sql"cast(${this} as float64)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
+  def to_boolean in bigquery: boolean = sql"cast(${this} as bool)"
   def to_string: string = sql"cast(${this} as varchar)"
   def to_string in hive: string = sql"cast(${this} as string)"
+  def to_string in bigquery: string = sql"cast(${this} as string)"
 
   def or_else(other:long): long = sql"coalesce(${this},${other})"
   def round(decimal:int=0): double = sql"round(${this},${decimal})"
@@ -20,7 +26,10 @@ type long = {
   def exp: double = sql"exp(${this})"
   def ln: double = sql"ln(${this})"
   def log10: double = sql"log10(${this})"
+  def log10 in snowflake: double = sql"log(10,${this})"
   def log2: double = sql"log2(${this})"
+  def log2 in snowflake: double = sql"log(2,${this})"
+  def log2 in bigquery: double = sql"log(${this}, 2)"
   def power(exponent:double): double = sql"power(${this},${exponent})"
   def mod(divisor:long): long = sql"mod(${this},${divisor})"
   def sign: int = sql"sign(${this})"
@@ -29,6 +38,8 @@ type long = {
   def from_unixtime in duckdb: timestamp = sql"make_timestamp(cast(${this} as bigint) * 1000000)"
   def from_unixtime in trino: timestamp = sql"cast(from_unixtime(${this}) AT TIME ZONE 'UTC' as timestamp)"
   def from_unixtime in hive: timestamp = sql"cast(from_unixtime(${this}) as timestamp)"
+  def from_unixtime in snowflake: timestamp = sql"to_timestamp_ntz(${this})"
+  def from_unixtime in bigquery: timestamp = sql"timestamp_seconds(${this})"
 
   def in(v:any*): boolean = sql"${this} in (${v})"
   def not_in(v:any*): boolean = sql"${this} not in (${v})"

--- a/wvlet-stdlib/module/standard/map.wv
+++ b/wvlet-stdlib/module/standard/map.wv
@@ -13,8 +13,12 @@ type map[K,V] = {
   def contains_key(key:K): boolean = sql"contains(map_keys(${this}),${key})"
   def contains_key(key:K) in hive: boolean = sql"array_contains(map_keys(${this}),${key})"
 
+  def size in snowflake: int = sql"map_size(${this})"
+  def contains_key(key:K) in snowflake: boolean = sql"map_contains_key(${key},${this})"
+
   -- The value for the given key, or null if the key is absent
   def get(key:K) in duckdb: V = sql"${this}[${key}]"
   def get(key:K) in trino: V = sql"element_at(${this},${key})"
   def get(key:K) in hive: V = sql"${this}[${key}]"
+  def get(key:K) in snowflake: V = sql"${this}[${key}]"
 }

--- a/wvlet-stdlib/module/standard/null.wv
+++ b/wvlet-stdlib/module/standard/null.wv
@@ -2,12 +2,18 @@ package wvlet.standard
 
 type null = {
   def to_int: int = sql"cast(${this} as bigint)"
+  def to_int in bigquery: int = sql"cast(${this} as int64)"
   def to_long: long = sql"cast(${this} as bigint)"
+  def to_long in bigquery: long = sql"cast(${this} as int64)"
   def to_float: float = sql"cast(${this} as double)"
+  def to_float in bigquery: float = sql"cast(${this} as float64)"
   def to_double: double = sql"cast(${this} as double)"
+  def to_double in bigquery: double = sql"cast(${this} as float64)"
   def to_boolean: boolean = sql"cast(${this} as boolean)"
+  def to_boolean in bigquery: boolean = sql"cast(${this} as bool)"
   def to_date: date = sql"cast(${this} as date)"
   def to_timestamp: timestamp = sql"cast(${this} as timestamp)"
   def to_string: string = sql"cast(${this} as varchar)"
   def to_string in hive: string = sql"cast(${this} as string)"
+  def to_string in bigquery: string = sql"cast(${this} as string)"
 }

--- a/wvlet-stdlib/module/standard/string.wv
+++ b/wvlet-stdlib/module/standard/string.wv
@@ -109,3 +109,55 @@ type string in hive = {
   def json_extract(path:string): json = sql"get_json_object(${this},${path})"
   def json_extract_string(path:string): string = sql"get_json_object(${this},${path})"
 }
+
+type string in snowflake = {
+  -- Snowflake's REGEXP_LIKE matches the entire string, so use REGEXP_INSTR for the
+  -- partial-match semantics of the other engines
+  def regexp_like(pattern:string): boolean = sql"regexp_instr(${this},${pattern}) > 0"
+  -- Replace every substring matching the regular expression with the replacement
+  def regexp_replace(pattern:string, replacement:string): string = sql"regexp_replace(${this},${pattern},${replacement})"
+  -- Extract the first substring matching the regular expression
+  def regexp_extract(pattern:string): string = sql"regexp_substr(${this},${pattern})"
+  def regexp_extract(pattern:string, group_index:int): string = sql"regexp_substr(${this},${pattern},1,1,'c',${group_index})"
+  -- 1-origin position of the first occurrence of the substring (0 if not found)
+  def strpos(substr:string): int = sql"charindex(${substr},${this})"
+  def contains(substr:string): boolean = sql"contains(${this},${substr})"
+  def starts_with(prefix:string): boolean = sql"startswith(${this},${prefix})"
+  def ends_with(suffix:string): boolean = sql"endswith(${this},${suffix})"
+  -- Split the string by the separator into an array of strings
+  def split(separator:string): array[string] = sql"split(${this},${separator})"
+  -- Hex-encoded digest strings
+  def md5: string = sql"md5(${this})"
+  def sha256: string = sql"sha2(${this},256)"
+  -- Edit distance between two strings
+  def levenshtein(other:string): int = sql"editdistance(${this},${other})"
+  -- Extract a JSON value from a string holding JSON text. Note: Snowflake paths omit the
+  -- leading '$.' (e.g. 'a.b' instead of '$.a.b')
+  def json_extract(path:string): json = sql"get_path(parse_json(${this}),${path})"
+  def json_extract_string(path:string): string = sql"json_extract_path_text(${this},${path})"
+}
+
+type string in bigquery = {
+  -- BigQuery cast type names differ from the other engines
+  def to_int: int = sql"cast(${this} as int64)"
+  def to_long: long = sql"cast(${this} as int64)"
+  def to_float: float = sql"cast(${this} as float64)"
+  def to_double: double = sql"cast(${this} as float64)"
+  def to_boolean: boolean = sql"cast(${this} as bool)"
+
+  def regexp_like(pattern:string): boolean = sql"regexp_contains(${this},${pattern})"
+  -- Replace every substring matching the regular expression with the replacement
+  def regexp_replace(pattern:string, replacement:string): string = sql"regexp_replace(${this},${pattern},${replacement})"
+  def contains(substr:string): boolean = sql"strpos(${this},${substr}) > 0"
+  def ends_with(suffix:string): boolean = sql"ends_with(${this},${suffix})"
+  -- Split the string by the separator into an array of strings
+  def split(separator:string): array[string] = sql"split(${this},${separator})"
+  -- Hex-encoded digest strings (BigQuery digests return BYTES)
+  def md5: string = sql"lower(to_hex(md5(${this})))"
+  def sha256: string = sql"lower(to_hex(sha256(${this})))"
+  -- Edit distance between two strings
+  def levenshtein(other:string): int = sql"edit_distance(${this},${other})"
+  -- Extract a JSON value from a string holding JSON text (JSONPath, e.g. '$.a.b')
+  def json_extract(path:string): json = sql"json_extract(${this},${path})"
+  def json_extract_string(path:string): string = sql"json_extract_scalar(${this},${path})"
+}

--- a/wvlet-stdlib/module/standard/timestamp.wv
+++ b/wvlet-stdlib/module/standard/timestamp.wv
@@ -93,3 +93,55 @@ type timestamp in hive = {
 
   def to_string: string = sql"cast(${this} as string)"
 }
+
+type timestamp in snowflake = {
+  -- ISO day of week (1 = Monday, 7 = Sunday) and day of year
+  def day_of_week: int = sql"dayofweekiso(${this})"
+  def day_of_year: int = sql"dayofyear(${this})"
+
+  def add_seconds(n:int): timestamp = sql"dateadd('second',${n},${this})"
+  def add_minutes(n:int): timestamp = sql"dateadd('minute',${n},${this})"
+  def add_hours(n:int): timestamp = sql"dateadd('hour',${n},${this})"
+  def add_days(n:int): timestamp = sql"dateadd('day',${n},${this})"
+  def add_months(n:int): timestamp = sql"dateadd('month',${n},${this})"
+  def add_years(n:int): timestamp = sql"dateadd('year',${n},${this})"
+
+  -- Format the timestamp with a SQL format model (e.g. 'YYYY-MM-DD HH24:MI:SS')
+  def format(pattern:string): string = sql"to_char(${this},${pattern})"
+
+  def diff_seconds(other:timestamp): long = sql"datediff('second',${this},${other})"
+  def diff_minutes(other:timestamp): long = sql"datediff('minute',${this},${other})"
+  def diff_hours(other:timestamp): long = sql"datediff('hour',${this},${other})"
+  def diff_days(other:timestamp): long = sql"datediff('day',${this},${other})"
+
+  -- Unix epoch seconds of this timestamp
+  def to_unixtime: long = sql"cast(date_part('epoch_second',${this}) as bigint)"
+
+  -- Render without the sub-second part, matching the other engines
+  def to_string: string = sql"to_char(${this},'YYYY-MM-DD HH24:MI:SS')"
+}
+
+type timestamp in bigquery = {
+  -- ISO day of week (1 = Monday, 7 = Sunday; BigQuery's DAYOFWEEK starts at 1 = Sunday)
+  def day_of_week: int = sql"mod(extract(dayofweek from ${this}) + 5, 7) + 1"
+  def day_of_year: int = sql"extract(dayofyear from ${this})"
+
+  def add_seconds(n:int): timestamp = sql"timestamp_add(${this}, interval (${n}) second)"
+  def add_minutes(n:int): timestamp = sql"timestamp_add(${this}, interval (${n}) minute)"
+  def add_hours(n:int): timestamp = sql"timestamp_add(${this}, interval (${n}) hour)"
+  def add_days(n:int): timestamp = sql"timestamp_add(${this}, interval (${n}) day)"
+
+  -- Format the timestamp with a strftime-style pattern (e.g. '%Y-%m-%d %H:%M:%S')
+  def format(pattern:string): string = sql"format_timestamp(${pattern},${this})"
+
+  def diff_seconds(other:timestamp): long = sql"timestamp_diff(${other},${this},second)"
+  def diff_minutes(other:timestamp): long = sql"timestamp_diff(${other},${this},minute)"
+  def diff_hours(other:timestamp): long = sql"timestamp_diff(${other},${this},hour)"
+  def diff_days(other:timestamp): long = sql"timestamp_diff(${other},${this},day)"
+
+  -- Unix epoch seconds of this timestamp
+  def to_unixtime: long = sql"unix_seconds(${this})"
+
+  -- Render without the sub-second part, matching the other engines
+  def to_string: string = sql"format_timestamp('%Y-%m-%d %H:%M:%S',${this})"
+}


### PR DESCRIPTION
## Summary

Extends the stdlib's dialect-aware function resolution (#1966, #1972, #1973) to **Snowflake** and **BigQuery**, keeping the established type-centric layout: `in snowflake` / `in bigquery` variants live beside the neutral and other dialect defs in each type file (the resolver merges dialect blocks only within a file). `db_contexts.wv` gains `type snowflake` / `type bigquery`; `DBType.Snowflake` / `DBType.BigQuery` already map to those contexts.

### Snowflake highlights
- `regexp_instr(s,p) > 0` for `regexp_like` — Snowflake's own `REGEXP_LIKE` matches the **entire** string, so this preserves the partial-match semantics of the other engines
- `charindex` / `startswith` / `endswith` / `editdistance` / `sha2` / `json_extract_path_text` (paths omit the leading `$.`, documented)
- `dateadd`/`datediff` date-time arithmetic, `dayofweekiso`, `date_part('epoch_second')` for `to_unixtime`
- 0-indexed array `get`, `array_size`, `array_cat`, `to_variant`-based `array_contains`/`array_position`, `listagg`, `booland_agg`/`boolor_agg`, exact `median` (neutral)
- `log(base, x)` for `log2`/`log10` (no `log2`/`log10` functions)

### BigQuery highlights
- Cast type names: `int64` / `float64` / `string` / `bool` across all conversion functions (BigQuery rejects `bigint`, `double`, `varchar`, `boolean`)
- `regexp_contains`, `edit_distance`, `to_hex`-wrapped `md5`/`sha256` (BigQuery digests return BYTES), `json_extract_scalar` (JSONPath compatible)
- Interval-based arithmetic with keyword date parts: `date_add(d, interval (n) day)`, `timestamp_diff(a, b, second)`, `unix_seconds`/`timestamp_seconds`
- `arr[ordinal(i)]` (1-origin), `x in unnest(arr)` for contains, `countif`, `logical_and`/`logical_or`, `approx_quantiles`-based `median`/`approx_quantile`, `is_nan`/`is_inf`
- Known gap: `truncate_to(unit)` can't be mapped — BigQuery's `DATE_TRUNC` takes the unit as a keyword, not a string parameter

## Verification

Neither engine has an execution backend in this repo, so mappings are verified by generated-SQL assertions in the new `SnowflakeBigQueryDialectResolutionTest` (10 tests covering strings, date/timestamp, arrays, aggregations, casts, and DuckDB non-regression).

- `langJVM/testOnly *` — 1897 tests pass (incl. StdLibParseCheck and the coverage ratchet)
- `runnerJVM/testOnly *` — 673 pass (DuckDB + Trino execution specs unaffected)
- `projectJS` / `projectNative` test compile clean; scalafmt applied
- Docs updated with the new dialects and pattern-string caveats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDVq4Etzaj8C8XCUm2iJiP