### PR TITLE
feature: Cancel and resume flow runs from the web UI

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -723,11 +723,17 @@ Runs are managed with `wvlet flow session` subcommands:
 
 ### Flow Runs in the Web UI
 
-`wvlet ui -w <folder>` serves a read-only **Flow Runs** page next to the query editor:
-recent runs with state badges, and per-run stage states, attempts, and errors. The page
-reads the same run store as the `wvlet flow session` commands, so runs triggered from the
-CLI or a scheduler daemon on the same working folder appear as they happen. Cancelling and
-resuming runs stays in the CLI.
+`wvlet ui -w <folder>` serves a **Flow Runs** page next to the query editor: recent runs
+with state badges, per-run stage states, attempts, and errors, and a flow-name filter. The
+page reads the same run store as the `wvlet flow session` commands, so runs triggered from
+the CLI or a scheduler daemon on the same working folder appear as they happen, and the
+list auto-refreshes while a run is in flight.
+
+A selected run also offers **Cancel** (for running runs) and **Resume** (for failed or
+cancelled runs) buttons, each with a confirmation step. They follow the same semantics as
+`wvlet flow session cancel`/`resume`: cancellation is requested through the shared run
+store, so it reaches runs owned by other processes, and a resumed flow is recompiled from
+the server's working folder and re-executed in the background with its recorded arguments.
 
 ### Run Liveness Leases
 

--- a/wvlet-api/src/main/scala/wvlet/lang/api/v1/flow/FlowApi.scala
+++ b/wvlet-api/src/main/scala/wvlet/lang/api/v1/flow/FlowApi.scala
@@ -17,8 +17,9 @@ import wvlet.uni.http.router.RxRouter
 import wvlet.uni.http.router.RxRouterProvider
 
 /**
-  * Read-only inspection of recorded flow runs for the web UI. Mutations (cancel, resume) stay in
-  * the `wvlet flow session` CLI
+  * Inspection and control of recorded flow runs for the web UI: read endpoints for the runs view,
+  * plus cancel/resume mutations delegating to the same run-store and launcher paths as the `wvlet
+  * flow session` CLI
   */
 trait FlowApi:
   import FlowApi.*
@@ -28,6 +29,21 @@ trait FlowApi:
 
   /** The per-stage details of a recorded run */
   def getRun(request: FlowRunRequest): FlowRunDetail
+
+  /**
+    * Request cancellation of a running flow run. The owning executor observes the request through
+    * the shared run store, so cancelling works across processes. Cancelling an already-terminal run
+    * is a no-op reported in the result message
+    */
+  def cancelRun(request: FlowRunRequest): FlowRunActionResult
+
+  /**
+    * Resume a failed, cancelled, or stale-running (crashed process) run. The flow is recompiled
+    * from the server's work folder and re-executed in the background with its recorded arguments;
+    * completed stages are skipped. Resuming a succeeded run is a no-op; a run still held by a live
+    * process cannot be resumed
+    */
+  def resumeRun(request: FlowRunRequest): FlowRunActionResult
 
 object FlowApi extends RxRouterProvider:
   override def router = RxRouter.of[FlowApi]
@@ -84,5 +100,18 @@ object FlowApi extends RxRouterProvider:
 
   /** A recorded run with its per-stage states, attempts, and errors */
   case class FlowRunDetail(run: FlowRunSummary, stages: List[StageRunInfo])
+
+  /**
+    * Outcome of a cancel/resume mutation
+    *
+    * @param runId
+    *   The targeted run id
+    * @param accepted
+    *   True when the action was applied (cancellation requested, resume launched); false for no-op
+    *   outcomes such as cancelling a terminal run or resuming a succeeded one
+    * @param message
+    *   Human-readable description of what happened
+    */
+  case class FlowRunActionResult(runId: String, accepted: Boolean, message: String)
 
 end FlowApi

--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/WvletFlowCommand.scala
@@ -35,6 +35,7 @@ import wvlet.lang.model.plan.Query
 import wvlet.lang.model.plan.RunFlow
 import wvlet.lang.runner.CronSchedule
 import wvlet.lang.runner.FlowExecutor
