### PR TITLE
feature: Attach external databases with use 'path' as name

### DIFF
--- a/spec/basic/ddl/attach-database.wv
+++ b/spec/basic/ddl/attach-database.wv
@@ -1,0 +1,14 @@
+-- Attach an external database under an alias with `use '<path>' as <name>`.
+-- An in-memory database keeps this spec free of filesystem side effects
+use ':memory:' as ddl4_mem
+
+-- Write into the attached database through its alias
+save to ddl4_mem.ddl4_items {
+  from [[1, 'apple'], [2, 'banana']] as t(id, name)
+}
+
+-- Read back through the alias
+from ddl4_mem.ddl4_items
+order by id
+test _.size should be 2
+test _.columns should contain 'name'

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -162,3 +162,27 @@ save as view active_users {
 drop view active_users
 drop view active_users if exists
 ```
+
+## Attaching External Databases
+
+`use '<path>' as <name>` attaches an external database under an alias, making its tables
+addressable as `<name>.<table>`. The path is self-describing: a file path attaches a database
+file, and a URI scheme such as `postgres://` selects the matching engine automatically.
+
+```wvlet
+-- Attach a local DuckDB file
+use 'archive.duckdb' as archive
+
+from archive.events
+where year = 2025
+
+-- Attach a remote PostgreSQL database (engine inferred from the scheme)
+use 'postgres://host/mydb' as pg
+
+-- Engine-specific modifiers ride in trailing options
+use 'archive.duckdb' as archive with read_only: true
+```
+
+Attachment is currently supported on DuckDB. Options are passed through to the engine
+(`read_only: true` becomes `READ_ONLY`); `engine: '<name>'` overrides the engine type
+inferred from the path.

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -145,6 +145,14 @@ object GenSQL extends Phase("generate-sql"):
     given Context = context
     val gen       = sqlGeneratorFor(context.dbType)
     ddl match
+      case a: AttachDatabase if context.dbType != DBType.DuckDB =>
+        throw StatusCode
+          .NOT_IMPLEMENTED
+          .newException(
+            s"use '...' as ${a.alias.fullName} (database attachment) is not supported on ${context
+                .dbType}",
+            a.sourceLocation
+          )
       case a: AlterTable if a.operations.size > 1 =>
         // A reshape block carries multiple operations; emit one ALTER TABLE statement per
         // operation so each runs as its own SQL statement

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -232,6 +232,41 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
             expr(c.schema)
           )
         )
