### PR TITLE
feature: PostgreSQL flow run store for cross-machine run coordination

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -478,6 +478,15 @@ lazy val runner = crossProject(JVMPlatform, JSPlatform, NativePlatform)
         "org.apache.arrow" % "arrow-vector" % "19.0.0",
         // SQLite-backed flow run store (cross-process cancellation and concurrency claims)
         "org.xerial" % "sqlite-jdbc" % "3.53.2.1",
+        // Postgres-backed flow run store (shared across machines: concurrency claims,
+        // scheduler catch-up, and the web UI observe runs from any process)
+        "org.postgresql" % "postgresql" % "42.7.7",
+        // In-process real PostgreSQL for run-store tests (no Docker needed), mirroring the
+        // TestingTrinoServer pattern below. Binaries are resolved as jar dependencies per
+        // platform, so tests run offline after the first sbt update
+        "io.zonky.test"          % "embedded-postgres"                       % "2.1.0"  % Test,
+        "io.zonky.test.postgres" % "embedded-postgres-binaries-darwin-arm64v8" % "17.5.0" % Test,
+        "io.zonky.test.postgres" % "embedded-postgres-binaries-linux-amd64" % "17.5.0" % Test,
         // trino-jdbc removed in PR-D: TrinoConnector now talks the Trino REST protocol via uni's
         // HttpSyncClient (see wvlet-lang's TrinoSqlConnector). trino-testing stays in test scope
         // for the in-process TestingTrinoServer — that artifact doesn't pull in trino-jdbc.

--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -682,14 +682,24 @@ wvlet flow session list -w ./pipelines
 wvlet flow session show <run_id> -w ./pipelines
 ```
 
-Every flow run is recorded in a local run store, updated live as stages change state. Two
+Every flow run is recorded in a run store, updated live as stages change state. Three
 store backends are available and can be selected with `--run-store <type>` (or the
 `WVLET_FLOW_STORE` environment variable):
 
 - `file` (default): one JSON file per run (`target/flow-runs/<run_id>.json`), no dependencies
 - `sqlite`: a single SQLite database (`target/flow-runs/registry.db`) in WAL mode. Records are
   transactional across processes, which a scheduler daemon needs for enforcing flow-level
-  `concurrency:` limits Cross-flow dependencies (`depends on X`,
+  `concurrency:` limits
+- `postgres`: a shared PostgreSQL database, so `concurrency:` enforcement, scheduler
+  catch-up, `session` commands, and the web UI observe runs recorded on **any machine**
+  pointing at the same database. The connection comes from environment variables only —
+  never CLI flags — keeping credentials out of the process list:
+  `WVLET_FLOW_STORE_PG_URL` (e.g. `jdbc:postgresql://host:5432/wvlet`), and optionally
+  `WVLET_FLOW_STORE_PG_USER` (default `postgres`) and `WVLET_FLOW_STORE_PG_PASSWORD`.
+  Concurrent slot claims are serialized with a per-flow advisory lock, so a `concurrency:`
+  limit holds across hosts
+
+Cross-flow dependencies (`depends on X`,
 `if X.failed`, `if X.done`) are evaluated against the latest recorded run of the referenced
 flow: when the dependency is not satisfied, the flow run is recorded as `skipped` without
 executing any stage.

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -54,7 +54,11 @@ case class WvletFlowOption(
     catalog: Option[String] = None,
     @option(prefix = "--schema", description = "Context database schema to use")
     schema: Option[String] = None,
-    @option(prefix = "--run-store", description = "Flow run store type: file (default) or sqlite")
+    @option(
+      prefix = "--run-store",
+      description =
+        "Flow run store type: file (default), sqlite, or postgres (connection via WVLET_FLOW_STORE_PG_* env)"
+    )
     runStore: Option[String] = None
 )
 

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowRunStore.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowRunStore.scala
@@ -22,10 +22,11 @@ import java.nio.file.Path
   * Persistent store of flow run records, observable across processes so that `wvlet flow session`
   * commands and schedulers can inspect, cancel, and resume runs.
   *