+import wvlet.lang.runner.FlowRunLauncher
 import wvlet.lang.runner.FlowRunRecord
 import wvlet.lang.runner.FlowRunRetention
 import wvlet.lang.runner.FlowRunStore
@@ -108,51 +109,18 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
       resumeFrom: Option[FlowRunRecord],
       args: List[FunctionArg] = Nil
   ): Unit =
-    withFlows(flowOption) { (flows, compileResult, workEnv) =>
-      val (unit, flow) = findFlow(flows, name)
-      val profile = Profile.getProfile(flowOption.profile, flowOption.catalog, flowOption.schema)
-      // System.exit is deferred until the resource blocks release the connector and run store
-      var failed = false
-      Control.withResource(ConnectorProvider(workEnv)) { dbConnectorProvider =>
-        val connector = dbConnectorProvider.getConnector(profile)
-
-        given ctx: Context = compileResult
-          .context
-          .withCompilationUnit(unit)
-          .newContext(Symbol.NoSymbol)
-
-        Control.withResource(newRunStore(flowOption, workEnv)) { store =>
-          val result = FlowExecutor(
-            connector,
-            workEnv,
-            registry = Some(store),
-            engineResolver = Some(name =>
-              profile
-                .connectors
-                .find(_.name == name)
-                .map(dbConnectorProvider.getConnector)
-                .getOrElse(
-                  throw StatusCode
-                    .INVALID_ARGUMENT
-                    .newException(s"Connector '${name}' is not defined in the profile")
-                )
-            ),
-            defaultEngineName = profile.defaultEngine.name,
-            activationSinks =
-              FlowExecutor.defaultActivationSinks ++
-                profile
-                  .connectors
-                  .map(c =>
-                    ConnectorActivationSink(c.name, () => dbConnectorProvider.getConnector(c))
-                  )
-          ).execute(flow, resumeFrom, args)
-          println(result.toPrettyBox())
-          failed = result.hasError
-        }
-      }
-      if failed && !WvletMain.isInSbt then
-        System.exit(1)
+    val workEnv = WorkEnv(flowOption.workFolder, opts.logLevel)
+    val loaded  = FlowRunLauncher.loadFlows(flowOption.workFolder, workEnv)
+    val profile = Profile.getProfile(flowOption.profile, flowOption.catalog, flowOption.schema)
+    // System.exit is deferred until the resource block releases the run store
+    var failed = false
+    Control.withResource(newRunStore(flowOption, workEnv)) { store =>
+      val result = FlowRunLauncher.execute(loaded, name, profile, workEnv, store, resumeFrom, args)
+      println(result.toPrettyBox())
+      failed = result.hasError
     }
+    if failed && !WvletMain.isInSbt then
+      System.exit(1)
 
   /** Create the run store selected with --run-store (or the WVLET_FLOW_STORE environment) */
   private def newRunStore(flowOption: WvletFlowOption, workEnv: WorkEnv): FlowRunStore = flowOption
@@ -737,22 +705,9 @@ class WvletFlowCommand(opts: WvletGlobalOption) extends LogSupport:
   private def loadFlows(
       flowOption: WvletFlowOption
   ): (List[(CompilationUnit, FlowDef)], CompileResult, WorkEnv) =
-    val workEnv  = WorkEnv(flowOption.workFolder, opts.logLevel)
-    val compiler = Compiler(
-      CompilerOptions(sourceFolders = List(flowOption.workFolder), workEnv = workEnv)
-    )
-    val compileResult = compiler.compile()
-    val flows         = List.newBuilder[(CompilationUnit, FlowDef)]
-    compileResult
-      .units
-      .foreach { unit =>
-        unit
-          .resolvedPlan
-          .traverse { case f: FlowDef =>
-            flows += unit -> f
-          }
-      }
-    (flows.result(), compileResult, workEnv)
+    val workEnv = WorkEnv(flowOption.workFolder, opts.logLevel)
+    val loaded  = FlowRunLauncher.loadFlows(flowOption.workFolder, workEnv)
+    (loaded.flows, loaded.compileResult, workEnv)
 
   /** Extract the flows that have a cron schedule, paired with their defining units */
   private def scheduledFlowsOf(

--- a/wvlet-client/src/main/scala/wvlet/lang/api/v1/frontend/client/FlowApiClient.scala
+++ b/wvlet-client/src/main/scala/wvlet/lang/api/v1/frontend/client/FlowApiClient.scala
@@ -15,6 +15,7 @@ package wvlet.lang.api.v1.frontend.client
 
 import wvlet.lang.api.v1.flow.FlowApi
 import wvlet.lang.api.v1.flow.FlowApi.{
+  FlowRunActionResult,
   FlowRunDetail,
   FlowRunListRequest,
   FlowRunRequest,
@@ -45,6 +46,18 @@ object FlowApiClient:
       Seq(request)
     )
 
+    def cancelRun(request: FlowRunRequest): FlowRunActionResult = rpc.callSync(
+      client,
+      "cancelRun",
+      Seq(request)
+    )
+
+    def resumeRun(request: FlowRunRequest): FlowRunActionResult = rpc.callSync(
+      client,
+      "resumeRun",
+      Seq(request)
+    )
+
   class AsyncClient(client: HttpAsyncClient):
     def listRuns(request: FlowRunListRequest): Rx[List[FlowRunSummary]] = rpc.callAsync(
       client,
@@ -55,6 +68,18 @@ object FlowApiClient:
     def getRun(request: FlowRunRequest): Rx[FlowRunDetail] = rpc.callAsync(
       client,
       "getRun",
+      Seq(request)
+    )
+
+    def cancelRun(request: FlowRunRequest): Rx[FlowRunActionResult] = rpc.callAsync(
+      client,
+      "cancelRun",
+      Seq(request)
+    )
+
+    def resumeRun(request: FlowRunRequest): Rx[FlowRunActionResult] = rpc.callAsync(
+      client,
+      "resumeRun",
       Seq(request)
     )
 

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowRunLauncher.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowRunLauncher.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.runner
+
+import wvlet.lang.api.StatusCode
+import wvlet.lang.catalog.Profile
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.CompileResult
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.Context
+import wvlet.lang.compiler.Symbol
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.model.expr.FunctionArg
+import wvlet.lang.model.plan.FlowDef
+import wvlet.lang.runner.connector.ConnectorProvider
+import wvlet.uni.control.Control
+import wvlet.uni.log.LogSupport
+
+/**
+  * Compiles the flows of a work folder and executes (or resumes) them with profile-selected
+  * connectors. Shared by the `wvlet flow` CLI and the server's flow mutation API so both launch
+  * runs through the same path
+  */
+object FlowRunLauncher extends LogSupport:
+
+  /** Flow definitions compiled from the .wv sources of a work folder, with their defining units */
+  case class LoadedFlows(flows: List[(CompilationUnit, FlowDef)], compileResult: CompileResult):
+    /** The flow with the given name, or a FLOW_NOT_FOUND error listing the available flows */
+    def find(name: String): (CompilationUnit, FlowDef) = flows
+      .find(_._2.name.name == name)
+      .getOrElse(
+        throw StatusCode
+          .FLOW_NOT_FOUND
+          .newException(
+            s"Flow '${name}' is not found. Available flows: ${flows
+                .map(_._2.name.name)
+                .mkString(", ")}"
+          )
+      )
+
+  /** Compile all .wv files in the work folder and collect flow definitions */
+  def loadFlows(workFolder: String, workEnv: WorkEnv): LoadedFlows =
+    val compiler = Compiler(CompilerOptions(sourceFolders = List(workFolder), workEnv = workEnv))
+    val compileResult = compiler.compile()
+    val flows         = List.newBuilder[(CompilationUnit, FlowDef)]
+    compileResult
+      .units
+      .foreach { unit =>
+        unit
+          .resolvedPlan
+          .traverse { case f: FlowDef =>
+            flows += unit -> f
+          }
+      }
+    LoadedFlows(flows.result(), compileResult)
+
+  /**
+    * Execute (or resume) a compiled flow. Connectors are resolved through the profile, and run
+    * records land in the given store (owned by the caller)
+    */
+  def execute(
+      loaded: LoadedFlows,
+      flowName: String,
+      profile: Profile,
+      workEnv: WorkEnv,
+      store: FlowRunStore,
+      resumeFrom: Option[FlowRunRecord] = None,
+      args: List[FunctionArg] = Nil
+  ): FlowExecutionResult =
+    val (unit, flow) = loaded.find(flowName)
+    Control.withResource(ConnectorProvider(workEnv)) { dbConnectorProvider =>
+      val connector = dbConnectorProvider.getConnector(profile)
+
+      given ctx: Context = loaded
+        .compileResult
+        .context
+        .withCompilationUnit(unit)
+        .newContext(Symbol.NoSymbol)
+
+      FlowExecutor(
+        connector,
+        workEnv,
+        registry = Some(store),
+        engineResolver = Some(name =>
+          profile
+            .connectors
+            .find(_.name == name)
+            .map(dbConnectorProvider.getConnector)
+            .getOrElse(
+              throw StatusCode
+                .INVALID_ARGUMENT
+                .newException(s"Connector '${name}' is not defined in the profile")
+            )
+        ),
+        defaultEngineName = profile.defaultEngine.name,
+        activationSinks =
+          FlowExecutor.defaultActivationSinks ++
+            profile
+              .connectors
+              .map(c => ConnectorActivationSink(c.name, () => dbConnectorProvider.getConnector(c)))
+      ).execute(flow, resumeFrom, args)
+    }
+
+  end execute
+
+end FlowRunLauncher

--- a/wvlet-server/src/main/scala/wvlet/lang/server/FlowApiImpl.scala
+++ b/wvlet-server/src/main/scala/wvlet/lang/server/FlowApiImpl.scala
@@ -13,21 +13,30 @@
  */
 package wvlet.lang.server
 
+import wvlet.lang.api.WvletLangException
 import wvlet.lang.api.v1.flow.FlowApi
 import wvlet.lang.api.v1.flow.FlowApi.*
+import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.runner.FlowRunLauncher
 import wvlet.lang.runner.FlowRunRecord
 import wvlet.lang.runner.FlowRunStore
+import wvlet.lang.runner.ThreadManager
+import wvlet.uni.control.Control
 import wvlet.uni.http.rpc.RPCStatus
 import wvlet.uni.log.LogSupport
 
 /**
-  * Read-only [[FlowApi]] over the local flow run store of the server's working folder. The store is
-  * opened once per server session (both store backends read fresh state on every list/get, so runs
-  * written by other processes — CLI runs, scheduler daemons — stay visible) and closed with the DI
-  * session
+  * [[FlowApi]] over the local flow run store of the server's working folder. The store is opened
+  * once per server session (both store backends read fresh state on every list/get, so runs written
+  * by other processes — CLI runs, scheduler daemons — stay visible) and closed with the DI session.
+  * Cancel and resume mutations follow the same store/launcher paths as `wvlet flow session`, so the
+  * web UI and the CLI observe identical semantics
   */
-class FlowApiImpl(workEnv: WorkEnv) extends FlowApi with AutoCloseable with LogSupport:
+class FlowApiImpl(workEnv: WorkEnv, profile: Profile, threadManager: ThreadManager)
+    extends FlowApi
+    with AutoCloseable
+    with LogSupport:
 
   private lazy val store: FlowRunStore = FlowRunStore.forWorkEnv(workEnv)
 
@@ -63,6 +72,86 @@ class FlowApiImpl(workEnv: WorkEnv) extends FlowApi with AutoCloseable with LogS
         )
       case None =>
         throw RPCStatus.NOT_FOUND_U5.newException(s"Flow run '${request.runId}' is not found")
+
+  override def cancelRun(request: FlowRunRequest): FlowRunActionResult =
+    val r = recordOf(request.runId)
+    if r.isTerminal then
+      FlowRunActionResult(
+        runId = r.runId,
+        accepted = false,
+        message = s"Run ${r.runId} is already ${r.state}"
+      )
+    else
+      store.requestCancel(r.runId)
+      FlowRunActionResult(
+        runId = r.runId,
+        accepted = true,
+        message = s"Requested cancellation of run ${r.runId}"
+      )
+
+  override def resumeRun(request: FlowRunRequest): FlowRunActionResult =
+    val r   = recordOf(request.runId)
+    val now = System.currentTimeMillis()
+    r.state match
+      // A stale running record belongs to a crashed process and can be resumed
+      case FlowRunRecord.STATE_RUNNING if !r.isStaleAt(now) =>
+        throw RPCStatus
+          .INVALID_REQUEST_U1
+          .newException(s"Run ${r.runId} is still running and cannot be resumed")
+      case FlowRunRecord.STATE_SUCCESS =>
+        FlowRunActionResult(
+          runId = r.runId,
+          accepted = false,
+          message = s"Run ${r.runId} already succeeded; nothing to resume"
+        )
+      case FlowRunRecord.STATE_SKIPPED =>
+        throw RPCStatus
+          .INVALID_REQUEST_U1
+          .newException(
+            s"Run ${r
+                .runId} was skipped (its dependency was not satisfied); start a new run instead"
+          )
+      case _ =>
+        // Compile synchronously so unknown flows and compile errors surface to the caller;
+        // the run itself executes in the background (an RPC must not block for a whole flow)
+        val loaded =
+          try
+            val l = FlowRunLauncher.loadFlows(workEnv.path, workEnv)
+            l.find(r.flowName)
+            l
+          catch
+            case e: WvletLangException =>
+              throw RPCStatus.INVALID_REQUEST_U1.newException(e.getMessage, e)
+        threadManager.runBackgroundTask { () =>
+          try
+            // A dedicated store instance: the background run outlives this RPC call and must
+            // not race the session-scoped store's lifecycle
+            Control.withResource(FlowRunStore.forWorkEnv(workEnv)) { runStore =>
+              FlowRunLauncher.execute(
+                loaded,
+                r.flowName,
+                profile,
+                workEnv,
+                runStore,
+                resumeFrom = Some(r)
+              )
+            }
+          catch
+            case e: Throwable =>
+              warn(s"Resumed run ${r.runId} of flow '${r.flowName}' failed: ${e.getMessage}")
+        }
+        FlowRunActionResult(
+          runId = r.runId,
+          accepted = true,
+          message = s"Resuming run ${r.runId} of flow '${r.flowName}' in the background"
+        )
+    end match
+
+  end resumeRun
+
+  private def recordOf(runId: String): FlowRunRecord = store
+    .get(runId)
+    .getOrElse(throw RPCStatus.NOT_FOUND_U5.newException(s"Flow run '${runId}' is not found"))
 
   private def toSummary(r: FlowRunRecord, nowMillis: Long): FlowRunSummary = FlowRunSummary(
     runId = r.runId,

--- a/wvlet-server/src/test/scala/wvlet/lang/server/FlowApiImplTest.scala
+++ b/wvlet-server/src/test/scala/wvlet/lang/server/FlowApiImplTest.scala
@@ -1,6 +1,7 @@
 package wvlet.lang.server
 
 import wvlet.lang.api.v1.flow.FlowApi
+import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.WorkEnv
 import wvlet.lang.runner.FlowRunRecord
 import wvlet.lang.runner.FlowRunRegistry
@@ -61,17 +62,29 @@ class FlowApiImplTest extends WvletDITest:
         )
       )
     )
