### PR TITLE
feature: Bearer-token authentication for the remote wvlet-server backend

### DIFF
--- a/website/docs/usage/remote-server.md
+++ b/website/docs/usage/remote-server.md
@@ -1,0 +1,95 @@
+# Remote Wvlet Server
+
+The `wvlet` CLI can run queries on a central wvlet server instead of a local engine. The server holds the profiles, catalogs, and database credentials; thin clients — including the native `wv` binary and the Node.js CLI (`npx @wvlet/cli`) — send the original Wvlet query text and receive structured results, with no local database engine or credentials required.
+
+## Starting a server
+
+```bash
+# Start a wvlet server on the default port 9090
+wvlet ui --port 9090 --profile your-profile
+```
+
+The server compiles and executes queries with its own profile (`~/.wvlet/profiles.json` on the server host), so clients never need direct access to the underlying database.
+
+## Running queries remotely
+
+Use `-t wvlet` with the server's host (and port, when it is not the default 9090 for HTTP or 443 for HTTPS):
+
+```bash
+# Run a query on a remote wvlet server
+wvlet run -t wvlet --host wvlet.example.com --port 9090 "from lineitem select count(*)"
+
+# Run a query file
+wvlet run -t wvlet --host wvlet.example.com -f daily_report.wv
+
+# Use HTTPS (default port 443)
+wvlet run -t wvlet --host wvlet.example.com --https "from orders limit 10"
+```
+
+Each CLI invocation holds one server-side session, so multi-statement scripts keep their state — `use` statements and temporary tables work across statements within a run.
+
+A profile entry can hold the connection settings so you only pass `-p`:
+
+```jsonc title='~/.wvlet/profiles.json'
+{
+  "profiles": [
+    {
+      "name": "remote",
+      "connectors": [
+        {
+          "name": "wvlet",
+          "type": "wvlet",
+          "default": true,
+          "host": "wvlet.example.com",
+          "port": 9090,
+          "properties": {
+            // Optional: run under this profile name defined on the SERVER
+            "remoteProfile": "production"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+```bash
+wvlet run -p remote "from lineitem select count(*)"
+```
+
+## Authentication
+
+To require a bearer token for all query (RPC) requests, start the server with a token. Prefer the environment variable so the secret stays out of the process list:
+
+```bash
+WVLET_SERVER_TOKEN=your-secret-token wvlet ui --port 9090
+```
+
+(`--auth-token your-secret-token` also works.)
+
+Clients supply the token through the profile's `token` property. Environment variables are interpolated with `${VAR}`, so the secret does not need to be written into the file:
+
+```jsonc title='~/.wvlet/profiles.json'
+{
+  "profiles": [
+    {
+      "name": "remote",
+      "connectors": [
+        {
+          "name": "wvlet",
+          "type": "wvlet",
+          "default": true,
+          "host": "wvlet.example.com",
+          "port": 9090,
+          "useHttps": true,
+          "properties": {
+            "token": "${WVLET_TOKEN}"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+The token is sent as an `Authorization: Bearer` header on every request. Requests without a valid token are rejected with an authentication error; the static Web UI assets remain reachable without a token. Always combine token authentication with HTTPS (for example, behind a TLS-terminating reverse proxy) so the token is not sent in clear text.

--- a/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
+++ b/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
@@ -162,7 +162,9 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
     val client = WvletServerClient(
       baseUri = s"${scheme}://${host}:${port}",
       // The server resolves this name in ITS profiles.json; unset runs on the server default
-      profile = engine.flatMap(_.properties.get("remoteProfile")).map(_.toString)
+      profile = engine.flatMap(_.properties.get("remoteProfile")).map(_.toString),
+      // Credentials come from the profile only (with ${ENV} interpolation) — never CLI flags
+      token = engine.flatMap(_.properties.get("token")).map(_.toString)
     )
     try client.runQuery(query)
     finally client.close()

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/WvletServerClient.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/connector/WvletServerClient.scala
@@ -50,6 +50,8 @@ class WvletServerClient(
     baseUri: String,
     // Server-side profile to run under; None uses the server's default profile
     profile: Option[String] = None,
+    // Bearer token sent as `Authorization: Bearer <token>` when the server requires authentication
+    token: Option[String] = None,
     maxRows: Int = WvletServerClient.DefaultMaxRows,
     pollIntervalMillis: Long = 100
 ) extends AutoCloseable
@@ -61,7 +63,10 @@ class WvletServerClient(
       .withBaseUri(baseUri)
       // The Native (libcurl) channel does not transparently decompress gzip responses the way
       // the JVM client does; ask the server for identity encoding so all platforms decode alike
-      .withRequestFilter(req => req.setHeader("Accept-Encoding", "identity"))
+      .withRequestFilter { req =>
+        val r = req.setHeader("Accept-Encoding", "identity")
+        token.map(t => r.setHeader("Authorization", s"Bearer ${t}")).getOrElse(r)
+      }
       .newSyncClient
   )
 

--- a/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/WvletServer.scala
@@ -47,9 +47,18 @@ case class WvletServerConfig(
     )
     quitImmediately: Boolean = false,
     @option(prefix = "--tpch", description = "Load a small demo TPC-H data (DuckDB only)")
-    prepareTPCH: Boolean = false
+    prepareTPCH: Boolean = false,
+    @option(
+      prefix = "--auth-token",
+      description =
+        "Require this bearer token on RPC requests. Prefer the WVLET_SERVER_TOKEN environment variable to keep the secret out of the process list"
+    )
+    authToken: Option[String] = None
 ):
   lazy val workEnv: WorkEnv = WorkEnv(path = workDir)
+
+  /** The effective bearer token: the explicit option, else the WVLET_SERVER_TOKEN env variable */
+  def resolvedAuthToken: Option[String] = authToken.orElse(sys.env.get("WVLET_SERVER_TOKEN"))
 
 object WvletServer extends LogSupport:
 
@@ -109,6 +118,36 @@ object WvletServer extends LogSupport:
           RPCStatus.INTERNAL_ERROR_I0.newException(e.getMessage, e).toResponse
 
   end MultiRpcHandler
+
+  /**
+    * Require `Authorization: Bearer <token>` on RPC (POST) requests. Non-POST requests pass through
+    * untouched so the static Web UI assets stay reachable; every RPC endpoint — queries, files,
+    * flows — rejects with UNAUTHENTICATED unless the token matches (constant-time comparison).
+    */
+  private def withBearerAuth(rpc: RxHttpHandler, token: String): RxHttpHandler =
+    val expected = token.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    (request) =>
+      if request.method != HttpMethod.POST then
+        rpc.handle(request)
+      else
+        val authorized = request
+          .header(HttpHeader.Authorization)
+          .exists { h =>
+            h.startsWith("Bearer ") &&
+            java
+              .security
+              .MessageDigest
+              .isEqual(
+                h.stripPrefix("Bearer ").getBytes(java.nio.charset.StandardCharsets.UTF_8),
+                expected
+              )
+          }
+        if authorized then
+          rpc.handle(request)
+        else
+          Rx.single(
+            RPCStatus.UNAUTHENTICATED_U13.newException("Missing or invalid bearer token").toResponse
+          )
 
   // Wrap an RPC handler with a static-content fallback. uni's path matcher doesn't support
   // airframe's "/*splat" pattern, so we cannot register a catch-all controller endpoint.
@@ -222,7 +261,14 @@ object WvletServer extends LogSupport:
             RPCRouter.of[FlowApi](flowApi)
           )
         )
-        val handler = withStaticFallback(rpc, staticApi)
+        val guardedRpc = resolvedConf
+          .resolvedAuthToken
+          .map { token =>
+            info("Bearer-token authentication is enabled for RPC requests")
+            withBearerAuth(rpc, token)
+          }
+          .getOrElse(rpc)
+        val handler = withStaticFallback(guardedRpc, staticApi)
         NettyHttpServer(
           NettyServerConfig().withName("wvlet-ui").withPort(port).withRxHandler(handler)
         )
@@ -234,7 +280,9 @@ object WvletServer extends LogSupport:
 
   // Bind port = 0 so the design's unusedPortFrom helper acquires whichever local
   // port the OS hands back — same effect the dropped airframe IOUtil.unusedPort had.
-  def testDesign: Design = design(WvletServerConfig(port = 0)).bindProvider {
+  def testDesign: Design = testDesign(WvletServerConfig(port = 0))
+
+  def testDesign(config: WvletServerConfig): Design = design(config.copy(port = 0)).bindProvider {
     (server: NettyHttpServer) =>
       // Force the JVM HTTP channel factory before constructing the client.
       // HttpCompat (which auto-registers the factory) is package-private, so we

--- a/wvlet-server/src/test/scala/wvlet/lang/server/WvletServerAuthTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/WvletServerAuthTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.server
+
+import wvlet.lang.runner.TableRows
+import wvlet.lang.runner.connector.WvletServerClient
+import wvlet.lang.test.WvletDITest
+import wvlet.uni.http.netty.NettyHttpServer
+
+/**
+  * End-to-end tests for bearer-token authentication on the wvlet server: RPC requests must carry
+  * `Authorization: Bearer <token>` when the server is started with an auth token, while static Web
+  * UI assets stay reachable without one.
+  */
+class WvletServerAuthTest extends WvletDITest:
+
+  private val serverToken = "test-secret-token"
+
+  initDesign:
+    _.add(WvletServer.testDesign(WvletServerConfig(authToken = Some(serverToken))))
+
+  private def withClient[U](token: Option[String])(body: WvletServerClient => U): U =
+    val server = dep[NettyHttpServer]
+    val client = WvletServerClient(s"http://localhost:${server.localPort}", token = token)
+    try body(client)
+    finally client.close()
+
+  test("accept queries carrying the correct bearer token") {
+    withClient(Some(serverToken)) { client =>
+      val result = client.runQuery("from [[1], [2]] as t(a) select a")
+      result match
+        case t: TableRows =>
+          t.totalRows shouldBe 2
+        case other =>
+          fail(s"Expected TableRows, got: ${other}")
+    }
+  }
+
+  test("reject queries without a token") {
+    withClient(None) { client =>
+      val e = intercept[Exception] {
+        client.runQuery("select 1")
+      }
+      e.getMessage shouldContain "bearer token"
+    }
+  }
+
+  test("reject queries with a wrong token") {
+    withClient(Some("wrong-token")) { client =>
+      val e = intercept[Exception] {
+        client.runQuery("select 1")
+      }
+      e.getMessage shouldContain "bearer token"
+    }
+  }
+
+end WvletServerAuthTest


### PR DESCRIPTION
## Summary

Completes the remote-backend story from #1970: the wvlet server previously accepted RPC requests from anyone who could reach its port, so `-t wvlet` was only safe on localhost. This adds optional bearer-token authentication end to end, mirroring the Trino bearer-token support from #1969.

## Changes

**Server** (`WvletServer`):
- New `--auth-token` option / `WVLET_SERVER_TOKEN` environment variable (env var preferred — keeps the secret out of the process list) on `WvletServerConfig`.
- When set, all RPC (POST) requests require `Authorization: Bearer <token>`, verified with a constant-time comparison; failures answer `UNAUTHENTICATED` (401). Non-POST requests pass through so static Web UI assets stay reachable.
- `testDesign` gained a config-taking overload for auth-enabled test servers.

**Client** (`WvletServerClient`, shared cross-platform source):
- New `token` option; when set, every request carries `Authorization: Bearer <token>` — works unchanged on JVM, Node.js, and Native since it rides the existing request filter.

**CLI** (`WvletCli`):
- `run -t wvlet` picks the token up from the profile's `token` property (with `${ENV}` interpolation) — credentials come from the profile only, never CLI flags, consistent with the Trino connector.

**Docs**: new `website/docs/usage/remote-server.md` covering the remote backend (`-t wvlet`, profiles, `remoteProfile`) and authentication setup — the backend shipped in #1970 without user docs.

## Tests

- New `WvletServerAuthTest`: end-to-end over a live in-process server — correct token runs queries, missing and wrong tokens are rejected.
- Full `server/test` suite green; `runnerJS` / `runnerNative` / `cliCoreJS` / `cliCoreNative` compile checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49