### PR TITLE
feature: Complete soft statement heads (`table`, `trait`, `reshape`) in LSP (#1999)

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/CompletionProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/CompletionProvider.scala
@@ -16,6 +16,7 @@ package wvlet.lang.compiler.lsp
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Compiler
 import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.compiler.parser.WvletParser
 import wvlet.lang.compiler.parser.WvletToken
 import wvlet.lang.compiler.typer.BuiltinFunctions
 import wvlet.lang.model.SyntaxTreeNode
@@ -63,13 +64,22 @@ object CompletionItemKind:
 object CompletionProvider:
 
   /**
-    * Keyword candidates. These are always available regardless of the cursor position.
+    * Keyword candidates. These are always available regardless of the cursor position. Soft
+    * statement heads (`table`, `trait`, `reshape`, #1999) are identifier tokens to the scanner, so
+    * they are appended explicitly — WvletToken.keywords cannot see them
     */
   def keywordItems: List[CompletionItem] =
-    WvletToken
-      .keywords
-      .map(k => CompletionItem(k.str, CompletionItemKind.Keyword, "keyword"))
+    val hardKeywords =
+      WvletToken
+        .keywords
+        .map(k => CompletionItem(k.str, CompletionItemKind.Keyword, "keyword"))
+        .toList
+    val softKeywords = WvletParser
+      .statementHeadSoftKeywords
       .toList
+      .sorted
+      .map(k => CompletionItem(k, CompletionItemKind.Keyword, "keyword"))
+    hardKeywords ++ softKeywords
 
   /**
     * Find the innermost syntax tree node whose span contains the given character offset.

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/CompletionProviderTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/CompletionProviderTest.scala
@@ -31,8 +31,14 @@ class CompletionProviderTest extends UniTest:
     labels shouldContain "from"
     labels shouldContain "select"
     labels shouldContain "where"
+    // Soft statement heads complete like keywords even though the scanner treats them as
+    // identifiers (#1999)
+    labels shouldContain "table"
+    labels shouldContain "trait"
+    labels shouldContain "reshape"
     // Keywords carry the Keyword kind
     items.find(_.label == "from").map(_.kind) shouldBe Some(CompletionItemKind.Keyword)
+    items.find(_.label == "table").map(_.kind) shouldBe Some(CompletionItemKind.Keyword)
 
   test("should complete in-file model names"):
     val src =


### PR DESCRIPTION
## Summary

First item of the #1999 polish bundle: the LSP now offers completion for the soft statement heads.

The scanner treats `table`, `trait`, and `reshape` as identifier tokens, so `WvletToken.keywords` — the source of the LSP keyword tier — never surfaced them, and editors offered no completion for the newest statement family. `CompletionProvider.keywordItems` now appends `WvletParser.statementHeadSoftKeywords`, keeping the completion list in lockstep with the parser as soft heads are added (no per-keyword bookkeeping).

Member-access contexts still exclude the keyword tier entirely, so the soft heads don't leak into `x.<cursor>` completions (covered by the existing test).

## Testing

- `CompletionProviderTest` extended: `table`/`trait`/`reshape` present with the Keyword kind; all 27 tests pass

Refs #1999 (remaining there: static-catalog warnings for drop/reshape targets, and the demand-gated `detach` / full `merge` spellings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ3mfchNEQAGtbs8NXa7Bx