### PR TITLE
feature: Add reshape, rename, and view statements for schema evolution

### DIFF
--- a/spec/basic/ddl/reshape-and-views.wv
+++ b/spec/basic/ddl/reshape-and-views.wv
@@ -1,0 +1,55 @@
+-- Phase 2 catalog statements: reshape blocks, rename statements, and views
+
+table ddl2_items = {
+  id: int
+  name: string
+}
+
+create table ddl2_items
+
+append to ddl2_items {
+  from [[1, 'pen'], [2, 'book']] as t(id, name)
+}
+
+-- Reshape: the query column operators applied to a table's schema, in an explicit block
+reshape ddl2_items {
+  add price: double
+  rename name as item_name
+}
+
+from ddl2_items
+test _.columns should contain 'price'
+test _.columns should contain 'item_name'
+
+reshape ddl2_items {
+  exclude price
+}
+
+from ddl2_items
+test _.size should be 2
+
+-- Renaming changes identity, not shape: a direct statement, not a reshape operation
+rename table ddl2_items to ddl2_products
+
+from ddl2_products
+test _.size should be 2
+
+-- Views: the save family owns row-writes; flow and block spellings compile identically
+from ddl2_products
+where id = 1
+save as view ddl2_first_item
+
+from ddl2_first_item
+test _.size should be 1
+
+save as view ddl2_all_items {
+  from ddl2_products
+}
+
+from ddl2_all_items
+test _.size should be 2
+
+drop view ddl2_first_item
+drop view ddl2_all_items
+drop view ddl2_all_items if exists
+drop table ddl2_products

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -92,3 +92,47 @@ save to calendar if not exists {
 | `save to t if not exists` | No-op (seed once) |
 | `append to t` | Rows are appended |
 | `create table t` | No-op (idempotent) |
+
+## Changing a Table's Columns
+
+The `reshape` statement evolves a table's schema using the same column operators you already
+use in queries — `add`, `rename ... as`, and `exclude` — enclosed in a block. Operations run
+in order, one `ALTER TABLE` statement each:
+
+```wvlet
+reshape users {
+  add email: string
+  rename name as full_name
+  exclude age
+}
+```
+
+## Renaming Tables and Schemas
+
+Renaming changes an object's identity rather than its shape, so it is a direct statement:
+
+```wvlet
+rename table users to customers
+rename schema staging to archive
+```
+
+## Views
+
+A view exports a query to engine-side consumers (BI tools, other SQL users). Like `save to`,
+view creation works in both spellings and is create-or-replace:
+
+```wvlet
+-- Flow form: develop the query, then persist it
+from users
+where active = true
+save as view active_users
+
+-- Block form: lead with the effect in pipeline scripts
+save as view active_users {
+  from users
+  where active = true
+}
+
+drop view active_users
+drop view active_users if exists
+```

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -150,7 +150,19 @@ object GenSQL extends Phase("generate-sql"):
   def generateDDLSQL(ddl: TopLevelStatement, context: Context): List[String] =
     given Context = context
     val gen       = sqlGeneratorFor(context.dbType)
-    List(withHeader(gen.print(ddl), ddl.sourceLocation))
+    ddl match
+      case a: AlterTable if a.operations.size > 1 =>
+        // A reshape block carries multiple operations; emit one ALTER TABLE statement per
+        // operation so each runs as its own SQL statement
+        a.operations
+          .map { op =>
+            withHeader(
+              gen.print(AlterTable(a.table, a.ifExists, List(op), a.span)),
+              a.sourceLocation
+            )
+          }
+      case _ =>
+        List(withHeader(gen.print(ddl), ddl.sourceLocation))
 
   def generateSaveSQL(save: Save, context: Context): List[String] =
     given Context  = context
@@ -174,6 +186,14 @@ object GenSQL extends Phase("generate-sql"):
 
         val ctasSQL = withHeader(s"${ctasCmd} ${c.targetName} as\n${baseSQL.sql}", c.sourceLocation)
         statements += ctasSQL
+      case c: CreateView =>
+        val baseSQL = generateSQLFromRelation(c.inputRelation, addHeader = false)
+        val cmd     =
+          if c.replace then
+            "create or replace view"
+          else
+            "create view"
+        statements += withHeader(s"${cmd} ${c.targetName} as\n${baseSQL.sql}", c.sourceLocation)
       case s: SaveTo if s.isForTable =>
         val baseSQL           = generateSQLFromRelation(save.inputRelation, addHeader = false)
         var needsTableCleanup = false

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -207,20 +207,6 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
             expr(c.table) + columns
           )
         )
