### PR TITLE
feature: SQL-equivalent create table semantics and declared-shape auto-create on append

### DIFF
--- a/spec/basic/ddl/create-table-sql-semantics.wv
+++ b/spec/basic/ddl/create-table-sql-semantics.wv
@@ -1,0 +1,40 @@
+-- SQL-equivalent create table semantics, and declaration-based auto-create on append
+
+table ddl5_items = {
+  id: int
+  name: string
+}
+
+-- Appending to a missing declared table auto-creates it with the declared shape
+append to ddl5_items {
+  from [[1, 'pen'], [2, 'book']] as t(id, name)
+}
+
+from ddl5_items
+test _.size should be 2
+test _.columns should contain 'name'
+
+-- if not exists skips silently when the table already exists; data remains
+create table ddl5_items if not exists
+
+from ddl5_items
+test _.size should be 2
+
+-- or replace drops and recreates from the declaration; the table becomes empty
+create or replace table ddl5_items
+
+from ddl5_items
+test _.size should be 0
+
+-- The bare form creates a fresh table from its declaration
+table ddl5_fresh = {
+  id: int
+}
+
+create table ddl5_fresh
+
+from ddl5_fresh
+test _.size should be 0
+
+drop table ddl5_items
+drop table ddl5_fresh

--- a/spec/basic/ddl/ddl-basic.wv
+++ b/spec/basic/ddl/ddl-basic.wv
@@ -9,9 +9,10 @@ table ddl_people = {
   name: string
 }
 
--- The create action reads the shape from the declaration (create-if-missing, idempotent)
+-- The create action reads the shape from the declaration; SQL semantics (fresh create)
 create table ddl_people
-create table ddl_people
+-- The if not exists modifier skips silently when the table already exists (SQL semantics)
+create table ddl_people if not exists
 
 -- Explicit block form of append: effect-first spelling for pipeline scripts
 append to ddl_people {

--- a/spec/neg/ddl/create-table-exists.wv
+++ b/spec/neg/ddl/create-table-exists.wv
@@ -1,0 +1,8 @@
+-- create table follows SQL semantics: creating a table that already exists is an error
+
+table ddl_neg_dup = {
+  id: int
+}
+
+create table ddl_neg_dup
+create table ddl_neg_dup

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -34,11 +34,13 @@ table users = {
 ## Creating and Dropping Tables
 
 The `create table` action materializes a declared shape in the target database. It takes
-nothing after the table name — the columns come from the `table` declaration — and it is
-idempotent: if the table already exists, the statement is a no-op.
+nothing after the table name — the columns come from the `table` declaration — and it
+follows SQL semantics exactly, so there is nothing new to learn:
 
 ```wvlet
-create table users     -- creates the table from its declaration if missing
+create table users                  -- fresh create; error if the table already exists
+create table users if not exists   -- create if missing; silently skip otherwise
+create or replace table users      -- drop and recreate (empties the table)
 
 drop table users
 drop table users if exists
@@ -48,6 +50,10 @@ truncate users         -- delete all rows, keep the table
 
 Running `create table` without a matching `table` declaration in scope is a compile-time
 error.
+
+In most pipelines an explicit `create table` is unnecessary: writing to a declared table
+with `save to` or `append to` creates it automatically (see below). `create table` exists
+for tables that only external systems write to.
 
 ## Writing Query Results to Tables
 
@@ -86,12 +92,35 @@ save to calendar if not exists {
 }
 ```
 
-| Statement | Behavior when the table exists |
-|-----------|-------------------------------|
-| `save to t` | Replaced with the new query result |
-| `save to t if not exists` | No-op (seed once) |
-| `append to t` | Rows are appended |
-| `create table t` | No-op (idempotent) |
+### Automatic Table Creation
+
+Writing to a table that does not exist yet creates it — no `create table` step is needed.
+`save to` always creates (or replaces) the target. `append to` creates the missing table
+before inserting; when a `table` declaration is in scope, the table is created with the
+*declared* column types, so the declaration — not the first query's inferred types — decides
+the shape:
+
+```wvlet
+table events = {
+  id: long
+  name: string
+}
+
+-- Runs in a completely fresh database: creates `events` with (id: long, name: string),
+-- then inserts the rows
+append to events {
+  from [[1, 'click'], [2, 'view']] as t(id, name)
+}
+```
+
+| Statement | Table missing | Table exists |
+|-----------|---------------|--------------|
+| `save to t` | Created from the query | Replaced with the new query result |
+| `save to t if not exists` | Created from the query | No-op (seed once) |
+| `append to t` | Created (declared shape if available), then rows inserted | Rows are appended |
+| `create table t` | Created from the declaration | Error (SQL semantics) |
+| `create table t if not exists` | Created from the declaration | No-op |
+| `create or replace table t` | Created from the declaration | Dropped and recreated empty |
 
 ## Updating Rows
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -153,6 +153,12 @@ object GenSQL extends Phase("generate-sql"):
                 .dbType}",
             a.sourceLocation
           )