-  * Two implementations exist: [[FlowRunRegistry]] (one JSON file per run, no dependencies) and
-  * [[SQLiteFlowRunStore]] (a single SQLite database, transactional across processes). The file
-  * store is the default; select the SQLite store with `--run-store sqlite` or the
-  * `WVLET_FLOW_STORE` environment variable
+  * Three implementations exist: [[FlowRunRegistry]] (one JSON file per run, no dependencies),
+  * [[SQLiteFlowRunStore]] (a single SQLite database, transactional across processes on one
+  * machine), and [[PostgresFlowRunStore]] (a shared PostgreSQL database, observable across
+  * machines). The file store is the default; select another with `--run-store sqlite|postgres` or
+  * the `WVLET_FLOW_STORE` environment variable
   */
 trait FlowRunStore extends AutoCloseable:
   /** Persist (create or overwrite) the record of a run */
@@ -76,8 +77,9 @@ trait FlowRunStore extends AutoCloseable:
 end FlowRunStore
 
 object FlowRunStore:
-  val STORE_TYPE_FILE   = "file"
-  val STORE_TYPE_SQLITE = "sqlite"
+  val STORE_TYPE_FILE     = "file"
+  val STORE_TYPE_SQLITE   = "sqlite"
+  val STORE_TYPE_POSTGRES = "postgres"
 
   /** The environment variable overriding the default run store type */
   val STORE_TYPE_ENV = "WVLET_FLOW_STORE"
@@ -91,7 +93,7 @@ object FlowRunStore:
     workEnv
   )
 
-  /** Create a run store of the given type (file or sqlite) under the work environment */
+  /** Create a run store of the given type (file, sqlite, or postgres) under the work environment */
   def ofType(storeType: String, workEnv: WorkEnv): FlowRunStore =
     val dir = Path.of(workEnv.targetFolder, "flow-runs")
     storeType match
@@ -99,9 +101,13 @@ object FlowRunStore:
         FlowRunRegistry(dir)
       case STORE_TYPE_SQLITE =>
         SQLiteFlowRunStore(dir.resolve("registry.db"))
+      case STORE_TYPE_POSTGRES =>
+        // Connection settings come from WVLET_FLOW_STORE_PG_* environment variables only, so
+        // that credentials never appear in the process list
+        PostgresFlowRunStore.fromEnv()
       case other =>
         throw StatusCode
           .INVALID_ARGUMENT
-          .newException(s"Unknown flow run store type: ${other}. Use file or sqlite")
+          .newException(s"Unknown flow run store type: ${other}. Use file, sqlite, or postgres")
 
 end FlowRunStore

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/PostgresFlowRunStore.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/PostgresFlowRunStore.scala
@@ -13,59 +13,55 @@
  */
 package wvlet.lang.runner
 
+import wvlet.lang.api.StatusCode
 import wvlet.uni.log.LogSupport
 import wvlet.uni.weaver.Weaver
 
-import java.nio.file.Files
-import java.nio.file.Path
 import java.sql.Connection
 import java.sql.DriverManager
-import java.sql.ResultSet
+import java.util.Properties
 import scala.util.Using
 import scala.util.control.NonFatal
 
 /**
-  * A SQLite-backed flow run store (`<targetFolder>/flow-runs/registry.db`). Unlike the JSON file
-  * store, records are transactional across processes: WAL mode supports a writer concurrent with
-  * readers (e.g. a scheduler daemon plus CLI commands), and run-slot claims for `concurrency:`
-  * enforcement are atomic single-statement inserts.
+  * A PostgreSQL-backed flow run store, sharing run records across machines: flow-level
+  * `concurrency:` limits, scheduler catch-up, and the web UI observe runs recorded by any process
+  * pointing at the same database.
+  *
+  * The schema mirrors [[SQLiteFlowRunStore]] (`runs` + `stages` with a JSON `args` column). Unlike
+  * SQLite, PostgreSQL does not serialize writers, so [[claimRunSlot]] takes a transaction-scoped
+  * advisory lock keyed on the flow name before its guarded insert — two concurrent claims of the
+  * same flow are evaluated one after the other, on any number of hosts.
   *
   * The store keeps one connection per instance; all operations are synchronized on it
   */