-      case c: CreateView =>
-        val sql = query(c.query, SQLBlock())(using InStatement)
-        group(
-          wl(
-            "create",
-            Option.when(c.replace) {
-              "or replace"
-            },
-            "view",
-            expr(c.viewName),
-            "as",
-            linebreak + sql
-          )
-        )
       case d: DropView =>
         group(
           wl(
@@ -305,7 +291,7 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
             case null =>
               unsupportedNode(s"alter table operation (null)", d.span)
 
-        group(
+        def alterStmt(op: AlterTableOps): Doc = group(
           wl(
             "alter",
             "table",
@@ -313,9 +299,11 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
               "if exists"
             },
             expr(a.table),
-            group(alterOp(a.operation))
+            group(alterOp(op))
           )
         )
+        // One ALTER TABLE statement per operation (portable across engines)
+        concat(a.operations.map(alterStmt), text(";") + linebreak)
       case p: PrepareStatement =>
         group(wl("prepare", expr(p.name), "as", render(p.statement)))
       case e: ExecuteStatement =>
@@ -391,6 +379,21 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
 
       case t: Truncate =>
         group(wl("truncate", "table", expr(t.target)))
+
+      case c: CreateView =>
+        val sql = query(c.child, SQLBlock())(using InStatement)
+        group(
+          wl(
+            "create",
+            Option.when(c.replace) {
+              "or replace"
+            },
+            "view",
+            expr(c.target),
+            "as",
+            linebreak + sql
+          )
+        )
 
       case _ =>
         unsupportedNode(s"Update ${u.nodeName}", u.span)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -153,6 +153,14 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
       case _ =>
         d
 
+  /** AlterTable operations expressible with the wvlet reshape / rename statements */
+  private def isReshapeOp(op: AlterTableOps): Boolean =
+    op match
+      case _: AddColumnOp | _: RenameColumnOp | _: DropColumnOp | _: RenameTableOp =>
+        true
+      case _ =>
+        false
+
   private def ddl(d: DDL)(using sc: SyntaxContext): Doc =
     d match
       case c: CreateSchema =>
@@ -196,6 +204,41 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
             )
           )
         }
+      case v: DropView =>
+        code(v) {
+          group(
+            wl(
+              "drop view",
+              expr(v.viewName),
+              Option.when(v.ifExists) {
+                "if exists"
+              }
+            )
+          )
+        }
+      case r: RenameDatabase =>
+        code(r) {
+          group(wl("rename schema", expr(r.database), "to", expr(r.renameTo)))
+        }
+      case a: AlterTable if a.operations.forall(isReshapeOp) =>
+        a.operations match
+          case List(r: RenameTableOp) =>
+            code(a) {
+              group(wl("rename table", expr(a.table), "to", expr(r.newName)))
+            }
+          case ops =>
+            val opDocs = ops.collect {
+              case c: AddColumnOp =>
+                wl("add", text(c.column.columnName.leafName) + ":", c.column.columnType.wvExpr)
+              case r: RenameColumnOp =>
+                wl("rename", expr(r.oldName), "as", expr(r.newName))
+              case d: DropColumnOp =>
+                wl("exclude", expr(d.column))
+            }
+            code(a) {
+              group(wl("reshape", expr(a.table), "{")) + nest(linebreak + lines(opDocs)) +
+                linebreak + "}"
+            }
       case _ =>
         val sqlGen = SqlGenerator(formatter.config)
         val doc    = sqlGen.render(d)
@@ -235,6 +278,11 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
         code(t) {
           group(wl("truncate", expr(t.target)))
         }
+      case c: CreateView =>
+        relation(c.child) /
+          code(c) {
+            group(wl("save as view", expr(c.target)))
+          }
       case _ =>
         val sqlGen = SqlGenerator(formatter.config)
         val d      = sqlGen.render(u)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -40,6 +40,14 @@ import scala.util.Try
   * Wvlet Language Parser. The grammar is described in `docs/internal/grammar.md` file.
   * @param unit
   */