+    registry.save(
+      FlowRunRecord(
+        runId = "run4",
+        flowName = "FlowD",
+        state = FlowRunRecord.STATE_SKIPPED,
+        startedAtMillis = 400L,
+        finishedAtMillis = Some(400L),
+        stages = Nil
+      )
+    )
     dir.toString
 
   end workDir
 
   initDesign:
-    _.bindImpl[FlowApi, FlowApiImpl].bindInstance[WorkEnv](WorkEnv(workDir))
+    _.bindImpl[FlowApi, FlowApiImpl]
+      .bindInstance[WorkEnv](WorkEnv(workDir))
+      .bindInstance[Profile](Profile.defaultDuckDBProfile)
 
   test("list recorded runs most recent first") {
     val api  = dep[FlowApi]
     val runs = api.listRuns(FlowApi.FlowRunListRequest())
-    runs.map(_.runId) shouldBe List("run3", "run2", "run1")
+    runs.map(_.runId) shouldBe List("run4", "run3", "run2", "run1")
     val r1 = runs.last
     r1.flowName shouldBe "FlowA"
     r1.flowCall shouldBe "FlowA(segment = 'a')"
@@ -85,7 +98,7 @@ class FlowApiImplTest extends WvletDITest:
     val api = dep[FlowApi]
     api.listRuns(FlowApi.FlowRunListRequest(flowName = Some("FlowA"))).map(_.runId) shouldBe
       List("run1")
-    api.listRuns(FlowApi.FlowRunListRequest(limit = 1)).map(_.runId) shouldBe List("run3")
+    api.listRuns(FlowApi.FlowRunListRequest(limit = 1)).map(_.runId) shouldBe List("run4")
     api.listRuns(FlowApi.FlowRunListRequest(flowName = Some("NoSuchFlow"))) shouldBe Nil
   }
 
