### PR TITLE
feature: Add window functions and support mixed no-arg/arg-taking member overloads

### DIFF
--- a/spec/basic/stdlib_array.wv
+++ b/spec/basic/stdlib_array.wv
@@ -11,6 +11,7 @@ select
   a.reverse.mk_string(',') as rev,
   a.concat([9]).mk_string(',') as cc,
   a.mk_string('-') as st,
+  a.mk_string as cat,
 
 test _.size should be 1
 test _.rows should be [[
@@ -23,4 +24,5 @@ test _.rows should be [[
   '2,2,1,3',
   '3,1,2,2,9',
   '3-1-2-2',
+  '3122',
 ]]

--- a/spec/basic/stdlib_window.wv
+++ b/spec/basic/stdlib_window.wv
@@ -1,0 +1,26 @@
+-- Standard library window (analytic) functions
+from [
+  [1, 'a', 10],
+  [1, 'b', 20],
+  [2, 'c', 30],
+] as t(g, k, v)
+select
+  k,
+  row_number() over (order by k) as rn,
+  rank() over (order by g) as rk,
+  dense_rank() over (order by g) as dr,
+  percent_rank() over (order by g) as pr,
+  ntile(2) over (order by k) as nt,
+  v.lag over (order by k) as lg,
+  v.lead over (order by k) as ld,
+  v.lag(2) over (order by k) as lg2,
+  v.first_value over (partition by g order by k) as fv,
+  v.sum over (partition by g) as gs,
+order by k
+
+test _.size should be 3
+test _.rows should be [
+  ['a', 1, 1, 1, 0.0, 1, null, 20, null, 10, 30],
+  ['b', 2, 1, 1, 0.0, 1, 10, 30, null, 10, 30],
+  ['c', 3, 3, 2, 1.0, 2, 20, null, 10, 30, 30],
+]

--- a/website/docs/syntax/stdlib.md
+++ b/website/docs/syntax/stdlib.md
@@ -132,7 +132,7 @@ On array values (e.g. from `split`, array literals, or `array_agg`):
 | `a.distinct` | Remove duplicates |
 | `a.concat(other)` | Concatenate arrays |
 | `a.flatten` | Flatten an array of arrays |
-| `a.mk_string(separator)` | Join elements into a string |
+| `a.mk_string` / `a.mk_string(separator)` | Join elements into a string |
 
 ## Map Functions
 
@@ -174,6 +174,32 @@ agg
   amount.sum as total,
   amount.approx_quantile(0.95) as p95,
   product.string_agg(',') as products
+```
+
+## Window Functions
+
+Window (analytic) functions compute a value over a set of rows related to the current row, selected with an `over(...)` clause:
+
+| Function | Description |
+|----------|-------------|
+| `row_number()` | Sequential row number within the window (1, 2, 3, ...) |
+| `rank()` / `dense_rank()` | Rank with / without gaps after ties |
+| `percent_rank()` / `cume_dist()` | Relative rank / cumulative distribution |
+| `ntile(n)` | Bucket number when the window is divided into `n` groups |
+| `c.lag` / `c.lag(offset)` / `c.lag(offset, default)` | Value from a preceding row |
+| `c.lead` / `c.lead(offset)` / `c.lead(offset, default)` | Value from a following row |
+| `c.first_value` / `c.last_value` / `c.nth_value(n)` | Value at a window position |
+
+Aggregation functions (`sum`, `avg`, `count`, ...) also accept an `over(...)` clause. The window clause supports `partition by`, `order by`, and row frames (`rows[-1, 0]`):
+
+```wvlet
+from orders
+select
+  customer_id,
+  order_date,
+  row_number() over (partition by customer_id order by order_date) as nth_order,
+  amount.lag over (partition by customer_id order by order_date) as prev_amount,
+  amount.sum over (partition by customer_id) as customer_total
 ```
 
 ## Engine-Specific Functions

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/AggregationResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/AggregationResolver.scala
@@ -21,6 +21,7 @@ import wvlet.lang.compiler.Name
 import wvlet.lang.compiler.Symbol
 import wvlet.lang.compiler.TypeSymbolInfo
 import wvlet.lang.compiler.ContextUtil.*
+import wvlet.lang.model.DataType.VarArgType
 import wvlet.lang.model.expr.*
 import wvlet.lang.model.plan.*
 
@@ -42,36 +43,97 @@ object AggregationResolver extends ContextLogSupport:
     .getOrElse(Nil)
 
   /**
-    * A single-node rewrite rule applied through a bottom-up traversal (transformUpExpression), so
-    * child expressions are already resolved when the rule fires. The rule must not re-traverse its
-    * subtree: doing so doubles the work at every tree level, which is exponential on deeply nested
-    * expressions (e.g. TPC-DS q4 never finishes)
+    * Select an aggregation-shorthand definition for the member reference `d` with the given call
+    * arguments: the name must be a member of the array type, and must not be a member of the
+    * qualifier's own type (e.g. map.size, string.split), which resolves through the typed member
+    * path with dialect selection instead.
     */
-  private def resolveAggregationExpr(aggFunctions: List[Symbol])(using
+  private def findAggShorthand(aggFunctions: List[Symbol], d: DotRef, knownArgs: List[FunctionArg])(
+      using ctx: Context
+  ): Option[MethodSymbolInfo] =
+    val nme = d.name.toTermName
+
+    def hasOwnMember: Boolean =
+      val qualType = d.qualifier.dataType
+      qualType.isResolved &&
+      ctx
+        .findSymbolByName(qualType.typeName)
+        .exists(sym => !sym.symbolInfo.findMember(nme).isNoSymbol)
+
+    aggFunctions
+      .find(_.name == nme)
+      .filterNot(_ => hasOwnMember)
+      .flatMap(sym => FunctionInliner.selectMethodVariant(List(sym.symbolInfo), knownArgs, ctx))
+
+  /**
+    * Resolve aggregation shorthands in a single-visit recursion. A FunctionApply and its base
+    * DotRef are handled as one unit so that a no-arg variant never shadows an arg-taking overload
+    * of the same member (e.g. lag and lag(offset)); parameterized members (count_if, min_by,
+    * lag(offset)) bind their arguments here. Each node is visited exactly once — re-traversing
+    * subtrees would be exponential on deeply nested expressions (e.g. TPC-DS q4 never finishes)
+    */
+  private def resolveAggregationExpr(aggFunctions: List[Symbol], e: Expression)(using
       ctx: Context
-  ): PartialFunction[Expression, Expression] =
-    case d: DotRef =>
-      val nme = d.name.toTermName
-
-      // A member of the qualifier's own type (e.g. map.size, string.split) resolves through
-      // the typed member path with dialect selection, so the aggregation shorthand must not
-      // shadow it
-      def hasOwnMember: Boolean =
-        val qualType = d.qualifier.dataType
-        qualType.isResolved &&
-        ctx
-          .findSymbolByName(qualType.typeName)
-          .exists(sym => !sym.symbolInfo.findMember(nme).isNoSymbol)
-
-      aggFunctions
-        .find(_.name == nme)
-        .filterNot(_ => hasOwnMember)
-        .flatMap(sym => FunctionInliner.selectMethodVariant(List(sym.symbolInfo), Nil, ctx))
-        // Members with parameters (e.g. count_if, min_by) are bound by their enclosing
-        // FunctionApply; inlining them here would drop the arguments
-        .filter(_.ft.args.isEmpty)
-        .map(m => FunctionInliner.inlineFunctionBody(d, m, Nil))
-        .getOrElse(d)
+  ): Expression =
+    e match
+      case f @ FunctionApply(d: DotRef, _, _, _, _, _) =>
+        // Resolve the apply and its base member as a unit; only the qualifier is a free
+        // expression
+        val q       = resolveAggregationExpr(aggFunctions, d.qualifier)
+        val newBase =
+          if q eq d.qualifier then
+            d
+          else
+            d.copy(qualifier = q)
+        val newArgs = f
+          .args
+          .map { a =>
+            resolveAggregationExpr(aggFunctions, a) match
+              case fa: FunctionArg =>
+                fa
+              case _ =>
+                a
+          }
+        val newWindow = f
+          .window
+          .map { w =>
+            resolveAggregationExpr(aggFunctions, w) match
+              case nw: Window =>
+                nw
+              case _ =>
+                w
+          }
+        val changed =
+          !(newBase eq d) || newArgs.lazyZip(f.args).exists(_ ne _) ||
+            newWindow.lazyZip(f.window).exists(_ ne _)
+        val nf =
+          if changed then
+            f.copy(base = newBase, args = newArgs, window = newWindow)
+          else
+            f
+        findAggShorthand(aggFunctions, newBase, nf.args) match
+          case Some(m)
+              if nf.args.size <= m.ft.args.size ||
+                m.ft.args.exists(_.dataType.isInstanceOf[VarArgType]) =>
+            FunctionInliner.inlineFunctionApply(nf, m)
+          case _ =>
+            nf
+      case d: DotRef =>
+        val q  = resolveAggregationExpr(aggFunctions, d.qualifier)
+        val nd =
+          if q eq d.qualifier then
+            d
+          else
+            d.copy(qualifier = q)
+        findAggShorthand(aggFunctions, nd, Nil)
+          // A genuinely bare member resolves only to a no-arg variant
+          .filter(_.ft.args.isEmpty)
+          .map(m => FunctionInliner.inlineFunctionBody(nd, m, Nil))
+          .getOrElse(nd)
+      case other =>
+        other.mapChildExpressions(e => resolveAggregationExpr(aggFunctions, e))
+    end match
+  end resolveAggregationExpr
 
   /**
     * Resolve aggregation expressions in a single traversal: inline aggregation functions applied
@@ -90,7 +152,7 @@ object AggregationResolver extends ContextLogSupport:
               // rewritten by their own transformUp visit, and test expressions stay as written
               // because TestRelation is not a GeneralSelection
               s.transformChildExpressions { case e: Expression =>
-                  e.transformUpExpression(resolveAggregationExpr(aggFunctions))
+                  resolveAggregationExpr(aggFunctions, e)
                 }
                 .asInstanceOf[Relation]
             case _ =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
@@ -146,10 +146,10 @@ object FunctionInliner extends ContextLogSupport:
 
   /**
     * Select the method definition for a bare member reference (a DotRef with no argument list, e.g.
-    * `expr.upper`). Returns a definition only when none of the dialect-compatible variants takes
-    * arguments: in the bottom-up inlining pass a DotRef that is the base of an enclosing
-    * FunctionApply is indistinguishable from a bare reference, so resolving a no-arg variant of an
-    * arity-overloaded member here would swallow the arguments of the enclosing call.
+    * `expr.upper`). Only no-arg variants are considered, but they may coexist with arg-taking
+    * overloads of the same name (e.g. `mk_string` and `mk_string(separator)`): the Typer resolves a
+    * FunctionApply and its base DotRef as one unit, so a DotRef reaching this path is genuinely
+    * bare and can never swallow an enclosing call's arguments.
     */
   private def selectBareMethodVariant(
       symbolInfos: List[SymbolInfo],
@@ -160,11 +160,8 @@ object FunctionInliner extends ContextLogSupport:
       .collect { case m: MethodSymbolInfo =>
         m
       }
-    val pool = preferNonZero(candidates, dialectScore(_, context))
-    if pool.nonEmpty && pool.forall(_.ft.args.isEmpty) then
-      pool.sortBy(variantRank(_, context)).headOption
-    else
-      None
+    val pool = preferNonZero(candidates, dialectScore(_, context)).filter(_.ft.args.isEmpty)
+    pool.sortBy(variantRank(_, context)).headOption
 
   /**
     * The maximum depth of nested function/partial-query inlining, used as a safety net against
@@ -408,11 +405,28 @@ object FunctionInliner extends ContextLogSupport:
       context: Context
   ): Expression =
     findFunctionDef(f) match
-      case Some(m: MethodSymbolInfo) if isEngineNative(m) =>
+      case Some(m: MethodSymbolInfo) =>
+        inlineFunctionApply(f, m, activeFunctions)
+      case _ =>
+        f
+
+  /**
+    * Inline a function application with an already-selected method definition, binding the call
+    * arguments to the definition's parameters. Used by [[resolveFunctionApply]] and by the
+    * aggregation shorthand (AggregationResolver), which finds the definition through the array-type
+    * member lookup instead of the qualifier's own type.
+    */
+  private[analyzer] def inlineFunctionApply(
+      f: FunctionApply,
+      m0: MethodSymbolInfo,
+      activeFunctions: List[Symbol] = Nil
+  )(using context: Context): Expression =
+    m0 match
+      case m: MethodSymbolInfo if isEngineNative(m) =>
         // Keep the call as written so it compiles to a plain SQL function call; the typing
         // rules assign the return type declared by the def to the FunctionApply node
         f
-      case Some(m: MethodSymbolInfo) =>
+      case m: MethodSymbolInfo =>
         val functionArgTypes = m.ft.args
         // Mapping function arguments aligned to the function definition
         var index        = 0
@@ -465,10 +479,8 @@ object FunctionInliner extends ContextLogSupport:
             WindowApply(expr.withDataType(m.ft.returnType), w, None, expr.span)
           case None =>
             expr.withDataType(m.ft.returnType)
-      case _ =>
-        f
     end match
-  end resolveFunctionApply
+  end inlineFunctionApply
 
   /**
     * Inline the body of the partial query referenced by the given PartialQueryApply.

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -30,7 +30,9 @@ import wvlet.lang.model.expr.ConditionalExpression
 import wvlet.lang.model.expr.ContextInputRef
 import wvlet.lang.model.expr.DotRef
 import wvlet.lang.model.expr.FunctionApply
+import wvlet.lang.model.expr.FunctionArg
 import wvlet.lang.model.expr.Identifier
+import wvlet.lang.model.expr.Window
 import wvlet.lang.model.expr.InRelation
 import wvlet.lang.model.expr.NotInRelation
 import wvlet.lang.model.expr.SubQueryExpression
@@ -459,21 +461,76 @@ object Typer extends Phase("typer") with LogSupport:
       while continue && rounds < maxFunctionResolutionRounds do
         rounds += 1
         // Inline function applications, bare member references, and native function
-        // references in a single bottom-up pass. Only no-arg methods are inlined from a bare
-        // DotRef: a DotRef with declared arguments is the base of an enclosing FunctionApply
-        // that must bind them first (possibly in a later round)
-        val inlineRule: PartialFunction[Expression, Expression] =
-          case f: FunctionApply =>
-            FunctionInliner.resolveFunctionApply(f)
-          case d: DotRef =>
-            FunctionInliner.findFunctionDef(d, bareMember = true) match
-              case Some(m) if m.ft.args.isEmpty =>
-                FunctionInliner.inlineFunctionBody(d, m, Nil)
-              case _ =>
-                d
-          case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
-            // Replace references to native (compile-time evaluated) functions
-            FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
+        // references in a single bottom-up pass. A FunctionApply and its base DotRef are
+        // resolved as one unit: the member name belongs to the apply, so the bare-member rule
+        // never sees it. This lets a name mix no-arg and arg-taking variants (e.g. mk_string
+        // and mk_string(separator)) — a bare DotRef reached directly is genuinely bare and
+        // resolves only to a no-arg variant
+        def inlineExpr(e: Expression): Expression =
+          e match
+            case f: FunctionApply =>
+              val newBase =
+                f.base match
+                  case d: DotRef =>
+                    // Only the qualifier is a free expression; the member name is bound by
+                    // this apply
+                    val q = inlineExpr(d.qualifier)
+                    if q eq d.qualifier then
+                      d
+                    else
+                      d.copy(qualifier = q)
+                  case other =>
+                    inlineExpr(other)
+              val newArgs = f
+                .args
+                .map { a =>
+                  inlineExpr(a) match
+                    case fa: FunctionArg =>
+                      fa
+                    case _ =>
+                      a
+                }
+              val newWindow = f
+                .window
+                .map { w =>
+                  inlineExpr(w) match
+                    case nw: Window =>
+                      nw
+                    case _ =>
+                      w
+                }
+              val newFilter = f.filter.map(inlineExpr)
+              val changed   =
+                !(newBase eq f.base) || newArgs.lazyZip(f.args).exists(_ ne _) ||
+                  newWindow.lazyZip(f.window).exists(_ ne _) ||
+                  newFilter.lazyZip(f.filter).exists(_ ne _)
+              val fa =
+                if changed then
+                  f.copy(base = newBase, args = newArgs, window = newWindow, filter = newFilter)
+                else
+                  f
+              FunctionInliner.resolveFunctionApply(fa)
+            case d: DotRef =>
+              val q  = inlineExpr(d.qualifier)
+              val nd =
+                if q eq d.qualifier then
+                  d
+                else
+                  d.copy(qualifier = q)
+              FunctionInliner.findFunctionDef(nd, bareMember = true) match
+                case Some(m) if m.ft.args.isEmpty =>
+                  FunctionInliner.inlineFunctionBody(nd, m, Nil)
+                case _ =>
+                  nd
+            case other =>
+              other.mapChildExpressions(inlineExpr) match
+                case id: Identifier if id.unresolved && id.nonEmpty && !hasResolvedType(id) =>
+                  // Replace references to native (compile-time evaluated) functions
+                  FunctionInliner.findNativeFunction(ctx, id.fullName).getOrElse(id)
+                case done =>
+                  done
+          end match
+        end inlineExpr
         val fnInlined = current
           .transformUp {
             // Test expressions form an assertion DSL evaluated by the test runner, so keep
@@ -482,7 +539,7 @@ object Typer extends Phase("typer") with LogSupport:
               t
             case r: Relation =>
               r.transformChildExpressions { case e: Expression =>
-                e.transformUpExpression(inlineRule)
+                inlineExpr(e)
               }
           }
           .asInstanceOf[Relation]

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/Expression.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/Expression.scala
@@ -205,6 +205,47 @@ trait Expression extends SyntaxTreeNode with LogSupport:
 
   end transformUpExpression
 
+  /**
+    * Apply the function to each direct child expression (one level, no recursion into the results)
+    * and rebuild this node when any child changes. Callers drive their own recursion, which enables
+    * traversals that resolve certain parent-child pairs as a unit (e.g. a FunctionApply and its
+    * base DotRef in the Typer's function inlining). A LogicalPlan child (e.g. a subquery
+    * expression's plan) has the function applied to each of its nodes' direct expressions.
+    */
+  def mapChildExpressions(f: Expression => Expression): Expression =
+    var changed                = false
+    def iter(arg: Any): AnyRef =
+      arg match
+        case e: Expression =>
+          val newExpr = f(e)
+          if !(newExpr eq e) then
+            changed = true
+          newExpr
+        case l: LogicalPlan =>
+          val newPlan = l.transformUp { case n: LogicalPlan =>
+            n.transformChildExpressions { case e: Expression =>
+              f(e)
+            }
+          }
+          if !(newPlan eq l) then
+            changed = true
+          newPlan
+        case Some(x) =>
+          Some(iter(x))
+        case s: Seq[?] =>
+          s.map(iter)
+        case other: AnyRef =>
+          other
+        case null =>
+          null
+    val newArgs = productIterator.map(iter).toIndexedSeq
+    if changed then
+      copyInstance(newArgs)
+    else
+      this
+
+  end mapChildExpressions
+
   def transformChildExpressions(rule: PartialFunction[Expression, Expression]): this.type =
     var changed = false
 

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/StdLibProbeTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/StdLibProbeTest.scala
@@ -74,6 +74,23 @@ class StdLibProbeTest extends UniTest:
     sql shouldContain "array_to_string(list_concat("
   }
 
+  test("resolve a member name mixing no-arg and arg-taking variants") {
+    val bare = generateSQL("from [[1]] as t(i)\nselect [3, 1, 2].mk_string as s\n")
+    bare shouldContain "array_to_string([3, 1, 2],'')"
+    val applied = generateSQL("from [[1]] as t(i)\nselect [3, 1, 2].mk_string('-') as s\n")
+    applied shouldContain "array_to_string([3, 1, 2],'-')"
+  }
+
+  test("resolve window functions with over clauses") {
+    val wv =
+      """from [[1, 10]] as t(k, v)
+        |select row_number() over (order by k) as rn, v.lag(1) over (order by k) as lg
+        |""".stripMargin
+    val sql = generateSQL(wv)
+    sql shouldContain "row_number() over (order by k)"
+    sql shouldContain "lag(v,1) over (order by k)"
+  }
+
   test("probe a member call with args chained on map keys") {
     val sql = generateSQL("select map {\"a\": 1} as m\nselect m.keys.mk_string(',') as ks\n")
     info(sql)

--- a/wvlet-stdlib/module/standard/array.wv
+++ b/wvlet-stdlib/module/standard/array.wv
@@ -75,6 +75,13 @@ type array[A] = {
   def contains(elem:A) in snowflake: boolean = sql"array_contains(to_variant(${elem}),${this})"
   def contains(elem:A) in bigquery: boolean = sql"${elem} in unnest(${this})"
 
+  -- Concatenate the array elements into a string without a separator
+  def mk_string in duckdb: string = sql"array_to_string(${this},'')"
+  def mk_string in trino: string = sql"array_join(${this},'')"
+  def mk_string in hive: string = sql"concat_ws('',${this})"
+  def mk_string in snowflake: string = sql"array_to_string(${this},'')"
+  def mk_string in bigquery: string = sql"array_to_string(${this},'')"
+
   -- Concatenate the array elements into a string with the separator
   def mk_string(separator:string) in duckdb: string = sql"array_to_string(${this},${separator})"
   def mk_string(separator:string) in trino: string = sql"array_join(${this},${separator})"
@@ -107,6 +114,18 @@ type array[A] = {
   def concat(other:any) in trino: array[A] = sql"concat(${this},${other})"
   def concat(other:any) in snowflake: array[A] = sql"array_cat(${this},${other})"
   def concat(other:any) in bigquery: array[A] = sql"array_concat(${this},${other})"
+
+  -- Window (analytic) functions, applied to a column with an over(...) clause,
+  -- e.g. v.lag(1) over (partition by g order by k)
+  def lag: A = sql"lag(${this})"
+  def lag(offset:int): A = sql"lag(${this},${offset})"
+  def lag(offset:int, default:any): A = sql"lag(${this},${offset},${default})"
+  def lead: A = sql"lead(${this})"
+  def lead(offset:int): A = sql"lead(${this},${offset})"
+  def lead(offset:int, default:any): A = sql"lead(${this},${offset},${default})"
+  def first_value: A = sql"first_value(${this})"
+  def last_value: A = sql"last_value(${this})"
+  def nth_value(n:int): A = sql"nth_value(${this},${n})"
 }
 
 -- array functions specific to numeric elements

--- a/wvlet-stdlib/module/standard/window.wv
+++ b/wvlet-stdlib/module/standard/window.wv
@@ -1,0 +1,23 @@
+package wvlet.standard
+
+-- Window (analytic) ranking functions, used with an over(...) clause,
+-- e.g. row_number() over (partition by g order by k).
+-- These are ANSI SQL functions with the same name on every supported engine.
+
+-- Sequential row number within the window (1, 2, 3, ...)
+def row_number: long = sql"row_number()"
+
+-- Rank with gaps after ties (1, 1, 3, ...)
+def rank: long = sql"rank()"
+
+-- Rank without gaps after ties (1, 1, 2, ...)
+def dense_rank: long = sql"dense_rank()"
+
+-- Relative rank in [0, 1]: (rank - 1) / (rows - 1)
+def percent_rank: double = sql"percent_rank()"
+
+-- Cumulative distribution in (0, 1]: rows preceding or peer / rows
+def cume_dist: double = sql"cume_dist()"
+
+-- Bucket number when the window is divided into n groups
+def ntile(n:int): long = sql"ntile(${n})"


### PR DESCRIPTION
## Summary

Addresses two follow-ups from the stdlib expansion (#1966): the bare-member/overload resolution limitation and method-style window function coverage. They're shipped together because window functions are the first real consumer of the overload fix (`lag` / `lag(offset)`).

### Window functions (stdlib)

- **Ranking functions** as top-level defs in a new `window.wv`: `row_number()`, `rank()`, `dense_rank()`, `percent_rank()`, `cume_dist()`, `ntile(n)`
- **Positional functions** as column members in `array.wv`: `c.lag` / `c.lag(offset)` / `c.lag(offset, default)`, `lead`, `first_value`, `last_value`, `nth_value(n)`
- All are ANSI functions shared by every supported engine, so single neutral definitions cover DuckDB/Trino/Hive/Snowflake/BigQuery
- The existing `over(partition by ... order by ...)` / frame syntax needed no changes — resolution plugs into the `FunctionApply.window` path
- New executable spec `spec/basic/stdlib_window.wv` verifies results on **DuckDB and real Trino** (via `TrinoStdLibSpec`)

### Overload resolution (compiler)

The Typer's bottom-up inlining pass previously visited a `FunctionApply`'s base `DotRef` before the apply itself, so a no-arg member variant could swallow an enclosing call's arguments — the stdlib had to avoid mixing no-arg and arg-taking variants of one name. Now:

- A new `Expression.mapChildExpressions` (one-level child mapping) lets the Typer and `AggregationResolver` drive single-visit recursions that resolve a `FunctionApply` and its base `DotRef` **as one unit** — a `DotRef` reached directly is genuinely bare
- `selectBareMethodVariant` accepts mixed pools, selecting only among no-arg variants
- The aggregation shorthand gains an arg-binding `FunctionApply` case: `v.lag(2) over (...)` and `count_if`-style parameterized members now resolve on scalar columns (previously only no-arg shorthands like `v.sum` worked)
- First stdlib beneficiaries: `a.mk_string` (no separator) alongside `mk_string(separator)`, and the `lag`/`lead` families

## Verification

- `langJVM/testOnly *` — 1925 tests pass (new probes for mixed pools and window resolution; TyperCoverageCheck ratchet intact)
- `runnerJVM/testOnly *` — 683 pass, including the new window spec executed on DuckDB and embedded Trino, and the full TPC-DS suite (guards the resolver recursion against the exponential-blowup regression noted in the old code)
- `projectJS` / `projectNative` compile clean; scalafmt applied; docs gain a Window Functions section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDVq4Etzaj8C8XCUm2iJiP