+object WvletParser:
+  /**
+    * Soft keywords that begin a statement (`table <name> = { ... }`, `reshape <name> { ... }`).
+    * They are plain identifiers everywhere else, but a bare occurrence after a query terminates the
+    * query block instead of being read as a partial query application
+    */
+  val statementHeadSoftKeywords: Set[String] = Set("table", "reshape")
+
 class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends LogSupport:
 
   given src: SourceFile                  = unit.sourceFile
@@ -280,6 +288,10 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     * statements := statement+
     * @return
     */
+  // A statement parsed while a query block was being read (e.g. `rename table ... to ...`
+  // directly following a query). statements() drains it right after the enclosing statement
+  private var pendingStatement: Option[LogicalPlan] = None
+
   def statements(): List[LogicalPlan] =
     val t = scanner.lookAhead()
     t.token match
@@ -290,7 +302,9 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         statements()
       case _ =>
         val stmt: LogicalPlan = statement()
-        stmt :: statements()
+        val pending           = pendingStatement.toList
+        pendingStatement = None
+        (stmt :: pending) ::: statements()
 
   /**
     * Parse a def statement, which can be either a regular function def or a partial query def. If
@@ -968,13 +982,102 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         Truncate(target, spanFrom(tt))
       case WvletToken.SAVE | WvletToken.APPEND =>
         saveBlockStatement()
+      case WvletToken.RENAME =>
+        renameStatement()
       case WvletToken.IDENTIFIER if t.str == "table" =>
         tableShapeDef()
+      case WvletToken.IDENTIFIER if t.str == "reshape" =>
+        reshapeStatement()
       case _ =>
         unexpected(t)
     end match
   }
   end statement
+
+  /**
+    * Schema evolution with the query column operators, enclosed in a block:
+    * {{{
+    *   reshape <table> {
+    *     add <column>: <type>
+    *     rename <column> as <new name>
+    *     exclude <column>
+    *   }
+    * }}}
+    * Each operation lowers to one AlterTableOps case; SQL generation emits one ALTER TABLE
+    * statement per operation. `reshape` is a soft keyword, matched only at statement head.
+    */
+  def reshapeStatement(): LogicalPlan = node {
+    val t      = consume(WvletToken.IDENTIFIER) // the `reshape` soft keyword
+    val target = qualifiedId()
+    consume(WvletToken.L_BRACE)
+    val ops = List.newBuilder[AlterTableOps]
+
+    def nextOp(): Unit =
+      val tk = scanner.lookAhead()
+      tk.token match
+        case WvletToken.ADD =>
+          consume(WvletToken.ADD)
+          val colName = identifier()
+          consume(WvletToken.COLON)
+          val tpe = dataType()
+          ops += AddColumnOp(ColumnDef(colName, tpe, spanFrom(tk)), span = spanFrom(tk))
+          nextOp()
+        case WvletToken.RENAME =>
+          consume(WvletToken.RENAME)
+          val oldName = identifier()
+          consume(WvletToken.AS)
+          val newName = identifier()
+          ops += RenameColumnOp(oldName, newName, span = spanFrom(tk))
+          nextOp()
+        case WvletToken.EXCLUDE =>
+          consume(WvletToken.EXCLUDE)
+          val colName = identifier()
+          ops += DropColumnOp(colName, span = spanFrom(tk))
+          nextOp()
+        case WvletToken.R_BRACE =>
+        // end of block
+        case _ =>
+          throw StatusCode
+            .SYNTAX_ERROR
+            .newException(
+              s"Invalid reshape operation. Expected 'add <column>: <type>', 'rename <column> as <name>', or 'exclude <column>'",
+              tk.sourceLocation
+            )
+    end nextOp
+
+    nextOp()
+    consume(WvletToken.R_BRACE)
+    AlterTable(target, false, ops.result(), spanFrom(t))
+  }
+
+  /**
+    * renameStatement := 'rename' ('table' | 'schema') qualifiedId 'to' qualifiedId
+    *
+    * Renaming changes an object's identity, not its shape, so it is a direct statement rather than
+    * a reshape operation.
+    */
+  def renameStatement(): LogicalPlan = node {
+    val t    = consume(WvletToken.RENAME)
+    val kind = identifierSingle()
+    kind.leafName match
+      case "table" =>
+        val name = qualifiedId()
+        consume(WvletToken.TO)
+        val newName = qualifiedId()
+        AlterTable(name, false, List(RenameTableOp(newName, spanFrom(t))), spanFrom(t))
+      case "schema" =>
+        val name = qualifiedId()
+        consume(WvletToken.TO)
+        val newName = qualifiedId()
+        RenameDatabase(name, newName, spanFrom(t))
+      case other =>
+        throw StatusCode
+          .SYNTAX_ERROR
+          .newException(
+            s"Unknown rename target '${other}'. Expected 'table' or 'schema'",
+            t.sourceLocation
+          )
+  }
 
   /**
     * Parse a side-effect-free table shape declaration:
@@ -1057,11 +1160,14 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
       case "table" =>
         val name = qualifiedId()
         DropTable(name, ifExistsModifier(), spanFrom(t))
+      case "view" =>
+        val name = qualifiedId()
+        DropView(name, ifExistsModifier(), spanFrom(t))
       case other =>
         throw StatusCode
           .SYNTAX_ERROR
           .newException(
-            s"Unknown drop target '${other}'. Expected 'schema' or 'table'",
+            s"Unknown drop target '${other}'. Expected 'schema', 'table', or 'view'",
             t.sourceLocation
           )
   }
@@ -1074,22 +1180,31 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     * }}}
     * These lower to the same plan nodes as the flow-suffix forms.
     */