@@ -115,6 +128,73 @@ class FlowApiImplTest extends WvletDITest:
     val api = dep[FlowApi]
     val e   = intercept[RPCException] {
       api.getRun(FlowApi.FlowRunRequest("nosuchrun"))
+    }
+    e.getMessage shouldContain "nosuchrun"
+  }
+
+  test("request cancellation of a running run through the shared store") {
+    val api    = dep[FlowApi]
+    val result = api.cancelRun(FlowApi.FlowRunRequest("run3"))
+    result.accepted shouldBe true
+    result.message shouldContain "run3"
+    // The cancel request is observable by the run's owning process through the store
+    val registry = FlowRunRegistry.forWorkEnv(WorkEnv(workDir))
+    registry.cancelRequested("run3") shouldBe true
+    registry.clearCancelRequest("run3")
+  }
+
+  test("report cancelling a terminal run as a no-op") {
+    val api    = dep[FlowApi]
+    val result = api.cancelRun(FlowApi.FlowRunRequest("run1"))
+    result.accepted shouldBe false
+    result.message shouldContain "already success"
+  }
+
+  test("report cancelling an unknown run as not found") {
+    val api = dep[FlowApi]
+    val e   = intercept[RPCException] {
+      api.cancelRun(FlowApi.FlowRunRequest("nosuchrun"))
+    }
+    e.getMessage shouldContain "nosuchrun"
+  }
+
+  test("reject resuming a run still held by a live process") {
+    val api = dep[FlowApi]
+    val e   = intercept[RPCException] {
+      api.resumeRun(FlowApi.FlowRunRequest("run3"))
+    }
+    e.getMessage shouldContain "still running"
+  }
+
+  test("report resuming a succeeded run as a no-op") {
+    val api    = dep[FlowApi]
+    val result = api.resumeRun(FlowApi.FlowRunRequest("run1"))
+    result.accepted shouldBe false
+    result.message shouldContain "already succeeded"
+  }
+
+  test("reject resuming a skipped run") {
+    val api = dep[FlowApi]
+    val e   = intercept[RPCException] {
+      api.resumeRun(FlowApi.FlowRunRequest("run4"))
+    }
+    e.getMessage shouldContain "skipped"
+  }
+
+  test("surface an unknown flow definition when resuming a failed run") {
+    // run2's flow 'FlowB' is not defined in the workspace, so the synchronous compile step
+    // reports the problem to the caller instead of failing silently in the background
+    val api = dep[FlowApi]
+    val e   = intercept[RPCException] {
+      api.resumeRun(FlowApi.FlowRunRequest("run2"))
+    }
+    e.getMessage shouldContain "FlowB"
+  }
+
+  test("report resuming an unknown run as not found") {
+    val api = dep[FlowApi]
+    val e   = intercept[RPCException] {
+      api.resumeRun(FlowApi.FlowRunRequest("nosuchrun"))
     }
     e.getMessage shouldContain "nosuchrun"
   }

