### PR TITLE
feature: Generate the stdlib reference docs from the library sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,5 +329,6 @@ For error reporting, use WvletLangException and StatusCode enum. If necessary er
 - Use `shouldContain "(keyword)"` for checking string fragment in UniTest
 - To debug SQL generator, add -L *GenSQL=trace to the test option
 - Typing coverage over spec/basic is guarded by a CI ratchet: `./sbt "langJVM/testOnly *TyperCoverageCheck"` (raise its thresholds when improving type resolution; never lower them)
+- The stdlib is freshness-gated in CI: after changing `wvlet-stdlib/module/standard/*.wv` or bumping an engine dependency, regenerate the engine catalogs (`./sbt "runnerJVM/Test/runMain wvlet.lang.runner.StdLibFunctionCatalogGenerator"` for DuckDB, `...StdLibTrinoFunctionCatalogGenerator` for Trino) and the docs reference page (`./sbt "langJVM/Test/runMain wvlet.lang.compiler.codegen.StdLibDocGenerator"`); `StdLibCatalogFreshnessTest` and `StdLibDocFreshnessTest` fail on drift with the exact command to run
 - For compiler performance work, compare before/after with `./sbt "langJVM/testOnly *TyperBench"` (log-only timing probe)
 

--- a/website/docs/syntax/stdlib-reference.md
+++ b/website/docs/syntax/stdlib-reference.md
@@ -1,0 +1,385 @@
+---
+sidebar_label: Stdlib Reference
+---
+
+# Standard Library Reference
+
+<!-- Generated from wvlet-stdlib/module/standard/*.wv. DO NOT EDIT.
+     Regenerate with: ./sbt "langJVM/Test/runMain wvlet.lang.compiler.codegen.StdLibDocGenerator" -->
+
+Complete listing of the functions defined in the Wvlet standard library, generated from
+its sources. Call these with dot syntax on a value of the listed type (e.g. `name.upper`,
+`price.round(2)`). See [Standard Library Functions](stdlib.md) for a guided tour with
+examples.
+
+The **Engines** column lists the engines a definition is specialized for; **all** means a
+single dialect-neutral definition serves every supported engine (DuckDB, Trino, Hive,
+Snowflake, and BigQuery). Engine-specific SQL is selected automatically for the compile
+target.
+
+## Any Values
+
+Available on values of every type.
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `to_string` | string | all |  |
+| `to_int` | int | all |  |
+| `to_long` | long | all |  |
+| `to_float` | float | all |  |
+| `to_double` | double | all |  |
+| `to_boolean` | boolean | all |  |
+| `to_date` | date | all | Cast to the SQL date type |
+| `to_timestamp` | timestamp | all | Cast to the SQL timestamp type |
+| `is_null` | boolean | all | True if this value is null |
+| `is_not_null` | boolean | all |  |
+| `or_else(other: any)` | any | all | Return the other value if this value is null |
+| `null_if(v: any)` | any | all | Return null if this value equals the given value |
+| `type_of` | string | all | Name of the runtime type of this value |
+| `to_json` | json | duckdb, trino |  |
+
+## Numeric Values
+
+Shared by all numeric types (int, long, float, real, double, decimal).
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `round(decimal: int)` | double | all | Round to the given number of decimal places |
+| `sqrt` | double | all |  |
+| `cbrt` | double | all |  |
+| `exp` | double | all |  |
+| `ln` | double | all |  |
+| `log10` | double | all |  |
+| `log2` | double | all |  |
+| `power(exponent: double)` | double | all |  |
+| `sign` | int | all |  |
+| `in(v: any*)` | boolean | all |  |
+| `not_in(v: any*)` | boolean | all |  |
+
+## Int Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `to_int` | int | all |  |
+| `to_long` | long | all |  |
+| `to_float` | float | all |  |
+| `to_double` | double | all |  |
+| `to_boolean` | boolean | all |  |
+| `to_string` | string | all |  |
+| `or_else(other: int)` | int | all |  |
+| `abs` | int | all |  |
+| `ceil` | int | all |  |
+| `floor` | int | all |  |
+| `mod(divisor: int)` | int | all |  |
+| `from_unixtime` | timestamp | duckdb, trino, hive, snowflake, bigquery | Interpret this value as a unix epoch second (in UTC) |
+| `between(l: int, r: int)` | boolean | all |  |
+
+## Long Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `to_int` | int | all |  |
+| `to_long` | long | all |  |
+| `to_float` | float | all |  |
+| `to_double` | double | all |  |
+| `to_boolean` | boolean | all |  |
+| `to_string` | string | all |  |
+| `or_else(other: long)` | long | all |  |
+| `abs` | long | all |  |
+| `ceil` | long | all |  |
+| `floor` | long | all |  |
+| `mod(divisor: long)` | long | all |  |
+| `from_unixtime` | timestamp | duckdb, trino, hive, snowflake, bigquery | Interpret this value as a unix epoch second (in UTC) |
+| `between(l: long, r: long)` | boolean | all |  |
+| `within(duration: string)` | boolean | td_trino |  |
+| `td_time_string(format: string)` | string | td_trino, td_hive |  |
+| `td_interval(duration: string)` | boolean | td_hive |  |
+
+## Float Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `to_int` | int | all |  |
+| `to_long` | long | all |  |
+| `to_float` | float | all |  |
+| `to_double` | double | all |  |
+| `to_boolean` | boolean | all |  |
+| `to_string` | string | all |  |
+| `or_else(other: float)` | float | all |  |
+| `abs` | float | all |  |
+| `ceil` | float | all |  |
+| `floor` | float | all |  |
+| `is_nan` | boolean | duckdb, trino, bigquery |  |
+| `is_finite` | boolean | duckdb, trino, bigquery |  |
+| `is_infinite` | boolean | duckdb, trino, bigquery |  |
+| `between(l: float, r: float)` | boolean | all |  |
+
+## Real Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `to_int` | int | all |  |
+| `to_long` | long | all |  |
+| `to_float` | float | all |  |
+| `to_double` | double | all |  |
+| `to_boolean` | boolean | all |  |
+| `to_string` | string | all |  |
+| `or_else(other: real)` | real | all |  |
+| `abs` | real | all |  |
+| `ceil` | real | all |  |
+| `floor` | real | all |  |
+| `between(l: real, r: real)` | boolean | all |  |
+
+## Double Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `to_int` | int | all |  |
+| `to_long` | long | all |  |
+| `to_float` | float | all |  |
+| `to_double` | double | all |  |
+| `to_boolean` | boolean | all |  |
+| `to_string` | string | all |  |
+| `or_else(other: double)` | double | all |  |
+| `abs` | double | all |  |
+| `ceil` | double | all |  |
+| `floor` | double | all |  |
+| `degrees` | double | all |  |
+| `radians` | double | all |  |
+| `sin` | double | all |  |
+| `cos` | double | all |  |
+| `tan` | double | all |  |
+| `asin` | double | all |  |
+| `acos` | double | all |  |
+| `atan` | double | all |  |
+| `truncate` | double | duckdb, trino, hive, snowflake, bigquery | Drop the fractional part of this value |
+| `is_nan` | boolean | duckdb, trino, bigquery |  |
+| `is_finite` | boolean | duckdb, trino, bigquery |  |
+| `is_infinite` | boolean | duckdb, trino, bigquery |  |
+| `between(l: double, r: double)` | boolean | all |  |
+
+## Decimal Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `to_int` | int | all |  |
+| `to_long` | long | all |  |
+| `to_float` | float | all |  |
+| `to_double` | double | all |  |
+| `to_boolean` | boolean | all |  |
+| `to_string` | string | all |  |
+| `or_else(other: decimal)` | decimal | all |  |
+| `abs` | decimal | all |  |
+| `ceil` | decimal | all |  |
+| `floor` | decimal | all |  |
+| `mod(divisor: decimal)` | decimal | all |  |
+| `truncate` | decimal | duckdb, trino, hive, snowflake, bigquery | Drop the fractional part of this value |
+| `between(l: decimal, r: decimal)` | boolean | all |  |
+
+## Boolean Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `to_int` | int | all |  |
+| `to_long` | long | all |  |
+| `to_string` | string | all |  |
+| `or_else(other: boolean)` | boolean | all | if the value is null, return the given default value |
+
+## String Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `to_int` | int | all |  |
+| `to_long` | long | all |  |
+| `to_float` | float | all |  |
+| `to_double` | double | all |  |
+| `to_boolean` | boolean | all |  |
+| `to_date` | date | all |  |
+| `to_timestamp` | timestamp | all |  |
+| `or_else(other: string)` | string | all | if the string is null, return the default value |
+| `length` | int | all | Number of characters in the string |
+| `upper` | string | all |  |
+| `lower` | string | all |  |
+| `trim` | string | all |  |
+| `ltrim` | string | all |  |
+| `rtrim` | string | all |  |
+| `reverse` | string | all |  |
+| `concat(other: string)` | string | all | Concatenate the given string after this string |
+| `replace(search: string, replacement: string)` | string | all | Replace all occurrences of the search string with the replacement string |
+| `lpad(length: int, pad: string)` | string | all | Pad the string to the given length by prepending (lpad) or appending (rpad) the pad string |
+| `rpad(length: int, pad: string)` | string | all |  |
+| `strpos(substr: string)` | int | all | 1-origin position of the first occurrence of the substring (0 if not found) |
+| `like(pattern: string)` | boolean | all |  |
+| `substring(start: int)` | string | all | Substring from the 1-origin start position (to the end, or of the given length) |
+| `substring(start: int, length: int)` | string | all |  |
+| `regexp_extract(pattern: string)` | string | all | Extract the first substring matching the regular expression |
+| `regexp_extract(pattern: string, group_index: int)` | string | all |  |
+| `starts_with(prefix: string)` | boolean | all |  |
+| `in(v: any*)` | boolean | all |  |
+| `not_in(expr: any*)` | boolean | all |  |
+| `regexp_like(pattern: string)` | boolean | duckdb, trino, hive, snowflake, bigquery | Snowflake's REGEXP_LIKE matches the entire string, so use REGEXP_INSTR for the partial-match semantics of the other engines |
+| `regexp_replace(pattern: string, replacement: string)` | string | duckdb, trino, hive, snowflake, bigquery | Replace every substring matching the regular expression with the replacement |
+| `contains(substr: string)` | boolean | duckdb, trino, hive, snowflake, bigquery |  |
+| `ends_with(suffix: string)` | boolean | duckdb, trino, hive, snowflake, bigquery |  |
+| `split(separator: string)` | array[string] | duckdb, trino, hive, snowflake, bigquery | Split the string by the separator into an array of strings |
+| `md5` | string | duckdb, trino, hive, snowflake, bigquery | Hex-encoded digest strings |
+| `sha256` | string | duckdb, trino, hive, snowflake, bigquery |  |
+| `levenshtein(other: string)` | int | duckdb, trino, hive, snowflake, bigquery | Edit distance between two strings |
+| `json_extract(path: string)` | json | duckdb, trino, hive, snowflake, bigquery | Extract a JSON value from a string holding JSON text |
+| `json_extract_string(path: string)` | string | duckdb, trino, hive, snowflake, bigquery |  |
+
+## Date Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `extract(field: string)` | int | all |  |
+| `year` | int | all |  |
+| `month` | int | all |  |
+| `day` | int | all |  |
+| `quarter` | int | all |  |
+| `week` | int | all |  |
+| `or_else(other: date)` | date | all |  |
+| `truncate_to(unit: string)` | date | all | Truncate to the given unit ('year', 'quarter', 'month', 'week', 'day') |
+| `diff_days(other: date)` | long | all | Difference between this and the other date, in the given unit |
+| `diff_months(other: date)` | long | all |  |
+| `diff_years(other: date)` | long | all |  |
+| `between(l: date, r: date)` | boolean | all |  |
+| `day_of_week` | int | duckdb, trino, hive, snowflake, bigquery | ISO day of week (1 = Monday, 7 = Sunday) and day of year |
+| `day_of_year` | int | duckdb, trino, hive, snowflake, bigquery |  |
+| `add_days(n: int)` | date | duckdb, trino, hive, snowflake, bigquery |  |
+| `add_months(n: int)` | date | duckdb, trino, hive, snowflake, bigquery |  |
+| `add_years(n: int)` | date | duckdb, trino, hive, snowflake, bigquery |  |
+| `format(pattern: string)` | string | duckdb, trino, hive, snowflake, bigquery | Format the date with a strftime-style pattern (e.g. '%Y-%m-%d') |
+| `last_day` | date | duckdb, trino, hive, snowflake, bigquery | The last day of the month of this date |
+
+## Timestamp Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `extract(field: string)` | int | all |  |
+| `year` | int | all |  |
+| `month` | int | all |  |
+| `day` | int | all |  |
+| `hour` | int | all |  |
+| `minute` | int | all |  |
+| `second` | int | all |  |
+| `quarter` | int | all |  |
+| `week` | int | all |  |
+| `or_else(other: timestamp)` | timestamp | all |  |
+| `to_date` | date | all |  |
+| `truncate_to(unit: string)` | timestamp | all | Truncate to the given unit ('year', 'month', 'day', 'hour', 'minute', 'second') |
+| `diff_seconds(other: timestamp)` | long | all | Difference between this and the other timestamp, in the given unit |
+| `diff_minutes(other: timestamp)` | long | all |  |
+| `diff_hours(other: timestamp)` | long | all |  |
+| `diff_days(other: timestamp)` | long | all |  |
+| `between(l: timestamp, r: timestamp)` | boolean | all |  |
+| `day_of_week` | int | duckdb, trino, hive, snowflake, bigquery | ISO day of week (1 = Monday, 7 = Sunday) and day of year |
+| `day_of_year` | int | duckdb, trino, hive, snowflake, bigquery |  |
+| `add_seconds(n: int)` | timestamp | duckdb, trino, hive, snowflake, bigquery | Timestamp arithmetic via unix epoch seconds (Hive has no timestamp interval functions) |
+| `add_minutes(n: int)` | timestamp | duckdb, trino, hive, snowflake, bigquery |  |
+| `add_hours(n: int)` | timestamp | duckdb, trino, hive, snowflake, bigquery |  |
+| `add_days(n: int)` | timestamp | duckdb, trino, hive, snowflake, bigquery |  |
+| `add_months(n: int)` | timestamp | duckdb, trino, snowflake |  |
+| `add_years(n: int)` | timestamp | duckdb, trino, snowflake |  |
+| `format(pattern: string)` | string | duckdb, trino, hive, snowflake, bigquery | Format the timestamp with a strftime-style pattern (e.g. '%Y-%m-%d %H:%M:%S') |
+| `to_unixtime` | long | duckdb, trino, hive, snowflake, bigquery | Unix epoch seconds of this timestamp |
+| `to_string` | string | duckdb, trino, hive, snowflake, bigquery | Render as 'YYYY-MM-DD HH:MM:SS'. Overridden per engine so the rendering is identical |
+
+## JSON Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `json_extract(path: string)` | json | all | Extract the JSON value at the JSONPath expression (e.g. '$.store.book') |
+| `json_extract_string(path: string)` | string | duckdb, trino | Extract the value at the JSONPath expression as a plain string |
+
+## Null Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `to_int` | int | all |  |
+| `to_long` | long | all |  |
+| `to_float` | float | all |  |
+| `to_double` | double | all |  |
+| `to_boolean` | boolean | all |  |
+| `to_date` | date | all |  |
+| `to_timestamp` | timestamp | all |  |
+| `to_string` | string | all |  |
+
+## Array Values
+
+A column reference after `group by` also has an array type, so aggregation functions apply to it with the same syntax.
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `length` | int | duckdb, trino, hive, snowflake, bigquery |  |
+| `size` | int | duckdb, trino, hive, snowflake, bigquery |  |
+| `get(index: int)` | A | all |  |
+| `count` | int | all |  |
+| `count_distinct` | int | all |  |
+| `count_if(cond: boolean)` | int | all |  |
+| `count_approx_distinct` | int | trino, duckdb, snowflake, bigquery | Fast and memory-efficient approximate counting of distinct elements |
+| `arbitrary` | A | all |  |
+| `any` | A | all |  |
+| `min` | A | all |  |
+| `max` | A | all |  |
+| `min_by(expr: sql)` | A | all |  |
+| `max_by(expr: sql)` | A | all |  |
+| `to_array` | array[A] | all |  |
+| `bool_and` | boolean | all | Aggregate boolean values of a grouped column |
+| `bool_or` | boolean | all |  |
+| `string_agg(separator: string)` | string | duckdb, trino, hive, snowflake, bigquery | Concatenate grouped string values with the separator |
+| `exclude(arr: sql)` | array[A] | duckdb, trino |  |
+| `exists` | boolean | all |  |
+| `not_exists` | boolean | all |  |
+| `contains(elem: A)` | boolean | all | True if the array contains the given element |
+| `mk_string` | string | duckdb, trino, hive, snowflake, bigquery | Concatenate the array elements into a string without a separator |
+| `mk_string(separator: string)` | string | duckdb, trino, hive, snowflake, bigquery | Concatenate the array elements into a string with the separator |
+| `distinct` | array[A] | all | Remove duplicate elements |
+| `flatten` | array[A] | all | Flatten an array of arrays into a single array |
+| `sort` | array[A] | duckdb, trino, hive, snowflake |  |
+| `reverse` | array[A] | duckdb, trino, snowflake, bigquery |  |
+| `index_of(elem: A)` | int | duckdb, trino, snowflake | 1-origin position of the first occurrence of the element (0 if not found) |
+| `concat(other: any)` | array[A] | duckdb, trino, snowflake, bigquery |  |
+| `lag` | A | all | Value of the column at a preceding row of the window |
+| `lag(offset: int)` | A | all |  |
+| `lag(offset: int, default: any)` | A | all |  |
+| `lead` | A | all | Value of the column at a following row of the window |
+| `lead(offset: int)` | A | all |  |
+| `lead(offset: int, default: any)` | A | all |  |
+| `first_value` | A | all | First value of the window |
+| `last_value` | A | all | Last value of the window |
+| `nth_value(n: int)` | A | all | Value at the n-th row (1-origin) of the window |
+| `sum` | A | all |  |
+| `avg` | A | all |  |
+| `median` | A | all |  |
+| `variance` | A | all |  |
+| `stddev` | A | all |  |
+| `stddev_pop` | A | all |  |
+| `stddev_samp` | A | all |  |
+| `var_pop` | A | all |  |
+| `var_samp` | A | all |  |
+| `approx_quantile(pos: double)` | A | trino, duckdb, hive, snowflake, bigquery |  |
+
+## Map Values
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `size` | int | all | Number of entries in the map |
+| `keys` | array[K] | all |  |
+| `values` | array[V] | all |  |
+| `contains_key(key: K)` | boolean | all | True if the map contains the given key |
+| `get(key: K)` | V | duckdb, trino, hive, snowflake | The value for the given key, or null if the key is absent |
+
+## Top-Level Functions
+
+Called without a receiver value (window functions require an `over(...)` clause).
+
+| Function | Returns | Engines | Description |
+|----------|---------|---------|-------------|
+| `ulid_string` | string | all | Generate a new ULID |
+| `row_number` | long | all | Sequential row number within the window (1, 2, 3, ...) |
+| `rank` | long | all | Rank with gaps after ties (1, 1, 3, ...) |
+| `dense_rank` | long | all | Rank without gaps after ties (1, 1, 2, ...) |
+| `percent_rank` | double | all | Relative rank in [0, 1]: (rank - 1) / (rows - 1) |
+| `cume_dist` | double | all | Cumulative distribution in (0, 1]: rows preceding or peer / rows |
+| `ntile(n: int)` | long | all | Bucket number when the window is divided into n groups |

--- a/website/docs/syntax/stdlib.md
+++ b/website/docs/syntax/stdlib.md
@@ -2,6 +2,8 @@
 
 Wvlet ships with a standard library of functions that you call with dot syntax on column values, e.g. `name.upper` or `price.round(2)`. Functions compile to the SQL of the target database engine: when engines differ (e.g. DuckDB, Trino, Hive, Snowflake, and BigQuery), Wvlet picks the right SQL for the engine you are compiling for, so the same query works across engines.
 
+This page is a guided tour of the most common functions. For the complete listing generated from the library sources, see the [Standard Library Reference](stdlib-reference.md).
+
 ```wvlet
 from orders
 select

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/codegen/StdLibDocFreshnessTest.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/codegen/StdLibDocFreshnessTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.codegen
+
+import wvlet.lang.compiler.SourceIO
+import wvlet.uni.test.UniTest
+
+/**
+  * Guard against drift between the standard-library sources and the generated reference page
+  * (website/docs/syntax/stdlib-reference.md). When stdlib definitions are added or changed, this
+  * test fails with the command that regenerates the page.
+  */
+class StdLibDocFreshnessTest extends UniTest:
+
+  test("stdlib reference doc matches the stdlib sources") {
+    val generated = StdLibDocGenerator.generateMarkdown()
+    val bundled   = SourceIO.readAsString(StdLibDocGenerator.targetPath)
+    if bundled != generated then
+      val bundledLines   = bundled.linesIterator.toIndexedSeq
+      val generatedLines = generated.linesIterator.toIndexedSeq
+      val firstDiff      = bundledLines
+        .zipAll(generatedLines, "<missing line>", "<missing line>")
+        .indexWhere(_ != _)
+      val diffReport =
+        if firstDiff >= 0 then
+          val expected = generatedLines.lift(firstDiff).getOrElse("<missing line>")
+          val actual   = bundledLines.lift(firstDiff).getOrElse("<missing line>")
+          s"First difference at line ${firstDiff +
+              1}:\n  checked-in: ${actual}\n  generated : ${expected}"
+        else
+          ""
+      fail(
+        s"""${StdLibDocGenerator.targetPath} is out of date (checked-in: ${bundledLines
+            .size} lines, regenerated: ${generatedLines.size} lines).
+           |${diffReport}
+           |Regenerate it with:
+           |  ${StdLibDocGenerator.regenCommand}""".stripMargin
+      )
+  }
+
+end StdLibDocFreshnessTest

