### PR TITLE
feature: Declare primary key, unique, and not null column constraints on tables

### DIFF
--- a/spec/basic/ddl/table-constraints.wv
+++ b/spec/basic/ddl/table-constraints.wv
@@ -1,0 +1,36 @@
+-- Column constraints on table declarations (#1997): `primary key`, `unique`, and `not null`
+-- as soft words in field position render into the generated CREATE TABLE, so the engine
+-- enforces integrity on declared tables
+
+table ddl_constrained = {
+  id: int primary key
+  email: string unique not null
+  score: double not null = 1.5
+}
+
+create table ddl_constrained
+
+append to ddl_constrained (id, email) {
+  from [[1, 'alice@example.com'], [2, 'bob@example.com']] as t(id, email)
+}
+
+from ddl_constrained
+test _.size should be 2
+
+-- The default fills the not-null column, satisfying its constraint
+from ddl_constrained
+where score = 1.5
+test _.size should be 2
+
+-- Constraints ride along on auto-created tables, too
+table ddl_constrained_auto like ddl_constrained
+
+append to ddl_constrained_auto (id, email) {
+  from [[3, 'carol@example.com']] as t(id, email)
+}
+
+from ddl_constrained_auto
+test _.size should be 1
+
+drop table ddl_constrained_auto
+drop table ddl_constrained

--- a/website/docs/syntax/table-management.md
+++ b/website/docs/syntax/table-management.md
@@ -74,6 +74,30 @@ Defaults compose with `like` and `extends`: a reused or mixed-in column keeps it
 default. Engines whose `CREATE TABLE` grammar has no `DEFAULT` clause (e.g. Trino) reject a
 create with column defaults at compile time instead of silently dropping them.
 
+### Column Constraints
+
+Columns can declare `primary key`, `unique`, and `not null` constraints as soft words after
+the type, making the declaration faithful to production tables and letting the engine
+enforce integrity:
+
+```wvlet
+table users = {
+  id: int primary key
+  email: string unique not null
+  name: string
+  active: boolean not null = true
+}
+```
+
+Constraints render into the generated `CREATE TABLE` — for explicit `create table` actions
+and auto-created append targets alike — and compose with `like` and `extends` the same way
+defaults do. Engines without column constraints in `CREATE TABLE` (e.g. Trino) reject the
+create at compile time.
+
+Keyed `append to ... on <keys>` works without any declared constraints (its MERGE lowering
+deliberately requires none); declaring them simply lets the engine enforce what the pipeline
+already assumes.
+
 ### Reusing a Shape with `like`
 
 `table <name> like <source>` declares a second table with the same columns as an existing

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/DBType.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/DBType.scala
@@ -35,7 +35,9 @@ enum DBType(
     // RLIKE operator support (regex pattern matching)
     val supportRLike: Boolean = false,
     // Column DEFAULT clauses in CREATE TABLE are supported
-    val supportColumnDefaultValues: Boolean = true
+    val supportColumnDefaultValues: Boolean = true,
+    // Column PRIMARY KEY / UNIQUE constraints in CREATE TABLE are supported
+    val supportKeyConstraints: Boolean = true
 ):
 
   /**
@@ -69,8 +71,9 @@ enum DBType(
         mapConstructorSyntax = SQLDialect.MapSyntax.ArrayPair,
         requireParenForValues = true,
         supportRLike = true,
-        // Trino's CREATE TABLE grammar has no column DEFAULT clause
-        supportColumnDefaultValues = false
+        // Trino's CREATE TABLE grammar has no column DEFAULT clause and no key constraints
+        supportColumnDefaultValues = false,
+        supportKeyConstraints = false
       )
 
   case Hive

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TableBindings.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/TableBindings.scala
@@ -128,7 +128,10 @@ object TableBindings:
             // fieldType decimal + params [10, 2]), so pass both to keep parameterized types
             DataTypeParser.parse(f.fieldType.fullName, f.params),
             f.span,
-            defaultValue = f.body
+            defaultValue = f.body,
+            notNull = f.notNull,
+            primaryKey = f.primaryKey,
+            unique = f.unique
           )
         }
       val inherited = (current.parents.map(_.leafName) ++ current.likeSource.map(_.leafName))

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/GenSQL.scala
@@ -171,12 +171,15 @@ object GenSQL extends Phase("generate-sql"):
               s"on ${context.dbType}",
             c.sourceLocation
           )
-      // Declared column defaults render as DEFAULT clauses; engines without them (e.g. Trino)
-      // reject the create loudly instead of dropping the semantics. Generic stays
-      // dialect-neutral and prints the standard spelling
-      case c: CreateTable
-          if hasColumnDefaults(c.tableElems) && !context.dbType.supportColumnDefaultValues =>
-        throw columnDefaultsNotSupported(c.table.fullName, c.sourceLocation)
+      // Declared column defaults and key constraints render into the CREATE TABLE columns;
+      // engines without them (e.g. Trino) reject the create loudly instead of dropping the
+      // semantics. Generic stays dialect-neutral and prints the standard spelling
+      case c: CreateTable if unsupportedColumnFeature(c.tableElems).nonEmpty =>
+        throw columnFeatureNotSupported(
+          unsupportedColumnFeature(c.tableElems).get,
+          c.table.fullName,
+          c.sourceLocation
+        )
       case c: CreateTable if c.replace && !context.dbType.supportCreateOrReplace =>
         // Engines without CREATE OR REPLACE decompose it into an explicit drop + create
         List(
@@ -223,20 +226,32 @@ object GenSQL extends Phase("generate-sql"):
     * inferred ones) and the rows are inserted into it; otherwise the append reduces to CREATE TABLE
     * AS with the query's shape
     */
-  private def hasColumnDefaults(tableElems: List[TableElement]): Boolean = tableElems.exists {
-    case c: ColumnDef =>
-      c.defaultValue.nonEmpty
-    case _ =>
-      false
-  }
-
-  private def columnDefaultsNotSupported(tableName: String, loc: SourceLocation)(using
+  /**
+    * The declared column feature the target engine cannot express in CREATE TABLE, if any: column
+    * defaults (#1997 defaults slice) or key constraints (#1997 constraints slice)
+    */
+  private def unsupportedColumnFeature(tableElems: List[TableElement])(using
       context: Context
+  ): Option[String] =
+    def has(f: ColumnDef => Boolean): Boolean = tableElems.exists {
+      case c: ColumnDef =>
+        f(c)
+      case _ =>
+        false
+    }
+    if has(_.defaultValue.nonEmpty) && !context.dbType.supportColumnDefaultValues then
+      Some("column default values")
+    else if has(c => c.primaryKey || c.unique) && !context.dbType.supportKeyConstraints then
+      Some("key constraints (primary key / unique)")
+    else
+      None
+
+  private def columnFeatureNotSupported(feature: String, tableName: String, loc: SourceLocation)(
+      using context: Context
   ): WvletLangException = StatusCode
     .NOT_IMPLEMENTED
     .newException(
-      s"creating table ${tableName} with column default values is not supported on ${context
-          .dbType}",
+      s"creating table ${tableName} with ${feature} is not supported on ${context.dbType}",
       loc
     )
 
@@ -247,8 +262,9 @@ object GenSQL extends Phase("generate-sql"):
       baseSQL: String
   )(using context: Context): List[String] =
     if declaredCols.nonEmpty then
