### PR TITLE
feature: Add flow-style row updates and keyed append for upserts

### DIFF
--- a/spec/basic/ddl/update-and-upsert.wv
+++ b/spec/basic/ddl/update-and-upsert.wv
@@ -1,0 +1,44 @@
+-- Phase 3 catalog statements: flow-style row updates and keyed append (insert-or-update)
+
+table ddl3_accounts = {
+  id: int
+  name: string
+  status: string
+}
+
+create table ddl3_accounts
+
+append to ddl3_accounts {
+  from [[1, 'alice', 'active'], [2, 'bob', 'active']] as t(id, name, status)
+}
+
+-- Flow update: select the rows first, then say what changes
+from ddl3_accounts
+where id = 2
+update status = 'dormant'
+
+from ddl3_accounts
+where status = 'dormant'
+test _.size should be 1
+
+-- Keyed append: rows whose keys match update their non-key columns; the rest insert
+append to ddl3_accounts on id {
+  from [[2, 'bobby', 'active'], [3, 'carol', 'new']] as t(id, name, status)
+}
+
+from ddl3_accounts
+test _.size should be 3
+
+from ddl3_accounts
+where id = 2
+test _.rows should be [[2, 'bobby', 'active']]
+
+-- An unfiltered update touches every row
+from ddl3_accounts
+update status = 'archived'
+
+from ddl3_accounts
+where status = 'archived'
+test _.size should be 3
+
+drop table ddl3_accounts

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -93,6 +93,32 @@ save to calendar if not exists {
 | `append to t` | Rows are appended |
 | `create table t` | No-op (idempotent) |
 
+## Updating Rows
+
+The `update` operator follows the same pattern as `delete`: select the rows first with
+`where`, then say what changes. The input must be filters over a single table.
+
+```wvlet
+from users
+where last_login < current_date() - '1 year':interval
+update status = 'dormant', updated_at = now()
+```
+
+## Keyed Append (Insert or Update)
+
+`append to ... on <keys>` is insert-or-update: rows whose key columns match an existing
+row replace its non-key columns; the rest insert. Plain `append to` stays pure insert.
+It works in both flow and block forms and compiles to `MERGE INTO`:
+
+```wvlet
+from staged_users
+append to users on user_id
+
+append to metrics on date, metric_name {
+  from daily_metrics
+}
+```
+
 ## Changing a Table's Columns
 
 The `reshape` statement evolves a table's schema using the same column operators you already

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -238,6 +238,73 @@ object GenSQL extends Phase("generate-sql"):
               .mkString("(", ", ", ")")
             s"${copySQL} ${opts}"
         statements += withHeader(sql, s.sourceLocation)
+      case a: AppendTo if a.isForTable && a.keyColumns.nonEmpty =>
+        // Keyed append (`append to t on k1, k2`): insert-or-update, lowered to MERGE INTO.
+        // Rows whose keys match an existing row replace its non-key columns; the rest insert
+        val baseSQL       = GenSQL.generateSQLFromRelation(save.inputRelation, addHeader = false)
+        val tbl           = TableName.parse(a.targetName)
+        val schema        = tbl.schema.getOrElse(context.defaultSchema)
+        val fullTableName = s"${schema}.${tbl.name}"
+        context.catalog.getTable(TableName.parse(fullTableName)) match
+          case Some(t) =>
+            val keys    = a.keyColumns.map(_.leafName)
+            val badKeys = keys.filterNot(k => t.columns.exists(_.name == k))
+            if badKeys.nonEmpty then
+              throw StatusCode
+                .SYNTAX_ERROR
+                .newException(
+                  s"Key column(s) ${badKeys.mkString(", ")} not found in table ${fullTableName}",
+                  a.sourceLocation
+                )
+            val allColumns    = t.columns.map(_.name).toList
+            val updateColumns = allColumns.filterNot(keys.contains)
+            val onCond        = keys.map(k => s"t.${k} = src.${k}").mkString(" and ")
+            val updateSet     = updateColumns.map(c => s"${c} = src.${c}").mkString(", ")
+            val insertCols    = allColumns.mkString(", ")
+            val insertVals    = allColumns.map(c => s"src.${c}").mkString(", ")
+            val whenMatched   =
+              if updateColumns.isEmpty then
+                ""
+              else
+                s"\nwhen matched then update set ${updateSet}"
+            val mergeSQL =
+              s"""merge into ${fullTableName} as t using (
+                 |${baseSQL.sql}
+                 |) as src on ${onCond}${whenMatched}
+                 |when not matched then insert (${insertCols}) values (${insertVals})""".stripMargin
+            statements += withHeader(mergeSQL, a.sourceLocation)
+          case None =>
+            // No existing table: nothing to merge with, so the keyed append reduces to a create
+            statements +=
+              withHeader(s"create table ${fullTableName} as\n${baseSQL.sql}", a.sourceLocation)
+        end match
+      case u: UpdateColumns =>
+        val gen = sqlGeneratorFor(context.dbType)
+
+        def filterExpr(x: Relation): List[String] =
+          x match
+            case q: Query =>
+              filterExpr(q.child)
+            case f: Filter =>
+              gen.print(f.filterExpr) :: filterExpr(f.child)
+            case l: LeafPlan =>
+              Nil
+            case other =>
+              throw StatusCode
+                .SYNTAX_ERROR
+                .newException(s"Unsupported update input: ${other.nodeName}", other.sourceLocation)
+
+        val setClause = u
+          .assignments
+          .map { a =>
+            s"${a.target.fullName} = ${gen.print(a.expr)}"
+          }
+          .mkString(", ")
+        val filters = filterExpr(u.inputRelation)
+        var sql     = s"update ${u.targetName} set ${setClause}"
+        if filters.nonEmpty then
+          sql += s"\nwhere ${filters.reverse.mkString(" and ")}"
+        statements += withHeader(sql, u.sourceLocation)
       case a: AppendTo if a.isForTable =>
         val baseSQL       = GenSQL.generateSQLFromRelation(save.inputRelation, addHeader = false)
         val tbl           = TableName.parse(a.targetName)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -274,6 +274,8 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
         relation(s)
       case a: AppendTo =>
         relation(a)
+      case u: UpdateColumns =>
+        relation(u)
       case t: Truncate =>
         code(t) {
           group(wl("truncate", expr(t.target)))
@@ -519,7 +521,17 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
                 group(wl("append to", expr(a.target)) + paren(cl(a.columns.map(_.fullName))))
               else
                 group(wl("append to", expr(a.target)))
-            targetExpr
+            val keys =
+              if a.keyColumns.isEmpty then
+                None
+              else
+                Some(ws + wl("on", cl(a.keyColumns.map(expr))))
+            group(targetExpr + keys)
+          }
+      case u: UpdateColumns =>
+        relation(u.child) /
+          code(u) {
+            group(wl("update", cl(u.assignments.map(a => wl(expr(a.target), "=", expr(a.expr))))))
           }
       case s: SaveTo =>
         val prev = relation(s.child)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1210,7 +1210,8 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         consume(WvletToken.TO)
         val target  = literalOrQualifiedName()
         val columns = appendColumnList()
-        AppendTo(blockQuery(), target, columns, spanFrom(t))
+        val keys    = appendKeyColumns()
+        AppendTo(blockQuery(), target, columns, spanFrom(t), keyColumns = keys)
       case _ =>
         unexpected(t)
   }