+      case c: CreateTable if c.replace && !context.dbType.supportCreateOrReplace =>
+        // Engines without CREATE OR REPLACE decompose it into an explicit drop + create
+        List(
+          withHeader(s"drop table if exists ${c.table.fullName}", c.sourceLocation),
+          withHeader(gen.print(c.copy(replace = false)), c.sourceLocation)
+        )
       case a: AlterTable if a.operations.size > 1 =>
         // A reshape block carries multiple operations; emit one ALTER TABLE statement per
         // operation so each runs as its own SQL statement
@@ -165,6 +171,47 @@ object GenSQL extends Phase("generate-sql"):
           }
       case _ =>
         List(withHeader(gen.print(ddl), ddl.sourceLocation))
+
+  end generateDDLSQL
+
+  /**
+    * SQL for appending into a table that does not exist yet. When a `table` shape declaration is in
+    * scope, the table is created from the declared columns (so declared types win over the query's
+    * inferred ones) and the rows are inserted into it; otherwise the append reduces to CREATE TABLE
+    * AS with the query's shape
+    */
+  private def appendToNewTableSQL(a: AppendTo, fullTableName: String, baseSQL: String)(using
+      context: Context
+  ): List[String] =
+    val declaredCols = Typer.declaredTableColumns(TableName.parse(a.targetName).name)
+    if declaredCols.nonEmpty then
+      val gen       = sqlGeneratorFor(context.dbType)
+      val createSQL = gen.print(
+        CreateTable(
+          UnquotedIdentifier(fullTableName, a.span),
+          ifNotExists = true,
+          tableElems = declaredCols,
+          span = a.span
+        )
+      )
+      val columnNames =
+        if a.columns.nonEmpty then
+          a.columns.map(_.fullName)
+        else
+          a.child.relationType.fields.map(_.name.name)
+      val columnList =
+        if columnNames.nonEmpty then
+          s" (${columnNames.mkString(", ")})"
+        else
+          ""
+      List(
+        withHeader(createSQL, a.sourceLocation),
+        withHeader(s"insert into ${fullTableName}${columnList}\n${baseSQL}", a.sourceLocation)
+      )
+    else
+      List(withHeader(s"create table ${fullTableName} as\n${baseSQL}", a.sourceLocation))
+
+  end appendToNewTableSQL
 
   def generateSaveSQL(save: Save, context: Context): List[String] =
     given Context  = context
@@ -283,8 +330,7 @@ object GenSQL extends Phase("generate-sql"):
             statements += withHeader(mergeSQL, a.sourceLocation)
           case None =>
             // No existing table: nothing to merge with, so the keyed append reduces to a create
-            statements +=
-              withHeader(s"create table ${fullTableName} as\n${baseSQL.sql}", a.sourceLocation)
+            statements ++= appendToNewTableSQL(a, fullTableName, baseSQL.sql)
         end match
       case u: UpdateColumns =>
         val gen = sqlGeneratorFor(context.dbType)
@@ -318,18 +364,20 @@ object GenSQL extends Phase("generate-sql"):
         val tbl           = TableName.parse(a.targetName)
         val schema        = tbl.schema.getOrElse(context.defaultSchema)
         val fullTableName = s"${schema}.${tbl.name}"
