### PR TITLE
feature: Add `cast` operation to `reshape` blocks (#1996)

### DIFF
--- a/spec/basic/ddl/reshape-and-views.wv
+++ b/spec/basic/ddl/reshape-and-views.wv
@@ -28,6 +28,19 @@ reshape ddl2_items {
 from ddl2_items
 test _.size should be 2
 
+-- Cast: change a column's type in place (#1996); re-running the same cast is a no-op
+reshape ddl2_items {
+  cast id as long
+}
+
+from ddl2_items
+where id = 1
+test _.size should be 1
+
+reshape ddl2_items {
+  cast id as long
+}
+
 -- Renaming changes identity, not shape: a direct statement, not a reshape operation
 rename table ddl2_items to ddl2_products
 

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -222,16 +222,20 @@ append to metrics on date, metric_name {
 ## Changing a Table's Columns
 
 The `reshape` statement evolves a table's schema using the same column operators you already
-use in queries — `add`, `rename ... as`, and `exclude` — enclosed in a block. Operations run
-in order, one `ALTER TABLE` statement each:
+use in queries — `add`, `rename ... as`, `exclude`, and `cast ... as` — enclosed in a block.
+Operations run in order, one `ALTER TABLE` statement each:
 
 ```wvlet
 reshape users {
   add email: string
   rename name as full_name
   exclude age
+  cast user_id as long
 }
 ```
+
+Each operation is retry-safe: `add` is a no-op when the column already exists with that type,
+`exclude` when it is already gone, and `cast` when the column already has the target type.
 
 ## Renaming Tables and Schemas
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -156,7 +156,8 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
   /** AlterTable operations expressible with the wvlet reshape / rename statements */
   private def isReshapeOp(op: AlterTableOps): Boolean =
     op match
-      case _: AddColumnOp | _: RenameColumnOp | _: DropColumnOp | _: RenameTableOp =>
+      case _: AddColumnOp | _: RenameColumnOp | _: DropColumnOp | _: RenameTableOp |
+          _: AlterColumnSetDataTypeOp =>
         true
       case _ =>
         false
@@ -266,6 +267,8 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
                 wl("rename", expr(r.oldName), "as", expr(r.newName))
               case d: DropColumnOp =>
                 wl("exclude", expr(d.column))
+              case c: AlterColumnSetDataTypeOp =>
+                wl("cast", expr(c.column), "as", c.dataType.wvExpr)
             }
             code(a) {
               group(wl("reshape", expr(a.table), "{")) + nest(linebreak + lines(opDocs)) +

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1036,15 +1036,27 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
           val colName = identifier()
           ops += DropColumnOp(colName, span = spanFrom(tk))
           nextOp()
+        case WvletToken.IDENTIFIER if tk.str == "cast" =>
+          // `cast <column> as <type>` (#1996): change a column's type in place. Casting to the
+          // type a column already has is a no-op on the engine side, so the operation is
+          // retry-safe like the other reshape ops
+          consume(WvletToken.IDENTIFIER)
+          val colName = identifier()
+          consume(WvletToken.AS)
+          val tpe = dataType()
+          ops += AlterColumnSetDataTypeOp(colName, tpe, span = spanFrom(tk))
+          nextOp()
         case WvletToken.R_BRACE =>
         // end of block
         case _ =>
           throw StatusCode
             .SYNTAX_ERROR
             .newException(
-              s"Invalid reshape operation. Expected 'add <column>: <type>', 'rename <column> as <name>', or 'exclude <column>'",
+              s"Invalid reshape operation. Expected 'add <column>: <type>', " +
+                s"'rename <column> as <name>', 'exclude <column>', or 'cast <column> as <type>'",
               tk.sourceLocation
             )
+      end match
     end nextOp
 
     nextOp()

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -142,12 +142,14 @@ class WvletGeneratorTest extends UniTest:
         |  add email: string
         |  rename name as full_name
         |  exclude age
+        |  cast age as long
         |}""".stripMargin)
     printed shouldContain "reshape users"
     printed shouldContain "add email: string"
     printed shouldContain "rename name as full_name"
     printed shouldContain "exclude age"
-    print(printed) shouldContain "reshape users"
+    printed shouldContain "cast age as long"
+    print(printed) shouldContain "cast age as long"
   }
 
   test("should round-trip rename statements") {


### PR DESCRIPTION
## Summary

Implements #1996: `reshape` blocks gain an in-place column type change, completing the operator set:

```wvlet
reshape users {
  add email: string
  rename name as full_name
  exclude age
  cast user_id as long
}
```

- `cast <column> as <type>` parses as a soft identifier inside the block (like the statement heads — `cast` is not a Wvlet keyword) and lowers to the existing `AlterColumnSetDataTypeOp`, emitting one `ALTER TABLE ... ALTER <col> TYPE <type>` statement like the other ops.
- Retry-safe like its siblings: casting to the type a column already has is an engine-side no-op — the spec re-runs the same cast to prove it.
- This unblocks the schema drift checker (#1994, in progress) from emitting type drifts as real `cast` operations instead of comments.

## Testing

- `spec/basic/ddl/reshape-and-views.wv`: cast executed on DuckDB, idempotent re-run included
- `WvletGeneratorTest`: reshape round-trip now covers `cast age as long`
- `RoundTripSpecBasic` (150), `RunnerSpecBasic` (149) green; scalafmt applied

Closes #1996. Refs #1994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3mfchNEQAGtbs8NXa7Bx