### PR TITLE
fix: Make the new DDL/update statements work through the default CLI profile

### DIFF
--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCompiler.scala
@@ -64,7 +64,16 @@ class WvletCompiler(
         debug(s"Using syntax for ${resolvedDBType}")
         Profile.defaultProfileFor(resolvedDBType)
       case _ =>
-        Profile.getProfile(compilerOption.profile, compilerOption.catalog, compilerOption.schema)
+        // Default to the DuckDB profile, matching the wv REPL and the actual default execution
+        // engine. The generic profile carries no catalog, which silently breaks catalog-dependent
+        // lowering (keyed append needs the target's columns; append auto-creation needs table
+        // existence). A dialect-neutral compile is still available with `-t generic`
+        Profile.getProfile(
+          compilerOption.profile,
+          compilerOption.catalog,
+          compilerOption.schema,
+          default = Profile.defaultDuckDBProfile
+        )
 
   private var _dbConnector: DBConnector = null
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -145,7 +145,10 @@ object GenSQL extends Phase("generate-sql"):
     given Context = context
     val gen       = sqlGeneratorFor(context.dbType)
     ddl match
-      case a: AttachDatabase if context.dbType != DBType.DuckDB =>
+      // Attachment runs on DuckDB. Generic is the CLI's default (no explicit profile) context
+      // type while the default execution engine is DuckDB, so it must pass the guard too
+      case a: AttachDatabase
+          if context.dbType != DBType.DuckDB && context.dbType != DBType.Generic =>
         throw StatusCode
           .NOT_IMPLEMENTED
           .newException(
@@ -171,6 +174,7 @@ object GenSQL extends Phase("generate-sql"):
           }
       case _ =>
         List(withHeader(gen.print(ddl), ddl.sourceLocation))
+    end match
 
   end generateDDLSQL
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -281,6 +281,8 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
             expr(d.schema)
           )
         )
+      case r: RenameDatabase =>
+        group(wl("alter", "schema", expr(r.database), "rename", "to", expr(r.renameTo)))
       case a: AlterTable =>
         def alterOp(op: AlterTableOps): Doc =
           op match

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/DdlSqlPrintTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/DdlSqlPrintTest.scala
@@ -1,0 +1,25 @@
+package wvlet.lang.compiler.codegen
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.parser.WvletParser
+
+class DdlSqlPrintTest extends UniTest:
+
+  private def generateSQL(wvlet: String): String =
+    val unit = CompilationUnit.fromWvletString(wvlet)
+    val plan = WvletParser(unit).parse()
+    SqlGenerator(CodeFormatterConfig(sqlDBType = DBType.DuckDB)).print(plan)
+
+  test("should print rename schema as an alter schema statement") {
+    val sql = generateSQL("rename schema staging to archive")
+    sql shouldContain "alter schema staging rename to archive"
+  }
+
+  test("should print rename table as an alter table statement") {
+    val sql = generateSQL("rename table users to customers")
+    sql shouldContain "alter table users rename to customers"
+  }
+
+end DdlSqlPrintTest


### PR DESCRIPTION
## Summary

An end-to-end CLI verification of the table-management statement family (#1976–#1988) — running a script exercising declarations, all create forms, block/keyed appends, flow update, reshape, views, `:memory:` attachment, truncate, and drops through `wvlet run` — surfaced three gaps that spec tests could not catch, because specs run under an explicit DuckDB profile while the CLI's no-profile default was the *generic* profile (no catalog, `dbType=Generic`):

1. **Keyed `append to … on` silently degraded to a plain INSERT** (the serious one): the MERGE lowering's catalog lookup always returned None under the catalog-less generic profile, so the missing-table path ran — `CREATE TABLE IF NOT EXISTS` (no-op) + `INSERT` — duplicating rows instead of updating them. **Fix**: the `wvlet` CLI now defaults to `Profile.defaultDuckDBProfile`, matching the `wv` REPL and the engine that actually executes by default. `-t generic` remains available for dialect-neutral compilation.
2. **`use '…' as name` was rejected in default CLI runs**: the attach guard only admitted `DBType.DuckDB`; it now also admits `Generic` (compile-only contexts).
3. **`rename schema a to b` was never executable**: `RenameDatabase` had no `SqlGenerator` DDL printer and emitted an empty-SQL comment that DuckDB rejected. It now prints `alter schema … rename to …` (Trino/Snowflake syntax; DuckDB reports its own clear engine error since it cannot rename schemas). Regression tests added for both rename statements.

Also verified during the same audit: all execution surfaces route DDL through the two covered interpreters — `GenSQL.generateSQL` (TypeScript SDK, Python SDK / wvc-lib / wvc native compile) and `BasePlanExecutor` (JVM CLI/REPL/server, cross-platform JS/Native `PlanExecutor`).

## Testing

- End-to-end CLI script now runs the full statement family correctly (keyed append verified to MERGE-update: 1 row, not 2)
- `cli/test`: 109/109 pass
- `RunnerSpec*` (482 tests), `TyperCoverageCheck`, generator tests, new `DdlSqlPrintTest`; Scala.js compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3mfchNEQAGtbs8NXa7Bx