### PR TITLE
feature: Enforce the flow-level timeout so a hung run fails at its declared deadline

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -190,6 +190,11 @@ flow daily_etl with {
 | `on_finish` | Activation | Notification hook fired for both outcomes |
 | `keep_runs` | Int | Retention cap: only the N most recent finished runs are kept |
 
+A flow-level `timeout:` bounds the whole run. When the deadline expires, in-flight stage
+attempts are stopped and every unfinished stage fails with a flow-timeout error, so the run
+is recorded as `failed` (not cancelled) and `on_failure:` hooks fire with the summary. A
+resumed run gets the full timeout budget again, measured from the resume start.
+
 ### Run Notifications
 
 The `on_failure:`, `on_success:`, and `on_finish:` hooks deliver a **run summary** — one row

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -908,12 +908,33 @@ class FlowExecutor(
             states(ls.name) = StageState.Cancelled
         }
 
+    // The flow-level `timeout:` deadline expired. A timeout is an error, not an operator
+    // cancel: in-flight attempts are stopped like a cancellation, but every non-terminal stage
+    // is marked failed with the flow-timeout error, so the run records as failed and the
+    // on_failure hooks fire. An already-processed cancellation takes precedence
+    var flowTimeoutDone                              = false
+    def handleFlowTimeout(timeoutMillis: Long): Unit =
+      if !flowTimeoutDone && !cancellationDone then
+        flowTimeoutDone = true
+        val message = s"Flow ${flow.name.name} timed out after ${timeoutMillis}ms (run: ${runId})"
+        workEnv.error(message)
+        (activeStatements.keySet().asScala ++ activeFutures.keySet().asScala)
+          .toSet
+          .foreach(cancelAttempt)
+        flowStages.foreach { ls =>
+          if !states(ls.name).isTerminal then
+            errors(ls.name) = StatusCode.OPERATION_TIMED_OUT.newException(message)
+            states(ls.name) = StageState.Failed
+        }
+
     def allTerminal: Boolean = states.values.forall(_.isTerminal)
+
+    val scheduleConfig = FlowScheduleConfig.fromFlow(flow)
 
     // Enforce the flow-level concurrency limit by atomically claiming a run slot in the run
     // store. Resumed runs already own their slot (their record is re-marked as running)
     val slotClaimed =
-      (registry, FlowScheduleConfig.fromFlow(flow).concurrency) match
+      (registry, scheduleConfig.concurrency) match
         case (Some(reg), Some(limit)) if resumeFrom.isEmpty =>
           reg.claimRunSlot(currentRecord(finished = false), limit)
         case _ =>
@@ -932,6 +953,21 @@ class FlowExecutor(
         runId,
         flowStages.map(ls => StageResult(ls.name, StageState.Skipped, 0))
       )
+
+    // Bound the whole run with the flow-level timeout. The deadline is armed when the run
+    // starts executing, so a resumed run gets the full budget from its resume start rather
+    // than the original invocation
+    scheduleConfig
+      .timeoutMillis
+      .foreach { timeout =>
+        timer.schedule(
+          new Runnable:
+            override def run(): Unit = eventQueue.put(FlowDeadlineExceeded)
+          ,
+          timeout,
+          TimeUnit.MILLISECONDS
+        )
+      }
 
     try
       var done = false
@@ -956,6 +992,8 @@ class FlowExecutor(
           eventQueue.take() match
             case CancelRequested =>
             // handled at the top of the loop via the cancelled flag
+            case FlowDeadlineExceeded =>
+              handleFlowTimeout(scheduleConfig.timeoutMillis.getOrElse(0L))
             case RetryDue(s, attempt) =>
               scheduledRetries -= 1
               if states(s.name) == StageState.Retrying then
@@ -1055,8 +1093,9 @@ class FlowExecutor(
     notifyRunResult(flow, result)
 
     // Trigger the control-only jumps recorded by successful stages, each as a new run of the
-    // target flow. Jump chains are bounded by maxJumpDepth to terminate cycles (A -> B -> A)
-    if pendingJumps.nonEmpty && !cancelled then
+    // target flow. Jump chains are bounded by maxJumpDepth to terminate cycles (A -> B -> A).
+    // A timed-out run does not jump: its deadline already expired
+    if pendingJumps.nonEmpty && !cancelled && !flowTimeoutDone then
       pendingJumps
         .toList
         .distinct
@@ -1477,5 +1516,7 @@ object FlowExecutor:
 
     case RetryDue(stage: FlowLowering.LoweredStage, attempt: Int)
     case CancelRequested
+    // The flow-level timeout: deadline expired; the run fails with all non-terminal stages
+    case FlowDeadlineExceeded
 
 end FlowExecutor

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowScheduler.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowScheduler.scala
@@ -33,26 +33,33 @@ import scala.util.control.NonFatal
   *   Time zone in which the cron expression is evaluated (defaults to the system zone)
   * @param concurrency
   *   Maximum number of concurrent runs of this flow
+  * @param timeoutMillis
+  *   Total flow timeout: a run exceeding it fails, cancelling its in-flight and pending stages
   */
 case class FlowScheduleConfig(
     cron: Option[String] = None,
     timezone: Option[String] = None,
     concurrency: Option[Int] = None,
-    keepRuns: Option[Int] = None
+    keepRuns: Option[Int] = None,
+    timeoutMillis: Option[Long] = None
 ):
-  def withCron(cron: String): FlowScheduleConfig      = copy(cron = Some(cron))
-  def noCron(): FlowScheduleConfig                    = copy(cron = None)
-  def withTimezone(tz: String): FlowScheduleConfig    = copy(timezone = Some(tz))
-  def noTimezone(): FlowScheduleConfig                = copy(timezone = None)
-  def withConcurrency(limit: Int): FlowScheduleConfig = copy(concurrency = Some(limit))
-  def noConcurrency(): FlowScheduleConfig             = copy(concurrency = None)
-  def withKeepRuns(n: Int): FlowScheduleConfig        = copy(keepRuns = Some(n))
-  def noKeepRuns(): FlowScheduleConfig                = copy(keepRuns = None)
+  def withCron(cron: String): FlowScheduleConfig          = copy(cron = Some(cron))
+  def noCron(): FlowScheduleConfig                        = copy(cron = None)
+  def withTimezone(tz: String): FlowScheduleConfig        = copy(timezone = Some(tz))
+  def noTimezone(): FlowScheduleConfig                    = copy(timezone = None)
+  def withConcurrency(limit: Int): FlowScheduleConfig     = copy(concurrency = Some(limit))
+  def noConcurrency(): FlowScheduleConfig                 = copy(concurrency = None)
+  def withKeepRuns(n: Int): FlowScheduleConfig            = copy(keepRuns = Some(n))
+  def noKeepRuns(): FlowScheduleConfig                    = copy(keepRuns = None)
+  def withTimeoutMillis(millis: Long): FlowScheduleConfig = copy(timeoutMillis = Some(millis))
+  def noTimeoutMillis(): FlowScheduleConfig               = copy(timeoutMillis = None)
 
   def zoneId: ZoneId = timezone.map(ZoneId.of).getOrElse(ZoneId.systemDefault())
 
 object FlowScheduleConfig:
-  /** Extract schedule, timezone, concurrency, and keep_runs from the flow's config items */
+  /**
+    * Extract schedule, timezone, concurrency, keep_runs, and timeout from the flow's config items
+    */
   def fromFlow(flow: FlowDef): FlowScheduleConfig =
     flow
       .config
@@ -94,6 +101,12 @@ object FlowScheduleConfig:
             item.value match
               case l: LongLiteral =>
                 config.withKeepRuns(l.value.toInt)
+              case _ =>
+                config
+          case "timeout" =>
+            item.value match
+              case d: DurationLiteral =>
+                config.withTimeoutMillis(d.toMillis)
               case _ =>
                 config
           case _ =>

--- a/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -301,6 +301,94 @@ class FlowExecutorTest extends UniTest:
     result.stageResult("fast").get.state shouldBe StageState.Success
   }
 
+  test("fail the run when the flow-level timeout expires") {
+    val runner =
+      new FlowStageRunner:
+        override def run(stage: StageDef, targetTable: String)(using Context): Unit = Thread.sleep(
+          10000
+        )
+    val result = runFlow(
+      """flow FlowTimeoutFlow with { timeout: 100ms } = {
+        |  stage slow = from [[1]] as t(id)
+        |  stage after = from slow | select *
+        |}""".stripMargin,
+      stageRunner = Some(runner)
+    )
+    // A flow timeout is an error: the in-flight stage and the pending downstream stage both
+    // fail with the flow-timeout message (unlike an operator cancel, which marks them cancelled)
+    result.hasError shouldBe true
+    val slow = result.stageResult("slow").get
+    slow.state shouldBe StageState.Failed
+    slow.error.get.getMessage shouldContain "timed out"
+    val after = result.stageResult("after").get
+    after.state shouldBe StageState.Failed
+    after.error.get.getMessage shouldContain "timed out"
+  }
+
+  test("leave a fast flow unaffected by the flow-level timeout") {
+    val result = runFlow("""flow FastFlowWithDeadline with { timeout: 30s } = {
+        |  stage src = from [[1]] as t(id)
+        |  stage out = from src | select *
+        |}""".stripMargin)
+    result.isSuccess shouldBe true
+  }
+
+  test("record a timed-out run as failed and fire on_failure hooks") {
+    val sink   = RecordingSink()
+    val runner =
+      new FlowStageRunner:
+        override def run(stage: StageDef, targetTable: String)(using Context): Unit = Thread.sleep(
+          10000
+        )
+    val registry    = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-timeout"))
+    val (flow, ctx) = compileFlow("""flow NotifyTimeoutFlow with {
+        |  timeout: 100ms
+        |  on_failure: activate('test_notify')
+        |} = {
+        |  stage slow = from [[1]] as t(id)
+        |}""".stripMargin)
+    val result =
+      FlowExecutor(
+        connector,
+        workEnv,
+        stageRunner = Some(runner),
+        registry = Some(registry),
+        activationSinks = List(sink)
+      ).execute(flow)(using ctx)
+    result.hasError shouldBe true
+    val record = registry.get(result.runId).get
+    record.state shouldBe FlowRunRecord.STATE_FAILED
+    record.stages.head.error.get shouldContain "timed out"
+    sink.requests.size shouldBe 1
+    sink.requests.head._2 shouldBe List("slow:failed")
+  }
+
+  test("give a resumed run the full flow-timeout budget from its resume start") {
+    val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-timeout"))
+    val stalling =
+      new FlowStageRunner:
+        override def run(stage: StageDef, targetTable: String)(using Context): Unit = Thread.sleep(
+          10000
+        )
+    val (flow, ctx) = compileFlow("""flow ResumeTimeoutFlow with { timeout: 200ms } = {
+        |  stage src = from [[1]] as t(id)
+        |}""".stripMargin)
+    val first =
+      FlowExecutor(connector, workEnv, stageRunner = Some(stalling), registry = Some(registry))
+        .execute(flow)(using ctx)
+    first.hasError shouldBe true
+    val record = registry.get(first.runId).get
+    record.state shouldBe FlowRunRecord.STATE_FAILED
+    // The resume is well past the original deadline in wall-clock terms, but its budget
+    // restarts from the resume start, so the (now fast) stage completes
+    val resumed =
+      FlowExecutor(connector, workEnv, registry = Some(registry)).execute(
+        flow,
+        resumeFrom = Some(record)
+      )(using ctx)
+    resumed.isSuccess shouldBe true
+  }
+
   test("cancel a timed-out SQL statement server-side to free the worker slot") {
     // A cross join large enough to run for minutes if not cancelled server-side. With a
     // single worker slot, the second stage can only complete once the timed-out statement

--- a/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/FlowSchedulerTest.scala
+++ b/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/FlowSchedulerTest.scala
@@ -26,11 +26,12 @@ class FlowSchedulerTest extends UniTest:
       }
     flow.getOrElse(fail("No FlowDef found"))
 
-  test("extract schedule, timezone, and concurrency from the flow config") {
+  test("extract schedule, timezone, concurrency, and timeout from the flow config") {
     val flow = compileFlow("""flow NightlyFlow with {
         |  schedule: cron('0 2 * * *')
         |  timezone: 'UTC'
         |  concurrency: 2
+        |  timeout: 5m
         |} = {
         |  stage src = from [[1]] as t(id)
         |}""".stripMargin)
@@ -39,6 +40,7 @@ class FlowSchedulerTest extends UniTest:
     config.timezone shouldBe Some("UTC")
     config.zoneId shouldBe ZoneId.of("UTC")
     config.concurrency shouldBe Some(2)
+    config.timeoutMillis shouldBe Some(5 * 60 * 1000L)
   }
 
   test("extract empty schedule config from an unconfigured flow") {
@@ -49,6 +51,7 @@ class FlowSchedulerTest extends UniTest:
     config.cron shouldBe None
     config.timezone shouldBe None
     config.concurrency shouldBe None
+    config.timeoutMillis shouldBe None
   }
 
   test("trigger due flows once per schedule fire") {


### PR DESCRIPTION
## Summary

Implements **#1858 item 1**: the flow-level properties table in `website/docs/syntax/flow.md` advertises `timeout: Duration — Total flow timeout`, but nothing parsed or enforced it — a flow hanging past its declared timeout just kept running. This was the round's sequenced-first item (a silent doc/implementation mismatch).

## Changes

- **`FlowScheduleConfig`** gains `timeoutMillis` (with `withTimeoutMillis`/`noTimeoutMillis`), parsed from a `timeout:` duration literal in `fromFlow` — same parsing as stage-level timeouts
- **`FlowExecutor`**: the deadline is armed on the existing single-thread timer when the run starts executing (after the concurrency-slot claim) and posts a new `FlowDeadlineExceeded` event so the queue-driven event loop wakes. The handler stops in-flight attempts through the same path as cancellation, but marks every non-terminal stage **failed** with a clear flow-timeout error — a timeout is an error, not an operator cancel — so:
  - the run record derives `failed` (stage-state derivation; `Failed` outranks `Cancelled`)
  - `on_failure:` hooks fire with the per-stage errors in the summary
  - the CLI exits non-zero
  - pending `-> Flow` jumps are suppressed (the deadline already expired)
  - an already-processed operator cancellation takes precedence over a late deadline
- **Resume semantics**: the deadline restarts from the resume start (armed per `executeInternal`), matching the issue's requirement — a resumed run gets the full budget rather than inheriting an expired deadline
- **Docs**: `flow.md` explains the timeout semantics under the flow-level properties table

## Tests

- `FlowSchedulerTest`: `fromFlow` extracts `timeout: 5m` → 300000ms; unconfigured flows have no timeout
- `FlowExecutorTest` (4 new):
  - flow exceeding its timeout fails both the in-flight and the pending stage with the timeout message
  - a fast flow with a generous deadline is unaffected
  - a timed-out run records `STATE_FAILED` in the run store and fires `on_failure` with the failed summary rows
  - a resumed run succeeds well past the original deadline (fresh budget from resume start)

Full `runnerJVM/test` suite passes; `projectJS/Test/compile` clean; scalafmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49