### PR TITLE
feature: Compose declarations with uniform extends mixins

### DIFF
--- a/spec/basic/ddl/table-mixins.wv
+++ b/spec/basic/ddl/table-mixins.wv
@@ -1,0 +1,36 @@
+-- Mixin declarations in DDL (#2012): `create table` and append auto-creation read the full
+-- composed shape, and a diamond mixin (the same base reached through two parents) dedupes
+-- to the first occurrence
+
+type tmd_base = {
+  id: int
+}
+
+type tmd_created extends tmd_base = {
+  created_at: string
+}
+
+type tmd_labeled extends tmd_base = {
+  label: string
+}
+
+table tmd_items extends tmd_created, tmd_labeled = {
+  own_score: int
+}
+
+-- `id` arrives through both parents but appears once, before own body columns
+create table tmd_items
+from tmd_items
+test _.columns should be ['id', 'created_at', 'label', 'own_score']
+
+-- Append auto-creation reads the same composed shape
+table tmd_copy extends tmd_created, tmd_labeled = {
+  own_score: int
+}
+
+from [[1, 'jan', 'a', 10]] as t(id, created_at, label, own_score)
+append to tmd_copy
+
+from tmd_copy
+test _.size should be 1
+test _.columns should be ['id', 'created_at', 'label', 'own_score']

--- a/spec/basic/table-mixins.wv
+++ b/spec/basic/table-mixins.wv
@@ -1,0 +1,39 @@
+-- Mixin declarations (#2012): `extends a, b` composes structural types (columns) and
+-- traits (def members) into a table declaration with one uniform, comma-separated spelling
+
+type tmx_timestamped = {
+  created_at: string
+}
+
+trait tmx_auditable = {
+  def audit_tag: string = created_at.upper()
+}
+
+table tmx_events extends tmx_timestamped, tmx_auditable = {
+  id: int
+  label: string
+}
+
+from [['jan', 1, 'a'], ['feb', 2, 'b']] as t(created_at, id, label)
+save to tmx_events
+
+-- The composed shape places mixed-in columns before own body columns
+from tmx_events
+test _.columns should be ['created_at', 'id', 'label']
+test _.size should be 2
+
+-- A trait method mixed into the table resolves on a direct scan (#2010) and can
+-- reference columns of the composing table
+from tmx_events
+where id = 1
+select id, _.audit_tag as tag
+test _.output should be """
+┌─────┬────────┐
+│ id  │  tag   │
+│ int │ string │
+├─────┼────────┤
+│   1 │ JAN    │
+├─────┴────────┤
+│ 1 rows       │
+└──────────────┘
+"""

--- a/spec/neg/trait-mixin-columns.wv
+++ b/spec/neg/trait-mixin-columns.wv
@@ -1,0 +1,17 @@
+-- A trait carries def members only (#2001), so extending a column-bearing declaration
+-- would smuggle storage into the trait: rejected at type composition (#2012)
+
+type neg_timestamped = {
+  created_at: string
+}
+
+trait neg_auditable extends neg_timestamped = {
+  def tag: string = sql"'a'"
+}
+
+table neg_events extends neg_auditable = {
+  id: int
+}
+
+from neg_events
+select id

--- a/website/docs/syntax/data-models.md
+++ b/website/docs/syntax/data-models.md
@@ -136,3 +136,34 @@ claim and warns toward `table`, and a def-only `type` is a method interface and 
 The `in` clause is unambiguous across the family: on a `trait` or `def` it always names an
 engine dialect; on a `table` declaration, `create schema`, or `use` it always names a storage
 location.
+
+#### Composing Declarations with Mixins
+
+Since `table` and `trait` are kinds of type, a declaration can compose others with a
+comma-separated `extends` list: structural `type` shapes and `table` declarations contribute
+their columns, and `trait` parents contribute their `def` members (including dialect-scoped
+variants):
+
+```wvlet
+type timestamped = { created_at: timestamp, updated_at: timestamp }
+trait auditable = { def is_recent: boolean = created_at > now() - interval '7 days' }
+
+table events extends timestamped, auditable = {
+  id: int
+  label: string
+}
+
+from events
+select created_at, id, _.is_recent
+```
+
+The composed shape places mixed-in columns before own body columns, in parent-list order.
+A column reached through multiple parents with the same type appears once, so diamond mixins
+are fine; the same name with conflicting types is a compile-time error. Method precedence
+follows Scala 3's intuition: own body defs shadow mixed-in ones, and among parents the later
+one wins (`extends a, b` means b refines a).
+
+Because a trait never describes storage, a `trait` cannot extend a column-carrying
+declaration — that is a compile-time error pointing toward `table`. A `table` extending a
+trait gains its methods; the single-parent forms (`trait ip_address extends string`,
+`type td_trino extends trino`) are unchanged as the one-element case of the same list.

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -62,6 +62,39 @@ from users
 append to users_backup   -- auto-creates users_backup with users' columns if missing
 ```
 
+### Composing Shapes with `extends`
+
+Where `like` copies one declaration exactly, `extends a, b, c` composes partial shapes: each
+parent in the comma-separated list contributes its columns (structural `type` shapes and
+`table` declarations) or its methods (`trait` parents), followed by the declaration's own
+body columns:
+
+```wvlet
+type timestamped = {
+  created_at: timestamp
+  updated_at: timestamp
+}
+
+trait auditable = {
+  def is_recent: boolean = created_at > now() - interval '7 days'
+}
+
+table events extends timestamped, auditable = {
+  id: int
+  label: string
+}
+
+-- events has columns (created_at, updated_at, id, label), and auditable's methods
+from events
+where _.is_recent
+```
+
+Mixed-in columns come before own body columns, in parent-list order. A column arriving
+through two parents with the same type (a diamond) appears once; the same name with
+conflicting types is a compile-time error. `create table` and automatic creation on write
+materialize the full composed shape. `extends` and `like` cannot combine on one declaration —
+`like` is the exact-copy form.
+
 ### Binding a Declaration to a Location
 
 `in <catalog>.<schema>` binds a declaration to the table's location, so references type-check

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
@@ -47,6 +47,39 @@ object FunctionInliner extends ContextLogSupport:
     name
   )
 
+  /**
+    * Find a member of a type, walking its `extends` parents (#2012) when the member is not defined
+    * in the type's own scope. Own defs shadow mixed-in ones, and later parents take precedence
+    * (`extends a, b` means b refines a), so parents are consulted right-to-left, depth-first.
+    * Cycle-guarded by the visited set of type names.
+    */
+  private def findMemberInHierarchy(
+      sym: Symbol,
+      methodName: TermName,
+      visited: Set[Name],
+      context: Context
+  ): Option[SymbolInfo] =
+    val ownMember = sym.symbolInfo.findMember(methodName)
+    if ownMember != Symbol.NoSymbol then
+      Some(ownMember.symbolInfo)
+    else
+      sym.tree match
+        case td: TypeDef =>
+          td.parents
+            .reverseIterator
+            .flatMap { p =>
+              val parentName = Name.typeName(p.leafName)
+              if visited.contains(parentName) then
+                None
+              else
+                lookupType(parentName, context).flatMap { parentSym =>
+                  findMemberInHierarchy(parentSym, methodName, visited + parentName, context)
+                }
+            }
+            .nextOption()
+        case _ =>
+          None
+
   private def flattenSymbolInfos(si: SymbolInfo): List[SymbolInfo] =
     si match
       case MultipleSymbolInfo(s1, s2) =>
@@ -218,8 +251,8 @@ object FunctionInliner extends ContextLogSupport:
         def memberOf(baseType: DataType): Option[MethodSymbolInfo] = lookupType(
           baseType.typeName,
           context
-        ).map { sym =>
-            sym.symbolInfo.findMember(methodName).symbolInfo
+        ).flatMap { sym =>
+            findMemberInHierarchy(sym, methodName, Set(baseType.typeName), context)
           }
           .flatMap { si =>
             if bareMember then

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.lang.compiler.analyzer
 
+import wvlet.lang.api.StatusCode
 import wvlet.lang.compiler.ValSymbolInfo
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Context
@@ -527,22 +528,68 @@ object SymbolLabeler extends Phase("symbol-labeler"):
             Nil
       }
 
-    val columns =
-      likeColumns ++
-        t.elems
-          .collect { case v: FieldDef =>
-            // Resolve simple primitive types earlier.
-            // TODO: DataType.parse(typeName) for complex types, including UnknownTypes
-            val dt = DataType.parse(v.fieldType.fullName, v.params)
-            NamedType(v.name, dt)
-          }
+    // Mixin composition (#2012): each `extends` parent contributes its columns (structural
+    // types and table shapes carry fields; traits carry none — their def members resolve
+    // through the parent symbols at method-lookup time). Forcing a parent's completion here
+    // resolves cross-unit references; a completion already in progress signals an `extends`
+    // cycle, whose columns resolve empty (Symbol.dataType yields UnknownType while completing)
+    val parentTypeSymbols: List[(NameExpr, Symbol)] = t
+      .parents
+      .map(p => p -> registerParentSymbols(p))
+    val mixinColumns: List[NamedType] = parentTypeSymbols.flatMap { (p, psym) =>
+      psym.dataType match
+        case s: SchemaType =>
+          if t.isTrait && s.fields.nonEmpty then
+            throw StatusCode
+              .TYPE_ERROR
+              .newException(
+                s"trait ${typeName.name} cannot extend '${p.leafName}', which declares " +
+                  s"columns: traits carry def members only. Declare stored relations with " +
+                  s"'table ${typeName.name} extends ${p.leafName} = {...}'",
+                ctx.sourceLocationAt(t.span)
+              )
+          s.fields
+        case _ =>
+          Nil
+    }
 
-    // The schema parent is only the extended type (None when the type has no parent); the
+    val ownColumns = t
+      .elems
+      .collect { case v: FieldDef =>
+        // Resolve simple primitive types earlier.
+        // TODO: DataType.parse(typeName) for complex types, including UnknownTypes
+        val dt = DataType.parse(v.fieldType.fullName, v.params)
+        NamedType(v.name, dt)
+      }
+
+    // Compose mixed-in columns before own body columns (mirroring how `like` prepends the
+    // source's columns). A column reappearing with the same type dedupes to its first
+    // occurrence, so diamond mixins are fine; the same name with a conflicting type is an error
+    val columns     = List.newBuilder[NamedType]
+    val seenColumns = collection.mutable.Map.empty[String, NamedType]
+    (mixinColumns ++ likeColumns ++ ownColumns).foreach { c =>
+      seenColumns.get(c.name.name) match
+        case None =>
+          seenColumns += c.name.name -> c
+          columns += c
+        case Some(prev) if prev.dataType == c.dataType =>
+        // same column reached through multiple mixin paths: keep the first occurrence
+        case Some(prev) =>
+          throw StatusCode
+            .TYPE_ERROR
+            .newException(
+              s"Conflicting column types for '${c.name.name}' in ${typeName.name}: " +
+                s"${prev.dataType.typeDescription} and ${c.dataType.typeDescription}",
+              ctx.sourceLocationAt(t.span)
+            )
+    }
+
+    // The schema parent is the first extended type (None when the type has no parent); the
     // owner symbol falls back to the enclosing package
-    val parentTypeSymbol = t.parent.map(registerParentSymbols)
+    val parentTypeSymbol = parentTypeSymbols.headOption.map(_._2)
     val parentTpe        = parentTypeSymbol.map(_.dataType)
     val ownerSymbol      = parentTypeSymbol.getOrElse(ctx.owner)
-    val tpe              = SchemaType(parent = parentTpe, typeName, columns)
+    val tpe              = SchemaType(parent = parentTpe, typeName, columns.result())
     val typeParams       = t.params
 
     trace(s"Completed type symbol ${sym}: ${tpe}")

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TableBindings.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TableBindings.scala
@@ -110,8 +110,11 @@ object TableBindings:
 
   /**
     * The declared columns of a table declaration, following `table <name> like <source>` chains
-    * (#1995) so like-declared tables auto-create with the source's columns. A reference cycle or an
-    * unknown source resolves to no columns (SymbolLabeler reports the error)
+    * (#1995) and `extends` mixin parents (#2012) so declared tables auto-create with the full
+    * composed shape. Mixed-in columns come before own body columns, and a column reached through
+    * multiple mixin paths dedupes to its first occurrence, mirroring SymbolLabeler's composition
+    * rules. A reference cycle or an unknown source resolves to no columns (SymbolLabeler reports
+    * the error)
     */
   private def declaredColumns(td: TypeDef)(using ctx: Context): List[ColumnDef] =
     def loop(current: TypeDef, visited: Set[String]): List[ColumnDef] =
@@ -124,13 +127,16 @@ object TableBindings:
             f.span
           )
         }
-      current.likeSource match
-        case Some(src) if !visited.contains(src.leafName) =>
-          declarationOf(src.leafName)
-            .map(srcTd => loop(srcTd, visited + src.leafName) ++ own)
-            .getOrElse(own)
-        case _ =>
-          own
-    loop(td, Set(td.name.name))
+      val inherited = (current.parents.map(_.leafName) ++ current.likeSource.map(_.leafName))
+        .flatMap { src =>
+          if visited.contains(src) then
+            Nil
+          else
+            declarationOf(src).map(srcTd => loop(srcTd, visited + src)).getOrElse(Nil)
+        }
+      inherited ++ own
+    val composed = loop(td, Set(td.name.name))
+    val seen     = scala.collection.mutable.Set.empty[String]
+    composed.filter(c => seen.add(c.columnName.leafName))
 
 end TableBindings

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -791,7 +791,11 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
             else
               bracket(cl(t.params.map(_.wvExpr)))
           val defContexts = wl(t.defContexts.map(x => wl("in", expr(x.contextType))))
-          val parent      = t.parent.map(p => wl("extends", expr(p)))
+          val parent      =
+            if t.parents.isEmpty then
+              None
+            else
+              Some(wl("extends", cl(t.parents.map(p => expr(p)))))
 
           val sep =
             if t.elems.isEmpty then

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1084,27 +1084,38 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
   /**
     * Parse a side-effect-free table shape declaration:
     * {{{
-    *   table <name> [in <catalog>.<schema>] = { <fields and def members> }
+    *   table <name> [in <catalog>.<schema>] [extends <type>, ...] = { <fields and def members> }
     * }}}
     * The declaration shares the TypeDef machinery (isTableDef = true): the relation type registers
     * in the same namespace as `type` definitions, and `create table <name>` actions read the shape
     * from it. `table` is a soft keyword, matched only at statement head.
     */
   def tableShapeDef(): TypeDef = node {
-    val t      = consume(WvletToken.IDENTIFIER) // the `table` soft keyword
-    val name   = Name.typeName(identifier().leafName)
-    val scopes = context()
+    val t       = consume(WvletToken.IDENTIFIER) // the `table` soft keyword
+    val name    = Name.typeName(identifier().leafName)
+    val scopes  = context()
+    val parents = typeExtends()
     scanner.lookAhead().token match
       case WvletToken.LIKE =>
         // `table <name> like <source>` (#1995): declaration-side shape reuse, so a shape is
-        // written exactly once. The columns resolve from the referenced declaration lazily
+        // written exactly once. The columns resolve from the referenced declaration lazily.
+        // `like` is the exact-copy form; composing partial shapes is what `extends` is for,
+        // so the two cannot combine on one declaration
+        if parents.nonEmpty then
+          throw StatusCode
+            .SYNTAX_ERROR
+            .newException(
+              s"'table ${name.name}' cannot combine 'extends' with 'like': 'like' copies one " +
+                s"declaration exactly; use 'extends' with a body to compose shapes",
+              t.sourceLocation
+            )
         consume(WvletToken.LIKE)
         val source = identifier()
         TypeDef(
           name,
           Nil,
           scopes,
-          None,
+          Nil,
           Nil,
           spanFrom(t),
           isTableDef = true,
@@ -1115,7 +1126,8 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         consume(WvletToken.L_BRACE)
         val elems = typeElems()
         consume(WvletToken.R_BRACE)
-        TypeDef(name, Nil, scopes, None, elems, spanFrom(t), isTableDef = true)
+        TypeDef(name, Nil, scopes, parents, elems, spanFrom(t), isTableDef = true)
+    end match
   }
 
   /**
@@ -1134,15 +1146,6 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
     val tp      = typeParams()
     val scopes  = context()
     val parents = typeExtends()
-    if parents.size > 1 then
-      throw StatusCode
-        .SYNTAX_ERROR
-        .newException(
-          s"extending multiple types is not supported: ${name} extends ${parents
-              .map(_.fullName)
-              .mkString(", ")}",
-          t.sourceLocation
-        )
     scopes
       .find(_.contextType.nameParts.sizeIs > 1)
       .foreach { c =>
@@ -1177,7 +1180,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
             t.sourceLocation
           )
       }
-    TypeDef(name, tp, scopes, parents.headOption, elems, spanFrom(t), isTrait = true)
+    TypeDef(name, tp, scopes, parents, elems, spanFrom(t), isTrait = true)
   }
 
   /** Parse a trailing `if not exists` modifier */
@@ -1543,18 +1546,9 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
         consume(WvletToken.L_BRACE)
         elems = typeElems()
         consume(WvletToken.R_BRACE)
-        if parents.size > 1 then
-          throw StatusCode
-            .SYNTAX_ERROR
-            .newException(
-              s"extending multiple types is not supported: ${name} extends ${parents
-                  .map(_.fullName)
-                  .mkString(", ")}",
-              t.sourceLocation
-            )
       case _ =>
       // no body
-    TypeDef(name, tp, scopes, parents.headOption, elems, spanFrom(t))
+    TypeDef(name, tp, scopes, parents, elems, spanFrom(t))
   }
 
   def typeParams(): List[TypeParameter] =
@@ -1603,7 +1597,7 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
             case WvletToken.COMMA =>
               consume(WvletToken.COMMA)
               nextParent
-            case WvletToken.EQ | WvletToken.EOF =>
+            case WvletToken.EQ | WvletToken.EOF | WvletToken.LIKE =>
             // ok
             case _ =>
               parents += identifier()

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
@@ -66,7 +66,12 @@ case class TypeDef(
     name: TypeName,
     params: List[TypeParameter],
     defContexts: List[DefContext],
-    parent: Option[NameExpr],
+    // The `extends` parent list (#2012). Multiple parents compose mixins: structural
+    // types/tables contribute columns, traits contribute def members. The first parent also
+    // serves as the subtype-chain parent (owner symbol, SchemaType parent), preserving the
+    // single-parent semantics of scalar traits (`trait ip_address extends string`) and dialect
+    // markers (`type duckdb extends db_context`)
+    parents: List[NameExpr],
     elems: List[TypeElem],
     span: Span,
     // true for `table <name> [in ...] = { ... }` table-shape declarations, which share the
@@ -90,6 +95,8 @@ case class TypeDef(
     .collectFirst { case catalog :: schema :: Nil =>
       (catalog, schema)
     }
+
+end TypeDef
 
 // type elements (def or column (field) definition)
 sealed trait TypeElem extends Expression

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -111,6 +111,25 @@ class WvletGeneratorTest extends UniTest:
     print(printed) shouldContain "trait ip_address in duckdb extends string"
   }
 
+  test("should round-trip comma-separated mixin parent lists (#2012)") {
+    val printed = print("""type timestamped = {
+        |  created_at: string
+        |}
+        |trait auditable = {
+        |  def tag: string = sql"'a'"
+        |}
+        |table events extends timestamped, auditable = {
+        |  id: int
+        |}
+        |trait combined extends auditable, string = {
+        |  def tag2: string = sql"'b'"
+        |}""".stripMargin)
+    printed shouldContain "table events extends timestamped, auditable"
+    printed shouldContain "trait combined extends auditable, string"
+    print(printed) shouldContain "table events extends timestamped, auditable"
+    print(printed) shouldContain "trait combined extends auditable, string"
+  }
+
   test("should round-trip a table declaration with an `in` binding") {
     val printed = print("""table events in mydb.analytics = {
         |  id: int

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/TraitDefTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/parser/TraitDefTest.scala
@@ -47,7 +47,7 @@ class TraitDefTest extends UniTest:
     t.isTableDef shouldBe false
     t.name.name shouldBe "ip_address"
     t.defContexts.map(_.contextType.fullName) shouldBe List("duckdb")
-    t.parent.map(_.fullName) shouldBe Some("string")
+    t.parents.map(_.fullName) shouldBe List("string")
   }
 
   test("parse a trait with type parameters") {
@@ -57,6 +57,32 @@ class TraitDefTest extends UniTest:
         |""".stripMargin))
     t.isTrait shouldBe true
     t.params.size shouldBe 1
+  }
+
+  test("parse a comma-separated mixin parent list (#2012)") {
+    val t = firstTypeDef(parse("""trait auditable extends recent, labeled = {
+        |  def tag: string = sql"'a'"
+        |}
+        |""".stripMargin))
+    t.isTrait shouldBe true
+    t.parents.map(_.fullName) shouldBe List("recent", "labeled")
+  }
+
+  test("parse mixin parents on a table declaration (#2012)") {
+    val t = firstTypeDef(parse("""table events extends timestamped, auditable = {
+        |  id: int
+        |}
+        |""".stripMargin))
+    t.isTableDef shouldBe true
+    t.parents.map(_.fullName) shouldBe List("timestamped", "auditable")
+  }
+
+  test("reject combining extends with like on a table declaration") {
+    val e = intercept[WvletLangException] {
+      parse("""table events extends timestamped like users
+          |""".stripMargin)
+    }
+    e.getMessage shouldContain "cannot combine 'extends' with 'like'"
   }
 
   test("reject column fields in a trait body") {


### PR DESCRIPTION
## Summary

Implements #2012 (design posted [on the issue](https://github.com/wvlet/wvlet/issues/2012#issuecomment-5399410650)): declarations compose with a **uniform, comma-separated `extends a, b, c` list** — structural `type` shapes and `table` declarations contribute columns, `trait` parents contribute def members (dialect-scoped variants included). Never Scala 2's mixed `extends A with B`; `with` repetition was rejected because `with key: value` is already the options spelling on `save`/`use`/schema DDL and declarations may want options later.

```wvlet
type timestamped = { created_at: timestamp, updated_at: timestamp }
trait auditable = { def is_recent: boolean = created_at > now() - interval '7 days' }

table events extends timestamped, auditable = {
  id: int
  label: string
}
```

## Semantics

- **Column order**: mixed-in columns before own body columns, in parent-list order (mirroring `like`).
- **Diamonds**: a column reached through two parents with the same type appears once; the same name with conflicting types is a compile-time error.
- **Methods**: own defs shadow mixed-in ones; among parents, later wins (`extends a, b` — b refines a). Member lookup in `FunctionInliner` now walks the declaration's parent chain (depth-first, later-parent-first, cycle-guarded), so mixed-in trait methods resolve on direct scans (#2010/#2011).
- **Trait purity**: a `trait` extending a column-bearing declaration is a compile-time error pointing toward `table` (checked at completion time, since the parent's kind isn't known at parse time across units).
- **`like` stays exact-copy**: `extends` + `like` on one declaration is a syntax error.
- **Single-parent behavior unchanged**: `trait ip_address extends string`, `type duckdb extends db_context` are the one-element case; `SchemaType.parent`/owner still point at the first parent.
- **Write side**: `TableBindings.declaredColumns` follows `extends` parents like `like` chains, so `create table` and append auto-creation materialize the full composed shape.

## Changes

- `TypeDef.parent: Option[NameExpr]` → `parents: List[NameExpr]`
- Parser: lifted the multi-parent rejection in `typeDef()`/`traitDef()`; `tableShapeDef()` now parses `extends` (and rejects combining it with `like`)
- `SymbolLabeler.computeTypeDefSymbolInfo`: registers all parents, composes mixed-in columns with dedupe/conflict rules
- `FunctionInliner.findMemberInHierarchy`: parent-chain member lookup
- `WvletGenerator`: prints the comma-separated parent list
- Docs: mixin sections in `data-models.md` and `table-management.md`

## Tests

- `TraitDefTest`: multi-parent parsing for trait/table, extends+like rejection
- `WvletGeneratorTest`: mixin parent-list round-trip
- `spec/basic/table-mixins.wv`: composed columns + trait method referencing a composing table's column, on a direct scan
- `spec/basic/ddl/table-mixins.wv`: `create table` and append auto-creation with a diamond mixin
- `spec/neg/trait-mixin-columns.wv`: trait extending a columned type errors (verified the TYPE_ERROR fires via CLI)

## Verification

- `runnerJVM/testOnly *RunnerSpec*`: 489 passed
- `langJVM/test` (incl. `*TyperCoverageCheck`, `*RoundTripSpecBasic`): 1045 passed / 2 pending
- `projectJS/Test/compile`, `projectNative/Test/compile`: pass
- E2E via no-profile CLI: `wvlet run -f spec/basic/table-mixins.wv` produces the composed shape and resolves the mixed-in method
- `scalafmtAll` applied

Closes #2012

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8nqE5sPpjr3U18ej2s1kb
