### PR TITLE
feature: Switch SQL dialect and catalog on use connector in the cross-platform runner

### DIFF
--- a/website/docs/usage/connectors.md
+++ b/website/docs/usage/connectors.md
@@ -76,6 +76,11 @@ Bare names are resolved connector-first: `use analytics` switches to a connector
 The switch is scoped to your session: in the web UI each browser page is its own session, so
 `use` statements of one client never change the engine, catalog, or schema of another.
 
+`use` works the same way in the lightweight CLIs (the native `wv` binary and the Node.js
+`npx @wvlet/cli`): it switches both the execution engine and the SQL dialect of the statements
+that follow. These thin clients compile without live catalog metadata, so table names should be
+written fully qualified when switching engines mid-script.
+
 ## Calling connector tools
 
 Connectors can expose callable tools (MCP-shaped methods) beyond tables and SQL execution. The

--- a/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
+++ b/wvlet-cli-core/src/main/scala/wvlet/lang/cli/WvletCli.scala
@@ -100,8 +100,11 @@ class WvletCli(opts: WvletCliGlobalOption) extends LogSupport:
             .map(_.connectors.filterNot(_.name == config.name).map(_.withDefault(false)))
             .getOrElse(Nil)
     )
-    val (unit, ctx) = WvletCliCompiler(opt.toCompileOption).compileForRun
-    val provider    = SqlConnectorProvider(runProfile)
+    // Compile with the EFFECTIVE backend's dialect: without this, `-p trino-profile` (no -t)
+    // would compile DuckDB SQL and execute it on Trino
+    val (unit, ctx) =
+      WvletCliCompiler(opt.toCompileOption.copy(targetDBType = Some(backend))).compileForRun
+    val provider = SqlConnectorProvider(runProfile)
     try
       val executor = PlanExecutor(
         provider,

--- a/wvlet-runner/src/main/scala/wvlet/lang/runner/PlanExecutor.scala
+++ b/wvlet-runner/src/main/scala/wvlet/lang/runner/PlanExecutor.scala
@@ -15,8 +15,10 @@ package wvlet.lang.runner
 
 import wvlet.lang.api.StatusCode
 import wvlet.lang.catalog.ConnectorConfig
+import wvlet.lang.catalog.InMemoryCatalog
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.DBType
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.compiler.codegen.GenSQL
 import wvlet.lang.compiler.connector.SqlConnector
@@ -30,8 +32,10 @@ import wvlet.lang.runner.connector.SqlConnectorProvider
   * DuckDB, Trino over REST) on JVM, Node.js, and Native alike. JVM-only plan nodes (save-to files,
   * flows) inherit [[BasePlanExecutor]]'s not-supported error.
   *
-  * Unlike the JVM `QueryExecutor`, `use <connector>` here switches the execution engine only — the
-  * thin CLIs compile catalog-free, so no catalog registration or SQL-dialect switch happens.
+  * `use <connector>` switches the execution engine AND the SQL dialect of subsequent statements
+  * (SQL is generated at execution time). Unlike the JVM `QueryExecutor`, no live catalog metadata
+  * is registered — the thin CLIs compile catalog-free, so the switched engine gets an in-memory
+  * catalog carrying its dialect and catalog/schema names.
   */
 class PlanExecutor(
     connectorProvider: SqlConnectorProvider,
@@ -108,14 +112,14 @@ class PlanExecutor(
               s"(available: ${defaultProfile.connectors.map(_.name).mkString(", ")})"
           )
       )
-    val schemaName =
+    val (catalogName, schemaName) =
       parts.tail match
         case Nil =>
-          config.schema
+          (config.catalog, config.schema)
         case schema :: Nil =>
-          Some(schema)
-        case _ :: schema :: Nil =>
-          Some(schema)
+          (config.catalog, Some(schema))
+        case catalog :: schema :: Nil =>
+          (Some(catalog), Some(schema))
         case _ =>
           throw StatusCode
             .SYNTAX_ERROR
@@ -127,10 +131,21 @@ class PlanExecutor(
     // failure leaves the previous engine fully active
     connectorProvider.getConnector(config)
     activeConfig = config
+    // Switch the SQL dialect along with the engine: SQL is generated at execution time from
+    // context.dbType (= defaultCatalog.dbType), so replacing the default catalog makes every
+    // statement after this `use` compile to the new engine's dialect. The thin CLIs run
+    // catalog-free, so an in-memory catalog carrying the dialect (and catalog/schema names for
+    // qualification) is all the switched engine needs
+    val newDBType = DBType.fromString(config.`type`)
+    context.global.defaultCatalog = InMemoryCatalog(
+      catalogName = catalogName.getOrElse(connectorName),
+      functions = Nil,
+      catalogDBType = newDBType
+    )
     schemaName.foreach { schema =>
       context.global.defaultSchema = schema
     }
-    workEnv.info(s"Switched to connector: ${connectorName}")
+    workEnv.info(s"Switched to connector: ${connectorName} (dialect: ${newDBType})")
     QueryResult.empty
 
   end switchConnector

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/PlanExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/PlanExecutorTest.scala
@@ -5,6 +5,8 @@ import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Compiler
 import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.DBType
 import wvlet.lang.compiler.Symbol
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.compiler.analyzer.duckdb.DuckDB
@@ -30,7 +32,9 @@ class PlanExecutorTest extends UniTest:
     List(ConnectorConfig(name = "duckdb", `type` = "duckdb", default = true))
   )
 
