### PR TITLE
feature: Add native DDL statements for schema and table management

### DIFF
--- a/spec/basic/ddl/ddl-basic.wv
+++ b/spec/basic/ddl/ddl-basic.wv
@@ -1,0 +1,49 @@
+-- Native catalog statements (Phase 1): schema and table lifecycle without `execute sql` escapes
+
+create schema staging if not exists
+drop schema staging if exists
+
+-- A side-effect-free table shape declaration: registers the type; never executes by itself
+table ddl_people = {
+  id: int
+  name: string
+}
+
+-- The create action reads the shape from the declaration (create-if-missing, idempotent)
+create table ddl_people
+create table ddl_people
+
+-- Explicit block form of append: effect-first spelling for pipeline scripts
+append to ddl_people {
+  from [[1, 'alice'], [2, 'bob']] as t(id, name)
+}
+
+from ddl_people
+test _.size should be 2
+test _.columns should contain 'name'
+
+-- Block form of save to (create-or-replace)
+save to ddl_people_snapshot {
+  from ddl_people
+}
+
+from ddl_people_snapshot
+test _.size should be 2
+
+-- Seed-once semantics: a no-op because the table already exists
+save to ddl_people_snapshot if not exists {
+  from ddl_people
+  limit 1
+}
+
+from ddl_people_snapshot
+test _.size should be 2
+
+truncate ddl_people
+
+from ddl_people
+test _.size should be 0
+
+drop table ddl_people_snapshot
+drop table ddl_people
+drop table ddl_people if exists

--- a/spec/basic/type-table-binding.wv
+++ b/spec/basic/type-table-binding.wv
@@ -2,7 +2,7 @@
 -- table location so that references type-check without a live catalog connection and compile
 -- to qualified table scans
 
-execute sql"create schema if not exists binding_test"
+create schema binding_test if not exists
 
 from [[1, 'apple'], [2, 'banana']] as t(id, name)
 save to binding_test.bound_orders

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -1,0 +1,94 @@
+# Managing Tables and Schemas
+
+Wvlet provides native statements for creating and managing database schemas and tables, so
+pipeline scripts no longer need `execute sql"..."` escapes for everyday catalog work.
+
+## Schema Management
+
+Create or drop a database schema (namespace). Modifiers like `if not exists` trail the
+name, following Wvlet's left-to-right style:
+
+```wvlet
+create schema staging
+create schema staging if not exists
+
+drop schema staging
+drop schema staging if exists
+```
+
+## Declaring a Table Shape
+
+A `table` declaration describes a table's columns using the same `name: type` notation as
+`type` definitions. The declaration itself is side-effect free — it only registers the
+schema for type checking, so declarations can live in shared files that other scripts
+`import` without touching the database:
+
+```wvlet
+table users = {
+  id: int
+  name: string
+  created_at: timestamp
+}
+```
+
+## Creating and Dropping Tables
+
+The `create table` action materializes a declared shape in the target database. It takes
+nothing after the table name — the columns come from the `table` declaration — and it is
+idempotent: if the table already exists, the statement is a no-op.
+
+```wvlet
+create table users     -- creates the table from its declaration if missing
+
+drop table users
+drop table users if exists
+
+truncate users         -- delete all rows, keep the table
+```
+
+Running `create table` without a matching `table` declaration in scope is a compile-time
+error.
+
+## Writing Query Results to Tables
+
+The `save to` and `append to` operators work in two spellings that compile identically.
+The *flow* form ends a query, which is convenient while exploring interactively:
+
+```wvlet
+from orders
+where amount > 0
+save to cleansed_orders
+```
+
+The *block* form leads with the effect, which makes committed pipeline scripts easier to
+scan — each statement announces what it writes before the query details:
+
+```wvlet
+save to cleansed_orders {
+  from orders
+  where amount > 0
+}
+
+append to events(id, name) {
+  from staged_events
+}
+```
+
+### Seeding a Table Once
+
+`save to` replaces the target table by default. Adding `if not exists` makes it a
+seed-once operation: the whole statement is a no-op when the table already exists, so
+re-running the script never overwrites or duplicates data:
+
+```wvlet
+save to calendar if not exists {
+  from date_dimension_source
+}
+```
+
+| Statement | Behavior when the table exists |
+|-----------|-------------------------------|
+| `save to t` | Replaced with the new query result |
+| `save to t if not exists` | No-op (seed once) |
+| `append to t` | Rows are appended |
+| `create table t` | No-op (idempotent) |

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -92,6 +92,8 @@ object GenSQL extends Phase("generate-sql"):
               statements += sql
             case _ =>
               warn(s"Unsupported command: ${cmd}")
