### PR TITLE
feature: Suggest user-defined trait and row methods in LSP member completion (#2018)

### DIFF
--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FunctionInliner.scala
@@ -80,6 +80,59 @@ object FunctionInliner extends ContextLogSupport:
         case _ =>
           None
 
+  /**
+    * Collect every method member callable on the type named `typeName`, for LSP member completion
+    * and hover (#2018). Mirrors the precedence of [[findMemberInHierarchy]]: the type's own defs
+    * come first and shadow mixed-in ones, then `extends` parents are consulted right-to-left,
+    * depth-first, cycle-guarded. Among same-name variants of one scope, definitions scoped to an
+    * engine other than the compile target are dropped when a variant matching the target (or a
+    * dialect-neutral one) exists; arity overloads are all kept.
+    */
+  private[compiler] def memberMethodsInHierarchy(
+      typeName: Name,
+      context: Context
+  ): List[MethodSymbolInfo] =
+    val visited   = scala.collection.mutable.Set[Name](typeName)
+    val seenNames = scala.collection.mutable.Set.empty[Name]
+    val buf       = List.newBuilder[MethodSymbolInfo]
+
+    def loop(sym: Symbol): Unit =
+      val ownMethods = sym
+        .symbolInfo
+        .members
+        .flatMap(m => flattenSymbolInfos(m.symbolInfo))
+        .collect { case m: MethodSymbolInfo =>
+          m
+        }
+      // A name already collected at an inner (higher-precedence) level shadows this scope's
+      // definition of the same name
+      val fresh = ownMethods.filterNot(m => seenNames.contains(m.name))
+      seenNames ++= fresh.map(_.name)
+      fresh
+        .map(_.name)
+        .distinct
+        .foreach { name =>
+          val variants = fresh.filter(_.name == name)
+          buf ++= preferNonZero(variants, dialectScore(_, context))
+        }
+      sym.tree match
+        case td: TypeDef =>
+          td.parents
+            .reverse
+            .foreach { p =>
+              val parentName = Name.typeName(p.leafName)
+              if !visited.contains(parentName) then
+                visited += parentName
+                lookupType(parentName, context).foreach(loop)
+            }
+        case _ =>
+    end loop
+
+    lookupType(typeName, context).foreach(loop)
+    buf.result()
+
+  end memberMethodsInHierarchy
+
   private def flattenSymbolInfos(si: SymbolInfo): List[SymbolInfo] =
     si match
       case MultipleSymbolInfo(s1, s2) =>

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/CompletionProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/CompletionProvider.scala
@@ -13,12 +13,19 @@
  */
 package wvlet.lang.compiler.lsp
 
+import wvlet.lang.api.Span
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.MethodSymbolInfo
+import wvlet.lang.compiler.Name
+import wvlet.lang.compiler.analyzer.FunctionInliner
 import wvlet.lang.compiler.parser.ParserPhase
 import wvlet.lang.compiler.parser.WvletParser
 import wvlet.lang.compiler.parser.WvletToken
 import wvlet.lang.compiler.typer.BuiltinFunctions
+import wvlet.lang.model.DataType
+import wvlet.lang.model.DataType.NamedType
 import wvlet.lang.model.SyntaxTreeNode
 import wvlet.lang.model.plan.*
 
@@ -158,6 +165,26 @@ object CompletionProvider:
     * being edited rather than an unrelated definition elsewhere in the file.
     */
   def columnItems(plan: LogicalPlan, offset: Int): List[CompletionItem] =
+    enclosingRelation(plan, offset) match
+      case None =>
+        Nil
+      case Some(enclosing) =>
+        val fields =
+          try
+            enclosing.inputRelationType.fields ++ enclosing.relationType.fields
+          catch
+            case _: Throwable =>
+              Nil
+        fields
+          .filter(f => !f.name.isEmpty && f.name.name != "<NoName>")
+          .map(f => CompletionItem(f.name.name, CompletionItemKind.Field, f.dataType.typeName.name))
+          .distinct
+
+  /**
+    * The query relation that most tightly encloses the cursor, falling back to the relation nearest
+    * to the cursor when none contains it (e.g. a trailing space or newline at the end of the file)
+    */
+  private def enclosingRelation(plan: LogicalPlan, offset: Int): Option[Relation] =
     val relations = plan
       .collectAllNodes
       .collect {
@@ -165,35 +192,25 @@ object CompletionProvider:
           r
       }
     if relations.isEmpty then
-      Nil
+      None
     else
-      val enclosing = relations
+      relations
         .filter(_.span.containsInclusive(offset))
         .sortBy(_.span.size)
         .headOption
-        .getOrElse {
+        .orElse {
           // Nearest relation by span distance to the cursor
-          relations.minBy { r =>
-            if offset < r.span.start then
-              r.span.start - offset
-            else if offset > r.span.end then
-              offset - r.span.end
-            else
-              0
-          }
+          Some(
+            relations.minBy { r =>
+              if offset < r.span.start then
+                r.span.start - offset
+              else if offset > r.span.end then
+                offset - r.span.end
+              else
+                0
+            }
+          )
         }
-      val fields =
-        try
-          enclosing.inputRelationType.fields ++ enclosing.relationType.fields
-        catch
-          case _: Throwable =>
-            Nil
-      fields
-        .filter(f => !f.name.isEmpty && f.name.name != "<NoName>")
-        .map(f => CompletionItem(f.name.name, CompletionItemKind.Field, f.dataType.typeName.name))
-        .distinct
-
-  end columnItems
 
   /**
     * Compute completion candidates for the given source at the given character offset.
@@ -480,27 +497,34 @@ object CompletionProvider:
 
     val typedUnit = CompilationUnit.fromWvletString(cleaned)
     try
-      compiler.compileSingleUnit(typedUnit)
-      val plan      = typedUnit.resolvedPlan
-      val qualifier = dotCtx.qualifier.last
-      val columns   =
+      val result                      = compiler.compileSingleUnit(typedUnit)
+      val plan                        = typedUnit.resolvedPlan
+      val qualifier                   = dotCtx.qualifier.last
+      val (columns, relationTypeName) =
         if plan.isEmpty then
-          Nil
+          (Nil, None)
         else
           relationFieldsFor(plan, qualifier, offset)
       if columns.nonEmpty then
-        columns
+        // A relation qualifier offers its columns plus the user-defined methods declared in
+        // (or mixed into) the relation's table/type declaration (#2018)
+        columns ++ userMethodItems(relationTypeName, result.context)
       else
         val tables = boundTableItems(compiler, typedUnit, dotCtx.qualifier)
         if tables.nonEmpty then
           tables
         else if plan.nonEmpty && qualifier == "_" then
-          // `_.` refers to the query input: offer the enclosing relation's columns, plus the
+          // `_.` refers to the query input: offer the enclosing relation's columns, the
+          // user-defined methods of the input relation's declared type (#2018), plus the
           // aggregation shorthands (array members like count/sum) that apply to `_`
-          columnItems(plan, offset) ++ stdlibMemberItemsOf(List("array"))
+          columnItems(plan, offset) ++
+            userMethodItems(contextInputTypeName(plan, offset), result.context) ++
+            stdlibMemberItemsOf(List("array"))
         else
-          // A column qualifier gets the stdlib members of its type (e.g. `name.` on a string
-          // column suggests upper, trim, ...); the members widen through `numeric` and `any`
+          // A column qualifier gets the user-defined methods of its declared type (e.g. a
+          // trait-typed column suggests the trait's defs, #2018) and the stdlib members of its
+          // type (e.g. `name.` on a string column suggests upper, trim, ...); the stdlib
+          // members widen through `numeric` and `any`
           val columnType =
             if plan.isEmpty then
               None
@@ -508,10 +532,11 @@ object CompletionProvider:
               qualifierColumnType(plan, qualifier, offset)
           columnType match
             case Some(t) =>
-              stdlibMemberItemsOf(List(t))
+              userMethodItems(Some(t), result.context) ++ stdlibMemberItemsOf(List(t))
             case None =>
               // Unknown qualifier: an empty member list is better than misleading suggestions
               Nil
+      end if
     catch
       case _: Throwable =>
         Nil
@@ -522,18 +547,20 @@ object CompletionProvider:
   end memberItems
 
   /**
-    * The columns of the relation that the given name refers to in the plan: a relation alias (`from
-    * orders as o ... o.`), or a scanned table/model name. When several relations match (e.g. the
-    * same alias in multiple queries of one file), the one nearest to the cursor wins. Names are
-    * matched case-insensitively, following SQL identifier semantics
+    * The columns of the relation that the given name refers to in the plan — a relation alias
+    * (`from orders as o ... o.`), or a scanned table/model name — paired with the relation's
+    * declared type name (when it has a usable one) so user-defined method members can be offered
+    * alongside the columns (#2018). When several relations match (e.g. the same alias in multiple
+    * queries of one file), the one nearest to the cursor wins. Names are matched
+    * case-insensitively, following SQL identifier semantics
     */
   private def relationFieldsFor(
       plan: LogicalPlan,
       name: String,
       offset: Int
-  ): List[CompletionItem] =
-    def sameName(a: String, b: String): Boolean  = a.equalsIgnoreCase(b)
-    def distance(span: wvlet.lang.api.Span): Int =
+  ): (List[CompletionItem], Option[String]) =
+    def sameName(a: String, b: String): Boolean = a.equalsIgnoreCase(b)
+    def distance(span: Span): Int               =
       if !span.exists then
         Int.MaxValue
       else if offset < span.start then
@@ -542,9 +569,9 @@ object CompletionProvider:
         offset - span.end
       else
         0
-    def nearestFields(
-        matches: List[(wvlet.lang.api.Span, () => Seq[wvlet.lang.model.DataType.NamedType])]
-    ): Option[Seq[wvlet.lang.model.DataType.NamedType]] = matches
+    def nearestMatch(
+        matches: List[(Span, () => (Seq[NamedType], String))]
+    ): Option[(Seq[NamedType], String)] = matches
       .sortBy((span, _) => distance(span))
       .iterator
       .flatMap((_, fields) => scala.util.Try(fields()).toOption)
@@ -563,26 +590,131 @@ object CompletionProvider:
         case _ =>
           plan
     val nodes = searchPlan.collectAllNodes
-    // Aliases take precedence over table/model names
+    // Aliases take precedence over table/model names. The relation type's typeName names the
+    // underlying declared type even through an alias (AliasedType keeps its base type's name)
     val aliasMatches = nodes.collect {
       case a: AliasedRelation if sameName(a.alias.leafName, name) =>
-        (a.span, () => a.relationType.fields)
+        (a.span, () => (a.relationType.fields, a.relationType.typeName.name))
     }
     val scanMatches = nodes.collect {
       case t: TableScan if sameName(t.name.name, name) =>
-        (t.span, () => t.columns: Seq[wvlet.lang.model.DataType.NamedType])
+        (t.span, () => (t.columns: Seq[NamedType], t.relationType.typeName.name))
       case m: ModelScan if sameName(m.name.name, name) =>
-        (m.span, () => m.relationType.fields)
+        (m.span, () => (m.relationType.fields, m.relationType.typeName.name))
     }
-    nearestFields(aliasMatches)
-      .orElse(nearestFields(scanMatches))
-      .getOrElse(Nil)
-      .filter(f => !f.name.isEmpty && f.name.name != "<NoName>")
-      .map(f => CompletionItem(f.name.name, CompletionItemKind.Field, f.dataType.typeName.name))
-      .distinct
-      .toList
+    val matched = nearestMatch(aliasMatches).orElse(nearestMatch(scanMatches))
+    val items   =
+      matched
+        .map(_._1)
+        .getOrElse(Nil)
+        .filter(f => !f.name.isEmpty && f.name.name != "<NoName>")
+        .map(f => CompletionItem(f.name.name, CompletionItemKind.Field, f.dataType.typeName.name))
+        .distinct
+        .toList
+    (items, matched.map(_._2).flatMap(declaredTypeName))
 
   end relationFieldsFor
+
+  /** A usable declared type name: non-empty and not an internal placeholder like `<empty>` */
+  private def declaredTypeName(name: String): Option[String] = Option(name).filter(n =>
+    n.nonEmpty && !n.startsWith("<")
+  )
+
+  /**
+    * The declared type name of the query input that `_.` refers to at the cursor: the input
+    * relation type name of the enclosing relation (e.g. `events` after `from events`), used to look
+    * up user-defined method members (#2018)
+    */
+  private def contextInputTypeName(plan: LogicalPlan, offset: Int): Option[String] =
+    enclosingRelation(plan, offset).flatMap { r =>
+      try
+        declaredTypeName(r.inputRelationType.typeName.name)
+      catch
+        case _: Throwable =>
+          None
+    }
+
+  /**
+    * Resolve the qualifier of a member access to the name of a declared type whose method members
+    * apply: the input relation type for `_`, the scanned/aliased relation's declared type, or the
+    * qualifier column's type. Shared with [[HoverProvider]] (#2018)
+    */
+  private[lsp] def qualifierTypeName(
+      plan: LogicalPlan,
+      qualifier: String,
+      offset: Int
+  ): Option[String] =
+    if qualifier == "_" then
+      contextInputTypeName(plan, offset)
+    else
+      relationFieldsFor(plan, qualifier, offset)
+        ._2
+        .orElse(qualifierColumnType(plan, qualifier, offset))
+
+  /**
+    * Completion items for the user-defined method members (`def`s in `table` / `trait` / `type`
+    * bodies, #2018) of the type named by the qualifier. Methods mixed in through `extends` parents
+    * are included via the same hierarchy walk the compiler uses to resolve method calls
+    * ([[FunctionInliner.memberMethodsInHierarchy]]); methods inherited from stdlib parents (e.g. a
+    * trait extending `string`) surface through the stdlib index instead, so their details and docs
+    * match the stdlib items
+    */
+  private def userMethodItems(typeName: Option[String], context: Context): List[CompletionItem] =
+    typeName
+      .flatMap(declaredTypeName)
+      .toList
+      .flatMap { t =>
+        try
+          val methods = FunctionInliner.memberMethodsInHierarchy(Name.typeName(t), context)
+          val (preset, userDefined) = methods.partition(_.compilationUnit.isPreset)
+          val userItems             = userDefined.map(m =>
+            CompletionItem(m.name.name, CompletionItemKind.Function, methodDetail(m))
+          )
+          val inheritedStdlibItems =
+            val owners = preset.map(_.owner.name.name).distinct
+            if owners.isEmpty then
+              Nil
+            else
+              stdlibMemberItemsOf(owners)
+          userItems ++ inheritedStdlibItems
+        catch
+          case _: Throwable =>
+            Nil
+      }
+      .distinct
+
+  /**
+    * The completion detail of a user-defined method: its `(args): ret` signature rendered from the
+    * resolved FunctionType, matching the shape of the stdlib member details
+    */
+  private def methodDetail(m: MethodSymbolInfo): String =
+    val sig = methodSignatureOf(m)
+    if sig.isEmpty then
+      "function"
+    else
+      sig
+
+  /**
+    * The `(args): ret` signature of a method definition (empty when the def declares neither
+    * arguments nor a resolved return type). Also used by [[HoverProvider]] for user-defined method
+    * hovers
+    */
+  private[lsp] def methodSignatureOf(m: MethodSymbolInfo): String =
+    val args =
+      if m.ft.args.isEmpty then
+        ""
+      else
+        m.ft
+          .args
+          .map(a => s"${a.name.name}: ${a.dataType.typeDescription}")
+          .mkString("(", ", ", ")")
+    val ret =
+      m.ft.returnType match
+        case DataType.UnknownType =>
+          ""
+        case rt =>
+          s": ${rt.typeDescription}"
+    s"${args}${ret}"
 
   /**
     * The table types bound to the schema (or catalog.schema) named by the qualifier, collected from

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/HoverProvider.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/lsp/HoverProvider.scala
@@ -15,7 +15,10 @@ package wvlet.lang.compiler.lsp
 
 import wvlet.lang.compiler.CompilationUnit
 import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.MethodSymbolInfo
 import wvlet.lang.compiler.ModelSymbolInfo
+import wvlet.lang.compiler.Name
+import wvlet.lang.compiler.analyzer.FunctionInliner
 import wvlet.lang.model.DataType
 import wvlet.lang.model.DataType.NamedType
 import wvlet.lang.model.RelationType
@@ -85,8 +88,11 @@ object HoverProvider:
   def hover(content: String, offset: Int, compiler: Compiler): Option[HoverResult] =
     // A member name of a value.function call (e.g. the `upper` of `name.upper`) hovers the
     // stdlib signatures and docs. This runs on a parse-only pass first: after typing, stdlib
-    // calls are inlined into SQL fragments and their reference nodes no longer exist
-    stdlibFunctionHover(content, offset).orElse(typedHover(content, offset, compiler))
+    // calls are inlined into SQL fragments and their reference nodes no longer exist. Member
+    // names not defined in the stdlib then try the user-defined method members (#2018)
+    stdlibFunctionHover(content, offset)
+      .orElse(userMethodHover(content, offset, compiler))
+      .orElse(typedHover(content, offset, compiler))
 
   private def typedHover(content: String, offset: Int, compiler: Compiler): Option[HoverResult] =
     val unit = CompilationUnit.fromWvletString(content)
@@ -202,6 +208,83 @@ object HoverProvider:
         None
 
   end stdlibFunctionHover
+
+  /**
+    * Hover result for a user-defined method reference (#2018): the member name of a `value.method`
+    * access where the method is a `def` declared in a user `table` / `trait` / `type` body, own or
+    * mixed in through `extends` parents. The definition is found with the same hierarchy walk the
+    * compiler uses to resolve method calls. The member location comes from a parse-only pass (typed
+    * plans inline user method calls, so their reference nodes no longer exist), then a typed pass
+    * resolves the qualifier's declared type
+    */
+  private def userMethodHover(
+      content: String,
+      offset: Int,
+      compiler: Compiler
+  ): Option[HoverResult] =
+    try
+      val unit       = CompilationUnit.fromWvletString(content)
+      val parsedPlan = wvlet.lang.compiler.parser.ParserPhase.parseOnly(unit)
+      val sf         = unit.sourceFile
+      sf.ensureLoaded
+      val memberHit =
+        parsedPlan
+          .collectAllNodes
+          .collect {
+            case d: wvlet.lang.model.expr.DotRef
+                if d.name.span.exists && d.name.span.containsInclusive(offset) =>
+              (d.qualifier, d.name)
+          }
+          .headOption
+      memberHit.flatMap { (qualifier, name) =>
+        val qualifierName =
+          qualifier match
+            case n: NameExpr =>
+              n.leafName
+            case _ =>
+              ""
+        if qualifierName.isEmpty then
+          None
+        else
+          val typedUnit = CompilationUnit.fromWvletString(content)
+          try
+            val result = compiler.compileSingleUnit(typedUnit)
+            val plan   = typedUnit.resolvedPlan
+            if plan.isEmpty then
+              None
+            else
+              CompletionProvider
+                .qualifierTypeName(plan, qualifierName, offset)
+                .flatMap { t =>
+                  val methods = FunctionInliner
+                    .memberMethodsInHierarchy(Name.typeName(t), result.context)
+                    .filter(m => m.name.name.equalsIgnoreCase(name.leafName))
+                    // Stdlib members are rendered with their docs by stdlibFunctionHover
+                    .filterNot(_.compilationUnit.isPreset)
+                  if methods.isEmpty then
+                    None
+                  else
+                    Some(toResult(userMethodMarkdown(methods), name, sf))
+                }
+          finally
+            compiler.releaseUnit(typedUnit)
+      }
+    catch
+      case _: Throwable =>
+        // Hover is opportunistic: never surface a parse or compile error to the editor
+        None
+
+  end userMethodHover
+
+  /**
+    * Render user-defined method definitions as markdown: a fenced code block with the owning type
+    * and the distinct signatures of the definition's variants
+    */
+  private def userMethodMarkdown(methods: List[MethodSymbolInfo]): String =
+    val header   = s"-- member of ${methods.head.owner.name.name}"
+    val sigLines =
+      methods.map(m => s"def ${m.name.name}${CompletionProvider.methodSignatureOf(m)}").distinct
+    codeBlock((header :: sigLines).mkString("\n"))
 
   /** Maximum number of owning-type groups rendered in a stdlib function hover */
   private val MaxHoverGroups: Int = 3

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/CompletionProviderTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/CompletionProviderTest.scala
@@ -285,4 +285,89 @@ class CompletionProviderTest extends UniTest:
     val ntile = items.find(_.label == "ntile")
     ntile.map(_.detail) shouldBe Some("(n: int): long")
 
+  test("should suggest user-defined row methods after an underscore dot"):
+    val src =
+      """table cm_users = {
+        |  id: int
+        |  deleted_at: string
+        |  def is_active: boolean = deleted_at.is_null
+        |}
+        |from cm_users
+        |where _.""".stripMargin
+    val items = complete(src, src.length)
+    val m     = items.find(_.label == "is_active")
+    m.map(_.kind) shouldBe Some(CompletionItemKind.Function)
+    m.map(_.detail) shouldBe Some(": boolean")
+    // Columns of the input relation stay present
+    items.map(_.label).toSet shouldContain "deleted_at"
+
+  test("should suggest trait methods mixed in through extends parents"):
+    val src =
+      """type cm_ts = {
+        |  created_at: string
+        |}
+        |trait cm_audit = {
+        |  def audit_tag: string = created_at.upper()
+        |}
+        |table cm_events extends cm_ts, cm_audit = {
+        |  id: int
+        |}
+        |from cm_events
+        |where _.""".stripMargin
+    val items = complete(src, src.length)
+    val m     = items.find(_.label == "audit_tag")
+    m.map(_.kind) shouldBe Some(CompletionItemKind.Function)
+    m.map(_.detail) shouldBe Some(": string")
+    // The mixed-in column is offered too (already covered by the composed schema)
+    items.map(_.label).toSet shouldContain "created_at"
+
+  test("should suggest row methods after an aliased relation dot"):
+    val src =
+      """table cm_users2 = {
+        |  id: int
+        |  deleted_at: string
+        |  def is_active: boolean = deleted_at.is_null
+        |}
+        |from cm_users2 as u
+        |select u.""".stripMargin
+    val items  = complete(src, src.length)
+    val labels = items.map(_.label).toSet
+    labels shouldContain "id"
+    labels shouldContain "is_active"
+    items.find(_.label == "is_active").map(_.detail) shouldBe Some(": boolean")
+
+  test("should suggest trait methods of a trait-typed column after a dot"):
+    val src =
+      """trait cm_masked extends string = {
+        |  def masked: string = sql"'***'"
+        |}
+        |table cm_secrets = {
+        |  id: int
+        |  secret: cm_masked
+        |}
+        |from cm_secrets
+        |select secret.""".stripMargin
+    val items = complete(src, src.length)
+    val m     = items.find(_.label == "masked")
+    m.map(_.kind) shouldBe Some(CompletionItemKind.Function)
+    m.map(_.detail) shouldBe Some(": string")
+    // Members inherited from the stdlib parent (string) widen through the stdlib index
+    val labels = items.map(_.label).toSet
+    labels shouldContain "upper"
+    labels shouldNotContain "sqrt"
+
+  test("should prefer method variants of the target dialect after a dot"):
+    // The default compile target is DuckDB, so the trino-scoped variant must not surface
+    val src =
+      """table cm_dialect = {
+        |  x: int
+        |  def fmt in duckdb: string = sql"'d'"
+        |  def fmt in trino: int = sql"1"
+        |}
+        |from cm_dialect
+        |where _.""".stripMargin
+    val details = complete(src, src.length).filter(_.label == "fmt").map(_.detail).toSet
+    details shouldContain ": string"
+    details shouldNotContain ": int"
+
 end CompletionProviderTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/HoverProviderTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/lsp/HoverProviderTest.scala
@@ -115,4 +115,56 @@ class HoverProviderTest extends UniTest:
     val result = hover(src, offset)
     result.foreach(r => r.content shouldNotContain "member of")
 
+  test("should show the def signature when hovering a user-defined row method"):
+    val src =
+      """table hv_users = {
+        |  id: int
+        |  deleted_at: string
+        |  def is_active: boolean = deleted_at.is_null
+        |}
+        |from hv_users
+        |where _.is_active""".stripMargin
+    val offset = src.lastIndexOf("is_active") + 1
+    val result = hover(src, offset)
+    result.isDefined shouldBe true
+    val content = result.get.content
+    content shouldContain "member of hv_users"
+    content shouldContain "def is_active: boolean"
+
+  test("should show the owning trait when hovering a mixed-in method"):
+    val src =
+      """trait hv_audit = {
+        |  def audit_tag: string = created_at.upper()
+        |}
+        |table hv_events extends hv_audit = {
+        |  id: int
+        |  created_at: string
+        |}
+        |from hv_events
+        |select id, _.audit_tag as tag""".stripMargin
+    val offset = src.lastIndexOf("audit_tag") + 1
+    val result = hover(src, offset)
+    result.isDefined shouldBe true
+    val content = result.get.content
+    content shouldContain "member of hv_audit"
+    content shouldContain "def audit_tag: string"
+
+  test("should show the trait method signature when hovering through a trait-typed column"):
+    val src =
+      """trait hv_masked extends string = {
+        |  def masked: string = sql"'***'"
+        |}
+        |table hv_secrets = {
+        |  id: int
+        |  secret: hv_masked
+        |}
+        |from hv_secrets
+        |select secret.masked""".stripMargin
+    val offset = src.lastIndexOf("masked") + 1
+    val result = hover(src, offset)
+    result.isDefined shouldBe true
+    val content = result.get.content
+    content shouldContain "member of hv_masked"
+    content shouldContain "def masked: string"
+
 end HoverProviderTest


### PR DESCRIPTION
## Summary

Fixes #2018: LSP member completion (`x.` / `_.`) now suggests **user-defined** trait and row methods, including ones mixed in through `extends` parents (#2012/#2015), and hover shows their def signatures. Previously only columns and stdlib members appeared, so `def`s declared in user `table` / `trait` / `type` bodies were invisible while editing.

## Changes

### FunctionInliner
- New `memberMethodsInHierarchy(typeName, context)`: enumerates every `MethodSymbolInfo` member of a type with the same precedence as `findMemberInHierarchy` — own defs shadow mixed-in ones, `extends` parents are consulted right-to-left depth-first, cycle-guarded. Among same-name variants of one scope, definitions scoped to an engine other than the compile target are dropped when a matching or dialect-neutral variant exists (via the existing `dialectScore` / `preferNonZero`); arity overloads are all kept.

### CompletionProvider
- `memberItems` now resolves the qualifier to a declared type and appends its user-defined method items, with the `def` signature (`(args): ret`) as the completion detail, matching the stdlib items:
  - `_.` → the enclosing relation's input type (e.g. `events` after `from events`)
  - a scanned/aliased table or model qualifier → the relation's declared type (`AliasedType` keeps its base type's name, so aliases work too)
  - a column qualifier → the column's declared type (e.g. a trait-typed column offers the trait's defs)
