### PR TITLE
doc: Announce flow orchestration as experimental with a feedback channel

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -222,6 +222,23 @@ join address_table
   on p.id = address_table.person_id
 ```
 
+### Flow Orchestration (Experimental)
+
+Organize queries into data pipelines with `flow` and `stage` constructs, including retries, timeouts, scheduling, sensors, and failure notifications:
+
+```wvlet
+flow daily_report with {
+  schedule: cron('0 2 * * *')  -- 2 AM daily
+  concurrency: 1
+} = {
+  stage extract = from raw_events | where event_date = current_date
+  stage load = from extract | append to daily_summary
+  stage fallback if extract.failed = from backup_events | append to daily_summary
+}
+```
+
+Flow orchestration is experimental — see [Flow & Stage Syntax](./syntax/flow) for details, and share syntax feedback on [this tracking issue](https://github.com/wvlet/wvlet/issues/2021).
+
 ### Managing Queries As A Reusable Module
 
 :::warning

--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -6,6 +6,10 @@ sidebar_position: 2
 
 Wvlet provides `flow` and `stage` constructs for defining data pipelines with orchestration capabilities such as retries, timeouts, scheduling, and error handling. Flows organize stages into directed acyclic graphs (DAGs) with explicit data and control dependencies.
 
+:::info Experimental
+Flow orchestration is **experimental**: it works end-to-end (DuckDB and Trino execution, scheduling, sensors, run stores, web UI), but the syntax and semantics described here may still change based on user feedback. In particular, the `wait until` sensor grammar, sensor row semantics, and notification payload shapes are open for refinement — share feedback on the [flow syntax feedback issue](https://github.com/wvlet/wvlet/issues/2021). Breaking changes will be called out in release notes while the feature is experimental.
+:::
+
 ## From Queries to Data Flows
 
 | Construct | Purpose | Scope | Reusable |


### PR DESCRIPTION
## Summary

Items 1–3 of #1858 (flow-level `timeout:` #1985, Postgres run store #1992, sensor observability #1990) have landed, meeting the round's stated gate for announcing flow support as **experimental**. This PR completes the announcement:

- Adds an experimental-status banner to the flow syntax page (`website/docs/syntax/flow.md`), noting that the `wait until` grammar, sensor row semantics, and notification payload shapes may still change, and linking to the new feedback channel
- Adds a **Flow Orchestration (Experimental)** feature section to the docs landing page (`website/docs/index.md`) with a small example using only documented syntax
- Filed #2021 as the syntax-feedback tracking issue both pages link to

## Related

- #1858 (flow orchestration round 7 — announcement gate)
- #2021 (new feedback tracking issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADwW9QKqzMo5Yf6kNqoLvz