-class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
-  Option(dbPath.getParent).foreach(Files.createDirectories(_))
+class PostgresFlowRunStore(jdbcUrl: String, user: String, password: String)
+    extends FlowRunStore
+    with LogSupport:
 
   import SQLiteFlowRunStore.RunArgs
 
   // Bound flow arguments are stored as a single JSON object column
   private val argsWeaver = Weaver.of[RunArgs]
 
-  private val conn: Connection = DriverManager.getConnection(s"jdbc:sqlite:${dbPath}")
+  private val conn: Connection =
+    val props = Properties()
+    props.setProperty("user", user)
+    props.setProperty("password", password)
+    DriverManager.getConnection(jdbcUrl, props)
 
   Using.resource(conn.createStatement()) { stmt =>
-    stmt.execute("pragma journal_mode = WAL")
-    stmt.execute("pragma busy_timeout = 10000")
     stmt.execute("""create table if not exists runs(
         |  run_id           text primary key,
         |  flow_name        text not null,
         |  state            text not null,
-        |  started_at       integer not null,
-        |  finished_at      integer,
+        |  started_at       bigint not null,
+        |  finished_at      bigint,
         |  cancel_requested integer not null default 0,
-        |  lease_expires_at integer,
+        |  lease_expires_at bigint,
         |  args             text,
-        |  run_time         integer
+        |  run_time         bigint
         |)""".stripMargin)
-    // Migrate databases created before these columns were introduced
-    val existingColumns =
-      Using.resource(stmt.executeQuery("pragma table_info(runs)")) { rs =>
-        Iterator.continually(rs).takeWhile(_.next()).map(_.getString("name").toLowerCase).toSet
-      }
-    List("lease_expires_at" -> "integer", "args" -> "text", "run_time" -> "integer").foreach {
-      (column, sqlType) =>
-        if !existingColumns.contains(column) then
-          stmt.execute(s"alter table runs add column ${column} ${sqlType}")
-    }
     stmt.execute("""create table if not exists stages(
         |  run_id        text not null,
         |  ordinal       integer not null,
@@ -74,24 +70,14 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
         |  attempts      integer not null,
         |  error         text,
         |  table_name    text,
-        |  waiting_since integer,
-        |  last_poll_at  integer,
+        |  waiting_since bigint,
+        |  last_poll_at  bigint,
         |  primary key(run_id, ordinal)
         |)""".stripMargin)
-    // Migrate stage tables created before the sensor-liveness columns were introduced
-    val existingStageColumns =
-      Using.resource(stmt.executeQuery("pragma table_info(stages)")) { rs =>
-        Iterator.continually(rs).takeWhile(_.next()).map(_.getString("name").toLowerCase).toSet
-      }
-    List("waiting_since" -> "integer", "last_poll_at" -> "integer").foreach { (column, sqlType) =>
-      if !existingStageColumns.contains(column) then
-        stmt.execute(s"alter table stages add column ${column} ${sqlType}")
-    }
   }
 
   override def save(record: FlowRunRecord): Unit = synchronized {
-    conn.setAutoCommit(false)
-    try
+    inTransaction {
       Using.resource(
         conn.prepareStatement(
           """insert into runs(run_id, flow_name, state, started_at, finished_at, lease_expires_at, args, run_time)
@@ -110,14 +96,21 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
         ps.executeUpdate()
       }
       saveStages(record)
+    }
+  }
+
+  private def inTransaction[A](body: => A): A =
+    conn.setAutoCommit(false)
+    try
+      val result = body
       conn.commit()
+      result
     catch
       case NonFatal(e) =>
         conn.rollback()
         throw e
     finally
       conn.setAutoCommit(true)
-  }
 
   private def bindRunColumns(ps: java.sql.PreparedStatement, record: FlowRunRecord): Unit =
     ps.setString(1, record.runId.toLowerCase)
@@ -189,29 +182,36 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
   }
 
   override def claimRunSlot(record: FlowRunRecord, concurrencyLimit: Int): Boolean = synchronized {
-    // A single insert statement is atomic in SQLite, so the running-count check and the claim
-    // cannot interleave with claims from other processes. Running records whose liveness lease
-    // has expired belong to dead processes and do not occupy a slot
-    val claimed =
-      Using.resource(
-        conn.prepareStatement(
-          """insert into runs(run_id, flow_name, state, started_at, finished_at, lease_expires_at, args, run_time)
-            |select ?, ?, ?, ?, ?, ?, ?, ?
-            |where (select count(*) from runs
-            |       where flow_name = ? and state = ?
-            |         and (lease_expires_at is null or lease_expires_at >= ?)) < ?""".stripMargin
-        )
-      ) { ps =>
-        bindRunColumns(ps, record)
-        ps.setString(9, record.flowName)
-        ps.setString(10, FlowRunRecord.STATE_RUNNING)
-        ps.setLong(11, System.currentTimeMillis())
-        ps.setInt(12, concurrencyLimit)
-        ps.executeUpdate() == 1
+    // Serialize claims of the same flow across processes with a transaction-scoped advisory
+    // lock: unlike SQLite, PostgreSQL evaluates the count subquery against a snapshot, so two
+    // concurrent guarded inserts could otherwise both pass the check. Running records whose
+    // liveness lease has expired belong to dead processes and do not occupy a slot
+    inTransaction {
+      Using.resource(conn.prepareStatement("select pg_advisory_xact_lock(hashtext(?))")) { ps =>
+        ps.setString(1, record.flowName)
+        ps.execute()
       }
-    if claimed then
-      saveStages(record)
-    claimed
+      val claimed =
+        Using.resource(
+          conn.prepareStatement(
+            """insert into runs(run_id, flow_name, state, started_at, finished_at, lease_expires_at, args, run_time)
+              |select ?, ?, ?, ?, ?, ?, ?, ?
+              |where (select count(*) from runs
+              |       where flow_name = ? and state = ?
+              |         and (lease_expires_at is null or lease_expires_at >= ?)) < ?""".stripMargin
+          )
+        ) { ps =>
+          bindRunColumns(ps, record)
+          ps.setString(9, record.flowName)
+          ps.setString(10, FlowRunRecord.STATE_RUNNING)
+          ps.setLong(11, System.currentTimeMillis())
+          ps.setInt(12, concurrencyLimit)
+          ps.executeUpdate() == 1
+        }
+      if claimed then
+        saveStages(record)
+      claimed
+    }
   }
 
   override def refreshLease(runId: String, leaseExpiresAtMillis: Long): Unit = synchronized {
@@ -343,11 +343,38 @@ class SQLiteFlowRunStore(dbPath: Path) extends FlowRunStore with LogSupport:
       }
     }
 
-end SQLiteFlowRunStore
+end PostgresFlowRunStore
 
-object SQLiteFlowRunStore:
+object PostgresFlowRunStore:
+  /** JDBC URL of the shared run-store database, e.g. jdbc:postgresql://host:5432/wvlet */
+  val URL_ENV = "WVLET_FLOW_STORE_PG_URL"
+
+  /** User of the run-store database (default: postgres) */
+  val USER_ENV = "WVLET_FLOW_STORE_PG_USER"
+
+  /** Password of the run-store database (default: empty) */
+  val PASSWORD_ENV = "WVLET_FLOW_STORE_PG_PASSWORD"
+
   /**
-    * JSON envelope of the bound flow arguments stored in the `args` column (shared with
-    * [[PostgresFlowRunStore]], which uses the same schema shape)
+    * Create a store from the WVLET_FLOW_STORE_PG_* environment variables. The connection settings
+    * come from the environment only — never from CLI flags — so that credentials stay out of the
+    * process list
     */
-  private[runner] case class RunArgs(args: Map[String, String] = Map.empty)
+  def fromEnv(): PostgresFlowRunStore =
+    val url = sys
+      .env
+      .getOrElse(
+        URL_ENV,
+        throw StatusCode
+          .INVALID_ARGUMENT
+          .newException(
+            s"The postgres run store requires the ${URL_ENV} environment variable (e.g. jdbc:postgresql://host:5432/wvlet)"
+          )
+      )
+    PostgresFlowRunStore(
+      url,
+      sys.env.getOrElse(USER_ENV, "postgres"),
+      sys.env.getOrElse(PASSWORD_ENV, "")
+    )
+
+end PostgresFlowRunStore

--- a/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/PostgresFlowRunStoreTest.scala
+++ b/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/PostgresFlowRunStoreTest.scala
@@ -1,0 +1,267 @@
+package wvlet.lang.runner
+
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import wvlet.uni.test.UniTest
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+import scala.util.control.NonFatal
+
+/**
+  * Tests for the PostgreSQL-backed flow run store, running against an in-process embedded
+  * PostgreSQL server (no Docker required; real binaries resolved as test dependencies). Set
+  * WVLET_TEST_PG_URL (+ _USER/_PASSWORD) to run against an external server instead. Auto-skips when
+  * the embedded server cannot start in this environment
+  */
+class PostgresFlowRunStoreTest extends UniTest:
+
+  private lazy val embedded: Option[EmbeddedPostgres] =
+    try
+      Some(EmbeddedPostgres.builder().start())
+    catch
+      case NonFatal(e) =>
+        warn(s"Embedded PostgreSQL is not available: ${e.getMessage}")
+        None
+
+  override def afterAll: Unit = embedded.foreach(_.close())
+
+  private def newStore(): Option[PostgresFlowRunStore] =
+    sys.env.get("WVLET_TEST_PG_URL") match
+      case Some(url) =>
+        Some(
+          PostgresFlowRunStore(
+            url,
+            sys.env.getOrElse("WVLET_TEST_PG_USER", "postgres"),
+            sys.env.getOrElse("WVLET_TEST_PG_PASSWORD", "")
+          )
+        )
+      case None =>
+        embedded.map(pg =>
+          PostgresFlowRunStore(pg.getJdbcUrl("postgres", "postgres"), "postgres", "")
+        )
+
+  /** Run the body against a store over a clean database, skipping when PostgreSQL is absent */
+  private def withStore(body: PostgresFlowRunStore => Unit): Unit =
+    newStore() match
+      case None =>
+        ignore("PostgreSQL is not available in this environment")
+      case Some(store) =>
+        try
+          // The store constructor ensured the tables exist; empty them for test isolation
+          store.list().foreach(r => store.delete(r.runId))
+          body(store)
+        finally
+          store.close()
+
+  private def record(
+      runId: String,
+      flowName: String,
+      state: String,
+      startedAt: Long
+  ): FlowRunRecord = FlowRunRecord(
+    runId,
+    flowName,
+    state,
+    startedAt,
+    finishedAtMillis =
+      if state == FlowRunRecord.STATE_RUNNING then
+        None
+      else
+        Some(startedAt + 10)
+    ,
+    stages = List(
+      StageRunRecord("src", "success", 1, None, Some(s"__wv_flow_${runId}_src")),
+      StageRunRecord("out", "failed", 2, Some("boom"), None)
+    )
+  )
+
+  test("save, get, and list runs most recent first") {
+    withStore { store =>
+      store.save(record("run1", "FlowA", FlowRunRecord.STATE_FAILED, 100L))
+      store.save(record("run2", "FlowB", FlowRunRecord.STATE_RUNNING, 200L))
+      store.save(record("run3", "FlowA", FlowRunRecord.STATE_SUCCESS, 300L))
+
+      val r1 = store.get("run1").getOrElse(fail("run1 not found"))
+      r1.flowName shouldBe "FlowA"
+      r1.state shouldBe FlowRunRecord.STATE_FAILED
+      r1.finishedAtMillis shouldBe Some(110L)
+      r1.stages.map(_.name) shouldBe List("src", "out")
+      r1.stages.head.table shouldBe Some("__wv_flow_run1_src")
+      r1.stages.last.error shouldBe Some("boom")
+
+      store.get("run2").get.finishedAtMillis shouldBe None
+      store.list().map(_.runId) shouldBe List("run3", "run2", "run1")
+      store.latestRunOf("FlowA").get.runId shouldBe "run3"
+      store.latestRunOf("NoSuchFlow") shouldBe None
+    }
+  }
+
+  test("overwrite a run record on save") {
+    withStore { store =>
+      store.save(record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L))
+      val updated = record("run1", "FlowA", FlowRunRecord.STATE_SUCCESS, 100L).copy(stages =
+        List(StageRunRecord("src", "success", 1))
+      )
+      store.save(updated)
+      val r = store.get("run1").get
+      r.state shouldBe FlowRunRecord.STATE_SUCCESS
+      r.stages.size shouldBe 1
+      store.list().size shouldBe 1
+    }
+  }
+
+  test("track and clear cancellation requests") {
+    withStore { store =>
+      store.save(record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L))
+      store.cancelRequested("run1") shouldBe false
+      store.requestCancel("run1")
+      store.cancelRequested("run1") shouldBe true
+      store.clearCancelRequest("run1")
+      store.cancelRequested("run1") shouldBe false
+    }
+  }
+
+  test("delete run records") {
+    withStore { store =>
+      store.save(record("run1", "FlowA", FlowRunRecord.STATE_SUCCESS, 100L))
+      store.delete("run1")
+      store.get("run1") shouldBe None
+      store.list() shouldBe Nil
+    }
+  }
+
+  test("claim run slots up to the concurrency limit, ignoring expired leases") {
+    withStore { store =>
+      val now = System.currentTimeMillis()
+      store.claimRunSlot(
+        record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L).copy(leaseExpiresAtMillis =
+          Some(now + 60000)
+        ),
+        concurrencyLimit = 1
+      ) shouldBe true
+      // The limit is reached: a second concurrent run of FlowA is rejected
+      store.claimRunSlot(
+        record("run2", "FlowA", FlowRunRecord.STATE_RUNNING, 200L).copy(leaseExpiresAtMillis =
+          Some(now + 60000)
+        ),
+        concurrencyLimit = 1
+      ) shouldBe false
+      store.get("run2") shouldBe None
+      // Other flows have their own slots
+      store.claimRunSlot(
+        record("runB", "FlowB", FlowRunRecord.STATE_RUNNING, 200L),
+        concurrencyLimit = 1
+      ) shouldBe true
+      // A running record whose lease expired belongs to a dead process and frees its slot
+      store.save(
+        record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L).copy(leaseExpiresAtMillis =
+          Some(now - 10000)
+        )
+      )
+      store.claimRunSlot(
+        record("run3", "FlowA", FlowRunRecord.STATE_RUNNING, 300L).copy(leaseExpiresAtMillis =
+          Some(now + 60000)
+        ),
+        concurrencyLimit = 1
+      ) shouldBe true
+    }
+  }
+
+  test("serialize concurrent slot claims from separate connections") {
+    withStore { store =>
+      newStore() match
+        case None =>
+          ignore("PostgreSQL is not available in this environment")
+        case Some(other) =>
+          try
+            // Two processes (separate connections) race for a single slot of the same flow;
+            // the advisory lock serializes the guarded inserts so exactly one claim wins
+            val ready                                                   = CountDownLatch(2)
+            val go                                                      = CountDownLatch(1)
+            val claimed                                                 = AtomicInteger(0)
+            val now                                                     = System.currentTimeMillis()
+            def claimer(s: PostgresFlowRunStore, runId: String): Thread = Thread { () =>
+              ready.countDown()
+              go.await()
+              val ok = s.claimRunSlot(
+                record(runId, "RacedFlow", FlowRunRecord.STATE_RUNNING, now).copy(
+                  leaseExpiresAtMillis = Some(now + 60000)
+                ),
+                concurrencyLimit = 1
+              )
+              if ok then
+                claimed.incrementAndGet()
+            }
+            val t1 = claimer(store, "race1")
+            val t2 = claimer(other, "race2")
+            t1.start()
+            t2.start()
+            ready.await()
+            go.countDown()
+            t1.join()
+            t2.join()
+            claimed.get() shouldBe 1
+            store.list().count(_.flowName == "RacedFlow") shouldBe 1
+          finally
+            other.close()
+    }
+  }
+
+  test("refresh run leases in place") {
+    withStore { store =>
+      store.save(
+        record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L).copy(leaseExpiresAtMillis =
+          Some(1000L)
+        )
+      )
+      store.refreshLease("run1", 5000L)
+      val r = store.get("run1").get
+      r.leaseExpiresAtMillis shouldBe Some(5000L)
+      // The stage records survive a lease refresh
+      r.stages.map(_.name) shouldBe List("src", "out")
+    }
+  }
+
+  test("persist bound arguments, the logical run time, and sensor liveness fields") {
+    withStore { store =>
+      store.save(
+        record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L).copy(
+          args = Map("segment" -> "'a'", "min_id" -> "3"),
+          runTimeMillis = Some(1234L),
+          stages = List(
+            StageRunRecord(
+              "gate",
+              "running",
+              1,
+              waitingSinceMillis = Some(150L),
+              lastPollAtMillis = Some(170L)
+            )
+          )
+        )
+      )
+      val r = store.get("run1").get
+      r.args shouldBe Map("segment" -> "'a'", "min_id" -> "3")
+      r.runTimeMillis shouldBe Some(1234L)
+      r.flowCallForm shouldBe "FlowA(min_id = 3, segment = 'a')"
+      r.stages.head.waitingSinceMillis shouldBe Some(150L)
+      r.stages.head.lastPollAtMillis shouldBe Some(170L)
+    }
+  }
+
+  test("share state between store instances on the same database") {
+    withStore { store =>
+      newStore() match
+        case None =>
+          ignore("PostgreSQL is not available in this environment")
+        case Some(observer) =>
+          try
+            store.save(record("run1", "FlowA", FlowRunRecord.STATE_RUNNING, 100L))
+            observer.get("run1").isDefined shouldBe true
+            observer.requestCancel("run1")
+            store.cancelRequested("run1") shouldBe true
+          finally
+            observer.close()
+    }
+  }
+
+end PostgresFlowRunStoreTest


### PR DESCRIPTION
## Summary

Implements **#1858 item 2** (tracked in #1833): a `postgres` run-store backend so that flow-level `concurrency:` enforcement, scheduler catch-up, `wvlet flow session` commands, and the web UI observe runs recorded on **any machine** pointing at the same database — previously all three surfaces only saw runs recorded locally.

## Changes

- **`PostgresFlowRunStore`**: implements the existing `FlowRunStore` trait with the same `runs` + `stages` schema shape as the SQLite store (JSON `args` column, bigint millis, sensor-liveness columns included from day one)
- **Cross-host atomicity**: SQLite serializes writers, so its guarded `insert … where count(…) < limit` claim is atomic for free — under PostgreSQL read-committed it is not (two concurrent claims can both pass the snapshot-based count check). `claimRunSlot` therefore takes a **transaction-scoped advisory lock** (`pg_advisory_xact_lock(hashtext(flow_name))`) before the guarded insert, serializing claims per flow across any number of hosts
- **Wiring**: `--run-store postgres` (and `WVLET_FLOW_STORE=postgres`); connection settings come from `WVLET_FLOW_STORE_PG_URL` / `_USER` / `_PASSWORD` environment variables **only** — never CLI flags — keeping credentials out of the process list
- **Docs**: the run-store section of `flow.md` documents the backend and its configuration

## Testing (the convenient-local-Postgres answer)

Mirrors the repo's `TestingTrinoServer` pattern — a **real in-process server, no Docker**:

- `io.zonky.test:embedded-postgres` starts real PostgreSQL 17 binaries in-process (~0.6s startup); the binaries are ordinary jar test-dependencies (darwin-arm64 + linux-amd64), so `./sbt "runnerJVM/testOnly *PostgresFlowRunStoreTest"` works offline after the first `sbt update`, locally and in CI
- Auto-skips (`ignore`) where the embedded server cannot start; `WVLET_TEST_PG_URL` (+ `_USER`/`_PASSWORD`) targets an external server instead
- 9 tests: save/get/list, overwrite, cancel markers, delete, concurrency claims incl. expired-lease reclamation, **a two-connection race proving exactly one claim wins**, in-place lease refresh, args/run_time/sensor-liveness round-trip, and cross-instance state sharing — all passing in ~6s

Full `runnerJVM/test` suite passes; `cli` compiles clean; scalafmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln8xTzVP5M3F6PWvqE4k49