### PR TITLE
fix: Report a compile-time error for cyclic extends chains in declarations

### DIFF
--- a/spec/neg/cyclic-extends-like.wv
+++ b/spec/neg/cyclic-extends-like.wv
@@ -1,0 +1,11 @@
+-- A reference cycle closed across `extends` and `like` (#2017): completing cyc_ext
+-- forces cyc_like, whose `like` source is cyc_ext again
+
+table cyc_ext extends cyc_like = {
+  a: int
+}
+
+table cyc_like like cyc_ext
+
+from cyc_ext
+select a

--- a/spec/neg/cyclic-extends-mutual.wv
+++ b/spec/neg/cyclic-extends-mutual.wv
@@ -1,0 +1,13 @@
+-- A cycle in the `extends` chain must be reported as a compile-time error (#2017),
+-- not silently resolve the mixin columns to empty
+
+table cyc_a extends cyc_b = {
+  a: int
+}
+
+table cyc_b extends cyc_a = {
+  b: int
+}
+
+from cyc_a
+select a

--- a/spec/neg/cyclic-extends-self.wv
+++ b/spec/neg/cyclic-extends-self.wv
@@ -1,0 +1,8 @@
+-- A declaration extending itself is the shortest `extends` cycle (#2017)
+
+table cyc_self extends cyc_self = {
+  a: int
+}
+
+from cyc_self
+select a

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/SymbolLabeler.scala
@@ -493,17 +493,22 @@ object SymbolLabeler extends Phase("symbol-labeler"):
     // `table <name> like <source>` (#1995) copies the source declaration's columns. This runs
     // from a completer after all units are labeled, so forcing the source's completion here
     // resolves cross-unit references; a completion already in progress signals a reference
-    // cycle (`table a like b` + `table b like a`), which resolves to no columns with an error
+    // cycle (`table a like b` + `table b like a`, or one closed through `extends`), reported
+    // at the declaration that closes it (#2017)
     val likeColumns: List[NamedType] = t
       .likeSource
       .toList
       .flatMap { src =>
         val srcName = Name.typeName(src.leafName)
-        ctx
-          .scope
-          .lookupSymbol(srcName)
-          .orElse(ctx.findSymbolByName(srcName))
-          .filterNot(_.isCompleting) match
+        ctx.scope.lookupSymbol(srcName).orElse(ctx.findSymbolByName(srcName)) match
+          case Some(srcSym) if srcSym.isCompleting =>
+            throw StatusCode
+              .CYCLIC_SYMBOL_REFERENCE
+              .newException(
+                s"Cyclic reference detected: ${declKind(t)} ${typeName.name} like " +
+                  s"'${src.leafName}', whose definition refers back to ${typeName.name}",
+                ctx.sourceLocationAt(t.span)
+              )
           case Some(srcSym) =>
             srcSym.symbolInfo.dataType match
               case s: SchemaType =>
@@ -526,17 +531,30 @@ object SymbolLabeler extends Phase("symbol-labeler"):
               )
             )
             Nil
+        end match
       }
 
     // Mixin composition (#2012): each `extends` parent contributes its columns (structural
     // types and table shapes carry fields; traits carry none — their def members resolve
     // through the parent symbols at method-lookup time). Forcing a parent's completion here
     // resolves cross-unit references; a completion already in progress signals an `extends`
-    // cycle, whose columns resolve empty (Symbol.dataType yields UnknownType while completing)
+    // cycle (#2017), reported at the declaration that closes it
     val parentTypeSymbols: List[(NameExpr, Symbol)] = t
       .parents
       .map(p => p -> registerParentSymbols(p))
     val mixinColumns: List[NamedType] = parentTypeSymbols.flatMap { (p, psym) =>
+      if psym.isCompleting then
+        val cycle =
+          if p.leafName == typeName.name then
+            "extends itself"
+          else
+            s"extends '${p.leafName}', whose definition refers back to ${typeName.name}"
+        throw StatusCode
+          .CYCLIC_SYMBOL_REFERENCE
+          .newException(
+            s"Cyclic extends chain detected: ${declKind(t)} ${typeName.name} ${cycle}",
+            ctx.sourceLocationAt(t.span)
+          )
       psym.dataType match
         case s: SchemaType =>
           if t.isTrait && s.fields.nonEmpty then
@@ -604,6 +622,15 @@ object SymbolLabeler extends Phase("symbol-labeler"):
     )
 
   end computeTypeDefSymbolInfo
+
+  /** The user-facing keyword of a declaration sharing the TypeDef machinery, for diagnostics */
+  private def declKind(t: TypeDef): String =
+    if t.isTrait then
+      "trait"
+    else if t.isTableDef then
+      "table"
+    else
+      "type"
 
   private def registerParentSymbols(parent: NameExpr)(using ctx: Context): Symbol =
     // TODO support full type path


### PR DESCRIPTION
## Summary

Fixes #2017.

A cycle in the `extends` chain of a declaration (#2012 / #2015) was guarded against infinite recursion (`Symbol.dataType` returns `UnknownType` while the symbol is completing) but produced no diagnostic: the mixin columns silently resolved to empty and the failure surfaced as a confusing engine error (`Catalog Error: Table with name cyc_a does not exist!`) far downstream.

## Changes

- **Mixin scan** (`SymbolLabeler.computeTypeDefSymbolInfo`): check `psym.isCompleting` before reading each registered parent's `dataType` and throw `StatusCode.CYCLIC_SYMBOL_REFERENCE` at the declaration that closes the cycle (`ctx.sourceLocationAt(t.span)`), naming the declaration and the offending parent — mirroring the two mixin-composition errors that already throw there. A self-cycle (`table a extends a`) gets dedicated "extends itself" wording.
- **`like` source scan** (#1995): replace the silent `.filterNot(_.isCompleting)` (which fell through to a misleading `Unknown table declaration` error) with the same cyclic-reference diagnostic, so cycles closed through `like` — including like+extends indirect cycles — also report clearly.
- **Neg specs**: `spec/neg/cyclic-extends-mutual.wv`, `cyclic-extends-self.wv`, `cyclic-extends-like.wv`. Completion is lazy, so each spec references the declaration with `from` to force it.

## Verification

Because `RunnerSpecNeg` also passes on silent success, each spec was additionally run through the CLI to confirm the diagnostic actually fires:

```
[CYCLIC_SYMBOL_REFERENCE] Cyclic extends chain detected: table cyc_b extends 'cyc_a', whose definition refers back to cyc_b
table cyc_b extends cyc_a = { (cyclic-extends-mutual.wv:8:1)

[CYCLIC_SYMBOL_REFERENCE] Cyclic extends chain detected: table cyc_self extends itself
table cyc_self extends cyc_self = { (cyclic-extends-self.wv:3:1)

[CYCLIC_SYMBOL_REFERENCE] Cyclic reference detected: table cyc_like like 'cyc_ext', whose definition refers back to cyc_like
table cyc_like like cyc_ext (cyclic-extends-like.wv:8:1)
```

- `runnerJVM/testOnly *RunnerSpec*`: all pass (new neg specs included)
- `langJVM/testOnly *TyperCoverageCheck *RoundTripSpecBasic`: 153/153 pass
- `projectJS/Test/compile`, `projectNative/Test/compile`: pass
- `scalafmtAll` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VuHuieo1zUeE2qe8WiVLz