-  def saveBlockStatement(): Relation = node {
-    def blockQuery(): Relation =
-      val bt = consume(WvletToken.L_BRACE)
-      val q  = queryBody()
-      consume(WvletToken.R_BRACE)
-      Query(q, spanFrom(bt))
+  /** Parse `{ <query> }` used as the body of a block-form save/append statement */
+  private def blockQuery(): Relation =
+    val bt = consume(WvletToken.L_BRACE)
+    val q  = queryBody()
+    consume(WvletToken.R_BRACE)
+    Query(q, spanFrom(bt))
 
+  def saveBlockStatement(): Relation = node {
     val t = scanner.lookAhead()
     t.token match
       case WvletToken.SAVE =>
         consume(WvletToken.SAVE)
-        consume(WvletToken.TO)
-        val target      = literalOrQualifiedName()
-        val ifNotExists = ifNotExistsModifier()
-        val opts        = saveOptions()
-        SaveTo(blockQuery(), target, opts, spanFrom(t), ifNotExists = ifNotExists)
+        scanner.lookAhead().token match
+          case WvletToken.AS =>
+            // save as view <name> { <query> }
+            consume(WvletToken.AS)
+            consumeViewKeyword()
+            val viewName = qualifiedId()
+            CreateView(viewName, replace = true, child = blockQuery(), spanFrom(t))
+          case _ =>
+            consume(WvletToken.TO)
+            val target      = literalOrQualifiedName()
+            val ifNotExists = ifNotExistsModifier()
+            val opts        = saveOptions()
+            SaveTo(blockQuery(), target, opts, spanFrom(t), ifNotExists = ifNotExists)
       case WvletToken.APPEND =>
         consume(WvletToken.APPEND)
         consume(WvletToken.TO)
@@ -1099,6 +1214,16 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
       case _ =>
         unexpected(t)
   }
+
+  /** Consume the soft keyword `view` after `save as` */
+  private def consumeViewKeyword(): Unit =
+    val v = scanner.lookAhead()
+    if v.token == WvletToken.IDENTIFIER && v.str == "view" then
+      consume(WvletToken.IDENTIFIER)
+    else
+      throw StatusCode
+        .SYNTAX_ERROR
+        .newException(s"Expected 'view' after 'save as', but found '${v.str}'", v.sourceLocation)
 
   def use(): Command = node {
     val t = consume(WvletToken.USE)
@@ -1734,21 +1859,41 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
       Nil
 
   def updateOpsIfExists(r: Relation): Relation = node {
+    // A `{` after the save/append target means the block form: the statement carries its own
+    // query, and the preceding query statement is already complete. The parsed block statement
+    // is handed to statements() through pendingStatement
+    def flowOrBlock(makeStatement: Relation => Relation): Relation =
+      if scanner.lookAhead().token == WvletToken.L_BRACE then
+        pendingStatement = Some(makeStatement(blockQuery()))
+        r
+      else
+        makeStatement(r)
+
     val t = scanner.lookAhead()
     t.token match
       case WvletToken.SAVE =>
         consume(WvletToken.SAVE)
-        consume(WvletToken.TO)
-        val target: StringLiteral | QualifiedName = literalOrQualifiedName()
-        val ifNotExists                           = ifNotExistsModifier()
-        val opts                                  = saveOptions()
-        SaveTo(r, target, opts, spanFrom(t), ifNotExists = ifNotExists)
+        scanner.lookAhead().token match
+          case WvletToken.AS =>
+            // from ... save as view <name>
+            consume(WvletToken.AS)
+            consumeViewKeyword()
+            val viewName = qualifiedId()
+            flowOrBlock(child => CreateView(viewName, replace = true, child, spanFrom(t)))
+          case _ =>
+            consume(WvletToken.TO)
+            val target: StringLiteral | QualifiedName = literalOrQualifiedName()
+            val ifNotExists                           = ifNotExistsModifier()
+            val opts                                  = saveOptions()
+            flowOrBlock(child =>
+              SaveTo(child, target, opts, spanFrom(t), ifNotExists = ifNotExists)
+            )
       case WvletToken.APPEND =>
         consume(WvletToken.APPEND)
         consume(WvletToken.TO)
         val target: StringLiteral | QualifiedName = literalOrQualifiedName()
         val columns                               = appendColumnList()
-        AppendTo(r, target, columns, spanFrom(t))
+        flowOrBlock(child => AppendTo(child, target, columns, spanFrom(t)))
       case WvletToken.DELETE =>
         consume(WvletToken.DELETE)
 
@@ -1937,7 +2082,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
       case WvletToken.EXCLUDE =>
         excludeColumnExpr(input)
       case WvletToken.RENAME =>
-        renameColumnExpr(input)
+        renameColumnOrStatement(input)
       case WvletToken.SHIFT =>
         shiftColumnsExpr(input)
       case WvletToken.GROUP =>
@@ -2012,6 +2157,10 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         flowEndExpr(input)
       case WvletToken.R_ARROW =>
         flowJumpExpr(input)
+      case id if id.isIdentifier && WvletParser.statementHeadSoftKeywords.contains(t.str) =>
+        // Soft statement heads (`table <name> = { ... }`, `reshape <name> { ... }`) terminate
+        // the query: they start a new statement, never a partial query application
+        input
       case id if id.isIdentifier =>
         // Potential partial query application: `relation | partial_query` or `relation | partial_query(args)`
         val name = identifier()
@@ -2136,6 +2285,60 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     nextItem
     ExcludeColumnsFromRelation(input, items.result, spanFrom(t))
   }
+
+  /**
+    * `rename` after a query is both the column-rename operator (`rename col as alias`) and the head
+    * of the rename statements (`rename table t to u`, `rename schema s to u`). Disambiguate after
+    * the first identifier: `as` continues the column operator; a further identifier after
+    * `table`/`schema` is a rename statement. A query block cannot return a statement, so the parsed
+    * statement is handed to statements() through pendingStatement and the query ends here.
+    */
+  def renameColumnOrStatement(input: Relation): Relation =
+    val t     = consume(WvletToken.RENAME)
+    val first = scanner.lookAhead()
+    first.token match
+      case WvletToken.IDENTIFIER | WvletToken.BACKQUOTED_IDENTIFIER =>
+        val name              = identifierSingle()
+        val next              = scanner.lookAhead()
+        val isRenameStatement =
+          (name.leafName == "table" || name.leafName == "schema") && next.token.isIdentifier
+        if isRenameStatement then
+          val target = qualifiedId()
+          consume(WvletToken.TO)
+          val newName = qualifiedId()
+          pendingStatement = Some(
+            if name.leafName == "table" then
+              AlterTable(target, false, List(RenameTableOp(newName, spanFrom(t))), spanFrom(t))
+            else
+              RenameDatabase(target, newName, spanFrom(t))
+          )
+          input
+        else
+          consume(WvletToken.AS)
+          val alias = identifierSingle()
+          val items = List.newBuilder[Alias]
+          items += Alias(alias, name, spanFrom(first))
+
+          def nextItem(): Unit =
+            val tk = scanner.lookAhead()
+            tk.token match
+              case WvletToken.COMMA =>
+                consume(WvletToken.COMMA)
+                val it = scanner.lookAhead()
+                val n  = identifierSingle()
+                consume(WvletToken.AS)
+                val a = identifierSingle()
+                items += Alias(a, n, spanFrom(it))
+                nextItem()
+              case _ =>
+          // finish
+          nextItem()
+          RenameColumnsFromRelation(input, items.result(), spanFrom(t))
+        end if
+      case _ =>
+        unexpected(first)
+    end match
+  end renameColumnOrStatement
 
   def renameColumnExpr(relation: Relation): RenameColumnsFromRelation = node {
     val t     = consume(WvletToken.RENAME)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -363,7 +363,28 @@ object Typer extends Phase("typer") with LogSupport:
             markNamespaceRef(dt.table)
           case ct: CreateTable =>
             markNamespaceRef(ct.table)
+          case v: DropView =>
+            markNamespaceRef(v.viewName)
+          case r: RenameDatabase =>
+            markNamespaceRef(r.database)
+            markNamespaceRef(r.renameTo)
+          case a: AlterTable =>
+            markNamespaceRef(a.table)
+            a.operations
+              .foreach {
+                case c: AddColumnOp =>
+                  markNamespaceRef(c.column.columnName)
+                case r: RenameColumnOp =>
+                  markNamespaceRef(r.oldName)
+                  markNamespaceRef(r.newName)
+                case dc: DropColumnOp =>
+                  markNamespaceRef(dc.column)
+                case r: RenameTableOp =>
+                  markNamespaceRef(r.newName)
+                case _ =>
+              }
           case _ =>
+        end match
         typeNode(d)
       case t: Truncate =>
         t.target match

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/ddl.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/ddl.scala
@@ -64,9 +64,19 @@ case class CreateTable(
 
 case class DropTable(table: NameExpr, ifExists: Boolean, span: Span) extends DDL
 
-// Unified ALTER TABLE structure
-case class AlterTable(table: NameExpr, ifExists: Boolean, operation: AlterTableOps, span: Span)
-    extends DDL
+// Unified ALTER TABLE structure. A `reshape t { ... }` block carries multiple operations;
+// SQL emits one ALTER TABLE statement per operation
+case class AlterTable(
+    table: NameExpr,
+    ifExists: Boolean,
+    operations: List[AlterTableOps],
+    span: Span
+) extends DDL
+
+object AlterTable:
+  /** Single-operation form used by the SQL parser (one op per ALTER TABLE statement) */
+  def apply(table: NameExpr, ifExists: Boolean, operation: AlterTableOps, span: Span): AlterTable =
+    AlterTable(table, ifExists, List(operation), span)
 
 // ALTER TABLE operations
 sealed trait AlterTableOps:
@@ -119,7 +129,5 @@ case class ExecuteOp(
     where: Option[Expression] = None,
     span: Span
 ) extends AlterTableOps
-
-case class CreateView(viewName: NameExpr, replace: Boolean, query: Relation, span: Span) extends DDL
 
 case class DropView(viewName: NameExpr, ifExists: Boolean, span: Span) extends DDL

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/update.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/update.scala
@@ -61,6 +61,15 @@ case class Delete(child: Relation, target: TableOrFileName, span: Span) extends 
 
 case class Truncate(target: TableOrFileName, span: Span) extends Update with LeafPlan
 
+/**
+  * Create or replace a view from a query: flow form `from ... save as view v` or block form
+  * `save as view v { query }`. A row-consuming statement, so it lives in the save family;
+  * semantically DDL (defines a catalog object)
+  */
+case class CreateView(target: TableOrFileName, replace: Boolean, child: Relation, span: Span)
+    extends Save:
+  override def category: StatementCategory = StatementCategory.DDL
+
 // SQL equivalent operators
 
 enum CreateMode:

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -91,6 +91,45 @@ class WvletGeneratorTest extends UniTest:
     print(printed) shouldContain "save to snapshot if not exists"
   }
 
+  test("should round-trip a reshape block") {
+    val printed = print("""reshape users {
+        |  add email: string
+        |  rename name as full_name
+        |  exclude age
+        |}""".stripMargin)
+    printed shouldContain "reshape users"
+    printed shouldContain "add email: string"
+    printed shouldContain "rename name as full_name"
+    printed shouldContain "exclude age"
+    print(printed) shouldContain "reshape users"
+  }
+
+  test("should round-trip rename statements") {
+    val printed = print("""rename table users to customers
+        |rename schema staging to archive""".stripMargin)
+    printed shouldContain "rename table users to customers"
+    printed shouldContain "rename schema staging to archive"
+    print(printed) shouldContain "rename table users to customers"
+  }
+
+  test("should round-trip save as view in flow and block forms") {
+    val printed = print("""from t
+        |save as view active_users""".stripMargin)
+    printed shouldContain "save as view active_users"
+    print(printed) shouldContain "save as view active_users"
+
+    val block = print("""save as view v2 {
+        |  from t
+        |}""".stripMargin)
+    block shouldContain "save as view v2"
+  }
+
+  test("should round-trip drop view") {
+    val printed = print("drop view v1 if exists")
+    printed shouldContain "drop view v1 if exists"
+    print(printed) shouldContain "drop view v1 if exists"
+  }
+
   test("should parse block-form save and append statements") {
     val printed = print("""save to snapshot {
         |  from t


### PR DESCRIPTION
## Summary

Phase 2 of the DDL/update statement design (follow-up to #1976), completing the catalog statement surface with schema evolution and views.

### New syntax

```wvlet
-- Schema evolution: the query column operators, in an explicit block
reshape users {
  add email: string
  rename name as full_name
  exclude age
}

-- Renaming changes identity, not shape: direct statements
rename table users to customers
rename schema staging to archive

-- Views: the save family owns row-writes; both spellings compile identically
from users
where active = true
save as view active_users

save as view active_users {
  from users
  where active = true
}

drop view active_users if exists
```

### Design decisions

- **`reshape`, not `alter`**: the statement changes a declared *shape*, and its body reuses the existing column-operator vocabulary (`add`/`rename ... as`/`exclude`) — zero new operator keywords, and `reshape` is a soft statement head, so the reserved-keyword count stays where Phase 1 left it.
- **One ALTER TABLE per operation**: `AlterTable.operation` generalizes to `operations: List[AlterTableOps]` (a companion apply overload keeps the ~15 SqlParser call sites unchanged); SQL generation emits one portable `ALTER TABLE` statement per op.
- **`CreateView` moved from DDL to the Save family** so the flow form `... save as view v` can end a query — per the design rule that row-consuming statements are save-family verbs. It routes through the existing `ExecuteSave` path with a new `generateSaveSQL` case.

### Parser disambiguation (statements after a query)

Wvlet queries are open-ended, so a statement directly following a query needs explicit rules:

- Soft statement heads (`table`, `reshape`) terminate a query block instead of parsing as partial-query applications.
- `rename` after a query branches on the token after the first identifier: `as` continues the column-rename operator, an identifier after `table`/`schema` is a rename statement.
- **A `{` after a save/append target always binds as the block form.** This also fixes a latent Phase 1 bug: block-form `save to t { ... }` directly after a query was silently consumed as a flow suffix of that query, with the brace body parsed as a separate statement. The new `reshape-and-views.wv` spec guards this with a block whose content differs from the preceding query.

Statements parsed mid-query-block are handed back to `statements()` through a small `pendingStatement` slot.

## Tests

- New spec `spec/basic/ddl/reshape-and-views.wv`: reshape add/rename/exclude with column assertions, table rename, flow + block view creation, drop view — all executed on DuckDB
- 4 new WvletGenerator round-trip tests (reshape, rename, save as view, drop view)
- Full `langJVM/test` (1003), `runnerJVM` Basic + SQL specs (332), TyperCoverageCheck, JS + Native compile all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3mfchNEQAGtbs8NXa7Bx