### PR TITLE
fix: Resolve aggregation shorthands and function inlining in flow stage bodies

### DIFF
--- a/spec/basic/flow-run.wv
+++ b/spec/basic/flow-run.wv
@@ -112,3 +112,14 @@ run flow JoinPipeline
 | where state = 'success'
 test _.size should be 5
 ;
+
+flow CountPipeline = {
+  stage events = from [[1], [2], [3]] as t(id)
+  stage counted = from events | agg _.count as cnt
+}
+
+-- Aggregation shorthands (agg _.count) resolve inside stage bodies just like top-level queries
+run flow CountPipeline
+| where state = 'success'
+test _.size should be 2
+;

--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -369,7 +369,7 @@ flow load_orders = {
 To wait on an aggregate condition, aggregate in the pipeline before the sensor:
 
 ```wvlet
-stage gate = from new_events | select count(*) as cnt | wait until _.cnt > 1000
+stage gate = from new_events | agg _.count as cnt | wait until _.cnt > 1000
 ```
 
 Polling respects the stage's `heartbeat:` config (a polling sensor is never mistaken for a

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/typer/TyperCoverageCheck.scala
@@ -137,10 +137,11 @@ class TyperCoverageCheck extends UniTest:
     info(s"top unresolved relations: ${top(c.unresolvedRelations, 10)}")
     info(s"top untyped expressions:  ${top(c.untypedExprs, 10)}")
 
-    // Ratchet (2026-08-22: 91.9% / 89.9% / 92.5%). Raise these as coverage improves toward 1.0
-    val minRelationCoverage = 0.915
-    val minExprCoverage     = 0.89
-    val minTpeSetCoverage   = 0.92
+    // Ratchet (2026-08-23: 92.5% / 89.8% / 92.9%, after flow stage bodies gained full
+    // resolution). Raise these as coverage improves toward 1.0
+    val minRelationCoverage = 0.92
+    val minExprCoverage     = 0.895
+    val minTpeSetCoverage   = 0.925
     if c.relationCoverage < minRelationCoverage then
       fail(
         f"Relation type coverage regressed: ${c.relationCoverage *

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -445,12 +445,21 @@ object Typer extends Phase("typer") with LogSupport:
     * aggregation expressions, and in-place typing. Also used by GenSQL to re-resolve model bodies
     * after model expansion
     */
-  def resolveRelation(r: Relation)(using ctx: Context): Relation =
+  def resolveRelation(r: Relation)(using ctx: Context): Relation = resolveRelation(r, Map.empty)
+
+  /**
+    * Scope-taking variant of resolveRelation. The scope carries locally-defined relation names
+    * (e.g. flow stage names) visible only within the enclosing definition, so their references are
+    * typed in place without symbol registration
+    */
+  private def resolveRelation(r: Relation, scope: Map[String, RelationType])(using
+      ctx: Context
+  ): Relation =
     // Resolve structural references (tables, models, files, partial queries, underscores) and
     // type each node's expressions in a single bottom-up pass. Interleaving resolution and
     // typing matters: several relation nodes memoize their relationType on first access, so a
     // parent must not read a child's relation type before the child's expressions are typed
-    val prepared = prepareRelation(r)
+    val prepared = prepare(r, scope).asInstanceOf[Relation]
     // Inline function calls and aggregation expressions only when candidates are present.
     // Chained method calls (e.g. x.to_double.round(1)) resolve one link per round, so iterate
     // to a fixpoint
@@ -707,7 +716,9 @@ object Typer extends Phase("typer") with LogSupport:
                 r.elseTarget.foreach(t => requireRouteTarget(t, s.name))
             }
           }
-        val newBody = s.body.map(b => prepare(b, stageScope).asInstanceOf[Relation])
+        // Stage bodies go through the same full resolution path as top-level queries (function
+        // inlining, aggregation shorthands like `agg _.count`), with prior stage names in scope
+        val newBody = s.body.map(b => resolveRelation(b, stageScope))
         // The engine name in `stage x on <connector>` is a namespace reference
         s.engine.foreach(markNamespaceRef)
         val bodyChanged =

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/FlowTypingTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/typer/FlowTypingTest.scala
@@ -7,6 +7,7 @@ import wvlet.lang.compiler.Compiler
 import wvlet.lang.compiler.CompilerOptions
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.model.DataType.SchemaType
+import wvlet.lang.model.expr.DotRef
 import wvlet.lang.model.plan.FlowDef
 import wvlet.uni.test.UniTest
 