--- a/wvlet-ui/src/main/scala/wvlet/lang/ui/component/flow/FlowRunsPage.scala
+++ b/wvlet-ui/src/main/scala/wvlet/lang/ui/component/flow/FlowRunsPage.scala
@@ -23,23 +23,50 @@ import wvlet.lang.api.v1.frontend.FrontendRPC.RPCAsyncClient
 import wvlet.lang.ui.component.MainFrame
 import wvlet.uni.dom.RxElement
 import wvlet.uni.dom.all.{*, given}
+import wvlet.uni.rx.Cancelable
 import wvlet.uni.rx.Rx
 
 import scala.scalajs.js
 
 /**
-  * A read-only list of recorded flow runs with per-run stage details, backed by [[FlowApi]].
-  * Mutations (cancel, resume) stay in the `wvlet flow session` CLI
+  * A list of recorded flow runs with per-run stage details, backed by [[FlowApi]]. The list
+  * auto-refreshes while a run is in flight, can be filtered by flow name, and offers cancel/resume
+  * actions (with a confirmation step) that delegate to the same run-store paths as the `wvlet flow
+  * session` CLI
   */
 class FlowRunsPage(rpcClient: RPCAsyncClient) extends RxElement:
 
   private val runs        = Rx.variable(List.empty[FlowRunSummary])
   private val selectedRun = Rx.variable(Option.empty[FlowRunDetail])
   private val loadError   = Rx.variable(Option.empty[String])