+        case ExecuteDDL(ddl) =>
+          statements ++= generateDDLSQL(ddl, ctx)
         case ExecuteNothing =>
         // ok
         case other =>
@@ -144,6 +146,12 @@ object GenSQL extends Phase("generate-sql"):
     trace(s"[plan]\n${expanded.pp}\n[SQL]\n${query}")
     GeneratedSQL(query, expanded)
 
+  /** Render a side-effecting catalog statement (create/drop schema or table, truncate) as SQL */
+  def generateDDLSQL(ddl: TopLevelStatement, context: Context): List[String] =
+    given Context = context
+    val gen       = sqlGeneratorFor(context.dbType)
+    List(withHeader(gen.print(ddl), ddl.sourceLocation))
+
   def generateSaveSQL(save: Save, context: Context): List[String] =
     given Context  = context
     val statements = List.newBuilder[String]
@@ -170,7 +178,10 @@ object GenSQL extends Phase("generate-sql"):
         val baseSQL           = generateSQLFromRelation(save.inputRelation, addHeader = false)
         var needsTableCleanup = false
         val ctasCmd           =
-          if context.dbType.supportCreateOrReplace then
+          if s.ifNotExists then
+            // `save to t if not exists`: seed once, no-op when the table exists
+            "create table if not exists"
+          else if context.dbType.supportCreateOrReplace then
             s"create or replace table"
           else
             needsTableCleanup = true

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -389,6 +389,9 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
 
         group(wl("delete", "from", expr(d.target), filteringQuery))
 
+      case t: Truncate =>
+        group(wl("truncate", "table", expr(t.target)))
+
       case _ =>
         unsupportedNode(s"Update ${u.nodeName}", u.span)
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -155,6 +155,47 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
 
   private def ddl(d: DDL)(using sc: SyntaxContext): Doc =
     d match
+      case c: CreateSchema =>
+        code(c) {
+          group(
+            wl(
+              "create schema",
+              expr(c.schema),
+              Option.when(c.ifNotExists) {
+                "if not exists"
+              }
+            )
+          )
+        }
+      case s: DropSchema =>
+        code(s) {
+          group(
+            wl(
+              "drop schema",
+              expr(s.schema),
+              Option.when(s.ifExists) {
+                "if exists"
+              }
+            )
+          )
+        }
+      case c: CreateTable if c.tableElems.isEmpty =>
+        // The action form: the table shape lives in the `table` declaration
+        code(c) {
+          group(wl("create table", expr(c.table)))
+        }
+      case t: DropTable =>
+        code(t) {
+          group(
+            wl(
+              "drop table",
+              expr(t.table),
+              Option.when(t.ifExists) {
+                "if exists"
+              }
+            )
+          )
+        }
       case _ =>
         val sqlGen = SqlGenerator(formatter.config)
         val doc    = sqlGen.render(d)
@@ -190,6 +231,10 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
         relation(s)
       case a: AppendTo =>
         relation(a)
+      case t: Truncate =>
+        code(t) {
+          group(wl("truncate", expr(t.target)))
+        }
       case _ =>
         val sqlGen = SqlGenerator(formatter.config)
         val d      = sqlGen.render(u)
@@ -441,9 +486,13 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
                 expr(x)
               }
             Some(ws + "with" + nest(wsOrNL + cl(lst)))