@@ -1893,34 +1894,69 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         consume(WvletToken.TO)
         val target: StringLiteral | QualifiedName = literalOrQualifiedName()
         val columns                               = appendColumnList()
-        flowOrBlock(child => AppendTo(child, target, columns, spanFrom(t)))
+        val keys                                  = appendKeyColumns()
+        flowOrBlock(child => AppendTo(child, target, columns, spanFrom(t), keyColumns = keys))
       case WvletToken.DELETE =>
         consume(WvletToken.DELETE)
+        Delete(r, updateTargetOf(r, "delete", t), spanFrom(t))
+      case WvletToken.UPDATE =>
+        consume(WvletToken.UPDATE)
+        val assignments = List.newBuilder[UpdateAssignment]
 
-        def iter(x: Relation): Relation =
-          x match
-            case f: FilteringRelation =>
-              iter(f.child)
-            case TableRef(qname: QualifiedName, _) =>
-              Delete(r, qname, spanFrom(t))
-            case f: FileRef =>
-              Delete(r, f.path, spanFrom(t))
-            case f: FileScan =>
-              Delete(r, f.path, spanFrom(t))
-            case other =>
-              throw StatusCode
-                .SYNTAX_ERROR
-                .newException(
-                  s"delete statement can't have ${other.nodeName} operator",
-                  t.sourceLocation
-                )
+        def nextAssignment(): Unit =
+          val it  = scanner.lookAhead()
+          val col = identifier()
+          consume(WvletToken.EQ)
+          val value = expression()
+          assignments += UpdateAssignment(col, value, spanFrom(it))
+          if scanner.lookAhead().token == WvletToken.COMMA then
+            consume(WvletToken.COMMA)
+            nextAssignment()
 
-        iter(r)
+        nextAssignment()
+        UpdateColumns(r, updateTargetOf(r, "update", t), assignments.result(), spanFrom(t))
       case _ =>
         r
     end match
   }
   end updateOpsIfExists
