### PR TITLE
fix: Resolve trait and row methods on direct table scans

### DIFF
--- a/spec/basic/table-row-methods.wv
+++ b/spec/basic/table-row-methods.wv
@@ -1,6 +1,6 @@
 -- Row methods on table declarations (#1998): `def` members travel with the table shape,
 -- so reusable predicates and expressions live next to the columns they read. Methods
--- resolve through relations annotated with the declared type (same as `type` methods)
+-- resolve directly on scans of the declared table (#2010)
 
 table rm_users = {
   id: int
@@ -13,6 +13,12 @@ table rm_users = {
 from [[1, 'alice', null], [2, 'bob', 'gone']] as t(id, name, deleted_at)
 save to rm_users
 
+from rm_users
+where _.is_active
+test _.size should be 1
+test _.columns should contain 'name'
+
+-- Regression: methods also resolve through a model annotated with the declared type
 model rm_all: rm_users = {
   from rm_users
 }

--- a/spec/basic/trait-methods.wv
+++ b/spec/basic/trait-methods.wv
@@ -1,6 +1,7 @@
 -- Traits (#2001): a method interface attached to a type. Columns typed with a trait get its
 -- def members inside the table declaration's own row methods (the cdp pattern), so domain
--- behavior composes: trait methods -> row methods -> queries
+-- behavior composes: trait methods -> row methods -> queries. Both resolve directly on a
+-- scan of the declared table (#2010)
 
 trait masked_str extends string = {
   def masked: string = sql"'***'"
@@ -16,11 +17,8 @@ table trm_users = {
 from [[1, 'pw1'], [2, 'pw2']] as t(id, secret)
 save to trm_users
 
-model trm_all: trm_users = {
-  from trm_users
-}
-
-from trm_all
-select id, _.secret_masked as m
+from trm_users
+select id, _.secret_masked as m, secret.masked as m2
 test _.size should be 2
 test _.columns should contain 'm'
+test _.columns should contain 'm2'

--- a/website/docs/syntax/data-models.md
+++ b/website/docs/syntax/data-models.md
@@ -93,6 +93,10 @@ table access_logs = {
   -- Row methods can call trait methods of the declared column types
   def client_country: string = client_ip.country_name
 }
+
+-- Both trait and row methods resolve directly on a scan of the declared table
+from access_logs
+select time, client_ip.country_name, _.client_country
 ```
 
 A trait re-opening an existing type with a *dialect scope* provides engine-specific

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -85,8 +85,9 @@ of your database.
 ### Row Methods
 
 A declaration body can also carry `def` members — reusable expressions over the table's
-columns — so behavior travels with the table declaration. Methods resolve through relations
-annotated with the declared type:
+columns — so behavior travels with the table declaration. Methods resolve on any relation
+that carries the declared type: a direct scan of the table, or a model annotated with the
+type (`model all_users: users = { ... }`):
 
 ```wvlet
 table users = {
@@ -97,11 +98,7 @@ table users = {
   def is_active: boolean = deleted_at is null
 }
 
-model all_users: users = {
-  from users
-}
-
-from all_users
+from users
 where _.is_active
 ```
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -25,6 +25,7 @@ import wvlet.lang.compiler.ContextUtil.*
 import wvlet.lang.compiler.typer.TableShapeDeclaredAsType
 import wvlet.lang.model.DataType
 import wvlet.lang.model.DataType.SchemaType
+import wvlet.lang.model.DataType.UnresolvedRelationType
 import wvlet.lang.model.RelationType
 import wvlet.lang.model.expr.*
 import wvlet.lang.model.plan.*
@@ -56,6 +57,10 @@ object RelationRefResolver extends ContextLogSupport:
     * TableScan using the symbols in scope and the catalog
     */
   def resolveTableRef(ref: TableRef)(using context: Context): Relation =
+    def resolveAsTable: Relation = resolveTableType(ref, context)
+      .orElse(resolveConnectorQualifiedRef(ref, context))
+      .getOrElse(resolveFromDefaultCatalog(ref, context))
+
     lookup(ref.name, context) match
       case Some(sym) if sym.isCompleting =>
         // A reference to a definition whose lazy completion is in progress, i.e. a recursive
@@ -69,7 +74,12 @@ object RelationRefResolver extends ContextLogSupport:
           case mi: ModelSymbolInfo =>
             mi.dataType match
               case r: RelationType =>
-                ModelScan(TableName(ref.name.fullName), Nil, r, ref.span)
+                ModelScan(
+                  TableName(ref.name.fullName),
+                  Nil,
+                  resolveNominalRelationType(r, context),
+                  ref.span
+                )
               case _ =>
                 ref
           case v: ValSymbolInfo =>
@@ -98,13 +108,32 @@ object RelationRefResolver extends ContextLogSupport:
               case _ =>
                 ref
           case _ =>
-            ref
+            // The name resolved to a term symbol that is not a relation definition, e.g. the
+            // target of a `save to <table>` statement. Such a symbol carries no schema, so
+            // resolve through the table declaration or the catalog instead; otherwise row and
+            // trait methods of a declared table would not resolve on a direct scan (#2010)
+            resolveAsTable
       case None =>
-        resolveTableType(ref, context)
-          .orElse(resolveConnectorQualifiedRef(ref, context))
-          .getOrElse(resolveFromDefaultCatalog(ref, context))
+        resolveAsTable
     end match
   end resolveTableRef
+
+  /**
+    * Expand a nominal relation type (e.g. a model's declared type annotation `model m: users`)
+    * through the referenced type declaration, so a scan of the model carries the declared columns
+    * and resolves them (and the declaration's row/trait methods) like a direct table scan (#2010)
+    */
+  private def resolveNominalRelationType(r: RelationType, context: Context): RelationType =
+    r match
+      case u: UnresolvedRelationType if u.typeName != Name.NoTypeName =>
+        lookupType(u.typeName, context)
+          .map(_.symbolInfo.dataType)
+          .collectFirst { case tpe: SchemaType =>
+            tpe
+          }
+          .getOrElse(r)
+      case _ =>
+        r
 
   /**
     * Resolve a table reference through a type definition, so table schemas described as source
@@ -303,7 +332,12 @@ object RelationRefResolver extends ContextLogSupport:
         si.tpe match
           case r: RelationType =>
             context.logTrace(s"Resolved model ref: ${ref.name.fullName} as ${r}")
-            ModelScan(TableName(sym.name.name), ref.args, r, ref.span)
+            ModelScan(
+              TableName(sym.name.name),
+              ref.args,
+              resolveNominalRelationType(r, context),
+              ref.span
+            )
           case _ =>
             ref
       case None =>
@@ -319,7 +353,7 @@ object RelationRefResolver extends ContextLogSupport:
         // isModelDef forces the lazy completion, so sym.tree is the typed model definition
         sym.tree match
           case md: ModelDef =>
-            val newModelScan = m.copy(schema = md.relationType)
+            val newModelScan = m.copy(schema = resolveNominalRelationType(md.relationType, context))
             newModelScan.symbol = md.child.symbol
             newModelScan
           case _ =>


### PR DESCRIPTION
## Summary

Fixes #2010: `_.method` and `column.method` now resolve identically whether the relation is a direct scan of a `table` declaration or a `ModelScan` of a type-annotated model — the wrapper-model pattern becomes optional style, not a requirement.

## Root cause

Two resolution gaps in `RelationRefResolver`, not in method lookup itself:

1. **`save to <table>` shadowed table-type resolution.** The save statement registers a term symbol (`SavedRelationSymbolInfo`) for the target name. `resolveTableRef` found that symbol, matched none of the relation-definition cases, and returned the `TableRef` unresolved — never falling through to `resolveTableType`. The scan therefore carried `UnresolvedRelationType` (whose `typeName` is `NoTypeName`), so `FunctionInliner`'s member lookup had no type symbol to consult and `_.method` / `column.method` passed through literally into SQL. Without a `save to` of the same name, the direct scan already worked — which is why the gap looked like a scan-kind difference.

2. **Nominal model annotations never expanded.** `model m: users` kept the parser's `UnresolvedRelationType("users")` with zero columns as the model's relation type. `_.method` resolved via the type *name*, but column references (`secret.masked`) could not be typed through the annotated model, so the wrapper pattern only ever half-worked.

## Changes

- `resolveTableRef`: a term symbol that is not a relation definition (e.g. a `save to` target) now falls through to the same table-type / connector / catalog resolution as an unknown name.
- New `resolveNominalRelationType` expands a model's nominal type annotation to the declared `SchemaType`, applied where model relation types are consumed (`resolveTableRef`, `resolveTableFunctionCall`, `resolveModelScan`).
- Simplified `spec/basic/trait-methods.wv` and `spec/basic/table-row-methods.wv` to the direct-scan form; kept one wrapper-model case in `table-row-methods.wv` for regression coverage. The trait spec now also covers the `column.method` form (`secret.masked`), which previously failed on both paths.
- Docs: Row Methods section of `table-management.md` and Traits section of `data-models.md` now show the direct form.

## Verification

- E2e through the no-profile CLI (`wv run -f`): direct scan and wrapper-model repros both produce correct SQL and results.
- `runnerJVM/testOnly *RunnerSpec*`: 486 passed (includes cdp behavior specs using this pattern, TPC-DS/TPC-H).
- `langJVM/test`: 1081 passed / 2 pending; `*TyperCoverageCheck` and `*RoundTripSpecBasic` pass explicitly.
- `projectJS/Test/compile` and `projectNative/Test/compile` pass; `scalafmtAll` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tvsZqH9rhtWngCW5cH8kq