+        val ifNotExists =
+          Option.when(s.ifNotExists) {
+            ws + "if not exists"
+          }
         prev /
           code(s) {
-            group(wl("save to", path) + opts)
+            group(wl("save to", path) + ifNotExists + opts)
           }
       case e: EmptyRelation =>
         empty
@@ -655,7 +704,12 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
               empty
             else
               "= "
-          group(wl("type", text(t.name.name) + typeParams, defContexts, parent, sep)) +
+          val keyword =
+            if t.isTableDef then
+              "table"
+            else
+              "type"
+          group(wl(keyword, text(t.name.name) + typeParams, defContexts, parent, sep)) +
             indentedBrace(concat(t.elems.map(e => group(expr(e))), linebreak))
         case p: PartialQueryDef =>
           val params =

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -958,11 +958,147 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         ExplainPlan(r, span = spanFrom(t))
       case WvletToken.USE =>
         use()
+      case WvletToken.CREATE =>
+        createStatement()
+      case WvletToken.DROP =>
+        dropStatement()
+      case WvletToken.TRUNCATE =>
+        val tt     = consume(WvletToken.TRUNCATE)
+        val target = qualifiedId()
+        Truncate(target, spanFrom(tt))
+      case WvletToken.SAVE | WvletToken.APPEND =>
+        saveBlockStatement()
+      case WvletToken.IDENTIFIER if t.str == "table" =>
+        tableShapeDef()
       case _ =>
         unexpected(t)
     end match
   }
   end statement
+
+  /**
+    * Parse a side-effect-free table shape declaration:
+    * {{{
+    *   table <name> [in <catalog>.<schema>] = { <fields and def members> }
+    * }}}
+    * The declaration shares the TypeDef machinery (isTableDef = true): the relation type registers
+    * in the same namespace as `type` definitions, and `create table <name>` actions read the shape
+    * from it. `table` is a soft keyword, matched only at statement head.
+    */
+  def tableShapeDef(): TypeDef = node {
+    val t      = consume(WvletToken.IDENTIFIER) // the `table` soft keyword
+    val name   = Name.typeName(identifier().leafName)
+    val scopes = context()
+    consume(WvletToken.EQ)
+    consume(WvletToken.L_BRACE)
+    val elems = typeElems()
+    consume(WvletToken.R_BRACE)
+    TypeDef(name, Nil, scopes, None, elems, spanFrom(t), isTableDef = true)
+  }
+
+  /** Parse a trailing `if not exists` modifier */
+  private def ifNotExistsModifier(): Boolean =
+    scanner.lookAhead().token match
+      case WvletToken.IF =>
+        consume(WvletToken.IF)
+        consume(WvletToken.NOT)
+        consume(WvletToken.EXISTS)
+        true
+      case _ =>
+        false
+
+  /** Parse a trailing `if exists` modifier */
+  private def ifExistsModifier(): Boolean =
+    scanner.lookAhead().token match
+      case WvletToken.IF =>
+        consume(WvletToken.IF)
+        consume(WvletToken.EXISTS)
+        true
+      case _ =>
+        false
+
+  /**
+    * createStatement := 'create' 'schema' qualifiedId ('if' 'not' 'exists')? | 'create' 'table'
+    * qualifiedId
+    *
+    * `create table` takes nothing after the name: the shape comes from a `table` declaration in
+    * scope, and the action is create-if-missing (idempotent), so no modifier is accepted.
+    */
+  def createStatement(): LogicalPlan = node {
+    val t    = consume(WvletToken.CREATE)
+    val kind = identifierSingle()
+    kind.leafName match
+      case "schema" =>
+        val name = qualifiedId()
+        CreateSchema(name, ifNotExistsModifier(), None, spanFrom(t))
+      case "table" =>
+        val name = qualifiedId()
+        // tableElems are filled from the `table` declaration in scope at typing time
+        CreateTable(name, ifNotExists = true, tableElems = Nil, span = spanFrom(t))
+      case other =>
+        throw StatusCode
+          .SYNTAX_ERROR
+          .newException(
+            s"Unknown create target '${other}'. Expected 'schema' or 'table'",
+            t.sourceLocation
+          )
+  }
+
+  /**
+    * dropStatement := 'drop' ('schema' | 'table') qualifiedId ('if' 'exists')?
+    */
+  def dropStatement(): LogicalPlan = node {
+    val t    = consume(WvletToken.DROP)
+    val kind = identifierSingle()
+    kind.leafName match
+      case "schema" =>
+        val name = qualifiedId()
+        DropSchema(name, ifExistsModifier(), spanFrom(t))
+      case "table" =>
+        val name = qualifiedId()
+        DropTable(name, ifExistsModifier(), spanFrom(t))
+      case other =>
+        throw StatusCode
+          .SYNTAX_ERROR
+          .newException(
+            s"Unknown drop target '${other}'. Expected 'schema' or 'table'",
+            t.sourceLocation
+          )
+  }
+
+  /**
+    * Explicit top-level block forms of the save-family flow suffixes, leading with the effect:
+    * {{{
+    *   save to <target> [if not exists] [with k: v, ...] { <query> }
+    *   append to <target> [(columns)] { <query> }
+    * }}}
+    * These lower to the same plan nodes as the flow-suffix forms.
+    */
+  def saveBlockStatement(): Relation = node {
+    def blockQuery(): Relation =
+      val bt = consume(WvletToken.L_BRACE)
+      val q  = queryBody()
+      consume(WvletToken.R_BRACE)
+      Query(q, spanFrom(bt))
+
+    val t = scanner.lookAhead()
+    t.token match
+      case WvletToken.SAVE =>
+        consume(WvletToken.SAVE)
+        consume(WvletToken.TO)
+        val target      = literalOrQualifiedName()
+        val ifNotExists = ifNotExistsModifier()
+        val opts        = saveOptions()
+        SaveTo(blockQuery(), target, opts, spanFrom(t), ifNotExists = ifNotExists)
+      case WvletToken.APPEND =>
+        consume(WvletToken.APPEND)
+        consume(WvletToken.TO)
+        val target  = literalOrQualifiedName()
+        val columns = appendColumnList()
+        AppendTo(blockQuery(), target, columns, spanFrom(t))
+      case _ =>
+        unexpected(t)
+  }
 
   def use(): Command = node {
     val t = consume(WvletToken.USE)
@@ -1536,80 +1672,82 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
   }
   end query
 