+  // The flow-name filter passed to listRuns; empty means no filter
+  private val flowNameFilter = Rx.variable("")
+  // A requested mutation ("cancel" or "resume", run id) awaiting user confirmation
+  private val pendingAction = Rx.variable(Option.empty[(String, String)])
+  // The outcome message of the last confirmed mutation
+  private val actionMessage = Rx.variable(Option.empty[String])
+
+  // Auto-refresh while any listed run is in flight and this page is visible. The page stays
+  // mounted permanently (MainFrame toggles visibility with a hidden class), so the timer guards
+  // on the current page instead of relying on unmount
+  private var autoRefresh = Cancelable.empty
+
+  override def onMount(node: Any): Unit =
+    autoRefresh = Rx
+      .intervalMillis(3000)
+      .map { _ =>
+        if MainFrame.currentPage.get == MainFrame.PAGE_FLOW_RUNS &&
+          runs.get.exists(_.state == "running")
+        then
+          refresh()
+      }
+      .subscribe()
+
+  override def beforeUnmount: Unit = autoRefresh.cancel
 
   private def refresh(): Unit = rpcClient
     .FlowApi
-    .listRuns(FlowRunListRequest())
+    .listRuns(FlowRunListRequest(flowName = Some(flowNameFilter.get.trim).filter(_.nonEmpty)))
     .map { lst =>
       loadError := None
       runs      := lst
@@ -65,6 +92,26 @@ class FlowRunsPage(rpcClient: RPCAsyncClient) extends RxElement:
       loadError := Some(e.getMessage)
     }
     .run()
