### PR TITLE
feature: Schema locations, schema DDL options, and `like`-based shape reuse (#1995)

### DIFF
--- a/spec/basic/ddl/drop-schema-cascade.wv
+++ b/spec/basic/ddl/drop-schema-cascade.wv
@@ -1,0 +1,17 @@
+-- `drop schema ... with cascade: true` (#1995): drop a schema together with its objects
+
+create schema cascade_test if not exists
+
+from [[1, 'x']] as t(id, v)
+save to cascade_test.items
+
+from cascade_test.items
+test _.size should be 1
+
+-- Without cascade, DuckDB refuses to drop a non-empty schema; with it, schema and
+-- contents go together
+drop schema cascade_test with cascade: true
+
+-- The schema can be recreated empty afterwards
+create schema cascade_test if not exists
+drop schema cascade_test if exists with cascade: true

--- a/spec/basic/ddl/table-like.wv
+++ b/spec/basic/ddl/table-like.wv
@@ -1,0 +1,24 @@
+-- `table <name> like <source>` (#1995): declaration-side shape reuse, so a shape is
+-- written exactly once and all actions/auto-creation work unchanged
+
+table tl_users = {
+  id: int
+  name: string
+}
+
+table tl_users_backup like tl_users
+
+-- The like-declared table auto-creates from the source's columns on a write
+from [[1, 'alice'], [2, 'bob']] as t(id, name)
+append to tl_users_backup
+
+from tl_users_backup
+test _.size should be 2
+test _.columns should contain 'name'
+
+-- `create table` reads the columns through the like chain as well
+create table tl_users_backup if not exists
+
+from tl_users_backup
+where id = 1
+test _.size should be 1

--- a/website/docs/syntax/index.md
+++ b/website/docs/syntax/index.md
@@ -223,7 +223,8 @@ Native statements for schemas, tables, and views — see
 |-----------|-------------|
 | `table users = { id: int, ... }` | Declare a table shape (side-effect-free; used for type checking and auto-creation) |
 | `trait ip_address extends string = { def ... }` | Declare a method interface attached to a type — see [Data Models](data-models.md) |
-| `create schema s [if not exists]` / `drop schema s [if exists]` | Schema lifecycle |
+| `table backup like users` | Declare a second table with the same columns |
+| `create schema s [in 'uri'] [if not exists] [with k: v]` / `drop schema s [if exists] [with cascade: true]` | Schema lifecycle, locations, and engine options |
 | `create table t` / `... if not exists` / `create or replace table t` | SQL-equivalent table creation from a declaration |
 | `drop table t [if exists]` / `truncate t` | Remove a table / delete all rows |
 | `reshape t { add c: type / rename a as b / exclude c }` | Evolve a table's columns |

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -16,6 +16,23 @@ drop schema staging
 drop schema staging if exists
 ```
 
+A schema can carry a self-describing storage location with `in '<uri>'`, and engine
+properties with `with key: value` options. Both render as schema properties on engines that
+support them (e.g. Trino's `WITH (location = ...)`) and are rejected with a clear error on
+engines that don't (e.g. DuckDB):
+
+```wvlet
+create schema sales in 's3://bucket/sales/' if not exists
+create schema sales in 's3://bucket/sales/' with owner: 'etl'
+```
+
+To drop a schema together with the objects it contains, pass `cascade: true` — an engine
+modifier riding in an option, keeping the keyword surface flat:
+
+```wvlet
+drop schema staging if exists with cascade: true
+```
+
 ## Declaring a Table Shape
 
 A `table` declaration describes a table's columns using the same `name: type` notation as
@@ -29,6 +46,20 @@ table users = {
   name: string
   created_at: timestamp
 }
+```
+
+### Reusing a Shape with `like`
+
+`table <name> like <source>` declares a second table with the same columns as an existing
+declaration, so a shape is written exactly once. Everything that works for a normal
+declaration — type checking, `create table`, automatic creation on write — reads its columns
+through the `like` reference:
+
+```wvlet
+table users_backup like users
+
+from users
+append to users_backup   -- auto-creates users_backup with users' columns if missing
 ```
 
 ### Binding a Declaration to a Location

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
@@ -33,6 +33,7 @@ import wvlet.lang.compiler.TermName
 import wvlet.lang.compiler.TypeSymbol
 import wvlet.lang.compiler.TypeSymbolInfo
 import wvlet.lang.compiler.typer.DuplicateTypeDefinition
+import wvlet.lang.compiler.typer.GenericTyperError
 import wvlet.lang.compiler.typer.MethodInterfaceDeclaredAsType
 import wvlet.lang.compiler.typer.ModelDefCompleter
 import wvlet.lang.model.DataType.NamedType
@@ -488,14 +489,53 @@ object SymbolLabeler extends Phase("symbol-labeler"):
         ft
       }
 
-    val columns = t
-      .elems
-      .collect { case v: FieldDef =>
-        // Resolve simple primitive types earlier.
-        // TODO: DataType.parse(typeName) for complex types, including UnknownTypes
-        val dt = DataType.parse(v.fieldType.fullName, v.params)
-        NamedType(v.name, dt)
+    // `table <name> like <source>` (#1995) copies the source declaration's columns. This runs
+    // from a completer after all units are labeled, so forcing the source's completion here
+    // resolves cross-unit references; a completion already in progress signals a reference
+    // cycle (`table a like b` + `table b like a`), which resolves to no columns with an error
+    val likeColumns: List[NamedType] = t
+      .likeSource
+      .toList
+      .flatMap { src =>
+        val srcName = Name.typeName(src.leafName)
+        ctx
+          .scope
+          .lookupSymbol(srcName)
+          .orElse(ctx.findSymbolByName(srcName))
+          .filterNot(_.isCompleting) match
+          case Some(srcSym) =>
+            srcSym.symbolInfo.dataType match
+              case s: SchemaType =>
+                s.fields
+              case _ =>
+                ctx.addTyperError(
+                  GenericTyperError(
+                    s"'${src.leafName}' referenced by 'table ${typeName.name} like " +
+                      s"${src.leafName}' is not a table declaration",
+                    t.span
+                  )
+                )
+                Nil
+          case None =>
+            ctx.addTyperError(
+              GenericTyperError(
+                s"Unknown table declaration '${src.leafName}' referenced by " +
+                  s"'table ${typeName.name} like ${src.leafName}'",
+                t.span
+              )
+            )
+            Nil
       }
+
+    val columns =
+      likeColumns ++
+        t.elems
+          .collect { case v: FieldDef =>
+            // Resolve simple primitive types earlier.
+            // TODO: DataType.parse(typeName) for complex types, including UnknownTypes
+            val dt = DataType.parse(v.fieldType.fullName, v.params)
+            NamedType(v.name, dt)
+          }
 
     // The schema parent is only the extended type (None when the type has no parent); the
     // owner symbol falls back to the enclosing package

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TableBindings.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TableBindings.scala
@@ -108,14 +108,29 @@ object TableBindings:
       td
     }
 
-  private def declaredColumns(td: TypeDef): List[ColumnDef] = td
-    .elems
-    .collect { case f: FieldDef =>
-      ColumnDef(
-        UnquotedIdentifier(f.name.name, f.span),
-        DataTypeParser.parse(f.fieldType.fullName),
-        f.span
-      )
-    }
+  /**
+    * The declared columns of a table declaration, following `table <name> like <source>` chains
+    * (#1995) so like-declared tables auto-create with the source's columns. A reference cycle or an
+    * unknown source resolves to no columns (SymbolLabeler reports the error)
+    */
+  private def declaredColumns(td: TypeDef)(using ctx: Context): List[ColumnDef] =
+    def loop(current: TypeDef, visited: Set[String]): List[ColumnDef] =
+      val own = current
+        .elems
+        .collect { case f: FieldDef =>
+          ColumnDef(
+            UnquotedIdentifier(f.name.name, f.span),
+            DataTypeParser.parse(f.fieldType.fullName),
+            f.span
+          )
+        }
+      current.likeSource match
+        case Some(src) if !visited.contains(src.leafName) =>
+          declarationOf(src.leafName)
+            .map(srcTd => loop(srcTd, visited + src.leafName) ++ own)
+            .getOrElse(own)
+        case _ =>
+          own
+    loop(td, Set(td.name.name))
 
 end TableBindings

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -157,6 +157,19 @@ object GenSQL extends Phase("generate-sql"):
                 .dbType}",
             a.sourceLocation
           )