+      case a: AttachDatabase =>
+        // The database engine type is self-described by the path's URI scheme; explicit
+        // options from `with k: v` ride along, with `k: true` printed as a bare flag.
+        // `engine: '<name>'` overrides scheme inference (`type` is a hard Wvlet keyword)
+        val path         = a.path.unquotedValue
+        val inferredType =
+          if a.options.exists(_.key.leafName.equalsIgnoreCase("engine")) then
+            None
+          else
+            path.takeWhile(_ != ':') match
+              case "postgres" | "postgresql" if path.contains("://") =>
+                Some(text("TYPE postgres"))
+              case "mysql" if path.contains("://") =>
+                Some(text("TYPE mysql"))
+              case _ =>
+                None
+        val userOpts = a
+          .options
+          .map { opt =>
+            opt.value match
+              case _: TrueLiteral =>
+                text(opt.key.leafName.toUpperCase)
+              case s: StringLiteral if opt.key.leafName.equalsIgnoreCase("engine") =>
+                // The engine name maps to ATTACH's TYPE option, which takes an identifier
+                wl("TYPE", text(s.unquotedValue))
+              case v =>
+                wl(text(opt.key.leafName.toUpperCase), expr(v))
+          }
+        val allOpts = inferredType.toList ++ userOpts
+        val optsDoc =
+          if allOpts.isEmpty then
+            None
+          else
+            Some(paren(cl(allOpts)))
+        group(wl("attach", expr(a.path), "as", expr(a.alias), optsDoc))
       case d: DropSchema =>
         group(
           wl(

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -220,6 +220,15 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
         code(r) {
           group(wl("rename schema", expr(r.database), "to", expr(r.renameTo)))
         }
+      case a: AttachDatabase =>
+        code(a) {
+          val opts =
+            if a.options.isEmpty then
+              None
+            else
+              Some(ws + "with" + nest(wsOrNL + cl(a.options.map(o => expr(o)))))
+          group(wl("use", expr(a.path), "as", expr(a.alias)) + opts)
+        }
       case a: AlterTable if a.operations.forall(isReshapeOp) =>
         a.operations match
           case List(r: RenameTableOp) =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1226,16 +1226,22 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         .SYNTAX_ERROR
         .newException(s"Expected 'view' after 'save as', but found '${v.str}'", v.sourceLocation)
 
-  def use(): Command = node {
+  def use(): TopLevelStatement = node {
     val t = consume(WvletToken.USE)
     // Support:
     // - use <name>                  (a connector name from the profile, or a schema)
     // - use schema <schema_name>    (explicit schema form)
     // - use connector <name>        (explicit connector form)
+    // - use 'file.duckdb' as name   (attach an external database under an alias)
     // Bare names are disambiguated at execution time: connector names of the active profile
     // shadow schema names.
     val nextToken = scanner.lookAhead()
-    if nextToken.token == WvletToken.IDENTIFIER && nextToken.str == "connector" then
+    if nextToken.token.isStringLiteral then
+      val path = stringLiteral()
+      consume(WvletToken.AS)
+      val alias = identifierSingle()
+      AttachDatabase(path, alias, saveOptions(), spanFrom(t))
+    else if nextToken.token == WvletToken.IDENTIFIER && nextToken.str == "connector" then
       consume(WvletToken.IDENTIFIER) // consume the "connector" soft keyword
       val connector = qualifiedId()
       UseConnector(connector, spanFrom(t))

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -370,6 +370,8 @@ object Typer extends Phase("typer") with LogSupport:
           case r: RenameDatabase =>
             markNamespaceRef(r.database)
             markNamespaceRef(r.renameTo)
+          case a: AttachDatabase =>
+            markNamespaceRef(a.alias)
           case a: AlterTable =>
             markNamespaceRef(a.table)
             a.operations

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/ddl.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/ddl.scala
@@ -64,6 +64,18 @@ case class CreateTable(
 
 case class DropTable(table: NameExpr, ifExists: Boolean, span: Span) extends DDL
 
+/**
+  * Attach an external database under an alias: `use 'file.duckdb' as archive [with read_only:
+  * true]`. The path is self-describing (file extension or URI scheme selects the engine type);
+  * engine-specific modifiers ride in the trailing `with` options
+  */
+case class AttachDatabase(
+    path: StringLiteral,
+    alias: NameExpr,
+    options: List[SaveOption],
+    span: Span
+) extends DDL
+
 // Unified ALTER TABLE structure. A `reshape t { ... }` block carries multiple operations;
 // SQL emits one ALTER TABLE statement per operation
 case class AlterTable(

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/AttachDatabaseSqlTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/AttachDatabaseSqlTest.scala
@@ -1,0 +1,38 @@
+package wvlet.lang.compiler.codegen
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.parser.WvletParser
+
+class AttachDatabaseSqlTest extends UniTest:
+
+  private def generateSQL(wvlet: String): String =
+    val unit = CompilationUnit.fromWvletString(wvlet)
+    val plan = WvletParser(unit).parse()
+    SqlGenerator(CodeFormatterConfig(sqlDBType = DBType.DuckDB)).print(plan)
+
+  test("should lower use-as to an attach statement") {
+    val sql = generateSQL("use 'archive.duckdb' as archive")
+    sql shouldContain "attach 'archive.duckdb' as archive"
+  }
+
+  test("should infer the engine type from the uri scheme") {
+    val sql = generateSQL("use 'postgres://host/db' as pg")
+    sql shouldContain "attach 'postgres://host/db' as pg"
+    sql shouldContain "TYPE postgres"
+  }
+
+  test("should print boolean options as bare flags") {
+    val sql = generateSQL("use 'x.duckdb' as x with read_only: true")
+    sql shouldContain "attach 'x.duckdb' as x"
+    sql shouldContain "READ_ONLY"
+  }
+
+  test("should let an explicit engine option override scheme inference") {
+    val sql = generateSQL("use 'postgres://host/db' as pg with engine: 'mysql'")
+    sql shouldContain "TYPE mysql"
+    sql.contains("TYPE postgres") shouldBe false
+  }
+
+end AttachDatabaseSqlTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -145,6 +145,24 @@ class WvletGeneratorTest extends UniTest:
     print(printed) shouldContain "append to users on id, name"
   }
 
+  test("should round-trip a database attachment") {
+    val printed = print("use 'archive.duckdb' as archive")
+    printed shouldContain "use 'archive.duckdb' as archive"
+    print(printed) shouldContain "use 'archive.duckdb' as archive"
+  }
+
+  test("should round-trip a database attachment with options") {
+    val printed = print("use 'postgres://host/db' as pg with read_only: true")
+    printed shouldContain "use 'postgres://host/db' as pg with read_only: true"
+    print(printed) shouldContain "use 'postgres://host/db' as pg with read_only: true"
+  }
+
+  test("should keep plain use statements as schema/connector switches") {
+    val printed = print("use memory.main")
+    printed shouldContain "use memory.main"
+    printed.contains("attach") shouldBe false
+  }
+
   test("should parse block-form save and append statements") {
     val printed = print("""save to snapshot {
         |  from t


### PR DESCRIPTION
## Summary

Phase 4 (part 1) of the DDL/update statement design (#1976, #1978, #1980): attach an external database under an alias.

```wvlet
-- Attach a DuckDB file
use 'archive.duckdb' as archive

from archive.events
where year = 2025

-- URI scheme infers the engine type (-> ATTACH ... (TYPE postgres))
use 'postgres://host/mydb' as pg

-- Engine modifiers ride in trailing options
use 'archive.duckdb' as archive with read_only: true
```

## Design notes

- **Zero new keywords**: reuses the existing `use` statement — a string literal after `use` is unambiguous against `use schema` / `use connector` / bare names.
- **Self-describing path**: the URI scheme selects the engine type (`postgres://`, `mysql://`); `engine: '<name>'` overrides inference (`type` is a hard Wvlet keyword, so DuckDB's option name can't be passed through verbatim).
- **Options pass-through**: `with read_only: true` prints as a bare `READ_ONLY` flag; other options print as `KEY value`.
- New `AttachDatabase` node extends `DDL`, so it flows through the existing `ExecuteDDL → generateDDLSQL → runStatements` path with no new runner plumbing. Non-DuckDB engines report NOT_IMPLEMENTED.

## Testing

- `spec/basic/ddl/attach-database.wv`: attaches `:memory:` (no filesystem side effects), writes through the alias with block-form `save to`, reads back — executed on DuckDB.
- `AttachDatabaseSqlTest`: ATTACH lowering, scheme→TYPE inference, bare-flag options, engine override.
- `WvletGeneratorTest`: round-trips with and without options; plain `use` statements stay schema/connector switches.
- Full `RunnerSpec*` (480 tests) and `TyperCoverageCheck` pass; Scala.js compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3mfchNEQAGtbs8NXa7Bx