--- a/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/codegen/StdLibDocGenerator.scala
+++ b/wvlet-lang/.jvm/src/test/scala/wvlet/lang/compiler/codegen/StdLibDocGenerator.scala
@@ -1,0 +1,241 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.codegen
+
+import wvlet.lang.catalog.StaticCatalogExporter
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.SourceIO
+import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.model.DataType
+import wvlet.lang.model.DataType.VarArgType
+import wvlet.lang.model.plan.*
+import wvlet.uni.log.LogSupport
+
+import scala.collection.mutable
+
+/**
+  * Generate the standard-library reference page (website/docs/syntax/stdlib-reference.md) from the
+  * hand-written stdlib .wv sources, so the documented function set can never drift from the
+  * implementation. Descriptions come from the `--` comments above each definition; engine coverage
+  * comes from the `in <dialect>` scopes.
+  *
+  * Run with: ./sbt "langJVM/Test/runMain wvlet.lang.compiler.codegen.StdLibDocGenerator"
+  */
+object StdLibDocGenerator extends LogSupport:
+  /** Path of the generated reference page, relative to the repository root */
+  val targetPath = "website/docs/syntax/stdlib-reference.md"
+
+  /** Regeneration command shown in the page header and in freshness-check failures */
+  val regenCommand = "./sbt \"langJVM/Test/runMain wvlet.lang.compiler.codegen.StdLibDocGenerator\""
+
+  /** One function definition collected from the stdlib sources */
+  private case class DefEntry(
+      typeName: String,
+      fn: FunctionDef,
+      // dialect scopes of the enclosing type block (e.g. `type any in duckdb`)
+      typeContexts: List[String],
+      description: String
+  ):
+    /** Dialect names this definition is scoped to; empty for a dialect-neutral definition */
+    def dialects: List[String] =
+      val own = fn.defContexts.map(_.contextType.leafName.toLowerCase)
+      (typeContexts ++ own).distinct
+
+    /** Signature key: same name and arity merge into one documented row */
+    def signature: String =
+      if fn.args.isEmpty then
+        fn.name.name
+      else
+        s"${fn.name.name}(${fn
+            .args
+            .map(a => s"${a.name.name}: ${typeStr(a.givenDataType)}")
+            .mkString(", ")})"
+
+  private def typeStr(dt: DataType): String =
+    dt match
+      case VarArgType(elem) =>
+        s"${typeStr(elem)}*"
+      case _: DataType.DecimalType =>
+        // Parsed `decimal` carries default precision/scale parameters; render the plain name
+        "decimal"
+      case _ if dt.typeParams.isEmpty =>
+        dt.typeName.name
+      case _ =>
+        s"${dt.typeName.name}[${dt.typeParams.map(typeStr).mkString(",")}]"
+
+  /**
+    * The doc comment of a definition: the run of `--` comment lines immediately above it. Comment
+    * lines separated by a blank line (file headers, section notes) are not part of the doc
+    */
+  private def commentText(
+      sf: wvlet.lang.compiler.SourceFile,
+      t: wvlet.lang.model.SyntaxTreeNode
+  ): String =
+    var expected = sf.offsetToLine(t.span.start) - 1
+    val adjacent = List.newBuilder[String]
+    // comments are stored innermost-last; walk upward from the definition line
+    t.comments
+      .foreach { c =>
+        val line = sf.offsetToLine(c.offset)
+        if line == expected then
+          adjacent += c.str.trim.stripPrefix("--").trim
+          expected = line - 1
+      }
+    adjacent.result().reverse.filter(_.nonEmpty).mkString(" ")
+
+  /** Section order and human titles of the reference page */
+  private val typeSections: List[(String, String, String)] = List(
+    ("any", "Any Values", "Available on values of every type."),
+    (
+      "numeric",
+      "Numeric Values",
+      "Shared by all numeric types (int, long, float, real, double, decimal)."
+    ),
+    ("int", "Int Values", ""),
+    ("long", "Long Values", ""),
+    ("float", "Float Values", ""),
+    ("real", "Real Values", ""),
+    ("double", "Double Values", ""),
+    ("decimal", "Decimal Values", ""),
+    ("boolean", "Boolean Values", ""),
+    ("string", "String Values", ""),
+    ("date", "Date Values", ""),
+    ("timestamp", "Timestamp Values", ""),
+    ("json", "JSON Values", ""),
+    ("null", "Null Values", ""),
+    (
+      "array",
+      "Array Values",
+      "A column reference after `group by` also has an array type, so aggregation functions apply to it with the same syntax."
+    ),
+    ("map", "Map Values", "")
+  )
+
+  def generateMarkdown(): String =
+    val handWritten = CompilationUnit
+      .stdLib
+      .filterNot(
+        _.sourceFile.getContentAsString.contains(StaticCatalogExporter.generatedFileHeader)
+      )
+      .sortBy(_.sourceFile.fileName)
+
+    val memberDefs   = mutable.ListBuffer.empty[DefEntry]
+    val topLevelDefs = mutable.ListBuffer.empty[DefEntry]
+
+    handWritten.foreach { unit =>
+      val sf = unit.sourceFile
+      ParserPhase.parseOnly(unit) match
+        case p: PackageDef =>
+          p.statements
+            .foreach {
+              case t: TypeDef =>
+                val typeContexts = t.defContexts.map(_.contextType.leafName.toLowerCase)
+                t.elems
+                  .foreach {
+                    case f: FunctionDef =>
+                      memberDefs += DefEntry(t.name.name, f, typeContexts, commentText(sf, f))
+                    case _ =>
+                  }
+              case t: TopLevelFunctionDef =>
+                val desc =
+                  commentText(sf, t) match
+                    case "" =>
+                      commentText(sf, t.functionDef)
+                    case s =>
+                      s
+                topLevelDefs += DefEntry("", t.functionDef, Nil, desc)
+              case _ =>
+            }
+        case _ =>
+    }
+
+    val sb = StringBuilder()
+    sb ++= s"""---
+         |sidebar_label: Stdlib Reference
+         |---
+         |
+         |# Standard Library Reference
+         |
+         |<!-- Generated from wvlet-stdlib/module/standard/*.wv. DO NOT EDIT.
+         |     Regenerate with: ${regenCommand} -->
+         |
+         |Complete listing of the functions defined in the Wvlet standard library, generated from
+         |its sources. Call these with dot syntax on a value of the listed type (e.g. `name.upper`,
+         |`price.round(2)`). See [Standard Library Functions](stdlib.md) for a guided tour with
+         |examples.
+         |
+         |The **Engines** column lists the engines a definition is specialized for; **all** means a
+         |single dialect-neutral definition serves every supported engine (DuckDB, Trino, Hive,
+         |Snowflake, and BigQuery). Engine-specific SQL is selected automatically for the compile
+         |target.
+         |""".stripMargin
+
+    def renderRows(entries: List[DefEntry]): Unit =
+      sb ++= "\n| Function | Returns | Engines | Description |\n"
+      sb ++= "|----------|---------|---------|-------------|\n"
+      // Merge same-signature dialect variants into one row, keeping source order
+      val seen = mutable.LinkedHashMap.empty[String, mutable.ListBuffer[DefEntry]]
+      entries.foreach(e => seen.getOrElseUpdate(e.signature, mutable.ListBuffer.empty) += e)
+      def cell(s: String): String = s.replace("|", "\\|")
+      seen.foreach { case (signature, defs) =>
+        val returns = defs.flatMap(_.fn.retType).headOption.map(typeStr).getOrElse("")
+        val engines =
+          if defs.exists(_.dialects.isEmpty) then
+            "all"
+          else
+            defs.flatMap(_.dialects).distinct.mkString(", ")
+        // A dialect variant's comment explains that engine's quirk, not the function: when a
+        // dialect-neutral definition exists, only its comment may serve as the description
+        val hasNeutral = defs.exists(_.dialects.isEmpty)
+        val descPool   =
+          if hasNeutral then
+            defs.filter(_.dialects.isEmpty)
+          else
+            defs
+        val desc = descPool.map(_.description).find(_.nonEmpty).getOrElse("")
+        sb ++= s"| `${cell(signature)}` | ${cell(returns)} | ${engines} | ${cell(desc)} |\n"
+      }
+
+    typeSections.foreach { case (typeName, title, intro) =>
+      val entries = memberDefs.filter(_.typeName == typeName).toList
+      if entries.nonEmpty then
+        sb ++= s"\n## ${title}\n"
+        if intro.nonEmpty then
+          sb ++= s"\n${intro}\n"
+        renderRows(entries)
+    }
+
+    // Types not covered by the curated section list (e.g. dialect-only extension types)
+    val knownSections = typeSections.map(_._1).toSet
+    val leftoverTypes = memberDefs.map(_.typeName).distinct.filterNot(knownSections.contains)
+    leftoverTypes.foreach { typeName =>
+      val entries = memberDefs.filter(_.typeName == typeName).toList
+      sb ++= s"\n## ${typeName} Values\n"
+      renderRows(entries)
+    }
+
+    if topLevelDefs.nonEmpty then
+      sb ++= "\n## Top-Level Functions\n"
+      sb ++= "\nCalled without a receiver value (window functions require an `over(...)` clause).\n"
+      renderRows(topLevelDefs.toList)
+
+    sb.result()
+  end generateMarkdown
+
+  def main(args: Array[String]): Unit =
+    val md = generateMarkdown()
+    SourceIO.writeString(targetPath, md)
+    info(s"Wrote ${targetPath}")
+
+end StdLibDocGenerator

