### PR TITLE
feature: Surface sensor waiting state so operators can tell a blocked sensor from a running query

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -381,6 +381,11 @@ Polling respects the stage's `heartbeat:` config (a polling sensor is never mist
 stalled attempt), and a `timeout:` expiry follows the stage's regular retry and failure
 policy.
 
+While a sensor is polling, `wvlet flow session show` and the web UI runs view report the
+stage as **waiting** — with how long it has been waiting and when it last checked the
+condition — so a stage blocked on upstream data is never mistaken for an expensive query
+that is still executing.
+
 ### Delivering Results with activate
 
 `activate('<target>', param: value, ...)` delivers the materialized stage output to an

--- a/wvlet-api/src/main/scala/wvlet/lang/api/v1/flow/FlowApi.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/v1/flow/FlowApi.scala
@@ -65,8 +65,22 @@ object FlowApi extends RxRouterProvider:
       runTimeMillis: Option[Long] = None
   )
 
-  /** Per-stage state of a recorded run */
-  case class StageRunInfo(name: String, state: String, attempts: Int, error: Option[String] = None)
+  /**
+    * Per-stage state of a recorded run
+    *
+    * @param waitingSinceMillis
+    *   Set while a running `wait until` sensor stage is polling: when the wait began
+    * @param lastPollAtMillis
+    *   Set while a running sensor stage is polling: the time of its latest condition check
+    */
+  case class StageRunInfo(
+      name: String,
+      state: String,
+      attempts: Int,
+      error: Option[String] = None,
+      waitingSinceMillis: Option[Long] = None,
+      lastPollAtMillis: Option[Long] = None
+  )
 
   /** A recorded run with its per-stage states, attempts, and errors */
   case class FlowRunDetail(run: FlowRunSummary, stages: List[StageRunInfo])

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -353,6 +353,14 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
       .finishedAtMillis
       .map(f => s"${f - r.startedAtMillis}ms")
       .getOrElse("-")