+      // Schema locations and properties render as Trino's WITH (...) clause; engines without
+      // schema properties (e.g. DuckDB) reject them loudly instead of dropping the semantics.
+      // Generic stays dialect-neutral and prints the Trino spelling
+      case c: CreateSchema
+          if (c.location.nonEmpty || c.options.nonEmpty) && context.dbType != DBType.Trino &&
+            context.dbType != DBType.Generic =>
+        throw StatusCode
+          .NOT_IMPLEMENTED
+          .newException(
+            s"create schema ${c.schema.fullName} with a location or options is not supported " +
+              s"on ${context.dbType}",
+            c.sourceLocation
+          )
       case c: CreateTable if c.replace && !context.dbType.supportCreateOrReplace =>
         // Engines without CREATE OR REPLACE decompose it into an explicit drop + create
         List(

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -221,6 +221,17 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
           )
         )
       case c: CreateSchema =>
+        // The `in '<uri>'` location and `with k: v` options render as schema properties
+        // (Trino's WITH (...) spelling); engines without schema properties reject them in
+        // GenSQL before printing
+        val props =
+          c.location.map(l => wl("location", "=", expr(l))).toList ++
+            c.options.map(opt => wl(text(opt.key.leafName), "=", expr(opt.value)))
+        val propsDoc =
+          if props.isEmpty then
+            None
+          else
+            Some(wl("with", paren(cl(props))))
         group(
           wl(
             "create",
@@ -230,7 +241,8 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
             else
               None
             ,
-            expr(c.schema)
+            expr(c.schema),
+            propsDoc
           )
         )
       case a: AttachDatabase =>