+
+  /** Parse the optional conflict keys of a keyed append: `on k1, k2` */
+  private def appendKeyColumns(): List[NameExpr] =
+    scanner.lookAhead().token match
+      case WvletToken.ON =>
+        consume(WvletToken.ON)
+        val keys = List.newBuilder[NameExpr]
+
+        def loop(): Unit =
+          keys += identifier()
+          if scanner.lookAhead().token == WvletToken.COMMA then
+            consume(WvletToken.COMMA)
+            loop()
+
+        loop()
+        keys.result()
+      case _ =>
+        Nil
+
+  /**
+    * Extract the target table of a flow-form delete/update: the input must be a chain of filtering
+    * operators over a single table or file reference
+    */
+  private def updateTargetOf(x: Relation, op: String, t: TokenData[WvletToken]): TableOrFileName =
+    x match
+      case f: FilteringRelation =>
+        updateTargetOf(f.child, op, t)
+      case TableRef(qname: QualifiedName, _) =>
+        qname
+      case f: FileRef =>
+        f.path
+      case f: FileScan =>
+        f.path
+      case other =>
+        throw StatusCode
+          .SYNTAX_ERROR
+          .newException(s"${op} statement can't have ${other.nodeName} operator", t.sourceLocation)
 
   def querySingle(): Relation = node {
     def readRest(input: Relation): Relation = node {

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletToken.scala
@@ -269,6 +269,7 @@ enum WvletToken(val tokenType: TokenType, val str: String):
   case SAVE     extends WvletToken(Keyword, "save")
   case APPEND   extends WvletToken(Keyword, "append")
   case DELETE   extends WvletToken(Keyword, "delete")
+  case UPDATE   extends WvletToken(Keyword, "update")
   case TRUNCATE extends WvletToken(Keyword, "truncate")
 
   // Flow/workflow keywords

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/update.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/update.scala
@@ -48,7 +48,11 @@ case class AppendTo(
     child: Relation,
     target: TableOrFileName,
     columns: List[NameExpr] = Nil,
-    span: Span
+    span: Span,
+    // `append to t on k1, k2`: keyed insert-or-update. Rows whose key columns match an
+    // existing row replace its non-key columns; the rest insert (lowered to MERGE INTO).
+    // Empty = plain insert
+    keyColumns: List[NameExpr] = Nil
 ) extends Save
 
 /**
@@ -58,6 +62,17 @@ case class AppendTo(
   * @param span
   */
 case class Delete(child: Relation, target: TableOrFileName, span: Span) extends Save
+
+/**
+  * Flow-style row update: `from t where ... update col = expr, ...`. Like Delete, the child must
+  * reduce to filters over a single table reference (validated at parse time)
+  */
+case class UpdateColumns(
+    child: Relation,
+    target: TableOrFileName,
+    assignments: List[UpdateAssignment],
+    span: Span
+) extends Save
 
 case class Truncate(target: TableOrFileName, span: Span) extends Update with LeafPlan
 

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -130,6 +130,21 @@ class WvletGeneratorTest extends UniTest:
     print(printed) shouldContain "drop view v1 if exists"
   }
 
+  test("should round-trip a flow update") {
+    val printed = print("""from users
+        |where id = 2
+        |update status = 'dormant', name = 'x'""".stripMargin)
+    printed shouldContain "update status = 'dormant', name = 'x'"
+    print(printed) shouldContain "update status = 'dormant', name = 'x'"
+  }
+
+  test("should round-trip keyed append") {
+    val printed = print("""from staged
+        |append to users on id, name""".stripMargin)
+    printed shouldContain "append to users on id, name"
+    print(printed) shouldContain "append to users on id, name"
+  }
+
   test("should parse block-form save and append statements") {
     val printed = print("""save to snapshot {
         |  from t


### PR DESCRIPTION
## Summary

Phase 3 of the DDL/update statement design (follow-up to #1976 and #1978), covering row-level mutations. This completes the design's keyword budget: `update` is the second and last new reserved word.

### New syntax

```wvlet
-- Flow update: select the rows first, then say what changes (the delete pattern, generalized)
from users
where last_login < current_date() - '1 year':interval
update status = 'dormant', updated_at = now()

-- Keyed append: insert-or-update without an upsert keyword
from staged_users
append to users on user_id

append to metrics on date, metric_name {
  from daily_metrics
}
```

### Design decisions

- **`update` follows the `delete` contract**: the input must reduce to filters over a single table reference, validated at parse time with shared target extraction (`updateTargetOf`, now reused by both). Chained `where` clauses combine into one `WHERE ... AND ...`.
- **Keyed append reuses `on`** (already binding targets to keys in joins) instead of reserving `upsert`/`merge`. `AppendTo` gains `keyColumns` (empty = plain insert) — no separate node.
- **Uniform MERGE lowering**: `MERGE INTO t USING (query) AS src ON t.k = src.k WHEN MATCHED THEN UPDATE ... WHEN NOT MATCHED THEN INSERT ...` works on DuckDB 1.4+ (the repo pins 1.5.5), Trino, and Snowflake, and — unlike `INSERT ... ON CONFLICT` — needs no unique constraint on the key. Update-set columns resolve from the catalog at generation time; unknown key columns are a compile-time-style error, and appending to a non-existent table reduces to `CREATE TABLE AS` (matching plain append).

## Tests

- New spec `spec/basic/ddl/update-and-upsert.wv`: filtered and unfiltered updates, keyed append verifying both the update side (`[2, 'bobby', 'active']`) and insert side of the merge — executed on DuckDB
- WvletGenerator round-trip tests for `update ... = ...` and `append to ... on ...`
- Full runner spec suite (478), langJVM tests, TyperCoverageCheck, JS + Native compile all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3mfchNEQAGtbs8NXa7Bx