- Methods inherited from **stdlib** parents (e.g. `trait masked_str extends string`) surface through the stdlib index instead of the raw hierarchy walk, so their details and docs match the existing stdlib items — a trait-typed column now also offers `upper`, `trim`, etc.
- `relationFieldsFor` additionally reports the matched relation's declared type name; the enclosing-relation lookup is extracted from `columnItems` for reuse.

### HoverProvider
- Same gap covered: hovering a user method reference (`_.is_active`, `secret.masked`, mixed-in `_.audit_tag`) shows a fenced block with the owning type and the distinct def signatures. Runs after the stdlib hover tier (stdlib members keep their doc rendering) and before the typed fallback. The member location comes from a parse-only pass since typed plans inline user method calls.

## Testing

- 5 new `CompletionProviderTest` cases: row methods after `_.`, mixed-in trait methods through `extends` parents, methods after an aliased relation dot, trait-typed column methods (incl. stdlib widening through the trait's `string` parent, and no numeric leakage), and dialect preference (`def fmt in duckdb` wins over `in trino` on the default DuckDB target).
- 3 new `HoverProviderTest` cases: row method, mixed-in method (owner shown as the trait), and trait method through a trait-typed column.
- All tests use the catalog-free static resolution path (`table` declarations + direct scans), no DuckDB needed.
- `langJVM/test`: 1044 tests, 1042 passed / 2 pending; `runnerJVM/testOnly *RunnerSpec*`: 489 passed; `projectJS/Test/compile` and `projectNative/Test/compile` pass; `scalafmtAll` applied.

Refs #2012, #2015, #2010, #1881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcMj3U19RPh6wSTVAGL3Cp