@@ -278,7 +290,8 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
             else
               None
             ,
-            expr(d.schema)
+            expr(d.schema),
+            Option.when(d.cascade)("cascade")
           )
         )
       case r: RenameDatabase =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -165,13 +165,20 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
     d match
       case c: CreateSchema =>
         code(c) {
+          val opts =
+            if c.options.isEmpty then
+              None
+            else
+              Some(wl("with", cl(c.options.map(o => expr(o)))))
           group(
             wl(
               "create schema",
               expr(c.schema),
+              c.location.map(l => wl("in", expr(l))),
               Option.when(c.ifNotExists) {
                 "if not exists"
-              }
+              },
+              opts
             )
           )
         }
@@ -183,6 +190,9 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
               expr(s.schema),
               Option.when(s.ifExists) {
                 "if exists"
+              },
+              Option.when(s.cascade) {
+                "with cascade: true"
               }
             )
           )
@@ -795,8 +805,13 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
               "trait"
             else
               "type"
-          group(wl(keyword, text(t.name.name) + typeParams, defContexts, parent, sep)) +
-            indentedBrace(concat(t.elems.map(e => group(expr(e))), linebreak))
+          t.likeSource match
+            case Some(source) =>
+              // `table <name> like <source>` carries no body of its own
+              group(wl(keyword, text(t.name.name), defContexts, "like", expr(source)))
+            case None =>
+              group(wl(keyword, text(t.name.name) + typeParams, defContexts, parent, sep)) +
+                indentedBrace(concat(t.elems.map(e => group(expr(e))), linebreak))
         case p: PartialQueryDef =>
           val params =
             if p.params.isEmpty then

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1094,11 +1094,28 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     val t      = consume(WvletToken.IDENTIFIER) // the `table` soft keyword
     val name   = Name.typeName(identifier().leafName)
     val scopes = context()
