### PR TITLE
feature: Share common math functions across numeric types via a numeric fallback

### DIFF
--- a/spec/basic/stdlib_math.wv
+++ b/spec/basic/stdlib_math.wv
@@ -40,3 +40,25 @@ test _.rows should be [[
   true,
   false,
 ]]
+;
+
+-- Decimal literals type as decimal: shared math functions resolve through the numeric type
+-- without per-type duplication (round/sqrt/power/sign/log live once on `type numeric`)
+from [[1.75, 4.25]] as t(d, e)
+select
+  d.round(1) as rd,
+  e.sqrt.round(1) as sq,
+  d.power(2.0).round(4) as pw,
+  d.sign as sg,
+  e.ln.round(2) as ln0,
+  d.between(1.0, 2.0) as bw,
+
+test _.size should be 1
+test _.rows should be [[
+  1.8,
+  2.1,
+  3.0625,
+  1,
+  1.45,
+  true,
+]]

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
@@ -252,15 +252,25 @@ object FunctionInliner extends ContextLogSupport:
             m
           }
 
-        // Retry with the any type when the method is not a member of the qualifier's type: with
-        // an unresolved qualifier this lookup has always consulted the any type, so typing the
-        // qualifier (as the new Typer does) must not narrow what could be resolved before
-        val m: Option[MethodSymbolInfo] = memberOf(qualType).orElse {
-          if qualType != DataType.AnyType then
-            memberOf(DataType.AnyType)
-          else
-            None
-        }
+        // Fall back along the widening chain when the method is not a member of the qualifier's
+        // own type: numeric values (int, long, float, real, double, decimal) consult the shared
+        // `numeric` type next, so common math functions need only one definition, and every
+        // lookup ends at the any type (with an unresolved qualifier this lookup has always
+        // consulted the any type, so typing the qualifier must not narrow what could be
+        // resolved before)
+        val m: Option[MethodSymbolInfo] = memberOf(qualType)
+          .orElse {
+            if qualType.isNumeric then
+              memberOf(DataType.GenericType(Name.typeName("numeric")))
+            else
+              None
+          }
+          .orElse {
+            if qualType != DataType.AnyType then
+              memberOf(DataType.AnyType)
+            else
+              None
+          }
 
         if m.isEmpty then
           context.logTrace(s"Failed to find function `${methodName}` for ${qual}:${qual.dataType}")

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/StdLibProbeTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/StdLibProbeTest.scala
@@ -34,6 +34,30 @@ class StdLibProbeTest extends UniTest:
     sql shouldContain "trunc(d)"
   }
 