-  private def run(query: String): QueryResult =
+  private def run(query: String): QueryResult = runWithContext(query, profile)._1
+
+  private def runWithContext(query: String, profile: Profile): (QueryResult, Context) =
     val workEnv       = WorkEnv(".", logLevel = LogLevel.WARN)
     val compiler      = Compiler(CompilerOptions(sourceFolders = List("."), workEnv = workEnv))
     val unit          = CompilationUnit.fromWvletString(query)
@@ -44,7 +48,7 @@ class PlanExecutorTest extends UniTest:
     val provider = SqlConnectorProvider(profile)
     try
       val executor = PlanExecutor(provider, profile, workEnv)
-      executor.execute(ExecutionPlanner.plan(unit, ctx), ctx)
+      (executor.execute(ExecutionPlanner.plan(unit, ctx), ctx), ctx)
     finally
       provider.close()
 
@@ -102,6 +106,74 @@ class PlanExecutorTest extends UniTest:
     // SqlConnector-backed results are string-coerced
     tables(0).rows.head.values.head shouldBe "10"
     tables(1).rows.head.values.head shouldBe "20"
+  }
+
+  private val multiEngineProfile = Profile(
+    "multi",
+    List(
+      ConnectorConfig(name = "duckdb", `type` = "duckdb", default = true),
+      // Construction is lazy — no coordinator needed to switch the dialect
+      ConnectorConfig(
+        name = "trino",
+        `type` = "trino",
+        host = Some("localhost"),
+        port = Some(1),
+        catalog = Some("hive"),
+        schema = Some("sales")
+      )
+    )
+  )
+
+  test("switch the SQL dialect and default catalog/schema on use connector") {
+    skipIfNoDuckDB()
+    val (result, ctx) = runWithContext(
+      """select 10 as x;
+        |use trino""".stripMargin,
+      multiEngineProfile
+    )
+    result.hasError shouldBe false
+    // Statements after `use trino` generate Trino SQL and qualify against its catalog/schema
+    ctx.dbType shouldBe DBType.Trino
+    ctx.catalog.catalogName shouldBe "hive"
+    ctx.global.defaultSchema shouldBe "sales"
+  }
+
+  test("switch dialect back and keep executing on the restored engine") {
+    skipIfNoDuckDB()
+    val (result, ctx) = runWithContext(
+      """use trino;
+        |use duckdb;
+        |select 42 as answer""".stripMargin,
+      multiEngineProfile
+    )
+    result.hasError shouldBe false
+    ctx.dbType shouldBe DBType.DuckDB
+    val tables =
+      collect(result) { case t: TableRows =>
+        t
+      }
+    tables.last.rows.head.values.head shouldBe "42"
+  }
+
+  test("honor catalog and schema parts in use connector references") {
+    skipIfNoDuckDB()
+    val (result, ctx) = runWithContext("use trino.iceberg.web", multiEngineProfile)
+    result.hasError shouldBe false
+    ctx.catalog.catalogName shouldBe "iceberg"
+    ctx.global.defaultSchema shouldBe "web"
+    ctx.dbType shouldBe DBType.Trino
+  }
+
+  test("raise a clear error when switching to an unsupported connector type") {
+    skipIfNoDuckDB()
+    val unsupportedProfile = multiEngineProfile.copy(connectors =
+      multiEngineProfile.connectors :+
+        ConnectorConfig(name = "sf", `type` = "snowflake", host = Some("example"))
+    )
+    val e = intercept[Exception] {
+      runWithContext("use sf", unsupportedProfile)
+    }
+    e.getMessage shouldContain "not supported"
   }
 
   test("share session state across statements") {


### PR DESCRIPTION
## Summary

Closes the last gap in the cross-platform runner (#1963): on the thin CLIs (`wvc`, the Node CLI), `use <connector>` switched only the execution engine — statements after the switch still compiled to the previous engine's SQL dialect and kept its default catalog/schema, so cross-engine scripts silently ran wrong SQL on the new engine.

## Changes

- **`PlanExecutor.switchConnector`**: since the cross-platform runner generates SQL at execution time (from `context.dbType = defaultCatalog.dbType`), replacing the global default catalog with an `InMemoryCatalog` carrying the new engine's dialect and catalog/schema names makes every subsequent statement compile to the right dialect — matching the JVM `QueryExecutor`'s behavior without needing live catalog metadata (the thin CLIs run catalog-free). `use <connector>.<catalog>.<schema>` forms now honor the catalog part too, using the same parsing as the JVM executor.
- **`WvletCli`**: the initial compilation now uses the *effective* backend's dialect. Previously the dialect came only from `-t`, so `wvlet run -p trino-profile "..."` (no `-t`) compiled DuckDB SQL and executed it on Trino.
- **Docs**: `connectors.md` notes that `use` switching works the same in the lightweight CLIs, with the caveat that thin clients compile without live catalog metadata (qualify table names when switching engines mid-script).

## Tests

Four new cross-platform `PlanExecutorTest` cases (shared source, run on JVM/JS/Native): dialect + default catalog/schema switch on `use trino`, switching back and executing on the restored engine, `connector.catalog.schema` references, and a clear error for unsupported connector types (`TrinoSqlConnector` construction is lazy, so no coordinator is needed to verify the switch).

Verified: full `runnerJVM/test` (253), `*RunnerSpec*` (475 incl. TPC-DS), `cliCoreJVM/test`, and `runnerJS`/`runnerNative`/`cliCoreJS`/`cliCoreNative` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49