+  private def saveOptions(): List[SaveOption] =
+    val t = scanner.lookAhead()
+    t.token match
+      case WvletToken.WITH =>
+        consume(WvletToken.WITH)
+        val options = List.newBuilder[SaveOption]
+
+        def nextOption: Unit =
+          val t = scanner.lookAhead()
+          t.token match
+            case WvletToken.COMMA =>
+              consume(WvletToken.COMMA)
+              nextOption
+            case WvletToken.IDENTIFIER =>
+              val key = identifierSingle()
+              consume(WvletToken.COLON)
+              val value = expression()
+              options += SaveOption(key, value, key.span.extendTo(value.span))
+              nextOption
+            case _ =>
+        // finish
+        nextOption
+        options.result()
+      case _ =>
+        List.empty
+
+  private def literalOrQualifiedName(): StringLiteral | QualifiedName =
+    scanner.lookAhead().token match
+      case s if s.isStringLiteral =>
+        stringLiteral()
+      case _ =>
+        qualifiedId()
+
+  /** Parse an optional column list like: append to users(id, email) */
+  private def appendColumnList(): List[NameExpr] =
+    if scanner.lookAhead().token == WvletToken.L_PAREN then
+      consume(WvletToken.L_PAREN)
+      def parseColumns(): List[NameExpr] =
+        // Use tail-recursive loop to avoid StackOverflowError with many columns
+        @annotation.tailrec
+        def loop(acc: List[NameExpr]): List[NameExpr] =
+          val id = identifier()
+          scanner.lookAhead().token match
+            case WvletToken.COMMA =>
+              consume(WvletToken.COMMA)
+              loop(id :: acc)
+            case _ =>
+              (id :: acc).reverse
+
+        // Handle empty column list
+        if scanner.lookAhead().token == WvletToken.R_PAREN then
+          Nil
+        else
+          loop(Nil)
+
+      val cols = parseColumns()
+      consume(WvletToken.R_PAREN)
+      cols
+    else
+      Nil
+
   def updateOpsIfExists(r: Relation): Relation = node {
-
-    def saveOptions(): List[SaveOption] =
-      val t = scanner.lookAhead()
-      t.token match
-        case WvletToken.WITH =>
-          consume(WvletToken.WITH)
-          val options = List.newBuilder[SaveOption]
-
-          def nextOption: Unit =
-            val t = scanner.lookAhead()
-            t.token match
-              case WvletToken.COMMA =>
-                consume(WvletToken.COMMA)
-                nextOption
-              case WvletToken.IDENTIFIER =>
-                val key = identifierSingle()
-                consume(WvletToken.COLON)
-                val value = expression()
-                options += SaveOption(key, value, key.span.extendTo(value.span))
-                nextOption
-              case _ =>
-          // finish
-          nextOption
-          options.result()
-        case _ =>
-          List.empty
-
-    def literalOrQualifiedName(): StringLiteral | QualifiedName =
-      scanner.lookAhead().token match
-        case s if s.isStringLiteral =>
-          stringLiteral()
-        case _ =>
-          qualifiedId()
-
     val t = scanner.lookAhead()
     t.token match
       case WvletToken.SAVE =>
         consume(WvletToken.SAVE)
         consume(WvletToken.TO)
         val target: StringLiteral | QualifiedName = literalOrQualifiedName()
+        val ifNotExists                           = ifNotExistsModifier()
         val opts                                  = saveOptions()
-        SaveTo(r, target, opts, spanFrom(t))
+        SaveTo(r, target, opts, spanFrom(t), ifNotExists = ifNotExists)
       case WvletToken.APPEND =>
         consume(WvletToken.APPEND)
         consume(WvletToken.TO)
         val target: StringLiteral | QualifiedName = literalOrQualifiedName()
-        // Handle optional column list like: append to users(id, email)
-        val columns =
-          if scanner.lookAhead().token == WvletToken.L_PAREN then
-            consume(WvletToken.L_PAREN)
-            def parseColumns(): List[NameExpr] =
-              // Use tail-recursive loop to avoid StackOverflowError with many columns
-              @annotation.tailrec
-              def loop(acc: List[NameExpr]): List[NameExpr] =
-                val id = identifier()
-                scanner.lookAhead().token match
-                  case WvletToken.COMMA =>
-                    consume(WvletToken.COMMA)
-                    loop(id :: acc)
-                  case _ =>
-                    (id :: acc).reverse
-
-              // Handle empty column list
-              if scanner.lookAhead().token == WvletToken.R_PAREN then
-                Nil
-              else
-                loop(Nil)
-
-            val cols = parseColumns()
-            consume(WvletToken.R_PAREN)
-            cols
-          else
-            Nil
+        val columns                               = appendColumnList()
         AppendTo(r, target, columns, spanFrom(t))
       case WvletToken.DELETE =>
         consume(WvletToken.DELETE)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
@@ -220,6 +220,7 @@ enum WvletToken(val tokenType: TokenType, val str: String):
   case RENAME   extends WvletToken(Keyword, "rename")
   case SHIFT    extends WvletToken(Keyword, "shift")
   case DROP     extends WvletToken(Keyword, "drop")
+  case CREATE   extends WvletToken(Keyword, "create")
   case DESCRIBE extends WvletToken(Keyword, "describe")
 
   // set operators

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/planner/ExecutionPlanner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/planner/ExecutionPlanner.scala
@@ -109,6 +109,10 @@ object ExecutionPlanner extends Phase("execution-plan"):
           ExecutionPlan(plans.result())
         case c: Command =>
           ExecuteCommand(c)
+        case d: DDL =>
+          ExecuteDDL(d)
+        case t: Truncate =>
+          ExecuteDDL(t)
         case v: ValDef =>
           ExecuteValDef(v)
         case f: FlowDef if f eq targetPlan =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/planner/ExecutionPlanner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/planner/ExecutionPlanner.scala
@@ -109,9 +109,12 @@ object ExecutionPlanner extends Phase("execution-plan"):
           ExecutionPlan(plans.result())
         case c: Command =>
           ExecuteCommand(c)
-        case d: DDL =>
+        // DDL executes only for Wvlet sources. SQL files (spec/sql corpora) keep their
+        // historical parse-only planning: many contain engine-specific DDL forms that are
+        // not runnable on the active engine
+        case d: DDL if !unit.sourceFile.isSQL =>
           ExecuteDDL(d)
-        case t: Truncate =>
+        case t: Truncate if !unit.sourceFile.isSQL =>
           ExecuteDDL(t)
         case v: ValDef =>
           ExecuteValDef(v)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -321,8 +321,10 @@ object Typer extends Phase("typer") with LogSupport:
       case u: UseConnector =>
         markNamespaceRef(u.connector)
         typeNode(u)
-      case c: CreateTable if c.tableElems.isEmpty =>
-        // `create table <name>` action: the columns come from the `table` declaration in scope
+      // `create table <name>` action (Wvlet sources only): the columns come from the `table`
+      // declaration in scope. SQL sources may legitimately have column-less CREATE TABLE forms
+      // (e.g. Trino's CREATE TABLE ... WITH (properties)), which are left as parsed
+      case c: CreateTable if c.tableElems.isEmpty && !ctx.compilationUnit.sourceFile.isSQL =>
         markNamespaceRef(c.table)
         val typeName = Name.typeName(c.table.leafName)
         val cols     = ctx

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -40,7 +40,11 @@ import wvlet.lang.model.DataType
 import wvlet.lang.model.RelationType
 import wvlet.lang.model.DataType.NamedType
 import wvlet.lang.model.DataType.SchemaType
+import wvlet.lang.model.expr.ColumnDef
 import wvlet.lang.model.expr.Expression
+import wvlet.lang.model.expr.QualifiedName
+import wvlet.lang.model.expr.UnquotedIdentifier
+import wvlet.lang.compiler.parser.DataTypeParser
 import wvlet.lang.model.plan.*
 import wvlet.lang.model.Type
 import wvlet.lang.model.Type.NoType
@@ -317,6 +321,54 @@ object Typer extends Phase("typer") with LogSupport:
       case u: UseConnector =>
         markNamespaceRef(u.connector)
         typeNode(u)
+      case c: CreateTable if c.tableElems.isEmpty =>
+        // `create table <name>` action: the columns come from the `table` declaration in scope
+        markNamespaceRef(c.table)
+        val typeName = Name.typeName(c.table.leafName)
+        val cols     = ctx
+          .findSymbolByName(typeName)
+          .map(_.tree)
+          .collect { case td: TypeDef =>
+            td.elems
+              .collect { case f: FieldDef =>
+                ColumnDef(
+                  UnquotedIdentifier(f.name.name, f.span),
+                  DataTypeParser.parse(f.fieldType.fullName),
+                  f.span
+                )
+              }
+          }
+          .getOrElse(Nil)
+        if cols.isEmpty then
+          throw StatusCode
+            .TABLE_NOT_FOUND
+            .newException(
+              s"No table declaration found for 'create table ${c.table.fullName}'. " +
+                s"Declare its shape first: table ${c.table.leafName} = { <column>: <type>, ... }",
+              c.sourceLocation
+            )
+        val typed = c.copy(tableElems = cols)
+        typed.copyMetadataFrom(c)
+        typeNode(typed)
+      case d: DDL =>
+        // DDL statement names are catalog references, not value expressions
+        d match
+          case c: CreateSchema =>
+            markNamespaceRef(c.schema)
+          case s: DropSchema =>
+            markNamespaceRef(s.schema)
+          case dt: DropTable =>
+            markNamespaceRef(dt.table)
+          case ct: CreateTable =>
+            markNamespaceRef(ct.table)
+          case _ =>
+        typeNode(d)
+      case t: Truncate =>
+        t.target match
+          case q: QualifiedName =>
+            markNamespaceRef(q)
+          case _ =>
+        typeNode(t)
       // Default: bottom-up typing for other nodes
       case other =>
         val withTypedChildren = other.mapChildren(typePlan)

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/execution.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/execution.scala
@@ -125,7 +125,10 @@ case class ExecuteTasks(tasks: List[ExecutionPlan]) extends ExecutionPlan
 case class ExecuteQuery(plan: LogicalPlan)                   extends ExecutionPlan
 case class ExecuteSave(save: Save, queryPlan: ExecutionPlan) extends ExecutionPlan
 case class ExecuteCommand(execute: Command)                  extends ExecutionPlan
-case class ExecuteTest(test: TestRelation)                   extends ExecutionPlan
+
+/** Run a side-effecting catalog statement (create/drop schema or table, truncate) as SQL */
+case class ExecuteDDL(ddl: TopLevelStatement) extends ExecutionPlan
+case class ExecuteTest(test: TestRelation)    extends ExecutionPlan
 
 case class ExecuteDebug(debug: Debug, debugExecutionPlan: ExecutionPlan) extends ExecutionPlan
 case class ExecuteValDef(v: ValDef)                                      extends ExecutionPlan

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
@@ -68,7 +68,10 @@ case class TypeDef(
     defContexts: List[DefContext],
     parent: Option[NameExpr],
     elems: List[TypeElem],
-    span: Span
+    span: Span,
+    // true for `table <name> [in ...] = { ... }` table-shape declarations, which share the
+    // TypeDef machinery but print back as `table` and can seed `create table <name>` actions
+    isTableDef: Boolean = false
 ) extends LanguageStatement:
 
   /**

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/update.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/update.scala
@@ -38,7 +38,10 @@ case class SaveTo(
     child: Relation,
     target: TableOrFileName,
     saveOptions: List[SaveOption],
-    span: Span
+    span: Span,
+    // `save to t if not exists`: seed-once semantics (CREATE TABLE IF NOT EXISTS ... AS);
+    // false = create-or-replace, the save-to default
+    ifNotExists: Boolean = false
 ) extends Save
 
 case class AppendTo(

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -55,4 +55,52 @@ class WvletGeneratorTest extends UniTest:
     print(printed) shouldContain "call slack.post_message(channel: '#reports', text: 'hello')"
   }
 
+  test("should round-trip schema statements with trailing modifiers") {
+    val printed = print("""create schema staging if not exists
+        |drop schema staging if exists""".stripMargin)
+    printed shouldContain "create schema staging if not exists"
+    printed shouldContain "drop schema staging if exists"
+    print(printed) shouldContain "create schema staging if not exists"
+  }
+
+  test("should round-trip a table shape declaration as `table`, not `type`") {
+    val printed = print("""table users = {
+        |  id: int
+        |  name: string
+        |}""".stripMargin)
+    printed shouldContain "table users"
+    printed shouldContain "id: int"
+    printed.contains("type users") shouldBe false
+    print(printed) shouldContain "table users"
+  }
+
+  test("should round-trip table actions") {
+    val printed = print("""create table users
+        |truncate users
+        |drop table users if exists""".stripMargin)
+    printed shouldContain "create table users"
+    printed shouldContain "truncate users"
+    printed shouldContain "drop table users if exists"
+    print(printed) shouldContain "drop table users if exists"
+  }
+
+  test("should round-trip save to with the if not exists modifier") {
+    val printed = print("""from t
+        |save to snapshot if not exists""".stripMargin)
+    printed shouldContain "save to snapshot if not exists"
+    print(printed) shouldContain "save to snapshot if not exists"
+  }
+
+  test("should parse block-form save and append statements") {
+    val printed = print("""save to snapshot {
+        |  from t
+        |}""".stripMargin)
+    printed shouldContain "save to snapshot"
+
+    val appended = print("""append to users(id, name) {
+        |  from t
+        |}""".stripMargin)
+    appended shouldContain "append to users(id, name)"
+  }
+
 end WvletGeneratorTest

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/BasePlanExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/BasePlanExecutor.scala
@@ -48,6 +48,12 @@ abstract class BasePlanExecutor(val workEnv: WorkEnv) extends LogSupport with Au
   protected def executeSave(save: Save)(using Context): QueryResult =
     throw notSupported("save statements")
 
+  /** Run a catalog statement (create/drop schema or table, truncate) as SQL on the engine */
+  protected def executeDDL(ddl: TopLevelStatement)(using ctx: Context): QueryResult =
+    val statements = GenSQL.generateDDLSQL(ddl, ctx)
+    runStatements(statements)
+    QueryResult.empty
+
   protected def executeFlow(flow: FlowDef)(using Context): QueryResult =
     throw notSupported("flow execution")
 
@@ -112,6 +118,8 @@ abstract class BasePlanExecutor(val workEnv: WorkEnv) extends LogSupport with Au
         case ExecuteCommand(e) =>
           // Command produces no QueryResult other than errors
           report(executeCommand(e))
+        case ExecuteDDL(ddl) =>
+          report(executeDDL(ddl))
         case ExecuteFlow(flow) =>
           report(executeFlow(flow))
         case ExecuteValDef(v) =>


### PR DESCRIPTION
## Summary

Phase 1 of the DDL/update statement design: native catalog statements so pipeline scripts no longer need `execute sql"..."` escapes for everyday schema and table work.

### New syntax

```wvlet
create schema staging if not exists
drop schema staging if exists

-- Side-effect-free table shape declaration (registers the schema for type checking)
table users = {
  id: int
  name: string
}

create table users        -- idempotent action; columns come from the declaration
drop table users if exists
truncate users

-- Effect-first block forms of the save family
save to snapshot { from users }
append to users(id, name) { from staged }

-- Seed-once: no-op when the table already exists
save to calendar if not exists { from date_source }
```

### Design decisions (from the design doc)

- **Shape/action split**: `table ... = { ... }` declarations are side-effect-free like `type`/`model`/`def` (they reuse the `TypeDef` machinery and body grammar verbatim), while `create table` is the explicit executable action. Schema is written exactly once.
- **Keyword economy**: only one new reserved keyword (`create`); `table` and the object nouns (`schema`) are soft keywords matched in position; modifiers (`if not exists`, `if exists`) reuse existing tokens and trail the object name per the left-to-right policy.
- **One node vocabulary**: statements lower to the existing plan nodes (`CreateSchema`, `DropSchema`, `CreateTable`, `DropTable`, `Truncate`, `SaveTo`, `AppendTo`) and reuse the existing `SqlGenerator` printers via a new `ExecuteDDL` execution-plan node.
- `save to ... if not exists` maps to `CREATE TABLE IF NOT EXISTS ... AS` — genuinely different from `append to` (which would re-insert on every run).

### Implementation notes

- The Typer fills `CreateTable.tableElems` from the `table` declaration in scope and errors with a clear message when none is found; DDL name expressions are marked as namespace refs so the TyperCoverageCheck ratchet stays green.
- `WvletGenerator` prints all new statements natively (round-trip tested) instead of falling back to `execute sql`.
- Dogfood: `spec/basic/type-table-binding.wv` now uses the native `create schema` statement.
- Follow-up phases (per the design): `reshape` blocks, `rename table/schema ... to`, keyed `append to ... on`, flow `update`, `use 'file' as name`, drift diffing with generated migrations.

## Tests

- New spec `spec/basic/ddl/ddl-basic.wv` exercises the full lifecycle (create/drop schema, declaration + create table idempotency, block-form append/save, seed-once, truncate, drop) with embedded assertions on DuckDB
- `WvletGeneratorTest`: round-trip tests for every new statement form
- Full `runnerJVM/test` (276), `langJVM/test` (1004), `TyperCoverageCheck`, JS + Native compile all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3mfchNEQAGtbs8NXa7Bx