### PR TITLE
feature: Add wvlet catalog diff for schema drift detection

### DIFF
--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -269,6 +269,9 @@ reshape users {
 
 Each operation is retry-safe: `add` is a no-op when the column already exists with that type,
 `exclude` when it is already gone, and `cast` when the column already has the target type.
+When a table declaration and the database schema have drifted apart,
+[`wvlet catalog diff`](../usage/catalog-import.md#detecting-schema-drift) generates a
+ready-to-run `reshape` block for the migration.
 
 ## Renaming Tables and Schemas
 

--- a/website/docs/usage/catalog-import.md
+++ b/website/docs/usage/catalog-import.md
@@ -114,6 +114,42 @@ Committed catalog files behave like a lockfile: the compile-time schema stays de
 even while the database evolves, and queries still execute against the real tables. Schedule
 the import in CI or cron to keep the snapshot fresh.
 
+## Detecting schema drift
+
+`wvlet catalog diff` compares every `table` declaration of your project — imported catalog
+files and hand-written declarations alike — against the connected database, and reports where
+the two have drifted apart. For each drifted table it prints a ready-to-run
+[`reshape`](../syntax/table-management.md) migration block:
+
+```bash
+$ wvlet catalog diff --profile production
+table users has drifted from its declaration. To migrate, run:
+  reshape users {
+    add created_at: timestamp
+    exclude legacy_flag
+    cast user_id as long -- the catalog has int
+  }
+```
+
+- `reshape` operations have *ensure* semantics (`add` is a no-op when the column already
+  exists; `exclude` when it is already gone; `cast` when the column already has the target
+  type), so a generated migration is safe to re-run.
+- A rename cannot be inferred from a diff — it shows up as an `exclude`/`add` pair, which would
+  drop the column's data. When the output contains such a pair, the block includes a hint:
+  replace the pair with a hand-written `rename <old> as <new>` to preserve the data.
+- Column type drift becomes a `cast <column> as <declared type>` operation, with the current
+  catalog type noted in a trailing comment.
+- Declared tables that do not exist in the database are not drift: a declared table
+  materializes automatically on the first write to it.
+
+The command exits with a non-zero status when any drift is found, so it can gate CI:
+
+```yaml
+# GitHub Actions example
+- name: Check schema drift
+  run: wvlet catalog diff --profile production
+```
+
 ## Validating queries in CI
 
 Because the catalog is plain source, query compilation needs no database credentials. Compile

--- a/website/docs/usage/catalog-import.md
+++ b/website/docs/usage/catalog-import.md
@@ -150,6 +150,28 @@ The command exits with a non-zero status when any drift is found, so it can gate
   run: wvlet catalog diff --profile production
 ```
 
+### Applying the migrations
+
+Pass `--apply` to run the generated `reshape` blocks against the database (sqldef /
+`db:migrate` style). The migrations execute through the regular compile-and-run path — exactly
+what pasting the blocks into a script would do — and the command re-diffs afterwards, exiting
+zero only when the catalog now matches the declarations:
+
+```bash
+$ wvlet catalog diff --profile production --apply
+table users has drifted from its declaration. To migrate, run:
+  reshape users {
+    add created_at: timestamp
+    exclude legacy_flag
+  }
+[info] Applied 1 migration(s); the catalog matches the declarations
+```
+
+Review the printed blocks before reaching for `--apply` on a production database: `exclude`
+drops the column *and its data*, and a rename always diffs as an exclude/add pair — apply a
+hand-written `rename <old> as <new>` first when that is what actually happened. A typical
+workflow gates CI with the plain check and runs `--apply` as an explicit deploy step.
+
 ## Validating queries in CI
 
 Because the catalog is plain source, query compilation needs no database credentials. Compile

--- a/wvlet-api/src/main/scala/wvlet/lang/api/StatusCode.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/StatusCode.scala
@@ -59,6 +59,7 @@ enum StatusCode(statusType: StatusType):
   case NOT_A_RELATION                    extends StatusCode(StatusType.UserError)
   case FILE_NOT_FOUND                    extends StatusCode(StatusType.UserError)
   case SCHEMA_ALREADY_EXISTS             extends StatusCode(StatusType.UserError)
+  case SCHEMA_DRIFT_DETECTED             extends StatusCode(StatusType.UserError)
   case TABLE_ALREADY_EXISTS              extends StatusCode(StatusType.UserError)
   case UNAUTHENTICATED                   extends StatusCode(StatusType.UserError)
   case PERMISSION_DENIED                 extends StatusCode(StatusType.UserError)

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCatalogCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCatalogCommand.scala
@@ -59,7 +59,13 @@ case class WvletCatalogDiffOption(
       prefix = "--schema",
       description = "Default schema of unbound table declarations (default: profile schema)"
     )
-    schema: Option[String] = None
+    schema: Option[String] = None,
+    @option(
+      prefix = "--apply",
+      description =
+        "Run the generated reshape migrations against the database (exclude drops columns!)"
+    )
+    apply: Boolean = false
 )
 
 /**
@@ -212,12 +218,46 @@ class WvletCatalogCommand(opts: WvletGlobalOption) extends LogSupport:
         .foreach { drift =>
           println(SchemaDriftDetector.render(drift))
         }
-      if report.hasDrift then
+      if !report.hasDrift then
+        info(s"No schema drift detected (checked ${report.checkedTables} table(s))")
+      else if diffOpts.apply then
+        SchemaDriftChecker.applyMigrations(
+          drifts = report.drifted,
+          sourceFolders = List(diffOpts.workFolder),
+          workEnv = workEnv,
+          connectorProvider = connectorProvider,
+          profile = profile,
+          defaultCatalog = catalogName,
+          defaultSchema = schemaName,
+          dbType = dbType
+        )
+        // Re-diff after applying: a clean result proves the migrations converged the catalog
+        // to the declarations
+        val recheck = SchemaDriftChecker.check(
+          sourceFolders = List(diffOpts.workFolder),
+          workEnv = workEnv,
+          connector = connector,
+          defaultCatalog = catalogName,
+          defaultSchema = schemaName,
+          dbType = dbType
+        )
+        if recheck.hasDrift then
+          throw StatusCode
+            .SCHEMA_DRIFT_DETECTED
+            .newException(
+              s"Schema drift remains in ${recheck
+                  .drifted
+                  .size} table(s) after applying the migrations"
+            )
+        info(s"Applied ${report.drifted.size} migration(s); the catalog matches the declarations")
+      else
         // A non-zero exit code so the check can gate CI
         throw StatusCode
           .SCHEMA_DRIFT_DETECTED
-          .newException(s"Schema drift detected in ${report.drifted.size} table(s)")
-      info(s"No schema drift detected (checked ${report.checkedTables} table(s))")
+          .newException(
+            s"Schema drift detected in ${report.drifted.size} table(s). Run with --apply to migrate"
+          )
+      end if
     }
   }
 

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCatalogCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletCatalogCommand.scala
@@ -17,11 +17,15 @@ import wvlet.uni.cli.launcher.command
 import wvlet.uni.cli.launcher.option
 import wvlet.uni.control.Control
 import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
+import wvlet.lang.catalog.ConnectorConfig
 import wvlet.lang.catalog.Profile
+import wvlet.lang.catalog.SchemaDriftDetector
 import wvlet.lang.catalog.StaticCatalogExporter
 import wvlet.lang.compiler.DBType
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.runner.connector.ConnectorProvider
+import wvlet.lang.runner.SchemaDriftChecker
 import wvlet.uni.log.LogSupport
 
 import java.nio.file.Path
@@ -44,6 +48,20 @@ case class WvletCatalogOption(
     noFunctions: Boolean = false
 )
 
+case class WvletCatalogDiffOption(
+    @option(prefix = "-w", description = "Working folder")
+    workFolder: String = ".",
+    @option(prefix = "--profile", description = "Profile to use")
+    profile: Option[String] = None,
+    @option(prefix = "--catalog", description = "Catalog to check (default: profile catalog)")
+    catalog: Option[String] = None,
+    @option(
+      prefix = "--schema",
+      description = "Default schema of unbound table declarations (default: profile schema)"
+    )
+    schema: Option[String] = None
+)
+
 /**
   * `wvlet catalog` subcommands for importing database table schemas as Wvlet type definitions
   * (#1881), enabling offline query validation
@@ -51,15 +69,22 @@ case class WvletCatalogOption(
 class WvletCatalogCommand(opts: WvletGlobalOption) extends LogSupport:
 
   @command(description = "Show the usage of catalog commands", isDefault = true)
-  def help: Unit = info("Usage: wvlet catalog import [--profile p] [--catalog c] [--schema s]")
+  def help: Unit = info(
+    "Usage: wvlet catalog (import|diff) [--profile p] [--catalog c] [--schema s]"
+  )
 
-  @command(description = "Import database table schemas as Wvlet type definitions")
-  def `import`(catalogOpts: WvletCatalogOption): Unit =
-    val workEnv = WorkEnv(catalogOpts.workFolder)
-    val profile = Profile.getProfile(catalogOpts.profile, catalogOpts.catalog, catalogOpts.schema)
-    val engine  = profile.defaultEngine
-    val catalogName = catalogOpts
-      .catalog
+  private def handleError[U](body: => U): U =
+    try
+      body
+    catch
+      case e: WvletLangException =>
+        error(e.getMessage)
+        if !WvletMain.isInSbt then
+          System.exit(1)
+        throw e
+
+  private def resolveCatalogName(engine: ConnectorConfig, catalogOpt: Option[String]): String =
+    catalogOpt
       .orElse(engine.catalog)
       .getOrElse {
         if engine.dbType == DBType.DuckDB || engine.dbType == DBType.Generic then
@@ -72,6 +97,13 @@ class WvletCatalogCommand(opts: WvletGlobalOption) extends LogSupport:
               s"Specify --catalog or add a catalog to the '${engine.name}' connector in the profile"
             )
       }
+
+  @command(description = "Import database table schemas as Wvlet type definitions")
+  def `import`(catalogOpts: WvletCatalogOption): Unit =
+    val workEnv = WorkEnv(catalogOpts.workFolder)
+    val profile = Profile.getProfile(catalogOpts.profile, catalogOpts.catalog, catalogOpts.schema)
+    val engine  = profile.defaultEngine
+    val catalogName = resolveCatalogName(engine, catalogOpts.catalog)
 
     Control.withResource(ConnectorProvider(workEnv)) { connectorProvider =>
       val connector = connectorProvider.getConnector(profile)
@@ -134,5 +166,59 @@ class WvletCatalogCommand(opts: WvletGlobalOption) extends LogSupport:
         info(s"Imported ${written.size} schema(s) from catalog ${catalogName}")
     }
   end `import`
+
+  @command(description =
+    "Check table declarations against the connected catalog and print reshape migrations on drift"
+  )
+  def diff(diffOpts: WvletCatalogDiffOption): Unit = handleError {
+    val workEnv = WorkEnv(diffOpts.workFolder)
+    // Default to the DuckDB profile like `wvlet run`: the generic profile carries no catalog,
+    // which would leave nothing to diff against
+    val profile = Profile.getProfile(
+      diffOpts.profile,
+      diffOpts.catalog,
+      diffOpts.schema,
+      default = Profile.defaultDuckDBProfile
+    )
+    val engine      = profile.defaultEngine
+    val catalogName = resolveCatalogName(engine, diffOpts.catalog)
+    val schemaName  = diffOpts.schema.orElse(engine.schema).getOrElse("main")
+    // The Generic engine runs on an in-process DuckDB, so types normalize with DuckDB rules
+    val dbType =
+      if engine.dbType == DBType.Generic then
+        DBType.DuckDB
+      else
+        engine.dbType
+
+    Control.withResource(ConnectorProvider(workEnv)) { connectorProvider =>
+      val connector = connectorProvider.getConnector(profile)
+      val report    = SchemaDriftChecker.check(
+        sourceFolders = List(diffOpts.workFolder),
+        workEnv = workEnv,
+        connector = connector,
+        defaultCatalog = catalogName,
+        defaultSchema = schemaName,
+        dbType = dbType
+      )
+      report
+        .missingTables
+        .foreach { table =>
+          info(
+            s"Table ${table} is not in the catalog yet; declared tables materialize on the first write"
+          )
+        }
+      report
+        .drifted
+        .foreach { drift =>
+          println(SchemaDriftDetector.render(drift))
+        }
+      if report.hasDrift then
+        // A non-zero exit code so the check can gate CI
+        throw StatusCode
+          .SCHEMA_DRIFT_DETECTED
+          .newException(s"Schema drift detected in ${report.drifted.size} table(s)")
+      info(s"No schema drift detected (checked ${report.checkedTables} table(s))")
+    }
+  }
 
 end WvletCatalogCommand

--- a/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletCatalogDiffTest.scala
+++ b/wvlet-cli/src/test/scala/wvlet/lang/cli/WvletCatalogDiffTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.cli
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.compiler.SourceIO
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class WvletCatalogDiffTest extends UniTest:
+
+  test("help") {
+    WvletMain.main("catalog diff --help")
+  }
+
+  test("exit successfully when no declared table exists in the catalog yet") {
+    Files.createDirectories(Path.of("target"))
+    val projectDir = Files.createTempDirectory(Path.of("target"), "catalog-diff").toString
+    SourceIO.writeString(
+      s"${projectDir}/tables.wv",
+      """table users = {
+        |  id: int
+        |  name: string
+        |}
+        |""".stripMargin
+    )
+    // The default profile connects to a fresh in-memory DuckDB: the declared table is not
+    // created yet, which is not drift (it materializes on the first write)
+    WvletMain.main(s"catalog diff -w ${projectDir}")
+  }
+
+end WvletCatalogDiffTest

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/SchemaDriftDetector.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/SchemaDriftDetector.scala
@@ -122,8 +122,12 @@ object SchemaDriftDetector:
       case _ =>
         StaticCatalogExporter.quote(name)
 
-  /** Render one table's drift as a message with a ready-to-paste `reshape` migration block */
-  def render(drift: TableDrift): String =
+  /**
+    * The runnable `reshape` statement of a drift, without the surrounding message. Comment lines
+    * (the previous type of a `cast`, the rename hint) are part of the statement text and parse as
+    * trivia, so the source can be executed as-is
+    */
+  def migrationSource(drift: TableDrift): String =
     val quote = StaticCatalogExporter.quote
     val ops   = List.newBuilder[String]
     drift
@@ -150,12 +154,16 @@ object SchemaDriftDetector:
     if drift.addColumns.nonEmpty && drift.excludeColumns.nonEmpty then
       ops +=
         "-- If an exclude/add pair is actually a rename, use `rename <old> as <new>` instead to preserve data"
-    val body = ops.result().map(op => s"    ${op}").mkString("\n")
-    s"""table ${drift.tableName} has drifted from its declaration. To migrate, run:
-       |  reshape ${drift.tableName} {
+    val body = ops.result().map(op => s"  ${op}").mkString("\n")
+    s"""reshape ${drift.tableName} {
        |${body}
-       |  }""".stripMargin
+       |}""".stripMargin
 
-  end render
+  end migrationSource
+
+  /** Render one table's drift as a message with a ready-to-paste `reshape` migration block */
+  def render(drift: TableDrift): String =
+    val block = migrationSource(drift).linesIterator.map(line => s"  ${line}").mkString("\n")
+    s"table ${drift.tableName} has drifted from its declaration. To migrate, run:\n${block}"
 
 end SchemaDriftDetector

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/SchemaDriftDetector.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/SchemaDriftDetector.scala
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.catalog
+
+import wvlet.lang.compiler.DBType
+import wvlet.lang.model.DataType
+
+/**
+  * Diffs a `table` shape declaration against the actual table schema of a connected catalog and
+  * renders the drift as a ready-to-run `reshape` migration block (#1994). All emitted `reshape` ops
+  * (`add`, `exclude`, `cast`) have ensure semantics, so a generated block is retry-safe.
+  */
+object SchemaDriftDetector:
+
+  /** A column whose declared type differs from the type reported by the catalog */
+  case class TypeChange(column: String, declaredType: DataType, actualType: DataType)
+
+  /**
+    * The drift of one table: the declared columns missing from the catalog (to `add`), the catalog
+    * columns absent from the declaration (to `exclude`), and columns whose types differ (to `cast`)
+    *
+    * @param tableName
+    *   the reshape target name, as it should appear in the generated migration
+    */
+  case class TableDrift(
+      tableName: String,
+      addColumns: List[(String, DataType)],
+      excludeColumns: List[String],
+      typeChanges: List[TypeChange]
+  ):
+    def hasDrift: Boolean = addColumns.nonEmpty || excludeColumns.nonEmpty || typeChanges.nonEmpty
+
+  /**
+    * Diff the declared columns against the actual catalog columns. Column names match
+    * case-insensitively, following SQL identifier semantics; column order is not compared, as
+    * reshape ops cannot reorder columns
+    */
+  def diff(
+      tableName: String,
+      declared: Seq[(String, DataType)],
+      actual: Seq[Catalog.TableColumn],
+      dbType: DBType
+  ): TableDrift =
+    def norm(name: String): String = name.toLowerCase
+    val actualByName               = actual.map(c => norm(c.name) -> c).toMap
+    val declaredNames              = declared.map(c => norm(c._1)).toSet
+
+    val addColumns     = declared.filterNot(c => actualByName.contains(norm(c._1))).toList
+    val excludeColumns =
+      actual
+        .collect {
+          case c if !declaredNames.contains(norm(c.name)) =>
+            c.name
+        }
+        .toList
+    val typeChanges =
+      declared
+        .flatMap { case (name, declaredType) =>
+          actualByName
+            .get(norm(name))
+            .collect {
+              case c if !typesMatch(declaredType, c.dataType, dbType) =>
+                TypeChange(name, declaredType, c.dataType)
+            }
+        }
+        .toList
+    TableDrift(tableName, addColumns, excludeColumns, typeChanges)
+
+  end diff
+
+  /**
+    * True when a declared column type and the type reported by the catalog denote the same storage
+    * type. Declared and catalog types both parse through DataTypeParser, but engines widen some
+    * types on `create table` (e.g. DuckDB stores an `int` column as BIGINT and reports it back as
+    * such), so types also match when they map to the same SQL type for the target engine — the same
+    * normalization writes use to materialize declared tables. A declared `any` (the catalog-import
+    * fallback for types outside the Wvlet grammar) matches any catalog type
+    */
+  def typesMatch(declared: DataType, actual: DataType, dbType: DBType): Boolean =
+    declared == DataType.AnyType || declared.wvExpr.equalsIgnoreCase(actual.wvExpr) || (
+      DataType.toSQLType(declared, dbType).equalsIgnoreCase(DataType.toSQLType(actual, dbType)) &&
+        declared.typeParams.size == actual.typeParams.size &&
+        declared
+          .typeParams
+          .zip(actual.typeParams)
+          .forall { case (d, a) =>
+            typesMatch(d, a, dbType)
+          }
+    )
+
+  /**
+    * The reshape target name of a declaration: the bare declared name when the declaration is
+    * unbound or bound to the context catalog/schema, and the fully qualified
+    * `<catalog>.<schema>.<name>` otherwise, so the generated block runs against the right location
+    * without depending on the session search path
+    */
+  def reshapeTarget(
+      name: String,
+      binding: Option[(String, String)],
+      defaultCatalog: String,
+      defaultSchema: String
+  ): String =
+    binding match
+      case Some((catalog, schema))
+          if !(
+            catalog.equalsIgnoreCase(defaultCatalog) && schema.equalsIgnoreCase(defaultSchema)
+          ) =>
+        s"${StaticCatalogExporter.quote(catalog)}.${StaticCatalogExporter.quote(
+            schema
+          )}.${StaticCatalogExporter.quote(name)}"
+      case _ =>
+        StaticCatalogExporter.quote(name)
+
+  /** Render one table's drift as a message with a ready-to-paste `reshape` migration block */
+  def render(drift: TableDrift): String =
+    val quote = StaticCatalogExporter.quote
+    val ops   = List.newBuilder[String]
+    drift
+      .addColumns
+      .foreach { case (name, tpe) =>
+        ops += s"add ${quote(name)}: ${tpe.wvExpr}"
+      }
+    drift
+      .excludeColumns
+      .foreach { name =>
+        ops += s"exclude ${quote(name)}"
+      }
+    drift
+      .typeChanges
+      .foreach { tc =>
+        // The previous type in a trailing comment, so a reviewer sees what the cast changes
+        ops +=
+          s"cast ${quote(tc.column)} as ${tc.declaredType.wvExpr} -- the catalog has ${tc
+              .actualType
+              .wvExpr}"
+      }
+    // Renames cannot be inferred from a diff: they appear as an exclude/add pair, which would
+    // drop the column data. Hint at the hand-written alternative
+    if drift.addColumns.nonEmpty && drift.excludeColumns.nonEmpty then
+      ops +=
+        "-- If an exclude/add pair is actually a rename, use `rename <old> as <new>` instead to preserve data"
+    val body = ops.result().map(op => s"    ${op}").mkString("\n")
+    s"""table ${drift.tableName} has drifted from its declaration. To migrate, run:
+       |  reshape ${drift.tableName} {
+       |${body}
+       |  }""".stripMargin
+
+  end render
+
+end SchemaDriftDetector

--- a/wvlet-lang/src/main/scala/wvlet/lang/catalog/StaticCatalogExporter.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/catalog/StaticCatalogExporter.scala
@@ -334,7 +334,8 @@ object StaticCatalogExporter extends LogSupport:
   private def isPlainIdentifier(name: String): Boolean =
     identifierPattern.matches(name) && !keywords.contains(name.toLowerCase)
 
-  private def quote(name: String): String =
+  /** Backquote a name when it does not parse as a plain identifier (shared with the drift check) */
+  private[catalog] def quote(name: String): String =
     if isPlainIdentifier(name) then
       name
     else

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TableBindings.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TableBindings.scala
@@ -114,16 +114,19 @@ object TableBindings:
     * composed shape. Mixed-in columns come before own body columns, and a column reached through
     * multiple mixin paths dedupes to its first occurrence, mirroring SymbolLabeler's composition
     * rules. A reference cycle or an unknown source resolves to no columns (SymbolLabeler reports
-    * the error)
+    * the error). Also used by the schema drift check (#1994) so drift is computed against the same
+    * columns writes materialize
     */
-  private def declaredColumns(td: TypeDef)(using ctx: Context): List[ColumnDef] =
+  def declaredColumns(td: TypeDef)(using ctx: Context): List[ColumnDef] =
     def loop(current: TypeDef, visited: Set[String]): List[ColumnDef] =
       val own = current
         .elems
         .collect { case f: FieldDef =>
           ColumnDef(
             UnquotedIdentifier(f.name.name, f.span),
-            DataTypeParser.parse(f.fieldType.fullName),
+            // Field types carry their parameters separately (e.g. decimal[10,2] parses as
+            // fieldType decimal + params [10, 2]), so pass both to keep parameterized types
+            DataTypeParser.parse(f.fieldType.fullName, f.params),
             f.span
           )
         }

--- a/wvlet-lang/src/test/scala/wvlet/lang/catalog/SchemaDriftDetectorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/catalog/SchemaDriftDetectorTest.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.catalog
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.catalog.Catalog.TableColumn
+import wvlet.lang.compiler.DBType
+import wvlet.lang.model.DataType
+
+class SchemaDriftDetectorTest extends UniTest:
+
+  private def declared(cols: (String, String)*): Seq[(String, DataType)] = cols.map {
+    case (name, tpe) =>
+      name -> DataType.parse(tpe)
+  }
+
+  private def actual(cols: (String, String)*): Seq[TableColumn] = cols.map { case (name, tpe) =>
+    TableColumn(name, DataType.parse(tpe))
+  }
+
+  private def diff(d: Seq[(String, DataType)], a: Seq[TableColumn]) = SchemaDriftDetector.diff(
+    "users",
+    d,
+    a,
+    DBType.DuckDB
+  )
+
+  test("report no drift when the declaration matches the catalog") {
+    val drift = diff(
+      declared("id" -> "int", "name"    -> "string"),
+      actual("id"   -> "bigint", "name" -> "varchar")
+    )
+    drift.hasDrift shouldBe false
+  }
+
+  test("normalize engine-widened types when comparing") {
+    // Writes materialize int as bigint and string as varchar; declared any matches any type
+    val drift = diff(
+      declared("a" -> "long", "b"   -> "string", "c"  -> "integer[]", "d" -> "any"),
+      actual("a"   -> "bigint", "b" -> "varchar", "c" -> "bigint[]", "d"  -> "json")
+    )
+    drift.hasDrift shouldBe false
+  }
+
+  test("match column names case-insensitively") {
+    val drift = diff(declared("User_ID" -> "int"), actual("user_id" -> "bigint"))
+    drift.hasDrift shouldBe false
+  }
+
+  test("detect added and removed columns") {
+    val drift = diff(
+      declared("id" -> "int", "created_at"     -> "timestamp"),
+      actual("id"   -> "bigint", "legacy_flag" -> "boolean")
+    )
+    drift.hasDrift shouldBe true
+    drift.addColumns.map(_._1) shouldBe List("created_at")
+    drift.excludeColumns shouldBe List("legacy_flag")
+    val rendered = SchemaDriftDetector.render(drift)
+    rendered shouldContain "table users has drifted from its declaration. To migrate, run:"
+    rendered shouldContain "reshape users {"
+    rendered shouldContain "add created_at: timestamp"
+    rendered shouldContain "exclude legacy_flag"
+    // A paired exclude/add may actually be a rename, which a diff cannot infer
+    rendered shouldContain "rename <old> as <new>"
+  }
+
+  test("skip the rename hint when no exclude/add pair exists") {
+    val drift = diff(declared("id" -> "int", "created_at" -> "timestamp"), actual("id" -> "bigint"))
+    val rendered = SchemaDriftDetector.render(drift)
+    rendered shouldContain "add created_at: timestamp"
+    rendered shouldNotContain "rename"
+  }
+
+  test("report type changes as cast operations inside the reshape block") {
+    val drift = diff(
+      declared("id" -> "int", "status"    -> "string", "extra" -> "int"),
+      actual("id"   -> "bigint", "status" -> "double")
+    )
+    drift.typeChanges.map(_.column) shouldBe List("status")
+    val rendered = SchemaDriftDetector.render(drift)
+    rendered shouldContain "add extra: int"
+    rendered shouldContain "cast status as string -- the catalog has double"
+  }
+
+  test("render type-only drift as a reshape block with cast operations") {
+    val drift = diff(declared("id" -> "string"), actual("id" -> "bigint"))
+    drift.hasDrift shouldBe true
+    val rendered = SchemaDriftDetector.render(drift)
+    rendered shouldContain "table users has drifted from its declaration. To migrate, run:"
+    rendered shouldContain "reshape users {"
+    rendered shouldContain "cast id as string -- the catalog has long"
+  }
+
+  test("detect precision changes of parameterized types") {
+    val drift = diff(declared("price" -> "decimal(10,2)"), actual("price" -> "decimal(12,2)"))
+    drift.typeChanges.map(_.column) shouldBe List("price")
+  }
+
+  test("backquote column names that need quoting") {
+    val drift = diff(declared("count" -> "int"), actual())
+    SchemaDriftDetector.render(drift) shouldContain "add `count`: int"
+  }
+
+  test("qualify the reshape target only when bound outside the context catalog/schema") {
+    SchemaDriftDetector.reshapeTarget("users", None, "memory", "main") shouldBe "users"
+    SchemaDriftDetector.reshapeTarget("users", Some(("memory", "Main")), "memory", "main") shouldBe
+      "users"
+    SchemaDriftDetector.reshapeTarget("users", Some(("mydb", "sales")), "memory", "main") shouldBe
+      "mydb.sales.users"
+  }
+
+end SchemaDriftDetectorTest

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/SchemaDriftChecker.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/SchemaDriftChecker.scala
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.catalog.SchemaDriftDetector
+import wvlet.lang.catalog.SchemaDriftDetector.TableDrift
+import wvlet.lang.compiler.analyzer.SymbolLabeler
+import wvlet.lang.compiler.analyzer.TableBindings
+import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.compiler.transform.PreprocessLocalExpr
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.connector.DBConnector
+import wvlet.lang.model.plan.PackageDef
+import wvlet.lang.model.plan.TypeDef
+import wvlet.uni.log.LogSupport
+
+/**
+  * The result of a schema drift check (#1994)
+  *
+  * @param checkedTables
+  *   number of declared tables that exist in the connected catalog and were diffed
+  * @param missingTables
+  *   declared tables absent from the catalog. Not drift: declared tables materialize automatically
+  *   on the first write
+  * @param drifted
+  *   tables whose catalog schema differs from the declaration
+  */
+case class SchemaDriftReport(
+    checkedTables: Int,
+    missingTables: List[String],
+    drifted: List[TableDrift]
+):
+  def hasDrift: Boolean = drifted.nonEmpty
+
+/**
+  * Diffs the `table` shape declarations of a project against the connected catalog (#1994). The
+  * catalog is always scanned directly through the connector (never through the ConnectorCatalog
+  * metadata cache), so the check reflects the current table schemas
+  */
+object SchemaDriftChecker extends LogSupport:
+
+  /**
+    * Check every table declaration under the given source folders against the connected catalog.
+    * Declarations without an `in <catalog>.<schema>` binding are checked against the given default
+    * catalog/schema, mirroring how a bare table reference resolves
+    */
+  def check(
+      sourceFolders: List[String],
+      workEnv: WorkEnv,
+      connector: DBConnector,
+      defaultCatalog: String,
+      defaultSchema: String,
+      dbType: DBType
+  ): SchemaDriftReport =
+    // Declarations are syntactic, so full typing (which would need catalog metadata for query
+    // statements) is unnecessary: parse and label symbols so `table x like y` chains resolve
+    val compiler = Compiler(
+      CompilerOptions(
+        sourceFolders = sourceFolders,
+        workEnv = workEnv,
+        catalog = Some(defaultCatalog),
+        schema = Some(defaultSchema),
+        dbType = dbType
+      ),
+      phases = List(List(ParserPhase, PreprocessLocalExpr, SymbolLabeler))
+    )
+    val compileResult = compiler.compile()
+
+    var checkedTables = 0
+    val missingTables = List.newBuilder[String]
+    val drifted       = List.newBuilder[TableDrift]
+
+    compiler
+      .localCompilationUnits
+      .foreach { unit =>
+        given ctx: Context = compileResult.context.withCompilationUnit(unit)
+        val tableDecls     =
+          unit.unresolvedPlan match
+            case p: PackageDef =>
+              // The legacy `type <name> in <catalog>.<schema>` form also declares a table shape
+              // and resolves reads/writes (TableBindings), so it is checked as well
+              p.statements
+                .collect {
+                  case td: TypeDef if !td.isTrait && (td.isTableDef || td.tableBinding.isDefined) =>
+                    td
+                }
+            case _ =>
+              Nil
+        tableDecls.foreach { td =>
+          val declared = TableBindings
+            .declaredColumns(td)
+            .map(c => c.columnName.leafName -> c.columnType)
+          if declared.nonEmpty then
+            val (catalogName, schemaName) = td
+              .tableBinding
+              .getOrElse((defaultCatalog, defaultSchema))
+            val tableName = td.name.name
+            connector.getTableDef(catalogName, schemaName, tableName) match
+              case None =>
+                missingTables += s"${catalogName}.${schemaName}.${tableName}"
+              case Some(actual) =>
+                checkedTables += 1
+                val target = SchemaDriftDetector.reshapeTarget(
+                  tableName,
+                  td.tableBinding,
+                  defaultCatalog,
+                  defaultSchema
+                )
+                val drift = SchemaDriftDetector.diff(target, declared, actual.columns, dbType)
+                if drift.hasDrift then
+                  drifted += drift
+        }
+      }
+    SchemaDriftReport(checkedTables, missingTables.result(), drifted.result())
+  end check
+
+end SchemaDriftChecker

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/SchemaDriftChecker.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/SchemaDriftChecker.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.lang.runner
 
+import wvlet.lang.catalog.Profile
 import wvlet.lang.catalog.SchemaDriftDetector
 import wvlet.lang.catalog.SchemaDriftDetector.TableDrift
 import wvlet.lang.compiler.analyzer.SymbolLabeler
@@ -24,9 +25,12 @@ import wvlet.lang.compiler.CompilerOptions
 import wvlet.lang.compiler.Context
 import wvlet.lang.compiler.DBType
 import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.connector.DBConnector
 import wvlet.lang.model.plan.PackageDef
 import wvlet.lang.model.plan.TypeDef
+import wvlet.lang.runner.connector.ConnectorProvider
+import wvlet.uni.control.Control
 import wvlet.uni.log.LogSupport
 
 /**
@@ -128,5 +132,44 @@ object SchemaDriftChecker extends LogSupport:
       }
     SchemaDriftReport(checkedTables, missingTables.result(), drifted.result())
   end check
+
+  /**
+    * Execute the generated `reshape` migrations of the given drifts against the connected catalog
+    * (`--apply`, sqldef/`db:migrate` style). The migrations run through the regular compile-and-
+    * execute path — exactly what pasting the generated blocks into a script would do — with the
+    * project's declarations in scope. Note that `exclude` drops columns (and their data); callers
+    * should surface the generated blocks before applying
+    */
+  def applyMigrations(
+      drifts: List[TableDrift],
+      sourceFolders: List[String],
+      workEnv: WorkEnv,
+      connectorProvider: ConnectorProvider,
+      profile: Profile,
+      defaultCatalog: String,
+      defaultSchema: String,
+      dbType: DBType
+  ): Unit =
+    if drifts.nonEmpty then
+      val compiler = Compiler(
+        CompilerOptions(
+          sourceFolders = sourceFolders,
+          workEnv = workEnv,
+          catalog = Some(defaultCatalog),
+          schema = Some(defaultSchema),
+          dbType = dbType
+        )
+      )
+      val connector = connectorProvider.getConnector(profile)
+      compiler.setDefaultCatalog(connector.getCatalog(defaultCatalog, defaultSchema))
+      compiler.setDefaultSchema(defaultSchema)
+
+      val source = drifts.map(SchemaDriftDetector.migrationSource).mkString("\n")
+      val unit   = CompilationUnit.fromWvletString(source)
+      val result = compiler.compileSingleUnit(unit)
+      result.reportAllErrors
+      Control.withResource(QueryExecutor(connectorProvider, profile, workEnv)) { executor =>
+        executor.executeSingle(unit, result.context)
+      }
 
 end SchemaDriftChecker

--- a/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/SchemaDriftCheckerTest.scala
+++ b/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/SchemaDriftCheckerTest.scala
@@ -14,6 +14,7 @@
 package wvlet.lang.runner
 
 import wvlet.uni.test.UniTest
+import wvlet.lang.catalog.Profile
 import wvlet.lang.catalog.SchemaDriftDetector
 import wvlet.lang.catalog.StaticCatalogExporter
 import wvlet.lang.compiler.parser.ParserPhase
@@ -181,6 +182,70 @@ class SchemaDriftCheckerTest extends UniTest:
       drifted.drifted.map(_.tableName) shouldBe List("memory.sales.customers")
       drifted.drifted.head.excludeColumns shouldBe List("vip")
     }
+  }
+
+  test("apply generated migrations and converge the catalog to the declarations") {
+    import wvlet.lang.runner.connector.ConnectorProvider
+    val workEnv  = WorkEnv()
+    val provider = ConnectorProvider(workEnv)
+    val profile  = Profile.defaultDuckDBProfile
+    Files.createDirectories(Path.of("target"))
+    val projectDir = Files.createTempDirectory(Path.of("target"), "schema-drift-apply").toString
+    try
+      // The provider caches the profile's connector: the checker, the migration executor, and
+      // this test all see the same in-memory DuckDB
+      val duckdb = provider.getConnector(profile)
+      duckdb.executeUpdate(
+        "create table users (user_id bigint, name varchar, status bigint, legacy_flag boolean)"
+      )
+      duckdb.executeUpdate("insert into users values (1, 'alice', 3, true)")
+      SourceIO.writeString(
+        s"${projectDir}/tables.wv",
+        """table users = {
+          |  user_id: int
+          |  name: string
+          |  status: string
+          |  created_at: timestamp
+          |}
+          |""".stripMargin
+      )
+      def runCheck(): SchemaDriftReport = SchemaDriftChecker.check(
+        sourceFolders = List(projectDir),
+        workEnv = WorkEnv(projectDir),
+        connector = duckdb,
+        defaultCatalog = "memory",
+        defaultSchema = "main",
+        dbType = DBType.DuckDB
+      )
+      val report = runCheck()
+      report.hasDrift shouldBe true
+
+      SchemaDriftChecker.applyMigrations(
+        drifts = report.drifted,
+        sourceFolders = List(projectDir),
+        workEnv = WorkEnv(projectDir),
+        connectorProvider = provider,
+        profile = profile,
+        defaultCatalog = "memory",
+        defaultSchema = "main",
+        dbType = DBType.DuckDB
+      )
+
+      // The catalog now matches the declarations, and re-applying would be a no-op
+      runCheck().hasDrift shouldBe false
+
+      // Existing rows survive the migration: add/cast preserve data, exclude drops its column
+      val migrated = duckdb.getTableDef("memory", "main", "users").get
+      migrated.columns.map(_.name) shouldBe List("user_id", "name", "status", "created_at")
+      duckdb.runQuery("select user_id, name, status from users") { rs =>
+        rs.next() shouldBe true
+        rs.getLong("user_id") shouldBe 1L
+        rs.getString("name") shouldBe "alice"
+        rs.getString("status") shouldBe "3"
+      }
+    finally
+      provider.close()
+    end try
   }
 
 end SchemaDriftCheckerTest

--- a/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/SchemaDriftCheckerTest.scala
+++ b/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/SchemaDriftCheckerTest.scala
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.catalog.SchemaDriftDetector
+import wvlet.lang.catalog.StaticCatalogExporter
+import wvlet.lang.compiler.parser.ParserPhase
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.SourceIO
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.connector.duckdb.DuckDBConnector
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+  * End-to-end check of `wvlet catalog diff` (#1994): diff table declarations of a project against a
+  * live DuckDB catalog and generate reshape migration blocks
+  */
+class SchemaDriftCheckerTest extends UniTest:
+
+  private def withDuckDB(testBody: (DuckDBConnector, String) => Unit): Unit =
+    val duckdb = DuckDBConnector(WorkEnv())
+    Files.createDirectories(Path.of("target"))
+    val projectDir = Files.createTempDirectory(Path.of("target"), "schema-drift").toString
+    try testBody(duckdb, projectDir)
+    finally duckdb.close()
+
+  private def check(duckdb: DuckDBConnector, projectDir: String): SchemaDriftReport =
+    SchemaDriftChecker.check(
+      sourceFolders = List(projectDir),
+      workEnv = WorkEnv(projectDir),
+      connector = duckdb,
+      defaultCatalog = "memory",
+      defaultSchema = "main",
+      dbType = DBType.DuckDB
+    )
+
+  test("detect drift and generate a reshape migration block") {
+    withDuckDB { (duckdb, projectDir) =>
+      duckdb.executeUpdate("create schema if not exists sales")
+      duckdb.executeUpdate(
+        "create table sales.users (user_id bigint, name varchar, status bigint, legacy_flag boolean)"
+      )
+      SourceIO.writeString(
+        s"${projectDir}/tables.wv",
+        """table users in memory.sales = {
+          |  user_id: int
+          |  name: string
+          |  status: string
+          |  created_at: timestamp
+          |}
+          |""".stripMargin
+      )
+      val report = check(duckdb, projectDir)
+      report.checkedTables shouldBe 1
+      report.hasDrift shouldBe true
+      report.drifted.size shouldBe 1
+
+      val drift = report.drifted.head
+      drift.addColumns.map(_._1) shouldBe List("created_at")
+      drift.excludeColumns shouldBe List("legacy_flag")
+      drift.typeChanges.map(_.column) shouldBe List("status")
+
+      val rendered = SchemaDriftDetector.render(drift)
+      rendered shouldContain "table memory.sales.users has drifted from its declaration"
+      rendered shouldContain "reshape memory.sales.users {"
+      rendered shouldContain "add created_at: timestamp"
+      rendered shouldContain "exclude legacy_flag"
+      rendered shouldContain "cast status as string -- the catalog has long"
+      rendered shouldContain "rename <old> as <new>"
+
+      // The generated block is ready to paste: the reshape statement (including the comment
+      // lines) must parse as-is
+      val migration = rendered
+        .linesIterator
+        .toList
+        .dropWhile(line => !line.trim.startsWith("reshape"))
+        .mkString("", "\n", "\n")
+      ParserPhase.parseOnly(CompilationUnit.fromWvletString(migration))
+    }
+  }
+
+  test("declared tables absent from the catalog are missing, not drifted") {
+    withDuckDB { (duckdb, projectDir) =>
+      SourceIO.writeString(
+        s"${projectDir}/tables.wv",
+        """table not_created_yet = {
+          |  id: int
+          |}
+          |""".stripMargin
+      )
+      val report = check(duckdb, projectDir)
+      report.hasDrift shouldBe false
+      report.checkedTables shouldBe 0
+      report.missingTables shouldBe List("memory.main.not_created_yet")
+    }
+  }
+
+  test("check unbound declarations against the default catalog and schema") {
+    withDuckDB { (duckdb, projectDir) =>
+      duckdb.executeUpdate("create table events (id bigint, extra varchar)")
+      SourceIO.writeString(
+        s"${projectDir}/tables.wv",
+        """table events = {
+          |  id: int
+          |}
+          |""".stripMargin
+      )
+      val report = check(duckdb, projectDir)
+      report.drifted.size shouldBe 1
+      val rendered = SchemaDriftDetector.render(report.drifted.head)
+      // Bound to the context catalog/schema: the bare name is enough
+      rendered shouldContain "reshape events {"
+      rendered shouldContain "exclude extra"
+      rendered shouldNotContain "add"
+    }
+  }
+
+  test("follow table like chains when diffing") {
+    withDuckDB { (duckdb, projectDir) =>
+      duckdb.executeUpdate("create table users_archive (user_id bigint)")
+      SourceIO.writeString(
+        s"${projectDir}/tables.wv",
+        """table users = {
+          |  user_id: int
+          |  name: string
+          |}
+          |
+          |table users_archive like users
+          |""".stripMargin
+      )
+      val report = check(duckdb, projectDir)
+      // users is missing; users_archive inherits the declared columns of users and drifts
+      report.missingTables shouldBe List("memory.main.users")
+      report.drifted.map(_.tableName) shouldBe List("users_archive")
+      report.drifted.head.addColumns.map(_._1) shouldBe List("name")
+    }
+  }
+
+  test("a freshly imported catalog diffs clean") {
+    withDuckDB { (duckdb, projectDir) =>
+      duckdb.executeUpdate("create schema if not exists sales")
+      duckdb.executeUpdate("""create table sales.orders (
+          |  order_id bigint,
+          |  status varchar,
+          |  price decimal(10,2),
+          |  created_at timestamp,
+          |  tags varchar[]
+          |)""".stripMargin)
+      duckdb.executeUpdate("create table sales.customers (customer_id bigint, name varchar)")
+
+      // Import the catalog as `wvlet catalog import` does, then diff: the round-trip must be clean
+      StaticCatalogExporter.exportSchemas(
+        "memory",
+        List("sales"),
+        schema => duckdb.listTableDefs("memory", schema),
+        s"${projectDir}/catalog"
+      )
+      val report = check(duckdb, projectDir)
+      report.checkedTables shouldBe 2
+      report.hasDrift shouldBe false
+
+      // The check reads the catalog fresh: schema changes after the import are drift
+      duckdb.executeUpdate("alter table sales.customers add column vip boolean")
+      val drifted = check(duckdb, projectDir)
+      drifted.hasDrift shouldBe true
+      drifted.drifted.map(_.tableName) shouldBe List("memory.sales.customers")
+      drifted.drifted.head.excludeColumns shouldBe List("vip")
+    }
+  }
+
+end SchemaDriftCheckerTest


### PR DESCRIPTION
## Summary

Implements the schema drift check proposed in #1994: `wvlet catalog diff` compares every `table` declaration of a project against the connected catalog and, for each drifted table, prints a ready-to-run `reshape` migration block (sqldef dry-run style), exiting non-zero so the check can gate CI. `--apply` runs the generated migrations (sqldef/`db:migrate` style) and re-diffs to verify convergence.

```
$ wvlet catalog diff --profile production
table users has drifted from its declaration. To migrate, run:
  reshape users {
    add created_at: timestamp
    exclude legacy_flag
    cast user_id as long -- the catalog has int
  }
```

## What's included

- **`SchemaDriftDetector`** (wvlet-lang, cross-platform): pure column diff + `reshape` block rendering. All emitted ops (`add`, `exclude`, `cast`) have ensure semantics, so generated migrations are retry-safe. Type drift is emitted as `cast <column> as <declared type>` (using the op merged in #2013), with the current catalog type in a trailing comment. Since renames cannot be inferred (they diff as exclude+add), a paired exclude/add adds a hint to use a hand-written `rename <old> as <new>` to preserve data.
- **`SchemaDriftChecker`** (wvlet-runner, JVM): compiles the project's units (parse + symbol labeling only, so no live catalog is needed for typing), collects `table` declarations — including imported `catalog/` files, the legacy `type t in c.s` form, `table x like y` chains, and `extends` mixin parents (#2015) — and diffs each against a **fresh** connector scan, never the ConnectorCatalog metadata cache. Declared tables absent from the database are reported as *missing*, not drift (they materialize on the first write).
- **`wvlet catalog diff` CLI command** next to `catalog import`, sharing its profile/connector wiring; defaults to the DuckDB profile like `wvlet run`. Exits non-zero via a new `SCHEMA_DRIFT_DETECTED` status code on drift.
- **`--apply`**: executes the generated blocks through the regular compile-and-run path (exactly what pasting them into a script would do), then re-diffs and exits zero only when the catalog now matches the declarations. The plain check remains the CI gate; apply is the explicit deploy step, with the destructive nature of `exclude` called out in the option help and docs.
- **Type normalization**: declared vs catalog types compare through the same engine mapping writes use to materialize columns (`int`/`long` → `bigint`, `string` → `varchar`, recursively through type parameters), so a freshly imported catalog always diffs clean — covered by a round-trip test.
- **Fix in `TableBindings.declaredColumns`**: field type parameters (`decimal[10,2]`, `array[string]`) were dropped when extracting declared columns; they now flow through `DataTypeParser.parse(name, params)`.
- **Docs**: new "Detecting schema drift" section in `catalog-import.md` (CI gating + `--apply` workflow) and a pointer from the `reshape` section of `table-management.md`.

## Tests

- `SchemaDriftDetectorTest` (wvlet-lang): diff semantics, type normalization, cast emission, rename hint, quoting, target qualification.
- `SchemaDriftCheckerTest` (wvlet-runner): end-to-end against embedded DuckDB — drift detection, generated block parses as-is (ready-to-paste guarantee), missing tables, unbound declarations, `like` chains, the import→diff clean round-trip including drift after a post-import `ALTER TABLE`, and the full apply loop (drift → migrate → clean re-check, with row data preserved through `add`/`cast` and the excluded column dropped).
- `WvletCatalogDiffTest` (wvlet-cli): command wiring smoke tests.
- Verified: `langJVM/test`, `runnerJVM/testOnly *RunnerSpec*`, `cli/test`, `TyperCoverageCheck` ratchet, JS/Native compilation, `scalafmtAll`, and manual e2e runs through the no-profile CLI (plain and `--apply`).

Closes #1994

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvhJmp4YJRfksjzGhJ5usL