+
+  /** Run a confirmed cancel/resume action and surface its outcome message */
+  private def performAction(action: String, runId: String): Unit =
+    val call =
+      action match
+        case "cancel" =>
+          rpcClient.FlowApi.cancelRun(FlowRunRequest(runId))
+        case _ =>
+          rpcClient.FlowApi.resumeRun(FlowRunRequest(runId))
+    pendingAction := None
+    call
+      .map { result =>
+        actionMessage := Some(result.message)
+        refresh()
+        showRun(runId)
+      }
+      .recover { case e: Throwable =>
+        actionMessage := Some(e.getMessage)
+      }
+      .run()
 
   private def stateBadge(state: String): RxElement =
     val color =
@@ -168,6 +215,40 @@ class FlowRunsPage(rpcClient: RPCAsyncClient) extends RxElement:
       )
   }
 
+  private def actionButton(label: String, action: String, runId: String): RxElement = button(
+    cls     -> "rounded-md bg-gray-700 px-2 py-1 text-xs text-gray-200 hover:bg-gray-600",
+    onclick -> { (_: dom.MouseEvent) =>
+      actionMessage := None
+      pendingAction := Some((action, runId))
+    },
+    label
+  )
+
+  /** The confirmation step of a requested cancel/resume, rendered inline in the detail header */
+  private def confirmStrip = pendingAction.map {
+    case Some((action, runId)) =>
+      span(
+        cls -> "flex items-center gap-x-2 text-xs text-amber-300",
+        span(s"${action.capitalize} run ${runId}?"),
+        button(
+          cls     -> "rounded-md bg-amber-700 px-2 py-1 text-xs text-amber-100 hover:bg-amber-600",
+          onclick -> { (_: dom.MouseEvent) =>
+            performAction(action, runId)
+          },
+          "Confirm"
+        ),
+        button(
+          cls     -> "rounded-md bg-gray-700 px-2 py-1 text-xs text-gray-200 hover:bg-gray-600",
+          onclick -> { (_: dom.MouseEvent) =>
+            pendingAction := None
+          },
+          "Dismiss"
+        )
+      )
+    case None =>
+      span()
+  }
+
   private def runDetail = selectedRun.map {
     case None =>
       div(cls -> "text-sm text-gray-400 px-3 py-4", "Select a run to see its stages")
@@ -177,7 +258,24 @@ class FlowRunsPage(rpcClient: RPCAsyncClient) extends RxElement:
           cls -> "px-3 py-2 text-sm text-gray-200 flex items-center gap-x-2",
           span(cls -> "font-mono text-xs text-gray-400", detail.run.runId),
           span(detail.run.flowCall),
-          stateBadge(detail.run.state)
+          stateBadge(detail.run.state),
+          // Cancel applies to in-flight runs; resume to failed/cancelled ones (a crashed
+          // process's stale running record is already reported as failed)
+          detail.run.state match
+            case "running" =>
+              actionButton("Cancel", "cancel", detail.run.runId)
+            case "failed" | "cancelled" =>
+              actionButton("Resume", "resume", detail.run.runId)
+            case _ =>
+              span()
+          ,
+          confirmStrip,
+          actionMessage.map {
+            case Some(msg) =>
+              span(cls -> "text-xs text-gray-400", msg)
+            case None =>
+              span()
+          }
         ),
         table(
           cls -> "w-full",
@@ -225,6 +323,16 @@ class FlowRunsPage(rpcClient: RPCAsyncClient) extends RxElement:
           refresh()
         },
         "Refresh"