+  test("resolve shared numeric members on every numeric type") {
+    // round/sqrt/power/sign live once on the numeric type; each qualifier type falls back to it
+    val sql = generateSQL("""from [[1, 10000000000, 1.75, 2.5e0]] as t(i, l, d, f)
+        |select i.sqrt as a, l.round(2) as b, d.power(2.0) as c, f.sign as e, d.ln as g
+        |""".stripMargin)
+    sql shouldContain "sqrt(i)"
+    sql shouldContain "round(l,2)"
+    sql shouldContain "power(d,2.0)"
+    sql shouldContain "sign(f)"
+    sql shouldContain "ln(d)"
+  }
+
+  test("resolve a type's own members alongside the numeric fallback") {
+    // decimal's own members (truncate, abs) resolve first; round comes from the numeric type
+    val sql = generateSQL("from [[1.75]] as t(d)\nselect d.truncate as tr, d.abs.round(1) as r\n")
+    sql shouldContain "trunc(d)"
+    sql shouldContain "round(abs(d),1)"
+  }
+
+  test("resolve dialect-scoped variants defined on the shared numeric type") {
+    val sql = generateSQL("from [[1.75]] as t(d)\nselect d.log2 as l\n", DBType.Snowflake)
+    sql shouldContain "log(2,d)"
+  }
+
   test("resolve dialect-scoped defs through a method chain") {
     val sql = generateSQL("from [[1.75]] as t(d)\nselect d.to_double.is_finite as fi\n")
     sql shouldContain "isfinite(cast(d as double))"

--- a/wvlet-stdlib/module/standard/decimal.wv
+++ b/wvlet-stdlib/module/standard/decimal.wv
@@ -17,23 +17,10 @@ type decimal = {
 
   def or_else(other:decimal): decimal = sql"coalesce(${this},${other})"
 
-  def round(decimal:int=0): double = sql"round(${this},${decimal})"
-
   def abs: decimal = sql"abs(${this})"
   def ceil: decimal = sql"ceil(${this})"
   def floor: decimal = sql"floor(${this})"
-  def sqrt: double = sql"sqrt(${this})"
-  def cbrt: double = sql"cbrt(${this})"
-  def exp: double = sql"exp(${this})"
-  def ln: double = sql"ln(${this})"
-  def log10: double = sql"log10(${this})"
-  def log10 in snowflake: double = sql"log(10,${this})"
-  def log2: double = sql"log2(${this})"
-  def log2 in snowflake: double = sql"log(2,${this})"
-  def log2 in bigquery: double = sql"log(${this}, 2)"
-  def power(exponent:double): double = sql"power(${this},${exponent})"
   def mod(divisor:decimal): decimal = sql"mod(${this},${divisor})"
-  def sign: int = sql"sign(${this})"
 
   -- Drop the fractional part of this value
   def truncate in duckdb: decimal = sql"trunc(${this})"
@@ -41,9 +28,6 @@ type decimal = {
   def truncate in hive: decimal = sql"cast(${this} as bigint)"
   def truncate in snowflake: decimal = sql"trunc(${this})"
   def truncate in bigquery: decimal = sql"trunc(${this})"
-
-  def in(v:any*): boolean = sql"${this} in (${v})"
-  def not_in(v:any*): boolean = sql"${this} not in (${v})"
 
   def between(l:decimal, r:decimal): boolean = sql"${this} between ${l} and ${r}"
 }

--- a/wvlet-stdlib/module/standard/double.wv
+++ b/wvlet-stdlib/module/standard/double.wv
@@ -17,22 +17,9 @@ type double = {
 
   def or_else(other:double): double = sql"coalesce(${this},${other})"
 
-  def round(decimal:int=0): double = sql"round(${this},${decimal})"
-
   def abs: double = sql"abs(${this})"
   def ceil: double = sql"ceil(${this})"
   def floor: double = sql"floor(${this})"
-  def sqrt: double = sql"sqrt(${this})"
-  def cbrt: double = sql"cbrt(${this})"
-  def exp: double = sql"exp(${this})"
-  def ln: double = sql"ln(${this})"
-  def log10: double = sql"log10(${this})"
-  def log10 in snowflake: double = sql"log(10,${this})"
-  def log2: double = sql"log2(${this})"
-  def log2 in snowflake: double = sql"log(2,${this})"
-  def log2 in bigquery: double = sql"log(${this}, 2)"
-  def power(exponent:double): double = sql"power(${this},${exponent})"
-  def sign: int = sql"sign(${this})"
 
   def degrees: double = sql"degrees(${this})"
   def radians: double = sql"radians(${this})"
@@ -59,9 +46,6 @@ type double = {
   def is_infinite in duckdb: boolean = sql"isinf(${this})"
   def is_infinite in trino: boolean = sql"is_infinite(${this})"
   def is_infinite in bigquery: boolean = sql"is_inf(${this})"
-
-  def in(v:any*): boolean = sql"${this} in (${v})"
-  def not_in(v:any*): boolean = sql"${this} not in (${v})"
 
   def between(l:double, r:double): boolean = sql"${this} between ${l} and ${r}"
 }

--- a/wvlet-stdlib/module/standard/float.wv
+++ b/wvlet-stdlib/module/standard/float.wv
@@ -17,21 +17,9 @@ type float = {
 
   def or_else(other:float): float = sql"coalesce(${this},${other})"
 
-  def round(decimal:int=0): double = sql"round(${this},${decimal})"
-
   def abs: float = sql"abs(${this})"
   def ceil: float = sql"ceil(${this})"
   def floor: float = sql"floor(${this})"
-  def sqrt: double = sql"sqrt(${this})"
-  def exp: double = sql"exp(${this})"
-  def ln: double = sql"ln(${this})"
-  def log10: double = sql"log10(${this})"
-  def log10 in snowflake: double = sql"log(10,${this})"
-  def log2: double = sql"log2(${this})"
-  def log2 in snowflake: double = sql"log(2,${this})"
-  def log2 in bigquery: double = sql"log(${this}, 2)"
-  def power(exponent:double): double = sql"power(${this},${exponent})"
-  def sign: int = sql"sign(${this})"
 
   def is_nan in duckdb: boolean = sql"isnan(${this})"
   def is_nan in trino: boolean = sql"is_nan(${this})"
@@ -42,9 +30,6 @@ type float = {
   def is_infinite in duckdb: boolean = sql"isinf(${this})"
   def is_infinite in trino: boolean = sql"is_infinite(${this})"
   def is_infinite in bigquery: boolean = sql"is_inf(${this})"
-
-  def in(v:any*): boolean = sql"${this} in (${v})"
-  def not_in(v:any*): boolean = sql"${this} not in (${v})"
 
   def between(l:float, r:float): boolean = sql"${this} between ${l} and ${r}"
 }
@@ -66,16 +51,10 @@ type real = {
   def to_string in bigquery: string = sql"cast(${this} as string)"
 
   def or_else(other:real): real = sql"coalesce(${this},${other})"
-  def round(decimal:int=0): double = sql"round(${this},${decimal})"
 
   def abs: real = sql"abs(${this})"
   def ceil: real = sql"ceil(${this})"
   def floor: real = sql"floor(${this})"
-  def sqrt: double = sql"sqrt(${this})"
-  def sign: int = sql"sign(${this})"
-
-  def in(v:any*): boolean = sql"${this} in (${v})"
-  def not_in(v:any*): boolean = sql"${this} not in (${v})"
 
   def between(l:real, r:real): boolean = sql"${this} between ${l} and ${r}"
 }

--- a/wvlet-stdlib/module/standard/int.wv
+++ b/wvlet-stdlib/module/standard/int.wv
@@ -16,23 +16,11 @@ type int = {
   def to_string in bigquery: string = sql"cast(${this} as string)"
 
   def or_else(other:int): int = sql"coalesce(${this},${other})"
-  def round(decimal:int=0): double = sql"round(${this},${decimal})"
 
   def abs: int = sql"abs(${this})"
   def ceil: int = sql"ceil(${this})"
   def floor: int = sql"floor(${this})"
-  def sqrt: double = sql"sqrt(${this})"
-  def cbrt: double = sql"cbrt(${this})"
-  def exp: double = sql"exp(${this})"
-  def ln: double = sql"ln(${this})"
-  def log10: double = sql"log10(${this})"
-  def log10 in snowflake: double = sql"log(10,${this})"
-  def log2: double = sql"log2(${this})"
-  def log2 in snowflake: double = sql"log(2,${this})"
-  def log2 in bigquery: double = sql"log(${this}, 2)"
-  def power(exponent:double): double = sql"power(${this},${exponent})"
   def mod(divisor:int): int = sql"mod(${this},${divisor})"
-  def sign: int = sql"sign(${this})"
 
   -- Interpret this value as a unix epoch second (in UTC)
   def from_unixtime in duckdb: timestamp = sql"make_timestamp(cast(${this} as bigint) * 1000000)"
@@ -40,9 +28,6 @@ type int = {
   def from_unixtime in hive: timestamp = sql"cast(from_unixtime(${this}) as timestamp)"
   def from_unixtime in snowflake: timestamp = sql"to_timestamp_ntz(${this})"
   def from_unixtime in bigquery: timestamp = sql"timestamp_seconds(${this})"
-
-  def in(v:any*): boolean = sql"${this} in (${v})"
-  def not_in(v:any*): boolean = sql"${this} not in (${v})"
 
   def between(l:int, r:int): boolean = sql"${this} between ${l} and ${r}"
 }

--- a/wvlet-stdlib/module/standard/long.wv
+++ b/wvlet-stdlib/module/standard/long.wv
@@ -16,23 +16,11 @@ type long = {
   def to_string in bigquery: string = sql"cast(${this} as string)"
 
   def or_else(other:long): long = sql"coalesce(${this},${other})"
-  def round(decimal:int=0): double = sql"round(${this},${decimal})"
 
   def abs: long = sql"abs(${this})"
   def ceil: long = sql"ceil(${this})"
   def floor: long = sql"floor(${this})"
-  def sqrt: double = sql"sqrt(${this})"
-  def cbrt: double = sql"cbrt(${this})"
-  def exp: double = sql"exp(${this})"
-  def ln: double = sql"ln(${this})"
-  def log10: double = sql"log10(${this})"
-  def log10 in snowflake: double = sql"log(10,${this})"
-  def log2: double = sql"log2(${this})"
-  def log2 in snowflake: double = sql"log(2,${this})"
-  def log2 in bigquery: double = sql"log(${this}, 2)"
-  def power(exponent:double): double = sql"power(${this},${exponent})"
   def mod(divisor:long): long = sql"mod(${this},${divisor})"
-  def sign: int = sql"sign(${this})"
 
   -- Interpret this value as a unix epoch second (in UTC)
   def from_unixtime in duckdb: timestamp = sql"make_timestamp(cast(${this} as bigint) * 1000000)"
@@ -40,9 +28,6 @@ type long = {
   def from_unixtime in hive: timestamp = sql"cast(from_unixtime(${this}) as timestamp)"
   def from_unixtime in snowflake: timestamp = sql"to_timestamp_ntz(${this})"
   def from_unixtime in bigquery: timestamp = sql"timestamp_seconds(${this})"
-
-  def in(v:any*): boolean = sql"${this} in (${v})"
-  def not_in(v:any*): boolean = sql"${this} not in (${v})"
 
   def between(l:long, r:long): boolean = sql"${this} between ${l} and ${r}"
 }

--- a/wvlet-stdlib/module/standard/numeric.wv
+++ b/wvlet-stdlib/module/standard/numeric.wv
@@ -1,0 +1,26 @@
+package wvlet.standard
+
+-- Functions shared by all numeric types (int, long, float, real, double, decimal).
+-- Member lookup on a numeric value falls back to this type when the value's own type
+-- does not define the member, so common math functions need only one definition here.
+-- Functions whose return type follows the value's own type (abs, ceil, floor, mod,
+-- truncate, or_else, between) stay defined per type.
+type numeric = {
+  -- Round to the given number of decimal places
+  def round(decimal:int=0): double = sql"round(${this},${decimal})"
+
+  def sqrt: double = sql"sqrt(${this})"
+  def cbrt: double = sql"cbrt(${this})"
+  def exp: double = sql"exp(${this})"
+  def ln: double = sql"ln(${this})"
+  def log10: double = sql"log10(${this})"
+  def log10 in snowflake: double = sql"log(10,${this})"
+  def log2: double = sql"log2(${this})"
+  def log2 in snowflake: double = sql"log(2,${this})"
+  def log2 in bigquery: double = sql"log(${this}, 2)"
+  def power(exponent:double): double = sql"power(${this},${exponent})"
+  def sign: int = sql"sign(${this})"
+
+  def in(v:any*): boolean = sql"${this} in (${v})"
+  def not_in(v:any*): boolean = sql"${this} not in (${v})"
+}


### PR DESCRIPTION
## Summary

Addresses item 10 (decimal ergonomics) of the stdlib follow-up tracker (after #1966).

Decimal literals (e.g. `1.75`) type as `decimal`, which previously forced every numeric type — int, long, float, real, double, decimal — to carry its own copy of the shared math functions.

- **Numeric fallback in member lookup**: `FunctionInliner.findFunctionDef` now widens along `own type → numeric → any` for numeric qualifiers. A type's own member always shadows the shared definition (e.g. decimal's `truncate` variants), and dialect selection works unchanged on the shared defs (e.g. `log2` → `log(2,x)` on Snowflake).
- **New `wvlet-stdlib/module/standard/numeric.wv`**: `round`, `sqrt`, `cbrt`, `exp`, `ln`, `log10`, `log2`, `power`, `sign`, `in`, `not_in` defined once; the duplicated copies are removed from the six per-type files (net −1 line despite the new file and comments).
- Functions whose return type follows the value's own type (`abs`, `ceil`, `floor`, `mod`, `truncate`, `or_else`, `between`) stay per type.
- `float` and `real` gain functions they previously lacked (`cbrt`, `exp`, `ln`, `log10`, `log2`, `power`) for free.

The bundled engine catalogs are unaffected: catalog exclusion counts only top-level defs, and the freshness check introduced in #1983 guards this.

## Test Plan

- New `StdLibProbeTest` cases: shared members resolve on every numeric qualifier type, own members shadow the fallback, dialect-scoped variants on `type numeric` select correctly (Snowflake `log2`)
- `spec/basic/stdlib_math.wv` extended with a decimal-typed query (`round`/`sqrt`/`power`/`sign`/`ln`/`between` on decimal literals), executed on DuckDB and real Trino
- `langJVM/testOnly *` (1941 tests), `runnerJVM/testOnly *` (684 tests incl. TPC-DS + Trino stdlib execution), `TyperCoverageCheck`, `projectJS`/`projectNative` compile, `scalafmtAll` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDVq4Etzaj8C8XCUm2iJiP