-    consume(WvletToken.EQ)
-    consume(WvletToken.L_BRACE)
-    val elems = typeElems()
-    consume(WvletToken.R_BRACE)
-    TypeDef(name, Nil, scopes, None, elems, spanFrom(t), isTableDef = true)
+    scanner.lookAhead().token match
+      case WvletToken.LIKE =>
+        // `table <name> like <source>` (#1995): declaration-side shape reuse, so a shape is
+        // written exactly once. The columns resolve from the referenced declaration lazily
+        consume(WvletToken.LIKE)
+        val source = identifier()
+        TypeDef(
+          name,
+          Nil,
+          scopes,
+          None,
+          Nil,
+          spanFrom(t),
+          isTableDef = true,
+          likeSource = Some(source)
+        )
+      case _ =>
+        consume(WvletToken.EQ)
+        consume(WvletToken.L_BRACE)
+        val elems = typeElems()
+        consume(WvletToken.R_BRACE)
+        TypeDef(name, Nil, scopes, None, elems, spanFrom(t), isTableDef = true)
   }
 
   /**
@@ -1216,7 +1233,23 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
             .SYNTAX_ERROR
             .newException("create or replace is not supported for schemas", t.sourceLocation)
         val name = qualifiedId()
-        CreateSchema(name, ifNotExistsModifier(), None, spanFrom(t))
+        // `in '<uri>'` (#1995): a storage location needs no label — schemas bind to places
+        // the same way `use '<path>' as <alias>` and `table ... in ...` do
+        val location =
+          scanner.lookAhead().token match
+            case WvletToken.IN =>
+              consume(WvletToken.IN)
+              Some(stringLiteral())
+            case _ =>
+              None
+        CreateSchema(
+          name,
+          ifNotExistsModifier(),
+          None,
+          spanFrom(t),
+          location = location,
+          options = saveOptions()
+        )
       case "table" =>
         val name = qualifiedId()
         // tableElems are filled from the `table` declaration in scope at typing time.
@@ -1236,6 +1269,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
             s"Unknown create target '${other}'. Expected 'schema' or 'table'",
             t.sourceLocation
           )
+    end match
   }
 
   /**
@@ -1246,8 +1280,31 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     val kind = identifierSingle()
     kind.leafName match
       case "schema" =>
-        val name = qualifiedId()
-        DropSchema(name, ifExistsModifier(), spanFrom(t))
+        val name     = qualifiedId()
+        val ifExists = ifExistsModifier()
+        // `with cascade: true` (#1995): the engine modifier rides in an option so the keyword
+        // budget stays flat. Only `cascade` with a boolean value is meaningful here
+        val cascade = saveOptions()
+          .map { opt =>
+            (opt.key.leafName.toLowerCase, opt.value) match
+              case ("cascade", _: TrueLiteral) =>
+                true
+              case ("cascade", _: FalseLiteral) =>
+                false
+              case ("cascade", _) =>
+                throw StatusCode
+                  .SYNTAX_ERROR
+                  .newException("cascade expects a boolean value: cascade: true", t.sourceLocation)
+              case (other, _) =>
+                throw StatusCode
+                  .SYNTAX_ERROR
+                  .newException(
+                    s"Unknown drop schema option '${other}'. Supported: cascade: true|false",
+                    t.sourceLocation
+                  )
+          }
+          .contains(true)
+        DropSchema(name, ifExists, spanFrom(t), cascade = cascade)
       case "table" =>
         val name = qualifiedId()
         DropTable(name, ifExistsModifier(), spanFrom(t))
@@ -1261,6 +1318,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
             s"Unknown drop target '${other}'. Expected 'schema', 'table', or 'view'",
             t.sourceLocation
           )
+    end match
   }
 
   /**

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/ddl.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/ddl.scala
@@ -44,10 +44,21 @@ case class CreateSchema(
     schema: NameExpr,
     ifNotExists: Boolean,
     properties: Option[Seq[SchemaProperty]],
-    span: Span
+    span: Span,
+    // `create schema s in '<uri>'` (#1995): a self-describing storage location, rendered as a
+    // schema property (e.g. Trino's WITH (location = ...)) on engines that support one
+    location: Option[StringLiteral] = None,
+    // `with key: value, ...` engine properties riding outside the keyword budget
+    options: List[SaveOption] = Nil
 ) extends DDL
 
-case class DropSchema(schema: NameExpr, ifExists: Boolean, span: Span) extends DDL
+case class DropSchema(
+    schema: NameExpr,
+    ifExists: Boolean,
+    span: Span,
+    // `drop schema s with cascade: true` (#1995): drop the contained objects as well
+    cascade: Boolean = false
+) extends DDL
 
 case class DropDatabase(database: NameExpr, ifExists: Boolean, cascade: Boolean, span: Span)
     extends DDL

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
@@ -74,7 +74,10 @@ case class TypeDef(
     isTableDef: Boolean = false,
     // true for `trait <name> [in <dialect>] [extends <type>] = { ... }` method-interface
     // declarations (#2001): def members only, never storage, printed back as `trait`
-    isTrait: Boolean = false
+    isTrait: Boolean = false,
+    // `table <name> like <source>` (#1995): declaration-side shape reuse. The columns come from
+    // the referenced table declaration, resolved lazily at symbol-completion time
+    likeSource: Option[NameExpr] = None
 ) extends LanguageStatement:
 
   /**

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/SchemaDdlTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/SchemaDdlTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.codegen
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.api.WvletLangException
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.compiler.parser.WvletParser
+
+/**
+  * Schema DDL refinements (#1995): `create schema s in '<uri>'` locations and `with k: v` options
+  * render as Trino schema properties (rejected loudly on engines without them), and
+  * `drop schema s with cascade: true` renders as a CASCADE drop
+  */
+class SchemaDdlTest extends UniTest:
+
+  private def generateSQL(wvlet: String, dbType: DBType = DBType.Trino): String =
+    val unit = CompilationUnit.fromWvletString(wvlet)
+    val plan = WvletParser(unit).parse()
+    SqlGenerator(CodeFormatterConfig(sqlDBType = dbType)).print(plan)
+
+  test("should render a schema location as a Trino location property") {
+    val sql = generateSQL("create schema sales in 's3://bucket/sales/' if not exists")
+    sql shouldContain "create schema if not exists sales"
+    sql shouldContain "with (location = 's3://bucket/sales/')"
+  }
+
+  test("should render schema options as properties alongside the location") {
+    val sql = generateSQL("create schema sales in 's3://b/' with owner: 'etl'")
+    sql shouldContain "with (location = 's3://b/', owner = 'etl')"
+  }
+
+  test("should render drop schema cascade") {
+    val sql = generateSQL("drop schema staging if exists with cascade: true")
+    sql shouldContain "drop schema if exists staging cascade"
+  }
+
+  test("should omit cascade when false") {
+    val sql = generateSQL("drop schema staging with cascade: false")
+    sql shouldContain "drop schema staging"
+    sql.contains("cascade") shouldBe false
+  }
+
+  test("should reject unknown drop schema options") {
+    val e = intercept[WvletLangException] {
+      generateSQL("drop schema s with force: true")
+    }
+    e.getMessage shouldContain "Unknown drop schema option 'force'"
+  }
+
+  test("should reject non-boolean cascade values") {
+    val e = intercept[WvletLangException] {
+      generateSQL("drop schema s with cascade: 'yes'")
+    }
+    e.getMessage shouldContain "cascade expects a boolean value"
+  }
+
+  test("should reject schema locations on engines without schema properties") {
+    val compiler = Compiler(CompilerOptions(workEnv = WorkEnv("."), dbType = DBType.DuckDB))
+    val unit     = CompilationUnit.fromWvletString("create schema sales in 's3://bucket/sales/'")
+    val result   = compiler.compileSingleUnit(unit)
+    val e        = intercept[WvletLangException] {
+      GenSQL.generateSQL(unit)(using result.context)
+    }
+    e.getMessage shouldContain "with a location or options is not supported on"
+  }
+
+end SchemaDdlTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -82,6 +82,26 @@ class WvletGeneratorTest extends UniTest:
     print(printed) shouldContain "model rm_all: rm_users"
   }
 