@@ -115,6 +116,52 @@ class FlowTypingTest extends UniTest:
     }
     e.statusCode shouldBe StatusCode.STAGE_NOT_FOUND
     e.getMessage shouldContain "missing_stage"
+  }
+
+  test("resolve aggregation shorthands inside stage bodies") {
+    val f = compileFlow(s"""${userType}
+        |flow AggFlow = {
+        |  stage entry = from users
+        |  stage counted = from entry | agg _.count as cnt
+        |}""".stripMargin)
+    val counted = f.stages.find(_.name.name == "counted").get
+    counted.relationType.isResolved shouldBe true
+    counted.relationType.fields.map(_.name.name) shouldBe List("cnt")
+    // `_.count` must be inlined into count(*); no bare member reference survives in the body
+    var bareCountRefs = 0
+    counted
+      .body
+      .get
+      .traverseExpressions {
+        case d: DotRef if d.name.fullName == "count" =>
+          bareCountRefs += 1
+      }
+    bareCountRefs shouldBe 0
+  }
+
+  test("resolve aggregation shorthands before an event sensor") {
+    val f = compileFlow(s"""${userType}
+        |flow SensorFlow = {
+        |  stage entry = from users
+        |  stage gate = from entry | agg _.count as cnt | wait until _.cnt > 1000
+        |}""".stripMargin)
+    val gate = f.stages.find(_.name.name == "gate").get
+    gate.relationType.isResolved shouldBe true
+    gate.relationType.fields.map(_.name.name) shouldBe List("cnt")
+  }
+
+  test("inline chained function calls inside stage bodies") {
+    val f = compileFlow(s"""type events = {
+        |  id: string
+        |  amount: double
+        |}
+        |flow ChainFlow = {
+        |  stage entry = from events
+        |  stage rounded = from entry | select id, amount.round(1) as amt
+        |}""".stripMargin)
+    val rounded = f.stages.find(_.name.name == "rounded").get
+    rounded.relationType.isResolved shouldBe true
+    rounded.relationType.fields.map(_.name.name) shouldBe List("id", "amt")
   }
 
   test("report an error for a trigger referencing a stage defined later") {


### PR DESCRIPTION
## Summary

Inside flow stage bodies, `agg cnt = _.count` was not resolved by the typer — GenSQL emitted the literal `select _.count as cnt`, which failed at execution. Top-level queries resolved it fine. This closes the **stage-body typing gap** standalone item of #1858.

## Root cause

`Typer.resolveFlowDef` typed each stage body with the private `prepare(body, stageScope)` pass only — the single bottom-up structural/typing pass. Top-level queries additionally run the `resolveRelation` fixpoint loop (FunctionInliner + AggregationResolver), which is what inlines aggregation shorthands (`_.count` → `count(*)`), chained method calls (`amount.round(1)`), and native function references. Stage bodies skipped all of that.

## Changes

- `Typer.resolveRelation` gains a private scope-taking variant; `resolveFlowDef` now routes stage bodies through it with the stage scope, so stages get the identical resolution pipeline as top-level queries
- `FlowTypingTest`: three new tests — `agg _.count` in a stage body, the aggregate-before-sensor pattern from the docs (`agg _.count as cnt | wait until _.cnt > 1000`), and chained function inlining in stage bodies
- `spec/basic/flow-run.wv`: an executed `CountPipeline` flow covering the shorthand end-to-end on DuckDB
- `TyperCoverageCheck` ratchet raised (relations 91.5% → 92%, expressions 89% → 89.5%, tpe-set 92% → 92.5%) per the improved coverage
- `website/docs/syntax/flow.md`: sensor example restored to the idiomatic `agg _.count as cnt` form

AggregationResolver only rewrites within `GeneralSelection` nodes, so `wait until` conditions and other flow-op expressions are unaffected.

## Testing

- `langJVM/test`: 1026 tests pass (incl. raised TyperCoverageCheck ratchet)
- `runnerJVM/test`: 272 pass; `RunnerSpecBasic` executes the new flow spec on DuckDB
- `projectJS/Test/compile` and `projectNative/Test/compile` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49