-        val insertSQL     =
-          context.catalog.getTable(TableName.parse(fullTableName)) match
-            case Some(t) =>
-              val columnList =
-                if a.columns.nonEmpty then
-                  s" (${a.columns.map(_.fullName).mkString(", ")})"
-                else
-                  ""
-              s"insert into ${fullTableName}${columnList}\n${baseSQL.sql}"
-            case None =>
-              s"create table ${fullTableName} as\n${baseSQL.sql}"
-        statements += withHeader(insertSQL, save.sourceLocation)
+        context.catalog.getTable(TableName.parse(fullTableName)) match
+          case Some(t) =>
+            val columnList =
+              if a.columns.nonEmpty then
+                s" (${a.columns.map(_.fullName).mkString(", ")})"
+              else
+                ""
+            statements +=
+              withHeader(
+                s"insert into ${fullTableName}${columnList}\n${baseSQL.sql}",
+                save.sourceLocation
+              )
+          case None =>
+            statements ++= appendToNewTableSQL(a, fullTableName, baseSQL.sql)
       case a: AppendTo if a.isForFile && context.dbType == DBType.DuckDB =>
         val baseSQL    = GenSQL.generateSQLFromRelation(save.inputRelation, addHeader = false)
         val targetPath = context.dataFilePath(a.targetName)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -199,6 +199,7 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
         group(
           wl(
             "create",
+            Option.when(c.replace)("or replace"),
             "table",
             if c.ifNotExists then
               Some("if not exists")

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -190,7 +190,20 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
       case c: CreateTable if c.tableElems.isEmpty =>
         // The action form: the table shape lives in the `table` declaration
         code(c) {
-          group(wl("create table", expr(c.table)))
+          val verb =
+            if c.replace then
+              "create or replace table"
+            else
+              "create table"
+          group(
+            wl(
+              verb,
+              expr(c.table),
+              Option.when(c.ifNotExists) {
+                "if not exists"
+              }
+            )
+          )
         }
       case t: DropTable =>
         code(t) {

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1128,16 +1128,43 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     * scope, and the action is create-if-missing (idempotent), so no modifier is accepted.
     */
   def createStatement(): LogicalPlan = node {
-    val t    = consume(WvletToken.CREATE)
+    val t = consume(WvletToken.CREATE)
+    // `create or replace table t` follows SQL's own spelling and semantics (drop-and-recreate)
+    val replace =
+      if scanner.lookAhead().token == WvletToken.OR then
+        consume(WvletToken.OR)
+        val r = identifierSingle()
+        if r.leafName != "replace" then
+          throw StatusCode
+            .SYNTAX_ERROR
+            .newException(
+              s"Expected 'replace' after 'create or', but found '${r.leafName}'",
+              t.sourceLocation
+            )
+        true
+      else
+        false
     val kind = identifierSingle()
     kind.leafName match
       case "schema" =>
+        if replace then
+          throw StatusCode
+            .SYNTAX_ERROR
+            .newException("create or replace is not supported for schemas", t.sourceLocation)
         val name = qualifiedId()
         CreateSchema(name, ifNotExistsModifier(), None, spanFrom(t))
       case "table" =>
         val name = qualifiedId()
-        // tableElems are filled from the `table` declaration in scope at typing time
-        CreateTable(name, ifNotExists = true, tableElems = Nil, span = spanFrom(t))
+        // tableElems are filled from the `table` declaration in scope at typing time.
+        // SQL semantics: the bare form fails if the table exists; `if not exists` skips silently
+        val ifNotExists = !replace && ifNotExistsModifier()
+        CreateTable(
+          name,
+          ifNotExists = ifNotExists,
+          tableElems = Nil,
+          span = spanFrom(t),
+          replace = replace
+        )
       case other =>
         throw StatusCode
           .SYNTAX_ERROR

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala
@@ -83,6 +83,25 @@ object Typer extends Phase("typer") with LogSupport:
           false
     )
 
+  /**
+    * Columns of the `table` shape declaration registered for the given table name, if any. Used to
+    * fill `create table` actions and to auto-create declared tables on `append to`
+    */
+  def declaredTableColumns(tableName: String)(using ctx: Context): List[ColumnDef] = ctx
+    .findSymbolByName(Name.typeName(tableName))
+    .map(_.tree)
+    .collect { case td: TypeDef =>
+      td.elems
+        .collect { case f: FieldDef =>
+          ColumnDef(
+            UnquotedIdentifier(f.name.name, f.span),
+            DataTypeParser.parse(f.fieldType.fullName),
+            f.span
+          )
+        }
+    }
+    .getOrElse(Nil)
+
   override def run(unit: CompilationUnit, context: Context): CompilationUnit =
     trace(s"Running new typer on ${unit.sourceFile.fileName}")
 
@@ -328,21 +347,7 @@ object Typer extends Phase("typer") with LogSupport:
       // (e.g. Trino's CREATE TABLE ... WITH (properties)), which are left as parsed
       case c: CreateTable if c.tableElems.isEmpty && !ctx.compilationUnit.sourceFile.isSQL =>
         markNamespaceRef(c.table)
-        val typeName = Name.typeName(c.table.leafName)
-        val cols     = ctx
-          .findSymbolByName(typeName)
-          .map(_.tree)
-          .collect { case td: TypeDef =>
-            td.elems
-              .collect { case f: FieldDef =>
-                ColumnDef(
-                  UnquotedIdentifier(f.name.name, f.span),
-                  DataTypeParser.parse(f.fieldType.fullName),
-                  f.span
-                )
-              }
-          }
-          .getOrElse(Nil)
+        val cols = Typer.declaredTableColumns(c.table.leafName)
         if cols.isEmpty then
           throw StatusCode
             .TABLE_NOT_FOUND

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/ddl.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/ddl.scala
@@ -59,7 +59,9 @@ case class CreateTable(
     ifNotExists: Boolean,
     tableElems: List[TableElement],
     properties: List[(NameExpr, Expression)] = Nil,
-    span: Span
+    span: Span,
+    // `create or replace table t`: drop-and-recreate, following SQL semantics exactly
+    replace: Boolean = false
 ) extends DDL
 
 case class DropTable(table: NameExpr, ifExists: Boolean, span: Span) extends DDL

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -145,6 +145,14 @@ class WvletGeneratorTest extends UniTest:
     print(printed) shouldContain "append to users on id, name"
   }
 
+  test("should round-trip SQL-equivalent create table forms") {
+    val printed = print("""create table users if not exists
+        |create or replace table users""".stripMargin)
+    printed shouldContain "create table users if not exists"
+    printed shouldContain "create or replace table users"
+    print(printed) shouldContain "create or replace table users"
+  }
+
   test("should round-trip a database attachment") {
     val printed = print("use 'archive.duckdb' as archive")
     printed shouldContain "use 'archive.duckdb' as archive"


### PR DESCRIPTION
## Summary

Phase 4 (part 2) of the DDL/update design (#1976, #1978, #1980, #1984), implementing two decisions from the design discussion:

**1. `create table` follows SQL semantics exactly.** Per the rule that SQL-looking syntax must keep SQL semantics (novel semantics get novel spelling):

```wvlet
create table users                  -- fresh create; ERROR if the table exists (was: silent no-op)
create table users if not exists   -- create if missing; silently skip otherwise
create or replace table users      -- drop and recreate from the declaration
```

All forms read their columns from the `table` declaration as before. On engines without CREATE OR REPLACE the replace form decomposes into `drop table if exists` + `create table`.

**2. `append to` auto-creates missing declared tables from the declared shape.** Appending already fell back to CTAS for missing tables; now, when a `table` declaration is in scope, the table is created with the *declared* column types (CREATE TABLE IF NOT EXISTS + INSERT with an explicit column list), so the declaration — not the first query's inferred types — decides the shape:

```wvlet
table events = { id: long, name: string }

-- Runs in a completely fresh database: creates events(id: long, name: string), then inserts
append to events {
  from [[1, 'click'], [2, 'view']] as t(id, name)
}
```

Together these make manual table creation largely unnecessary — writes materialize declared tables automatically, and `create table` remains as the SQL-familiar escape hatch for tables only external systems write.

## Testing

- `spec/basic/ddl/create-table-sql-semantics.wv`: append auto-create with declared shape, if-not-exists no-op preserving data, or-replace emptying the table, bare fresh create — executed on DuckDB
- `spec/neg/ddl/create-table-exists.wv`: double `create table` is an error
- `WvletGeneratorTest`: round-trips for both new forms
- Full `RunnerSpec*` (482 tests), `TyperCoverageCheck`, `ParserSpecBasic`, `RoundTripSpec` pass; Scala.js compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3mfchNEQAGtbs8NXa7Bx