-      if hasColumnDefaults(declaredCols) && !context.dbType.supportColumnDefaultValues then
-        throw columnDefaultsNotSupported(fullTableName, a.sourceLocation)
+      unsupportedColumnFeature(declaredCols).foreach { feature =>
+        throw columnFeatureNotSupported(feature, fullTableName, a.sourceLocation)
+      }
       val gen       = sqlGeneratorFor(context.dbType)
       val createSQL = gen.print(
         CreateTable(

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/SqlGenerator.scala
@@ -1837,6 +1837,9 @@ class SqlGenerator(config: CodeFormatterConfig)(using ctx: Context = Context.NoC
         val baseColumn       = wl(expr(c.columnName), text(c.columnType.sqlExpr))
         val columnAttributes =
           List(
+            // Add key constraints
+            Option.when(c.primaryKey)(text("primary key")),
+            Option.when(c.unique)(text("unique")),
             // Add NOT NULL constraint
             Option.when(c.notNull)(text("not null")),
             // Add COMMENT attribute

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/codegen/WvletGenerator.scala
@@ -1175,7 +1175,16 @@ class WvletGenerator(config: CodeFormatterConfig = CodeFormatterConfig())(using
             d.defaultValue.map(x => wl("=", expr(x)))
           )
         case f: FieldDef =>
-          group(wl(f.name.name + ":", expr(f.fieldType), f.body.map(b => wl("=", expr(b)))))
+          group(
+            wl(
+              f.name.name + ":",
+              expr(f.fieldType),
+              Option.when(f.primaryKey)(text("primary key")),
+              Option.when(f.unique)(text("unique")),
+              Option.when(f.notNull)(text("not null")),
+              f.body.map(b => wl("=", expr(b)))
+            )
+          )
         case e: Extract =>
           // Convert EXTRACT(field FROM expr) to expr.extract(field)
           expr(e.expr) + text(".extract") + paren(text(s"'${e.interval.toString.toLowerCase}'"))

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/parser/WvletParser.scala
@@ -1643,19 +1643,54 @@ class WvletParser(unit: CompilationUnit, isContextUnit: Boolean = false) extends
       case id if id.isIdentifier =>
         val name = identifier()
         consume(WvletToken.COLON)
-        val valType      = identifier()
-        val tp           = typeParams()
-        val defaultValue =
-          scanner.lookAhead().token match
+        val valType = identifier()
+        val tp      = typeParams()
+        // Field constraints (#1997) and the `= expr` default trail the type as soft words, in
+        // any order. A constraint word must sit on the same line as its field: type bodies
+        // have no separators, so the line check tells a trailing `unique` constraint apart
+        // from a next-line field named `unique`
+        val fieldLine                        = src.offsetToLine(t.offset)
+        var primaryKey                       = false
+        var unique                           = false
+        var notNull                          = false
+        var defaultValue: Option[Expression] = None
+        var continue                         = true
+        while continue do
+          val la                   = scanner.lookAhead()
+          def onFieldLine: Boolean = src.offsetToLine(la.offset) == fieldLine
+          la.token match
             case WvletToken.EQ =>
               consume(WvletToken.EQ)
-              Some(expression())
+              defaultValue = Some(expression())
+            case WvletToken.NOT if onFieldLine =>
+              consume(WvletToken.NOT)
+              consume(WvletToken.NULL)
+              notNull = true
+            case w if w.isIdentifier && onFieldLine && la.str.equalsIgnoreCase("primary") =>
+              identifier()
+              val key = identifier()
+              if !key.leafName.equalsIgnoreCase("key") then
+                unexpected(la)
+              primaryKey = true
+            case w if w.isIdentifier && onFieldLine && la.str.equalsIgnoreCase("unique") =>
+              identifier()
+              unique = true
             case _ =>
-              None
+              continue = false
 
-        FieldDef(Name.termName(name.leafName), valType, tp, defaultValue, spanFrom(t))
+        FieldDef(
+          Name.termName(name.leafName),
+          valType,
+          tp,
+          defaultValue,
+          spanFrom(t),
+          primaryKey = primaryKey,
+          unique = unique,
+          notNull = notNull
+        )
       case _ =>
         unexpected(t)
+    end match
   }
 
   def tableAlias(input: Relation): AliasedRelation = node {

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/expr/exprs.scala
@@ -1004,7 +1004,10 @@ case class ColumnDef(
     comment: Option[String] = None,
     defaultValue: Option[Expression] = None,
     properties: List[(NameExpr, Expression)] = Nil,
-    position: Option[String] = None // FIRST, LAST, or AFTER column_name
+    position: Option[String] = None, // FIRST, LAST, or AFTER column_name
+    // Key constraints (#1997), declared as soft words in table-declaration field position
+    primaryKey: Boolean = false,
+    unique: Boolean = false
 ) extends TableElement
     with UnaryExpression:
   override def toString: String                   = s"${columnName.leafName}:${columnType.wvExpr}"

--- a/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/model/plan/plan.scala
@@ -128,7 +128,11 @@ case class FieldDef(
     fieldType: NameExpr,
     params: List[TypeParameter],
     body: Option[Expression],
-    span: Span
+    span: Span,
+    // Column constraints (#1997): soft words in field position, e.g. `id: int primary key`
+    primaryKey: Boolean = false,
+    unique: Boolean = false,
+    notNull: Boolean = false
 ) extends TypeElem:
   override def children: List[Expression] = Nil
 

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/TableColumnConstraintsTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/TableColumnConstraintsTest.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.codegen
+
+import wvlet.uni.test.UniTest
+import wvlet.lang.api.WvletLangException
+import wvlet.lang.compiler.CompilationUnit
+import wvlet.lang.compiler.Compiler
+import wvlet.lang.compiler.CompilerOptions
+import wvlet.lang.compiler.DBType
+import wvlet.lang.compiler.WorkEnv
+
+/**
+  * Column constraints on `table` declarations (#1997): `primary key`, `unique`, and `not null` as
+  * soft words in field position render into generated CREATE TABLE columns on both explicit
+  * `create table` actions and append-to auto-creation. Engines without key constraints (Trino)
+  * reject the create loudly instead of dropping the semantics
+  */
+class TableColumnConstraintsTest extends UniTest:
+
+  private val usersTable =
+    """table dc_users = {
+      |  id: int primary key
+      |  email: string unique not null
+      |  name: string
+      |  active: boolean not null = true
+      |}
+      |""".stripMargin
+
+  private def compileToSQL(
+      typeDefs: String,
+      query: String,
+      dbType: DBType = DBType.DuckDB
+  ): String =
+    val queryUnit = CompilationUnit.fromWvletString(query)
+    val compiler  = Compiler(CompilerOptions(workEnv = WorkEnv("."), dbType = dbType))
+    val typeUnit  = CompilationUnit.fromWvletString(typeDefs)
+    val result    = compiler.compileMultipleUnits(List(typeUnit), queryUnit)
+    GenSQL.generateSQL(queryUnit)(using result.context)
+
+  test("should render declared constraints into an explicit create table") {
+    val sql = compileToSQL(usersTable, "create table dc_users\n")
+    sql shouldContain "primary key"
+    sql shouldContain "unique not null"
+    sql shouldContain "not null default true"
+    // Unconstrained columns stay plain
+    sql.contains("name string primary") shouldBe false
+  }
+
+  test("should render declared constraints into append-to auto-creation") {
+    val sql = compileToSQL(
+      usersTable,
+      "from [[1, 'a@x.com', 'a', true]] as t(id, email, name, active)\nappend to dc_users\n"
+    )
+    sql shouldContain "create table if not exists"
+    sql shouldContain "primary key"
+    sql shouldContain "unique not null"
+  }
+
+  test("should propagate constraints through extends and like") {
+    val sql = compileToSQL(
+      usersTable + "table dc_users_backup like dc_users\n",
+      "create table dc_users_backup\n"
+    )
+    sql shouldContain "primary key"
+    sql shouldContain "unique not null"
+  }
+
+  test("should keep a field named after a constraint word parsing as a field") {
+    val sql = compileToSQL(
+      """table dc_odd = {
+        |  id: int primary key
+        |  unique: string
+        |  key: string
+        |}
+        |""".stripMargin,
+      "create table dc_odd\n"
+    )
+    // SQL-keyword column names render quoted, proving they parsed as fields, not constraints
+    sql shouldContain "\"unique\" string"
+    sql shouldContain "\"key\" string"
+  }
+
+  test("should reject key constraints on engines without them") {
+    val e = intercept[WvletLangException] {
+      compileToSQL(
+        "table dc_pk = {\n  id: int primary key\n  name: string\n}\n",
+        "create table dc_pk\n",
+        dbType = DBType.Trino
+      )
+    }
+    e.getMessage shouldContain "key constraints"
+  }
+
+  test("should reject key constraints in append auto-creation on engines without them") {
+    val e = intercept[WvletLangException] {
+      compileToSQL(
+        "table dc_pk = {\n  id: int primary key\n  name: string\n}\n",
+        "from [[1, 'a']] as t(id, name)\nappend to dc_pk\n",
+        dbType = DBType.Trino
+      )
+    }
+    e.getMessage shouldContain "key constraints"
+  }
+
+end TableColumnConstraintsTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/codegen/WvletGeneratorTest.scala
@@ -85,6 +85,18 @@ class WvletGeneratorTest extends UniTest:
     print(printed) shouldContain "active: boolean = true"
   }
 
+  test("should round-trip table field constraints (#1997)") {
+    val printed = print("""table users = {
+        |  id: int primary key
+        |  email: string unique not null
+        |  active: boolean not null = true
+        |}""".stripMargin)
+    printed shouldContain "id: int primary key"
+    printed shouldContain "email: string unique not null"
+    printed shouldContain "active: boolean not null = true"
+    print(printed) shouldContain "id: int primary key"
+  }
+
   test("should round-trip a model with a type annotation") {
     val printed = print("""model rm_all: rm_users = {
         |  from rm_users


### PR DESCRIPTION
## Summary

The constraints slice of #1997, following the defaults slice (#2023):

- `primary key`, `unique`, and `not null` parse as **soft words in field position** (`id: int primary key`) — no new hard keywords — in any order relative to the `= expr` default
- Constraints render into generated `CREATE TABLE` columns on both explicit `create table` actions and append-to auto-creation, and compose through `like` and `extends` (they ride on the composed `ColumnDef`s)
- **Disambiguation**: a constraint word must sit on the same line as its field. Type bodies have no separators, so the line check cleanly tells a trailing `unique` constraint apart from a next-line column named `unique` — covered by a dedicated test where `unique` and `key` are column names
- Engines whose `CREATE TABLE` grammar has no key constraints (Trino) reject the create at compile time via a new `DBType.supportKeyConstraints` flag; the defaults and constraints gates share one `unsupportedColumnFeature` helper in GenSQL
- The Wvlet pretty-printer round-trips constraints (`email: string unique not null = ...`)

Keyed `append to ... on <keys>` is unchanged — its MERGE lowering deliberately requires no constraints; declaring them lets the engine enforce what the pipeline already assumes (engine-native conflict-handling lowerings remain possible follow-up work).

## Tests

- New `TableColumnConstraintsTest` (6 cases): explicit create, append auto-create, `like`/`extends` propagation, constraint-word column names, Trino rejection on both paths
- New DuckDB-executed spec `spec/basic/ddl/table-constraints.wv`: PK/unique/not-null tables created and appended for real, with a default satisfying its `not null`
- `WvletGeneratorTest` round-trip case
- Full `langJVM/test` green (1136 passed), `TyperCoverageCheck` ratchet green, `langJS`/`langNative` compile green

## Docs

- New **Column Constraints** section in `website/docs/syntax/table-management.md`

Closes #1997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADwW9QKqzMo5Yf6kNqoLvz