+    def fmtDuration(millis: Long): String =
+      val seconds = (millis / 1000).max(0L)
+      if seconds < 60 then
+        s"${seconds}s"
+      else if seconds < 3600 then
+        s"${seconds / 60}m${seconds % 60}s"
+      else
+        s"${seconds / 3600}h${(seconds % 3600) / 60}m"
 
     def requireRunId(usage: String): String = runId.getOrElse(
       throw StatusCode.INVALID_ARGUMENT.newException(s"Usage: wvlet flow session ${usage}")
@@ -388,10 +396,24 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
           r.runTimeMillis.foreach(t => println(s"run_time: ${fmtTime(t)}"))
           println(s"started:  ${fmtTime(r.startedAtMillis)}")
           r.finishedAtMillis.foreach(f => println(s"finished: ${fmtTime(f)}"))
+          val now = System.currentTimeMillis()
           r.stages
             .foreach { s =>
               val err = s.error.map(e => s" - ${e}").getOrElse("")
-              println(f"  stage ${s.name}%-24s ${s.state}%-14s attempts: ${s.attempts}${err}")
+              // A polling `wait until` sensor is shown distinctly from running query work
+              val waiting = s
+                .waitingSinceMillis
+                .map { since =>
+                  val lastPoll = s
+                    .lastPollAtMillis
+                    .map(p => s", last poll ${fmtDuration(now - p)} ago")
+                    .getOrElse("")
+                  s" [waiting for ${fmtDuration(now - since)}${lastPoll}]"
+                }
+                .getOrElse("")
+              println(
+                f"  stage ${s.name}%-24s ${s.state}%-14s attempts: ${s.attempts}${waiting}${err}"
+              )
             }
         case "cancel" =>
           val id = requireRunId("cancel <run_id>")

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -542,24 +542,35 @@ class FlowExecutor(
               }
             // Event sensors poll their condition until it holds. The stage's timeout: (and the
             // regular retry/failure policy) bounds the polling like any other attempt work
-            ls.waitUntil
-              .foreach { sensor =>
-                val pollSql = FlowExecutor.sensorPollSql(
-                  sensor,
-                  stageNames,
-                  tableFor,
-                  routeFilters,
-                  ls.name
-                )
-                val interval = stageConfigs(ls.name).pollIntervalMillis.max(1L)
-                workEnv.info(s"Stage ${ls.name} waits until its sensor condition holds")
-                debug(s"Sensor poll of stage ${ls.name}:\n${pollSql}")
-                beat(attemptKey)
-                val sensorConnector = connectorFor(ls)
-                while sensorConnector.queryJsonRows(pollSql).isEmpty do
-                  sleepWithHeartbeat(interval)
+            if ls.waitUntil.nonEmpty then
+              // Report sensor liveness to the scheduler on every poll, so run snapshots can
+              // show "waiting since / last poll" instead of an indistinguishable running state
+              val waitingSinceMillis = System.currentTimeMillis()
+              def reportPoll(): Unit = eventQueue.put(
+                SensorWaiting(ls.name, waitingSinceMillis, System.currentTimeMillis())
+              )
+              ls.waitUntil
+                .foreach { sensor =>
+                  val pollSql = FlowExecutor.sensorPollSql(
+                    sensor,
+                    stageNames,
+                    tableFor,
+                    routeFilters,
+                    ls.name
+                  )
+                  val interval = stageConfigs(ls.name).pollIntervalMillis.max(1L)
+                  workEnv.info(s"Stage ${ls.name} waits until its sensor condition holds")
+                  debug(s"Sensor poll of stage ${ls.name}:\n${pollSql}")
                   beat(attemptKey)
-              }
+                  reportPoll()
+                  val sensorConnector = connectorFor(ls)
+                  while sensorConnector.queryJsonRows(pollSql).isEmpty do
+                    sleepWithHeartbeat(interval)
+                    beat(attemptKey)
+                    reportPoll()
+                }
+              // All sensors passed: the stage now does real work, no longer waiting
+              eventQueue.put(SensorCleared(ls.name))
             materializeStage(
               ls,
               stageNames,
@@ -635,6 +646,10 @@ class FlowExecutor(
     val attempts = mutable.Map.empty[String, Int].withDefaultValue(0)
     resumedStages.foreach((name, s) => attempts(name) = s.attempts)
     val errors = mutable.Map.empty[String, Throwable]
+    // Sensor liveness of polling `wait until` stages, updated via SensorWaiting/SensorCleared
+    // events. Snapshots surface these so operators can tell a waiting sensor from a running query
+    val waitingSince = mutable.Map.empty[String, Long]
+    val lastPollAt   = mutable.Map.empty[String, Long]
     // (stage, attempt) pairs whose outcome has been decided (guards against duplicate events
     // from a timed-out attempt completing later)
     val handledAttempts  = mutable.Set.empty[(String, Int)]
@@ -710,6 +725,19 @@ class FlowExecutor(
             Some(tableFor(name))
           else
             None
+          ,
+          // Sensor liveness only applies while the stage is actually running its poll loop
+          waitingSinceMillis =
+            if state == StageState.Running then
+              waitingSince.get(name)
+            else
+              None
+          ,
+          lastPollAtMillis =
+            if state == StageState.Running then
+              lastPollAt.get(name)
+            else
+              None
         )
       }
       val flowState =
@@ -994,6 +1022,12 @@ class FlowExecutor(
             // handled at the top of the loop via the cancelled flag
             case FlowDeadlineExceeded =>
               handleFlowTimeout(scheduleConfig.timeoutMillis.getOrElse(0L))
+            case SensorWaiting(stage, since, lastPoll) =>
+              waitingSince(stage) = since
+              lastPollAt(stage) = lastPoll
+            case SensorCleared(stage) =>
+              waitingSince.remove(stage)
+              lastPollAt.remove(stage)
             case RetryDue(s, attempt) =>
               scheduledRetries -= 1
               if states(s.name) == StageState.Retrying then
@@ -1010,6 +1044,9 @@ class FlowExecutor(
                   clearAttempt((name, attempt))
                 runningCount -= 1
                 attempts(name) = attempt
+                // The attempt reached an outcome; any sensor-waiting marker is stale now
+                waitingSince.remove(name)
+                lastPollAt.remove(name)
                 if states(name) == StageState.Running then
                   error match
                     case None =>
@@ -1518,5 +1555,10 @@ object FlowExecutor:
     case CancelRequested
     // The flow-level timeout: deadline expired; the run fails with all non-terminal stages
     case FlowDeadlineExceeded
+    // A polling `wait until` stage reports when it started waiting and its latest poll time,
+    // so run snapshots can render the waiting state distinctly from running work
+    case SensorWaiting(stage: String, sinceMillis: Long, lastPollMillis: Long)
+    // The stage's sensors all passed; it is no longer waiting
+    case SensorCleared(stage: String)
 
 end FlowExecutor

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowRunRegistry.scala
@@ -27,13 +27,20 @@ import scala.util.control.NonFatal
 
 /**
   * The persisted state of a single stage within a flow run
+  *
+  * @param waitingSinceMillis
+  *   Set while a running `wait until` sensor stage is polling: when the wait began
+  * @param lastPollAtMillis
+  *   Set while a running sensor stage is polling: the time of its latest condition check
   */
 case class StageRunRecord(
     name: String,
     state: String,
     attempts: Int,
     error: Option[String] = None,
-    table: Option[String] = None
+    table: Option[String] = None,
+    waitingSinceMillis: Option[Long] = None,
+    lastPollAtMillis: Option[Long] = None
 )
 
 /**

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/SQLiteFlowRunStore.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/SQLiteFlowRunStore.scala
@@ -67,15 +67,26 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
           stmt.execute(s"alter table runs add column ${column} ${sqlType}")
     }
     stmt.execute("""create table if not exists stages(
-        |  run_id     text not null,
-        |  ordinal    integer not null,
-        |  name       text not null,
-        |  state      text not null,
-        |  attempts   integer not null,
-        |  error      text,
-        |  table_name text,
+        |  run_id        text not null,
+        |  ordinal       integer not null,
+        |  name          text not null,
+        |  state         text not null,
+        |  attempts      integer not null,
+        |  error         text,
+        |  table_name    text,
+        |  waiting_since integer,
+        |  last_poll_at  integer,
         |  primary key(run_id, ordinal)
         |)""".stripMargin)
+    // Migrate stage tables created before the sensor-liveness columns were introduced
+    val existingStageColumns =
+      Using.resource(stmt.executeQuery("pragma table_info(stages)")) { rs =>
+        Iterator.continually(rs).takeWhile(_.next()).map(_.getString("name").toLowerCase).toSet
+      }
+    List("waiting_since" -> "integer", "last_poll_at" -> "integer").foreach { (column, sqlType) =>
+      if !existingStageColumns.contains(column) then
+        stmt.execute(s"alter table stages add column ${column} ${sqlType}")
+    }
   }
 
   override def save(record: FlowRunRecord): Unit = synchronized {
@@ -140,9 +151,15 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
     }
     Using.resource(
       conn.prepareStatement(
-        "insert into stages(run_id, ordinal, name, state, attempts, error, table_name) values(?, ?, ?, ?, ?, ?, ?)"
+        "insert into stages(run_id, ordinal, name, state, attempts, error, table_name, waiting_since, last_poll_at) values(?, ?, ?, ?, ?, ?, ?, ?, ?)"
       )
     ) { ps =>
+      def setLongOpt(index: Int, value: Option[Long]): Unit =
+        value match
+          case Some(v) =>
+            ps.setLong(index, v)
+          case None =>
+            ps.setNull(index, java.sql.Types.BIGINT)
       record
         .stages
         .zipWithIndex
@@ -154,10 +171,14 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
           ps.setInt(5, s.attempts)
           ps.setString(6, s.error.orNull)
           ps.setString(7, s.table.orNull)
+          setLongOpt(8, s.waitingSinceMillis)
+          setLongOpt(9, s.lastPollAtMillis)
           ps.addBatch()
         }
       ps.executeBatch()
     }
+
+  end saveStages
 
   override def get(runId: String): Option[FlowRunRecord] = synchronized {
     queryRuns("where run_id = ?", _.setString(1, runId.toLowerCase)).headOption
@@ -295,11 +316,17 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
   private def stagesOf(runId: String): List[StageRunRecord] =
     Using.resource(
       conn.prepareStatement(
-        "select name, state, attempts, error, table_name from stages where run_id = ? order by ordinal"
+        "select name, state, attempts, error, table_name, waiting_since, last_poll_at from stages where run_id = ? order by ordinal"
       )
     ) { ps =>
       ps.setString(1, runId.toLowerCase)
       Using.resource(ps.executeQuery()) { rs =>
+        def getLongOpt(index: Int): Option[Long] =
+          val v = rs.getLong(index)
+          if rs.wasNull() then
+            None
+          else
+            Some(v)
         val b = List.newBuilder[StageRunRecord]
         while rs.next() do
           b +=
@@ -308,7 +335,9 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
               state = rs.getString(2),
               attempts = rs.getInt(3),
               error = Option(rs.getString(4)),
-              table = Option(rs.getString(5))
+              table = Option(rs.getString(5)),
+              waitingSinceMillis = getLongOpt(6),
+              lastPollAtMillis = getLongOpt(7)
             )
         b.result()
       }

--- a/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
+++ b/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/FlowExecutorTest.scala
@@ -1482,6 +1482,53 @@ class FlowExecutorTest extends UniTest:
       connector.execute("drop table if exists __wv_sensor_dep")
   }
 
+  test("surface sensor liveness on the run record while a stage is waiting") {
+    connector.execute("drop table if exists __wv_sensor_live")
+    connector.execute("create table __wv_sensor_live as select 1 as x limit 0")
+    try
+      val registry = FlowRunRegistry(java.nio.file.Files.createTempDirectory("wv-flow-sensor"))
+      // Observe the persisted snapshot while the sensor polls, then satisfy the condition
+      @volatile
+      var observed: Option[StageRunRecord] = None
+      val feeder                           = Thread(
+        new Runnable:
+          override def run(): Unit =
+            val deadline = System.currentTimeMillis() + 10000
+            while observed.isEmpty && System.currentTimeMillis() < deadline do
+              registry
+                .list()
+                .headOption
+                .flatMap(_.stages.find(_.name == "gate"))
+                .filter(_.waitingSinceMillis.isDefined)
+                .foreach(s => observed = Some(s))
+              Thread.sleep(10)
+            connector.execute("insert into __wv_sensor_live values (10)")
+      )
+      feeder.setDaemon(true)
+      feeder.start()
+      val result = runFlow(
+        """flow SensorLivenessFlow = {
+          |  stage gate with { poll_interval: 20ms } = from __wv_sensor_live | wait until _.x > 5
+          |}""".stripMargin,
+        registry = Some(registry)
+      )
+      feeder.join()
+      result.isSuccess shouldBe true
+      // While polling, the persisted snapshot carried the waiting markers of the running stage
+      val waiting = observed.getOrElse(fail("No waiting snapshot was observed"))
+      waiting.state shouldBe "running"
+      waiting.waitingSinceMillis.isDefined shouldBe true
+      waiting.lastPollAtMillis.isDefined shouldBe true
+      // The terminal record no longer reports the stage as waiting
+      val finalStage = registry.get(result.runId).get.stages.find(_.name == "gate").get
+      finalStage.state shouldBe "success"
+      finalStage.waitingSinceMillis shouldBe None
+      finalStage.lastPollAtMillis shouldBe None
+    finally
+      connector.execute("drop table if exists __wv_sensor_live")
+    end try
+  }
+
   test("fail a sensor stage when its timeout expires before the condition holds") {
     connector.execute("drop table if exists __wv_sensor_empty")
     connector.execute("create table __wv_sensor_empty as select 1 as x limit 0")

--- a/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/FlowRunStoreTest.scala
+++ b/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/FlowRunStoreTest.scala
@@ -220,6 +220,83 @@ class FlowRunStoreTest extends UniTest:
     }
   }
 
+  test("round-trip sensor liveness fields of waiting stages") {
+    withStores { (kind, store) =>
+      val waiting = record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L).copy(stages =
+        List(
+          StageRunRecord(
+            "gate",
+            "running",
+            1,
+            waitingSinceMillis = Some(150L),
+            lastPollAtMillis = Some(170L)
+          ),
+          StageRunRecord("out", "pending", 0)
+        )
+      )
+      store.save(waiting)
+      val r = store.get("run1").getOrElse(fail(s"run1 not found in ${kind} store"))
+      r.stages.head.waitingSinceMillis shouldBe Some(150L)
+      r.stages.head.lastPollAtMillis shouldBe Some(170L)
+      r.stages.last.waitingSinceMillis shouldBe None
+      r.stages.last.lastPollAtMillis shouldBe None
+    }
+  }
+
+  test("migrate a SQLite stages table created before the sensor-liveness columns") {
+    val dir    = Files.createTempDirectory("wv-flow-store-migrate-stages")
+    val dbPath = dir.resolve("registry.db")
+    // Create a database whose stages table predates the waiting_since / last_poll_at columns
+    val conn = java.sql.DriverManager.getConnection(s"jdbc:sqlite:${dbPath}")
+    try
+      val stmt = conn.createStatement()
+      stmt.execute("""create table runs(
+          |  run_id           text primary key,
+          |  flow_name        text not null,
+          |  state            text not null,
+          |  started_at       integer not null,
+          |  finished_at      integer,
+          |  cancel_requested integer not null default 0,
+          |  lease_expires_at integer,
+          |  args             text,
+          |  run_time         integer
+          |)""".stripMargin)
+      stmt.execute("""create table stages(
+          |  run_id     text not null,
+          |  ordinal    integer not null,
+          |  name       text not null,
+          |  state      text not null,
+          |  attempts   integer not null,
+          |  error      text,
+          |  table_name text,
+          |  primary key(run_id, ordinal)
+          |)""".stripMargin)
+      stmt.execute(
+        "insert into runs(run_id, flow_name, state, started_at) values('old1', 'FlowA', 'success', 100)"
+      )
+      stmt.execute(
+        "insert into stages(run_id, ordinal, name, state, attempts) values('old1', 0, 'src', 'success', 1)"
+      )
+      stmt.close()
+    finally
+      conn.close()
+    end try
+
+    val store = SQLiteFlowRunStore(dbPath)
+    try
+      val old = store.get("old1").getOrElse(fail("old1 not found after migration"))
+      old.stages.head.waitingSinceMillis shouldBe None
+      // New records persist the added stage columns
+      store.save(
+        record("new1", "FlowA", FlowRunRecord.STATE_RUNNING, 200L).copy(stages =
+          List(StageRunRecord("gate", "running", 1, waitingSinceMillis = Some(250L)))
+        )
+      )
+      store.get("new1").get.stages.head.waitingSinceMillis shouldBe Some(250L)
+    finally
+      store.close()
+  }
+
   test("migrate a SQLite database created before the args and run_time columns") {
     val dir    = Files.createTempDirectory("wv-flow-store-migrate")
     val dbPath = dir.resolve("registry.db")

--- a/wvlet-server/src/main/scala/wvlet/lang/server/FlowApiImpl.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/FlowApiImpl.scala
@@ -48,7 +48,18 @@ class FlowApiImpl(workEnv: WorkEnv) extends FlowApi with AutoCloseable with LogS
       case Some(r) =>
         FlowRunDetail(
           run = toSummary(r, System.currentTimeMillis()),
-          stages = r.stages.map(s => StageRunInfo(s.name, s.state, s.attempts, s.error))
+          stages = r
+            .stages
+            .map(s =>
+              StageRunInfo(
+                s.name,
+                s.state,
+                s.attempts,
+                s.error,
+                waitingSinceMillis = s.waitingSinceMillis,
+                lastPollAtMillis = s.lastPollAtMillis
+              )
+            )
         )
       case None =>
         throw RPCStatus.NOT_FOUND_U5.newException(s"Flow run '${request.runId}' is not found")

--- a/wvlet-server/src/test/scala/wvlet/lang/server/FlowApiImplTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/FlowApiImplTest.scala
@@ -42,6 +42,25 @@ class FlowApiImplTest extends WvletDITest:
         stages = List(StageRunRecord("broken", "failed", 3, Some("boom"), None))
       )
     )
+    registry.save(
+      FlowRunRecord(
+        runId = "run3",
+        flowName = "FlowC",
+        state = FlowRunRecord.STATE_RUNNING,
+        startedAtMillis = 300L,
+        finishedAtMillis = None,
+        leaseExpiresAtMillis = Some(Long.MaxValue),
+        stages = List(
+          StageRunRecord(
+            "gate",
+            "running",
+            1,
+            waitingSinceMillis = Some(310L),
+            lastPollAtMillis = Some(320L)
+          )
+        )
+      )
+    )
     dir.toString
 
   end workDir
@@ -52,7 +71,7 @@ class FlowApiImplTest extends WvletDITest:
   test("list recorded runs most recent first") {
     val api  = dep[FlowApi]
     val runs = api.listRuns(FlowApi.FlowRunListRequest())
-    runs.map(_.runId) shouldBe List("run2", "run1")
+    runs.map(_.runId) shouldBe List("run3", "run2", "run1")
     val r1 = runs.last
     r1.flowName shouldBe "FlowA"
     r1.flowCall shouldBe "FlowA(segment = 'a')"
@@ -66,7 +85,7 @@ class FlowApiImplTest extends WvletDITest:
     val api = dep[FlowApi]
     api.listRuns(FlowApi.FlowRunListRequest(flowName = Some("FlowA"))).map(_.runId) shouldBe
       List("run1")
-    api.listRuns(FlowApi.FlowRunListRequest(limit = 1)).map(_.runId) shouldBe List("run2")
+    api.listRuns(FlowApi.FlowRunListRequest(limit = 1)).map(_.runId) shouldBe List("run3")
     api.listRuns(FlowApi.FlowRunListRequest(flowName = Some("NoSuchFlow"))) shouldBe Nil
   }
 
@@ -81,6 +100,15 @@ class FlowApiImplTest extends WvletDITest:
     stage.state shouldBe "failed"
     stage.attempts shouldBe 3
     stage.error shouldBe Some("boom")
+  }
+
+  test("surface sensor liveness of a waiting stage") {
+    val api   = dep[FlowApi]
+    val stage = api.getRun(FlowApi.FlowRunRequest("run3")).stages.head
+    stage.name shouldBe "gate"
+    stage.state shouldBe "running"
+    stage.waitingSinceMillis shouldBe Some(310L)
+    stage.lastPollAtMillis shouldBe Some(320L)
   }
 
   test("report an unknown run id as not found") {

--- a/wvlet-ui/src/main/scala/wvlet/lang/ui/component/flow/FlowRunsPage.scala
+++ b/wvlet-ui/src/main/scala/wvlet/lang/ui/component/flow/FlowRunsPage.scala
@@ -18,6 +18,7 @@ import wvlet.lang.api.v1.flow.FlowApi.FlowRunDetail
 import wvlet.lang.api.v1.flow.FlowApi.FlowRunListRequest
 import wvlet.lang.api.v1.flow.FlowApi.FlowRunRequest
 import wvlet.lang.api.v1.flow.FlowApi.FlowRunSummary
+import wvlet.lang.api.v1.flow.FlowApi.StageRunInfo
 import wvlet.lang.api.v1.frontend.FrontendRPC.RPCAsyncClient
 import wvlet.lang.ui.component.MainFrame
 import wvlet.uni.dom.RxElement
@@ -82,20 +83,45 @@ class FlowRunsPage(rpcClient: RPCAsyncClient) extends RxElement:
 
   private def fmtTime(millis: Long): String = new js.Date(millis.toDouble).toISOString()
 
+  private def fmtDuration(millis: Long): String =
+    if millis < 1000 then
+      s"${millis}ms"
+    else if millis < 60_000 then
+      f"${millis / 1000.0}%.1fs"
+    else if millis < 3600_000 then
+      s"${millis / 60_000}m ${(millis % 60_000) / 1000}s"
+    else
+      s"${millis / 3600_000}h ${(millis % 3600_000) / 60_000}m"
+
   private def fmtElapsed(r: FlowRunSummary): String = r
     .finishedAtMillis
-    .map { f =>
-      val millis = f - r.startedAtMillis
-      if millis < 1000 then
-        s"${millis}ms"
-      else if millis < 60_000 then
-        f"${millis / 1000.0}%.1fs"
-      else if millis < 3600_000 then
-        s"${millis / 60_000}m ${(millis % 60_000) / 1000}s"
-      else
-        s"${millis / 3600_000}h ${(millis % 3600_000) / 60_000}m"
-    }
+    .map(f => fmtDuration(f - r.startedAtMillis))
     .getOrElse("-")
+
+  /**
+    * The state cell of a stage row. A polling `wait until` sensor renders a distinct waiting badge
+    * with how long it has been waiting, so it is not mistaken for a running query
+    */
+  private def stageStateCell(s: StageRunInfo): RxElement =
+    s.waitingSinceMillis match
+      case Some(since) =>
+        val now      = js.Date.now().toLong
+        val lastPoll = s
+          .lastPollAtMillis
+          .map(p => s", last poll ${fmtDuration((now - p).max(0L))} ago")
+          .getOrElse("")
+        span(
+          span(
+            cls -> "rounded-md px-2 py-0.5 text-xs font-medium bg-violet-800 text-violet-100",
+            "waiting"
+          ),
+          span(
+            cls -> "pl-2 text-xs text-gray-400",
+            s"for ${fmtDuration((now - since).max(0L))}${lastPoll}"
+          )
+        )
+      case None =>
+        stateBadge(s.state)
 
   private def headerCell(name: String) = th(
     cls -> "px-3 py-2 text-left text-xs font-semibold text-gray-400",
@@ -169,7 +195,7 @@ class FlowRunsPage(rpcClient: RPCAsyncClient) extends RxElement:
               .map { s =>
                 tr(
                   cell(span(s.name)),
-                  cell(stateBadge(s.state)),
+                  cell(stageStateCell(s)),
                   cell(span(s.attempts.toString)),
                   td(cls -> "px-3 py-1.5 text-sm text-red-300", span(s.error.getOrElse("")))
                 )


### PR DESCRIPTION
## Summary

Implements **#1858 item 3 (sensor observability)**: a polling `wait until` sensor was indistinguishable from a running query in `wvlet flow session show` and the web UI — operators could not tell "blocked on upstream data for 3 hours" from "expensive query still executing".

## Design

Surfaces `waiting_since` / `last_poll_at` **fields** on the stage record rather than a new `StageState` — the executor's event loop applies attempt results only when `states(name) == StageState.Running`, so swapping the state out would silently drop the sensor's completion; timestamp fields sidestep that hazard entirely and old readers degrade gracefully.

Data flow:

- The sensor poll loop posts `SensorWaiting(stage, since, lastPoll)` on every poll and `SensorCleared(stage)` when its conditions pass. This keeps all mutable scheduler state single-threaded (the executor's stated invariant), and — because the loop persists a snapshot after each event — the waiting markers reach the run store **while** the sensor blocks, which no previous code path did (`eventQueue.take()` otherwise blocks with no snapshot writes).
- `currentRecord` attaches the markers only while the stage is actually `running`; they clear on sensor pass, attempt completion, and terminal snapshots.
- `StageRunRecord` → `StageRunInfo` (FlowApi DTO) → web UI, all with defaulted `Option[Long]` fields (JSON store stays backward-compatible); the SQLite `stages` table gains `waiting_since` / `last_poll_at` columns with an in-place `pragma table_info` migration mirroring the existing `runs` migration.

## Rendering

- `wvlet flow session show`: `stage gate  running  attempts: 1 [waiting for 3h12m, last poll 8s ago]`
- Web UI runs view: a distinct violet **waiting** badge with "for 3h 12m, last poll 8.0s ago" next to it
- Docs: the sensor section of `flow.md` documents the waiting visibility

## Tests

- `FlowExecutorTest`: while a sensor polls, the persisted snapshot carries `waitingSinceMillis`/`lastPollAtMillis` on the running stage; the terminal record reports neither
- `FlowRunStoreTest`: round-trip of the liveness fields through **both** the file and SQLite stores; migration of a pre-existing SQLite `stages` table
- `FlowApiImplTest`: the DTO mapping surfaces the fields for a running sensor stage

Full `runnerJVM/test` (279) and `server/test` suites pass; `cli`, `projectJS` (incl. the UI), and `projectNative` compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49