+  test("should round-trip schema locations, schema options, and cascade drops") {
+    val printed = print(
+      """create schema sales in 's3://bucket/sales/' if not exists with owner: 'etl'
+        |drop schema staging if exists with cascade: true""".stripMargin
+    )
+    printed shouldContain
+      "create schema sales in 's3://bucket/sales/' if not exists with owner: 'etl'"
+    printed shouldContain "drop schema staging if exists with cascade: true"
+    print(printed) shouldContain "drop schema staging if exists with cascade: true"
+  }
+
+  test("should round-trip a like-based table declaration") {
+    val printed = print("""table users = {
+        |  id: int
+        |}
+        |table users_backup like users""".stripMargin)
+    printed shouldContain "table users_backup like users"
+    print(printed) shouldContain "table users_backup like users"
+  }
+
   test("should round-trip a trait declaration as `trait`, not `type`") {
     val printed = print("""trait ip_address in duckdb extends string = {
         |  def country_name: string = sql"'N/A'"


### PR DESCRIPTION
## Summary

Implements the three remaining items of #1995, completing the table-management design's declaration/DDL refinements.

### 1. Schema locations: `create schema s in '<uri>'`

```wvlet
create schema sales in 's3://bucket/sales/' if not exists
```

`in` binds objects to places, consistently with `table ... in c.s` and `use '<path>' as x`; a URI needs no label. On Trino (and the dialect-neutral Generic target) the location renders as `create schema if not exists sales with (location = 's3://bucket/sales/')`. Engines without schema properties (DuckDB) reject it with a clear NOT_IMPLEMENTED instead of silently dropping the semantics.

### 2. `with key: value` options on schema DDL

```wvlet
create schema sales in 's3://b/' with owner: 'etl'   -- rides into the WITH (...) property list
drop schema staging if exists with cascade: true      -- renders as ... CASCADE
```

Engine modifiers stay out of the keyword budget by riding in options (the #1984 attach pattern). `drop schema` accepts only `cascade: true|false`, with dedicated parse errors for non-boolean values and unknown options.

### 3. Shape reuse: `table backup like users`

```wvlet
table users = { id: int, name: string }
table users_backup like users

from users
append to users_backup   -- auto-creates users_backup with users' columns
```

Declaration-side reuse so a shape is written exactly once. The columns resolve from the source declaration lazily at symbol-completion time (cross-unit safe; reference cycles and unknown/non-table sources produce typer errors instead of hangs), and the shared `TableBindings` resolution follows `like` chains, so `create table`, keyed append, and write auto-creation all work unchanged. `WvletGenerator` round-trips the form as `table x like y`.

## Testing

- New `SchemaDdlTest` (7 cases): Trino property rendering for locations and options, CASCADE rendering and omission, both drop-option rejection paths, and the DuckDB engine gate
- `WvletGeneratorTest`: round-trips for `create schema ... in ... with ...`, `drop schema ... with cascade: true`, and `table x like y`
- New specs `spec/basic/ddl/table-like.wv` and `spec/basic/ddl/drop-schema-cascade.wv`, executed on DuckDB (cascade verified against a non-empty schema)
- Full sweep: `langJVM/test`, `runnerJVM/test`, all `RunnerSpec*` (486 passed), TyperCoverageCheck ratchet, JS/Native `Test/compile`, scalafmtCheck; both new specs also verified through the no-profile CLI (`wvlet run`)

Closes #1995. Refs #1998, #2000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3mfchNEQAGtbs8NXa7Bx