+      ),
+      input(
+        cls ->
+          "rounded-md bg-zinc-700 px-2 py-1 text-xs text-gray-200 placeholder-gray-500 border border-zinc-600 focus:outline-none",
+        placeholder -> "Filter by flow name",
+        value       -> flowNameFilter.get,
+        oninput     -> { (e: dom.Event) =>
+          flowNameFilter := e.target.asInstanceOf[dom.html.Input].value
+          refresh()
+        }
       ),
       loadError.map {
         case Some(msg) =>


### PR DESCRIPTION
## Summary

Implements item 4 ("Web UI round 2: mutations and liveness") of #1858:

- **Cancel and resume buttons** with a confirmation step on the flow runs page — the server's first mutating flow endpoints (`FlowApi.cancelRun`/`resumeRun`), delegating to the same `FlowRunStore.requestCancel` and launcher paths as `wvlet flow session`, so CLI and UI semantics are identical: terminal runs report a no-op, a run held by a live process refuses resume, a stale-running record (crashed process) resumes like a failure, and a skipped run is rejected
- **Auto-refresh** of the runs list (3s interval) while any listed run is running and the page is visible
- **Flow-name filter** input, wiring up the `flowName` parameter the API already supported

Resume compiles the server's work folder synchronously — unknown flows and compile errors surface to the caller as RPC errors — then re-executes the flow in the background on the server's thread manager with a dedicated run-store instance, re-binding the run's recorded arguments and `run_time`.

To share the compile-and-execute path, the CLI's private `executeFlow` orchestration moves into a new `FlowRunLauncher` in wvlet-runner; `wvlet flow run`/`session resume` now go through it (behavior unchanged, covered by the existing CLI tests).

Mutations inherit the server's bearer-auth wrapper automatically (all RPC endpoints are guarded).

## Tests

- `FlowApiImplTest`: 8 new cases covering cancel (running/terminal/unknown) and resume preconditions (live-running, succeeded, skipped, unknown flow, unknown run) — 13 passed
- Full `server/test` (43 passed), `cli/test` (111 passed, includes session cancel/resume behavior through the shared launcher), runner flow tests (106 passed), `ui/test` headless (passed)
- Cross-platform compile checked for api/client on JS and Native

## Docs

- `website/docs/syntax/flow.md`: the web UI section now describes the mutations, auto-refresh, and filter (previously stated the page was read-only)

## Related

- #1858 (round 7 — this was the last numbered item; remaining are the standalone items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADwW9QKqzMo5Yf6kNqoLvz