### PR TITLE
feature: Fill omitted columns from table-declaration defaults

### DIFF
--- a/spec/basic/ddl/table-defaults.wv
+++ b/spec/basic/ddl/table-defaults.wv
@@ -1,0 +1,39 @@
+-- Column defaults on table declarations (#1997): `name: type = expr` renders a DEFAULT
+-- clause into generated CREATE TABLE columns, and the engine fills omitted columns
+
+table ddl_defaults = {
+  id: int
+  name: string
+  active: boolean = true
+  score: double = 1.5
+}
+
+create table ddl_defaults
+
+-- Append only a subset of the declared columns; the engine fills the rest from defaults
+append to ddl_defaults (id, name) {
+  from [[1, 'alice'], [2, 'bob']] as t(id, name)
+}
+
+from ddl_defaults
+test _.size should be 2
+test _.columns should contain 'active'
+
+-- Both rows got the declared defaults for the omitted columns
+from ddl_defaults
+where active = true and score = 1.5
+test _.size should be 2
+
+-- Auto-creation via append also carries the defaults into the created table
+table ddl_defaults_auto like ddl_defaults
+
+append to ddl_defaults_auto (id, name) {
+  from [[3, 'carol']] as t(id, name)
+}
+
+from ddl_defaults_auto
+where active = true and score = 1.5
+test _.size should be 1
+
+drop table ddl_defaults_auto
+drop table ddl_defaults

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -48,6 +48,32 @@ table users = {
 }
 ```
 
+### Column Defaults
+
+A column can declare a default value with `= expr`. The default renders as a `DEFAULT`
+clause in the generated `CREATE TABLE` — both for explicit `create table` actions and for
+tables auto-created by `append to` — so the engine fills omitted columns on insert:
+
+```wvlet
+table users = {
+  id: int
+  name: string
+  active: boolean = true
+  created_at: timestamp = now()
+}
+
+create table users
+
+-- Appending only a subset of columns: active and created_at get their defaults
+append to users (id, name) {
+  from new_signups select id, name
+}
+```
+
+Defaults compose with `like` and `extends`: a reused or mixed-in column keeps its declared
+default. Engines whose `CREATE TABLE` grammar has no `DEFAULT` clause (e.g. Trino) reject a
+create with column defaults at compile time instead of silently dropping them.
+
 ### Reusing a Shape with `like`
 
 `table <name> like <source>` declares a second table with the same columns as an existing

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/DBType.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/DBType.scala
@@ -33,7 +33,9 @@ enum DBType(
     // values 1, 2, ...   or (values 1, 2, ...)
     val requireParenForValues: Boolean = false,
     // RLIKE operator support (regex pattern matching)
-    val supportRLike: Boolean = false
+    val supportRLike: Boolean = false,
+    // Column DEFAULT clauses in CREATE TABLE are supported
+    val supportColumnDefaultValues: Boolean = true
 ):
 
   /**
@@ -66,7 +68,9 @@ enum DBType(
         arrayConstructorSyntax = SQLDialect.ArraySyntax.ArrayPrefix,
         mapConstructorSyntax = SQLDialect.MapSyntax.ArrayPair,
         requireParenForValues = true,
-        supportRLike = true
+        supportRLike = true,
+        // Trino's CREATE TABLE grammar has no column DEFAULT clause
+        supportColumnDefaultValues = false
       )
 
   case Hive

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TableBindings.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TableBindings.scala
@@ -127,7 +127,8 @@ object TableBindings:
             // Field types carry their parameters separately (e.g. decimal[10,2] parses as
             // fieldType decimal + params [10, 2]), so pass both to keep parameterized types
             DataTypeParser.parse(f.fieldType.fullName, f.params),
-            f.span
+            f.span,
+            defaultValue = f.body
           )
         }
       val inherited = (current.parents.map(_.leafName) ++ current.likeSource.map(_.leafName))

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -16,6 +16,7 @@ package wvlet.lang.compiler.codegen
 import wvlet.lang.BuildInfo
 import wvlet.lang.api.SourceLocation
 import wvlet.lang.api.StatusCode
+import wvlet.lang.api.WvletLangException
 import wvlet.lang.catalog.Catalog.TableName
 import wvlet.lang.compiler.planner.ExecutionPlanner
 import wvlet.lang.compiler.analyzer.TableBindings
@@ -170,6 +171,12 @@ object GenSQL extends Phase("generate-sql"):
               s"on ${context.dbType}",
             c.sourceLocation
           )
+      // Declared column defaults render as DEFAULT clauses; engines without them (e.g. Trino)
+      // reject the create loudly instead of dropping the semantics. Generic stays
+      // dialect-neutral and prints the standard spelling
+      case c: CreateTable
+          if hasColumnDefaults(c.tableElems) && !context.dbType.supportColumnDefaultValues =>
+        throw columnDefaultsNotSupported(c.table.fullName, c.sourceLocation)
       case c: CreateTable if c.replace && !context.dbType.supportCreateOrReplace =>
         // Engines without CREATE OR REPLACE decompose it into an explicit drop + create
         List(
@@ -216,6 +223,23 @@ object GenSQL extends Phase("generate-sql"):
     * inferred ones) and the rows are inserted into it; otherwise the append reduces to CREATE TABLE
     * AS with the query's shape
     */
+  private def hasColumnDefaults(tableElems: List[TableElement]): Boolean = tableElems.exists {
+    case c: ColumnDef =>
+      c.defaultValue.nonEmpty
+    case _ =>
+      false
+  }
+
+  private def columnDefaultsNotSupported(tableName: String, loc: SourceLocation)(using
+      context: Context
+  ): WvletLangException = StatusCode
+    .NOT_IMPLEMENTED
+    .newException(
+      s"creating table ${tableName} with column default values is not supported on ${context
+          .dbType}",
+      loc
+    )
+
   private def appendToNewTableSQL(
       a: AppendTo,
       fullTableName: String,
@@ -223,6 +247,8 @@ object GenSQL extends Phase("generate-sql"):
       baseSQL: String
   )(using context: Context): List[String] =
     if declaredCols.nonEmpty then
+      if hasColumnDefaults(declaredCols) && !context.dbType.supportColumnDefaultValues then
+        throw columnDefaultsNotSupported(fullTableName, a.sourceLocation)
       val gen       = sqlGeneratorFor(context.dbType)
       val createSQL = gen.print(
         CreateTable(

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/TableColumnDefaultsTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/TableColumnDefaultsTest.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.codegen
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.api.WvletLangException
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.WorkEnv
+
+/**
+  * Column defaults on `table` declarations (#1997): `name: type = expr` fields render a DEFAULT
+  * clause into generated CREATE TABLE columns, on both explicit `create table` actions and
+  * append-to auto-creation. Engines without column defaults (Trino) reject the create loudly
+  * instead of dropping the semantics
+  */
+class TableColumnDefaultsTest extends UniTest:
+
+  private val usersTable =
+    """table du_users = {
+      |  id: int
+      |  name: string
+      |  active: boolean = true
+      |  created_at: timestamp = now()
+      |}
+      |""".stripMargin
+
+  private def compileToSQL(
+      typeDefs: String,
+      query: String,
+      dbType: DBType = DBType.DuckDB
+  ): String =
+    val queryUnit = CompilationUnit.fromWvletString(query)
+    val compiler  = Compiler(CompilerOptions(workEnv = WorkEnv("."), dbType = dbType))
+    val typeUnit  = CompilationUnit.fromWvletString(typeDefs)
+    val result    = compiler.compileMultipleUnits(List(typeUnit), queryUnit)
+    GenSQL.generateSQL(queryUnit)(using result.context)
+
+  test("should render declared defaults into an explicit create table") {
+    val sql = compileToSQL(usersTable, "create table du_users\n")
+    sql shouldContain "create table"
+    sql shouldContain "default true"
+    sql shouldContain "default now()"
+    // Columns without a default stay plain
+    sql.contains("id int default") shouldBe false
+  }
+
+  test("should render declared defaults into append-to auto-creation") {
+    val sql = compileToSQL(
+      usersTable,
+      "from [[1, 'a', false, now()]] as t(id, name, active, created_at)\nappend to du_users\n"
+    )
+    sql shouldContain "create table if not exists"
+    sql shouldContain "default true"
+    sql shouldContain "default now()"
+    sql shouldContain "insert into"
+  }
+
+  test("should propagate defaults through extends mixins") {
+    val sql = compileToSQL(
+      """type du_audited = {
+        |  deleted: boolean = false
+        |}
+        |table du_events extends du_audited = {
+        |  id: int
+        |}
+        |""".stripMargin,
+      "create table du_events\n"
+    )
+    sql shouldContain "default false"
+  }
+
+  test("should propagate defaults through like-based declarations") {
+    val sql = compileToSQL(
+      usersTable + "table du_users_backup like du_users\n",
+      "create table du_users_backup\n"
+    )
+    sql shouldContain "default true"
+    sql shouldContain "default now()"
+  }
+
+  test("should reject creating a table with defaults on engines without DEFAULT clauses") {
+    val e = intercept[WvletLangException] {
+      compileToSQL(usersTable, "create table du_users\n", dbType = DBType.Trino)
+    }
+    e.getMessage shouldContain "column default values is not supported on"
+  }
+
+  test("should reject append auto-creation with defaults on engines without DEFAULT clauses") {
+    val e = intercept[WvletLangException] {
+      compileToSQL(
+        usersTable,
+        "from [[1, 'a', false, now()]] as t(id, name, active, created_at)\nappend to du_users\n",
+        dbType = DBType.Trino
+      )
+    }
+    e.getMessage shouldContain "column default values is not supported on"
+  }
+
+  test("should keep default-free declarations working on Trino") {
+    val sql = compileToSQL(
+      "table du_plain = {\n  id: int\n  name: string\n}\n",
+      "create table du_plain\n",
+      dbType = DBType.Trino
+    )
+    sql shouldContain "create table"
+    sql.contains("default") shouldBe false
+  }
+
+end TableColumnDefaultsTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -74,6 +74,17 @@ class WvletGeneratorTest extends UniTest:
     print(printed) shouldContain "table users"
   }
 
+  test("should round-trip table field defaults (#1997)") {
+    val printed = print("""table users = {
+        |  id: int
+        |  active: boolean = true
+        |  created_at: timestamp = now()
+        |}""".stripMargin)
+    printed shouldContain "active: boolean = true"
+    printed shouldContain "= now()"
+    print(printed) shouldContain "active: boolean = true"
+  }
+
   test("should round-trip a model with a type annotation") {
     val printed = print("""model rm_all: rm_users = {
         |  from rm_users


### PR DESCRIPTION
## Summary

The defaults slice of #1997. A `table` declaration field's `= expr` default was already parsed (`FieldDef.body`) but dropped when declared columns materialized into DDL. This PR propagates it into `ColumnDef.defaultValue`, so:

- Explicit `create table <declared>` renders `DEFAULT <expr>` clauses (the SQL renderer already knew how to print them)
- `append to` auto-creation carries the defaults into the created table
- A column-subset append (`append to t (id, name)`) relies on the engine to fill the omitted columns — proven end-to-end on DuckDB in the new spec
- Defaults compose through `like` and `extends`, since they ride on the composed columns

Engines whose `CREATE TABLE` grammar has no `DEFAULT` clause reject the create at compile time (`NOT_IMPLEMENTED`) instead of silently dropping semantics, via a new `DBType.supportColumnDefaultValues` capability flag (false for Trino), following the schema-options precedent from #2006.

## Tests

- New `TableColumnDefaultsTest`: explicit create, append auto-create, `extends`/`like` propagation, Trino rejection on both paths, default-free declarations unaffected on Trino
- New DuckDB-executed spec `spec/basic/ddl/table-defaults.wv`: column-subset appends get engine-filled defaults on both created and auto-created tables
- `WvletGeneratorTest`: field defaults round-trip through the Wvlet printer
- Full `langJVM/test` (1095 passed), `RunnerSpecBasic` (152 passed), `TyperCoverageCheck` ratchet green, `langJS/compile` green

## Docs

- New **Column Defaults** section in `website/docs/syntax/table-management.md`

## Related

- Part of #1997 (constraints `primary key`/`unique` remain as a follow-up slice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADwW9QKqzMo5Yf6kNqoLvz