### PR TITLE
fix: SQL codegen escaping and resource bugs (#1697, #1698, #1699)

### DIFF
--- a/wvlet-lang/.jvm/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
+++ b/wvlet-lang/.jvm/src/main/scala/wvlet/lang/compiler/analyzer/duckdb/DuckDBCompat.scala
@@ -29,17 +29,21 @@ trait DuckDBCompat:
       // doubles single quotes so paths like `O'Reilly.parquet` produce valid SQL.
       val sql = s"select * from '${DuckDB.escapeSqlString(path)}' limit 0"
       withConnection { conn =>
-        withResource(conn.createStatement().executeQuery(sql)) { rs =>
-          val metadata = rs.getMetaData
-          val columns  = (1 to metadata.getColumnCount)
-            .map { i =>
-              val name     = metadata.getColumnName(i)
-              val dataType = metadata.getColumnTypeName(i).toLowerCase
-              // TODO support non-primitive type parsing
-              NamedType(Name.termName(name), DataType.parse(dataType))
-            }
-            .toList
-          SchemaType(None, Name.typeName(RelationType.newRelationTypeName), columns)
+        // Close the Statement too — wrapping only the ResultSet leaks the statement handle
+        // (and its server-side cursor) until the connection itself is closed (#1699)
+        withResource(conn.createStatement()) { stmt =>
+          withResource(stmt.executeQuery(sql)) { rs =>
+            val metadata = rs.getMetaData
+            val columns  = (1 to metadata.getColumnCount)
+              .map { i =>
+                val name     = metadata.getColumnName(i)
+                val dataType = metadata.getColumnTypeName(i).toLowerCase
+                // TODO support non-primitive type parsing
+                NamedType(Name.termName(name), DataType.parse(dataType))
+              }
+              .toList
+            SchemaType(None, Name.typeName(RelationType.newRelationTypeName), columns)
+          }
         }
       }
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -39,12 +39,6 @@ case class GeneratedSQL(sql: String, plan: Relation)
 
 object GenSQL extends Phase("generate-sql"):
 
-  private def doubleQuoteIfNecessary(s: String): String =
-    if s.matches("^[_a-zA-Z][_a-zA-Z0-9]*$") then
-      s
-    else
-      s""""${s}""""
-
   override def run(unit: CompilationUnit, context: Context): CompilationUnit =
     // Generate SQL from the resolved plan
     // generateSQL(unit.resolvedPlan)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -36,7 +36,8 @@ object SqlGenerator:
     if identifierPattern.matches(s) then
       s
     else
-      s""""${s}""""
+      // Escape embedded double quotes by doubling them, as in `my"col` -> "my""col" (#1697)
+      s""""${s.replace("\"", "\"\"")}""""
 
   /**
     * A block corresponding to a single SQL SELECT statement
@@ -1575,8 +1576,9 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
       case l: Literal =>
         text(l.sqlExpr)
       case bq: BackQuotedIdentifier =>
-        // SQL needs to use double quotes for back-quoted identifiers, which represents table or column names
-        text("\"") + bq.unquotedValue + text("\"")
+        // SQL needs to use double quotes for back-quoted identifiers, which represents table or
+        // column names. Embedded double quotes are escaped by doubling them (#1697)
+        text("\"") + bq.unquotedValue.replace("\"", "\"\"") + text("\"")
       case i: Identifier =>
         text(i.toSQLAttributeName)
       case s: SortItem =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
@@ -76,7 +76,8 @@ sealed trait NameExpr extends Expression:
       if s.startsWith("\"") && s.endsWith("\"") then
         s
       else if requiresQuotation(s) then
-        s""""${s}""""
+        // Escape embedded double quotes by doubling them, as in `my"col` -> "my""col" (#1697)
+        s""""${s.replace("\"", "\"\"")}""""
       else
         s
     }
@@ -734,16 +735,17 @@ case class DoubleQuoteString(override val unquotedValue: String, span: Span) ext
 case class TripleQuoteString(override val unquotedValue: String, span: Span) extends StringLiteral:
   override def stringValue: String = s"\"\"\"${unquotedValue}\"\"\""
   override def sqlExpr: String     =
-    // SQL doesn't support multi-line triple quotes,
-    // So split the string into multiple lines
-    val lines               = unquotedValue.split("\n")
+    // SQL doesn't support multi-line triple quotes, so split the string into one literal per
+    // line, gluing them with chr(10) so the newlines survive in the result (#1698).
+    // The -1 limit keeps trailing empty lines, preserving trailing newlines too
+    val lines               = unquotedValue.split("\n", -1)
     val parts: List[String] =
       lines
         .map { line =>
           StringLiteral.fromString(line, span).sqlExpr
         }
         .toList
-    parts.mkString(" || ")
+    parts.mkString(" || chr(10) || ")
 
 case class StringPart(value: String, span: Span) extends Literal with LeafExpression:
   // Statically known type, assigned at construction (issue #71)

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/SqlQuotingTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/SqlQuotingTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.codegen
+
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.parser.WvletParser
+import wvlet.uni.test.UniTest
+
+/**
+  * Quoting and escaping edge cases in generated SQL: identifiers with embedded double quotes
+  * (#1697) and multi-line string literals (#1698)
+  */
+class SqlQuotingTest extends UniTest:
+
+  private def generateSQL(wv: String, dbType: DBType = DBType.DuckDB): String =
+    val unit      = CompilationUnit.fromWvletString(wv)
+    val plan      = WvletParser(unit).parse()
+    val generator = SqlGenerator(CodeFormatterConfig(sqlDBType = dbType))
+    generator.print(plan)
+
+  test("escape embedded double quotes in quoted identifiers") {
+    val sql = generateSQL("select 1 as `my\"col`")
+    sql shouldContain "\"my\"\"col\""
+  }
+
+  test("keep plain quoted identifiers unchanged") {
+    val sql = generateSQL("select 1 as `group by`")
+    sql shouldContain "\"group by\""
+  }
+
+  test("preserve newlines of triple-quoted strings via chr(10)") {
+    val sql = generateSQL("select \"\"\"hello\nworld\"\"\" as greeting")
+    sql shouldContain "'hello' || chr(10) || 'world'"
+  }
+
+  test("preserve trailing newlines of triple-quoted strings") {
+    val sql = generateSQL("select \"\"\"hello\n\"\"\" as greeting")
+    sql shouldContain "'hello' || chr(10) || ''"
+  }
+
+end SqlQuotingTest

--- a/wvlet-runner/src/test/scala/wvlet/lang/runner/PlanExecutorTest.scala
+++ b/wvlet-runner/src/test/scala/wvlet/lang/runner/PlanExecutorTest.scala
@@ -71,6 +71,16 @@ class PlanExecutorTest extends UniTest:
     tables.head.schema.fields.map(_.name.name) shouldBe List("id", "name")
   }
 
+  test("preserve newlines of triple-quoted string literals") {
+    skipIfNoDuckDB()
+    val result = run("select \"\"\"hello\nworld\"\"\" as greeting")
+    val tables =
+      collect(result) { case t: TableRows =>
+        t
+      }
+    tables.head.rows.head.values.head shouldBe "hello\nworld"
+  }
+
   test("evaluate passing and failing test statements") {
     skipIfNoDuckDB()
     val passing = run("""from [[1], [2]] as t(a) select a


### PR DESCRIPTION
## Summary

Bug sweep over three reported correctness issues, plus verification of a fourth:

### #1697 — embedded double quotes produce malformed SQL identifiers
An identifier like `` `my"col` `` rendered as `"my"col"`. There were actually **three** quoting sites with the bug, all now doubling embedded quotes to `"my""col"`:
- `NameExpr.toSQLAttributeName` (the path column/alias names take)
- `SqlGenerator.doubleQuoteIfNecessary` (non-ASCII function names)
- `BackQuotedIdentifier` rendering in `SqlGenerator`

`GenSQL`'s duplicate `doubleQuoteIfNecessary` had no call sites — removed instead of fixed.

### #1698 — triple-quoted strings drop embedded newlines
`select """hello\nworld"""` compiled to `'hello' || 'world'` (= `helloworld`). Line parts are now glued with `chr(10)` (supported by DuckDB, Trino, Hive, Snowflake), and `split("\n", -1)` keeps trailing newlines too.

### #1699 — JDBC Statement leak in DuckDB schema analysis
`withResource(conn.createStatement().executeQuery(sql))` closed only the `ResultSet`; the `Statement` is now nested in its own `withResource`, matching the other connector paths. (The code has moved to `DuckDBCompat.schemaOf` since the issue was filed.)

### #1322 — trailing semicolon in multi-statement output
Verified already fixed on main (`GenSQL.generateSQL` appends the final `;`); closed with a repro transcript.

## Tests

- New `SqlQuotingTest` (langJVM): quote escaping for backquoted identifiers, plain quoted identifiers unchanged, `chr(10)` gluing, trailing-newline preservation.
- `PlanExecutorTest`: end-to-end DuckDB round trip asserting the multi-line string value comes back with its newline intact.
- Full regression green: `langJVM/test`, `runnerJVM/test` (271), `*RunnerSpec*` (476 incl. TPC-DS round trips), `projectJS`/`projectNative` test compiles.

Fixes #1697, fixes #1698, fixes #1699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49