--- a/wvlet-stdlib/module/standard/any.wv
+++ b/wvlet-stdlib/module/standard/any.wv
@@ -13,15 +13,12 @@ type any = {
   def to_boolean: boolean = sql"cast(${this} as boolean)"
   def to_boolean in bigquery: boolean = sql"cast(${this} as bool)"
 
-  -- SQL types
+  -- Cast to the SQL date type
   def to_date: date = sql"cast(${this} as date)"
+  -- Cast to the SQL timestamp type
   def to_timestamp: timestamp = sql"cast(${this} as timestamp)"
-  -- TODO Support type args
-  -- def to_decimal[P,S]: decimal[P,S] = sql"cast(${this} as decimal(${type[P]},${type[S]}))"
 
-  -- TODO Support generic type cast
-  --def cast_as[A]: A = sql"cast(${this} as ${type[A]})"
-
+  -- True if this value is null
   def is_null: boolean = sql"${this} is null"
   def is_not_null: boolean = sql"${this} is not null"
 
@@ -32,6 +29,9 @@ type any = {
 
   -- Name of the runtime type of this value
   def type_of: string = sql"typeof(${this})"
+
+  -- TODO Support type args: def to_decimal[P,S]: decimal[P,S]
+  -- TODO Support generic type cast: def cast_as[A]: A = sql"cast(${this} as ${type[A]})"
 }
 
 type any in duckdb = {

--- a/wvlet-stdlib/module/standard/array.wv
+++ b/wvlet-stdlib/module/standard/array.wv
@@ -117,14 +117,20 @@ type array[A] = {
 
   -- Window (analytic) functions, applied to a column with an over(...) clause,
   -- e.g. v.lag(1) over (partition by g order by k)
+
+  -- Value of the column at a preceding row of the window
   def lag: A = sql"lag(${this})"
   def lag(offset:int): A = sql"lag(${this},${offset})"
   def lag(offset:int, default:any): A = sql"lag(${this},${offset},${default})"
+  -- Value of the column at a following row of the window
   def lead: A = sql"lead(${this})"
   def lead(offset:int): A = sql"lead(${this},${offset})"
   def lead(offset:int, default:any): A = sql"lead(${this},${offset},${default})"
+  -- First value of the window
   def first_value: A = sql"first_value(${this})"
+  -- Last value of the window
   def last_value: A = sql"last_value(${this})"
+  -- Value at the n-th row (1-origin) of the window
   def nth_value(n:int): A = sql"nth_value(${this},${n})"
 }
 

--- a/wvlet-stdlib/module/standard/string.wv
+++ b/wvlet-stdlib/module/standard/string.wv
@@ -14,6 +14,8 @@ type string = {
 
   -- TODO: Decide how to handle infix operators
   -- def +(other:string): string = sql"${this} || ${other}"
+
+  -- Number of characters in the string
   def length: int = sql"length(${this})"
   def upper: string = sql"upper(${this})"
   def lower: string = sql"lower(${this})"


### PR DESCRIPTION
## Summary

Addresses item 8 (auto-generated stdlib docs) of the stdlib follow-up tracker (after #1966).

- **`StdLibDocGenerator`** (langJVM test scope) generates `website/docs/syntax/stdlib-reference.md` from the hand-written stdlib `.wv` sources: one section per type with signatures, return types, engine coverage derived from `in <dialect>` scopes ("all" for dialect-neutral definitions), and descriptions taken from the `--` comment lines directly above each definition. Generated engine catalogs are excluded. Regenerate with `./sbt "langJVM/Test/runMain wvlet.lang.compiler.codegen.StdLibDocGenerator"`.
- **`StdLibDocFreshnessTest`** regenerates the page in CI and diffs it against the checked-in file, failing with the first differing line and the regen command — the same pattern as the engine-catalog gate from #1983. Adding or changing a stdlib def without regenerating the docs now fails CI.
- The curated `stdlib.md` guide stays hand-written (per-audience tour with examples) and links to the generated reference; the reference links back.
- Doc-comment extraction takes only the comment run immediately adjacent to a definition, so file headers and section notes don't leak into descriptions. A few stdlib source comments that mis-attached (grouping notes, TODO blocks) are relocated, and the window members gain descriptions — these flow straight into the generated page.
- CLAUDE.md documents the stdlib freshness gates and their regen commands.

## Test Plan

- `langJVM/testOnly *` — 1942 tests pass (includes the new freshness test)
- `runnerJVM/testOnly *` — 684 tests pass (stdlib comment edits don't affect resolution; catalog freshness still green)
- `projectJS`/`projectNative` compile, `scalafmtAll` clean
- Generated page reviewed manually: descriptions, engine columns, and signatures render correctly (pipes escaped, decimal default parameters elided)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDVq4Etzaj8C8XCUm2iJiP
