### PR TITLE
feature: Stream Trino query results in pages instead of materializing them

### DIFF
--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/DBConnector.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/DBConnector.scala
@@ -160,18 +160,28 @@ trait DBConnector(val dbType: DBType, workEnv: WorkEnv)
 
   /**
     * Run a query on a dedicated session and serialize each row as a JSON object string. Provides
-    * engine-independent row access for activation sinks and notification hooks; connectors without
-    * JDBC result sets (e.g. Trino over HTTP) override this
+    * engine-independent row access for activation sinks and notification hooks. Materializes the
+    * full result — for unbounded results use [[streamJsonRows]] instead
     */
-  private[lang] def queryJsonRows(sql: String): List[String] = withSession { conn =>
-    withResource(conn.createStatement()) { stmt =>
-      withResource(stmt.executeQuery(sql)) { rs =>
-        val rowWeaver = summon[Weaver[ListMap[String, Any]]]
-        JDBCCodec(rs)
-          .mapMsgPackMapRows(msgpack => rowWeaver.toJson(rowWeaver.unweave(msgpack)))
-          .toList
+  private[lang] def queryJsonRows(sql: String): List[String] = streamJsonRows(sql)(_.toList)
+
+  /**
+    * Run a query on a dedicated session and process its rows as JSON object strings through a
+    * single-pass iterator, without materializing the whole result set. The iterator is only valid
+    * inside `body` (it is backed by a live result set or HTTP page stream); return materialized
+    * data from `body` if rows must outlive the call. Connectors without JDBC result sets (e.g.
+    * Trino over HTTP) override this with their paginated result stream
+    */
+  private[lang] def streamJsonRows[U](sql: String)(body: Iterator[String] => U): U = withSession {
+    conn =>
+      withResource(conn.createStatement()) { stmt =>
+        withResource(stmt.executeQuery(sql)) { rs =>
+          val rowWeaver = summon[Weaver[ListMap[String, Any]]]
+          body(
+            JDBCCodec(rs).mapMsgPackMapRows(msgpack => rowWeaver.toJson(rowWeaver.unweave(msgpack)))
+          )
+        }
       }
-    }
   }
 
   protected def withStatement[U](

--- a/wvlet-connector/src/main/scala/wvlet/lang/connector/trino/TrinoConnector.scala
+++ b/wvlet-connector/src/main/scala/wvlet/lang/connector/trino/TrinoConnector.scala
@@ -100,10 +100,10 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
     * monitor implicitly so callers that already have one (e.g. `execute` / `executeUpdate`) can
     * thread it through, while metadata callers fall back to the class-level `noOp` default.
     *
-    * Note: `SqlConnector.execute` materializes the full result set today — same tradeoff PR-B
-    * shipped for `QueryExecutor`'s Trino path. Large exports that previously streamed through the
-    * JDBC `ResultSet` now build the whole `QueryResult` in memory. Adding chunked iteration to
-    * `QueryHandle` is the right fix; tracked as a follow-up.
+    * Note: `SqlConnector.execute` materializes the full result set — acceptable here because every
+    * caller of `http` is a metadata query or DDL with a small result. Row-streaming callers
+    * (activation sinks, file exports) go through `streamJsonRows`, which pages through the result
+    * via `QueryHandle.batches()` instead.
     */
   private def http(sql: String)(using QueryProgressMonitor): QueryResult = asSqlConnector.execute(
     sql
@@ -170,14 +170,29 @@ class TrinoConnector(val config: TrinoConfig, workEnv: WorkEnv)
       deregister()
       handle.close()
 
-  override private[lang] def queryJsonRows(sql: String): List[String] =
-    val result    = http(sql)
-    val names     = result.columns.map(_.name.name)
-    val rowWeaver = summon[Weaver[ListMap[String, Any]]]
-    result
-      .rows
-      .map(row => rowWeaver.toJson(ListMap.from(names.zip(row.values.map(v => v.orNull: Any)))))
-      .toList
+  /**
+    * Stream rows as JSON objects by paging through the Trino HTTP result via
+    * `QueryHandle.batches()`. Only one protocol page of rows is held in memory at a time, so
+    * activation sinks and file exports can process arbitrarily large results.
+    */
+  override private[lang] def streamJsonRows[U](sql: String)(body: Iterator[String] => U): U =
+    val handle = asSqlConnector.submit(sql)
+    try
+      val rowWeaver = summon[Weaver[ListMap[String, Any]]]
+      val jsonRows  = handle
+        .batches()
+        .flatMap { batch =>
+          val names = batch.columns.map(_.name.name)
+          batch
+            .rows
+            .iterator
+            .map(row =>
+              rowWeaver.toJson(ListMap.from(names.zip(row.values.map(v => v.orNull: Any))))
+            )
+        }
+      body(jsonRows)
+    finally
+      handle.close()
 
   override def createSchema(catalog: String, schema: String): TableSchema =
     http(s"create schema if not exists ${catalog}.${schema}")

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/trino/TrinoQueryHandle.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/trino/TrinoQueryHandle.scala
@@ -71,6 +71,9 @@ class TrinoQueryHandle(
   @volatile
   private var cachedResult: Option[QueryResult] = None
 
+  @volatile
+  private var streaming: Boolean = false
+
   private var columnsSnapshot: Option[Seq[NamedType]] = None
   private val rowsBuilder                             = List.newBuilder[QueryResultRow]
 
@@ -94,17 +97,89 @@ class TrinoQueryHandle(
       case Some(r) =>
         r
       case None =>
+        if streaming then
+          throw IllegalStateException(
+            s"Query ${_queryId.getOrElse(
+                "?"
+              )} is being streamed via batches(); its rows are handed off page by page and cannot be materialized with await()"
+          )
         while lastNextUri.isDefined && !cancelRequested do
-          val uri  = lastNextUri.get
-          val req  = Trino.withTrinoHeaders(Request(method = HttpMethod.GET, uri = uri), config)
-          val resp = Trino.sendOrThrow(client, req)
-          val json = Trino.parseBody(resp)
-          Trino.checkError(json)
-          consume(json)
+          consume(fetchNextPage())
         val result = QueryResult(columnsSnapshot.getOrElse(Seq.empty), rowsBuilder.result())
         cachedResult = Some(result)
         result
   }
+
+  /**
+    * Stream the result one Trino protocol page per batch, never holding more than a page of rows in
+    * memory. The first batch replays any rows already folded in by `submit`'s initial `consume`;
+    * subsequent pages are fetched lazily as the iterator advances. Follows the [[QueryHandle]]
+    * contract: every batch carries the column metadata, an empty result yields one zero-row batch,
+    * and `await()` becomes unavailable once streaming has started.
+    */
+  override def batches(): Iterator[QueryResult] = synchronized {
+    cachedResult match
+      case Some(r) =>
+        Iterator.single(r)
+      case None =>
+        if streaming then
+          throw IllegalStateException(
+            s"batches() of query ${_queryId.getOrElse(
+                "?"
+              )} was already consumed — the stream is single-pass"
+          )
+        streaming = true
+        new Iterator[QueryResult]:
+          // Rows accumulated before streaming began (the pages `submit` consumed eagerly)
+          private var firstRows: Option[List[QueryResultRow]] =
+            val rows = rowsBuilder.result()
+            rowsBuilder.clear()
+            Some(rows)
+          private var pending: Option[QueryResult] = None
+          private var yieldedAny                   = false
+
+          private def columns: Seq[NamedType] = columnsSnapshot.getOrElse(Seq.empty)
+
+          override def hasNext: Boolean =
+            while pending.isEmpty do
+              firstRows match
+                case Some(rows) =>
+                  firstRows = None
+                  if rows.nonEmpty then
+                    pending = Some(QueryResult(columns, rows))
+                case None =>
+                  if lastNextUri.isEmpty || cancelRequested then
+                    // Drained (or cancelled): emit a final empty batch if nothing was yielded so
+                    // consumers always observe the result schema
+                    if !yieldedAny then
+                      yieldedAny = true
+                      pending = Some(QueryResult(columns, Nil))
+                    else
+                      return false
+                  else
+                    val pageRows = consume(fetchNextPage())
+                    if pageRows.nonEmpty then
+                      pending = Some(QueryResult(columns, pageRows))
+            true
+
+          override def next(): QueryResult =
+            if !hasNext then
+              throw java.util.NoSuchElementException("next on an exhausted Trino batch stream")
+            val batch = pending.get
+            pending = None
+            yieldedAny = true
+            batch
+        end new
+  }
+
+  /** GET the next page of the pagination loop and parse its body, surfacing Trino errors. */
+  private def fetchNextPage(): JSONObject =
+    val uri  = lastNextUri.get
+    val req  = Trino.withTrinoHeaders(Request(method = HttpMethod.GET, uri = uri), config)
+    val resp = Trino.sendOrThrow(client, req)
+    val json = Trino.parseBody(resp)
+    Trino.checkError(json)
+    json
 
   /**
     * Ask Trino to abort the query. Sets a cooperative flag the `await()` loop checks at the next
@@ -128,23 +203,27 @@ class TrinoQueryHandle(
       // observe the terminal state without having to await.
       _stats = _stats.copy(state = QueryState.Canceled)
       progressMonitor.reportProgress(_stats)
-      lastNextUri.foreach { uri =>
-        val cancelClient = Http.client.withBaseUri(config.baseUri).newSyncClient
-        try
-          val req  = Trino.withTrinoHeaders(Request(method = HttpMethod.DELETE, uri = uri), config)
-          val resp = cancelClient.send(req)
-          if !resp.status.isSuccessful then
-            warn(
-              s"Trino cancel for query ${_queryId.getOrElse("?")} returned ${resp
-                  .status
-                  .code} ${resp.status.reason}"
-            )
-        catch
-          case e: Throwable =>
-            warn(s"Trino cancel for query ${_queryId.getOrElse("?")} failed: ${e.getMessage}")
-        finally
-          cancelClient.close()
-      }
+      lastNextUri.foreach(sendCancelRequest)
+
+  /**
+    * Fire the best-effort DELETE of `cancel()`. Factored out so protocol-level tests can stub it.
+    */
+  protected def sendCancelRequest(uri: String): Unit =
+    val cancelClient = Http.client.withBaseUri(config.baseUri).newSyncClient
+    try
+      val req  = Trino.withTrinoHeaders(Request(method = HttpMethod.DELETE, uri = uri), config)
+      val resp = cancelClient.send(req)
+      if !resp.status.isSuccessful then
+        warn(
+          s"Trino cancel for query ${_queryId.getOrElse("?")} returned ${resp.status.code} ${resp
+              .status
+              .reason}"
+        )
+    catch
+      case e: Throwable =>
+        warn(s"Trino cancel for query ${_queryId.getOrElse("?")} failed: ${e.getMessage}")
+    finally
+      cancelClient.close()
 
   override def close(): Unit =
     if !closed then
@@ -155,17 +234,22 @@ class TrinoQueryHandle(
       finally client.close()
 
   /**
-    * Internal: fold one Trino response page into the handle's accumulator. Used both by
-    * `Trino.submit` (first page) and `await()` (subsequent pages).
+    * Internal: fold one Trino response page into the handle's state and return the page's rows.
+    * Used by `Trino.submit` (first page), `await()`, and the `batches()` stream (subsequent pages).
+    * While streaming, rows are NOT accumulated in the handle — the returned page is the only copy,
+    * which is what keeps memory bounded.
     */
-  private[trino] def consume(json: JSONObject): Unit =
+  private[trino] def consume(json: JSONObject): List[QueryResultRow] =
     extractQueryId(json)
     collectColumns(json)
-    collectRows(json)
+    val pageRows = collectRows(json)
+    if !streaming then
+      rowsBuilder ++= pageRows
     val newStats = parseStats(json)
     _stats = newStats
     lastNextUri = nextUri(json)
     progressMonitor.reportProgress(newStats)
+    pageRows
 
   private def extractQueryId(json: JSONObject): Unit =
     if _queryId.isEmpty then
@@ -196,19 +280,17 @@ class TrinoQueryHandle(
           case _ =>
         }
 
-  private def collectRows(json: JSONObject): Unit = json
+  private def collectRows(json: JSONObject): List[QueryResultRow] = json
     .get("data")
-    .foreach {
-      case arr: JSONArray =>
-        arr
-          .v
-          .foreach {
-            case row: JSONArray =>
-              rowsBuilder += QueryResultRow(row.v.map(Trino.stringifyCell).toList)
-            case _ =>
-          }
-      case _ =>
+    .collect { case arr: JSONArray =>
+      arr
+        .v
+        .collect { case row: JSONArray =>
+          QueryResultRow(row.v.map(Trino.stringifyCell).toList)
+        }
+        .toList
     }
+    .getOrElse(Nil)
 
   private def nextUri(json: JSONObject): Option[String] = json
     .get("nextUri")

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/connector/QueryHandle.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/connector/QueryHandle.scala
@@ -32,6 +32,25 @@ trait QueryHandle extends AutoCloseable:
   def await(): QueryResult
   def cancel(): Unit
 
+  /**
+    * Stream the result in batches instead of materializing it whole. The contract:
+    *   - Every batch carries the full column metadata; concatenating the batches' rows in iteration
+    *     order yields the complete result.
+    *   - At least one batch is always produced — an empty result yields a single zero-row batch, so
+    *     consumers can read the result schema without a separate call.
+    *   - The iterator is single-pass and must be consumed on one thread. `cancel()` from another
+    *     thread stops iteration at the next batch boundary.
+    *   - Once streaming has begun, `await()` is no longer available (the streamed rows are handed
+    *     off, not retained) — implementations that truly stream throw `IllegalStateException` from
+    *     `await()` after `batches()` has been called. Calling `batches()` after `await()` is always
+    *     fine: it returns the materialized result as a single batch.
+    *
+    * The default implementation materializes via `await()` and yields one batch — correct for
+    * backends without result pagination and for small results. Paginating backends (Trino HTTP)
+    * override it to yield one batch per protocol page, keeping memory bounded by the page size.
+    */
+  def batches(): Iterator[QueryResult] = Iterator.single(await())
+
 /**
   * Normalized lifecycle states across SQL backends. Per-backend mapping functions live next to the
   * connector implementation (e.g. `QueryState.fromTrino`).

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/trino/TrinoQueryHandleTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/trino/TrinoQueryHandleTest.scala
@@ -1,0 +1,116 @@
+package wvlet.lang.compiler.analyzer.trino
+
+import wvlet.lang.compiler.query.QueryProgressMonitor
+import wvlet.uni.http.Http
+import wvlet.uni.http.HttpClientConfig
+import wvlet.uni.http.HttpSyncClient
+import wvlet.uni.http.Request
+import wvlet.uni.http.Response
+import wvlet.uni.json.JSON
+import wvlet.uni.json.JSON.JSONObject
+import wvlet.uni.test.UniTest
+
+/**
+  * Protocol-level tests for [[TrinoQueryHandle]]'s streaming `batches()` iterator, driven by a fake
+  * `HttpSyncClient` serving canned Trino client-protocol pages — no server needed, so the paging
+  * behavior is verified on JVM, JS, and Native.
+  */
+class TrinoQueryHandleTest extends UniTest:
+
+  private val trinoConfig = TrinoConfig(host = "localhost", user = "test")
+
+  /** Serves canned response bodies by request URI; unknown URIs return 404. */
+  private class FakePagingClient(pages: Map[String, String]) extends HttpSyncClient:
+    override def config: HttpClientConfig         = Http.client
+    override def send(request: Request): Response = pages
+      .get(request.uri)
+      .map(body => Response.ok.withJsonContent(body))
+      .getOrElse(Response.notFound)
+
+    override def noRetry: HttpSyncClient                              = this
+    override def withMaxRetry(maxRetries: Int): HttpSyncClient        = this
+    override def withConfig(config: HttpClientConfig): HttpSyncClient = this
+
+  private def page(json: String): JSONObject = JSON.parse(json).asInstanceOf[JSONObject]
+
+  private val firstResponse = page("""{"id":"q1","nextUri":"/p1","stats":{"state":"RUNNING"}}""")
+
+  private val multiPage = Map(
+    "/p1" ->
+      """{"id":"q1","columns":[{"name":"id","type":"bigint"}],
+        |"data":[[1],[2]],"nextUri":"/p2","stats":{"state":"RUNNING","processedRows":2}}"""
+        .stripMargin,
+    "/p2" -> """{"id":"q1","data":[[3],[4]],"nextUri":"/p3","stats":{"state":"RUNNING"}}""",
+    "/p3" -> """{"id":"q1","stats":{"state":"FINISHED"}}"""
+  )
+
+  private val emptyResult = Map(
+    "/p1" ->
+      """{"id":"q1","columns":[{"name":"id","type":"bigint"}],"nextUri":"/p2","stats":{"state":"RUNNING"}}""",
+    "/p2" -> """{"id":"q1","stats":{"state":"FINISHED"}}"""
+  )
+
+  private def newHandle(pages: Map[String, String]): TrinoQueryHandle =
+    val handle =
+      new TrinoQueryHandle(FakePagingClient(pages), trinoConfig, QueryProgressMonitor.noOp):
+        // The best-effort DELETE would hit a real network address; not under test here
+        override protected def sendCancelRequest(uri: String): Unit = ()
+    handle.consume(firstResponse)
+    handle
+
+  test("should stream one batch per Trino page carrying column metadata") {
+    val handle  = newHandle(multiPage)
+    val batches = handle.batches().toList
+    batches.size shouldBe 2
+    batches.foreach(b => b.columns.map(_.name.name) shouldBe List("id"))
+    batches(0).rows.map(_.values) shouldBe List(List(Some("1")), List(Some("2")))
+    batches(1).rows.map(_.values) shouldBe List(List(Some("3")), List(Some("4")))
+  }
+
+  test("should materialize the same rows through await()") {
+    val result = newHandle(multiPage).await()
+    result.rowCount shouldBe 4
+    result.rows.flatMap(_.values.flatten) shouldBe List("1", "2", "3", "4")
+  }
+
+  test("should reject await() once streaming has begun") {
+    val handle = newHandle(multiPage)
+    handle.batches()
+    intercept[IllegalStateException] {
+      handle.await()
+    }
+  }
+
+  test("should reject a second batches() call — the stream is single-pass") {
+    val handle = newHandle(multiPage)
+    handle.batches()
+    intercept[IllegalStateException] {
+      handle.batches()
+    }
+  }
+
+  test("should return the materialized result as a single batch after await()") {
+    val handle = newHandle(multiPage)
+    handle.await().rowCount shouldBe 4
+    val batches = handle.batches().toList
+    batches.size shouldBe 1
+    batches.head.rowCount shouldBe 4
+  }
+
+  test("should yield a single zero-row batch carrying the schema for an empty result") {
+    val batches = newHandle(emptyResult).batches().toList
+    batches.size shouldBe 1
+    batches.head.rowCount shouldBe 0
+    batches.head.columns.map(_.name.name) shouldBe List("id")
+  }
+
+  test("should stop streaming at the next page boundary after cancel()") {
+    val handle = newHandle(multiPage)
+    val it     = handle.batches()
+    it.hasNext shouldBe true
+    it.next().rowCount shouldBe 2
+    handle.cancel()
+    it.hasNext shouldBe false
+  }
+
+end TrinoQueryHandleTest

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/FlowExecutor.scala
@@ -1369,12 +1369,19 @@ class FlowExecutor(
       engineName: String
   ): Unit =
     val qualifiedName = table.name.catalog.toList ++ table.name.schema.toList :+ table.name.name
-    val rows          = SourceTableStaging.readTableAsJsonRows(source, qualifiedName)
-    workEnv.info(
-      s"Staging ${table.connectorName.getOrElse("")}.${table.name.name} (${rows
-          .size} rows) as ${stagingTable}"
+    val rowCount      = SourceTableStaging.stageTable(
+      source,
+      qualifiedName,
+      engine,
+      engineName,
+      stagingTable,
+      table.schema.fields
     )
-    SourceTableStaging.loadJsonRows(engine, engineName, stagingTable, rows, table.schema.fields)
+    workEnv.info(
+      s"Staged ${table.connectorName.getOrElse("")}.${table
+          .name
+          .name} (${rowCount} rows) as ${stagingTable}"
+    )
 
   end materializeForeignTable
 

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/QueryExecutor.scala
@@ -178,7 +178,6 @@ class QueryExecutor(
         val stagingTable = staged.getOrElseUpdate(
           (sourceName, t.name.name), {
             val source = profileEngineResolver(sourceName)
-            val rows   = SourceTableStaging.readTableAsJsonRows(source, List(t.name.name))
             // ULID-suffixed so concurrent queries staging the same source never collide;
             // the table is dropped when this query finishes
             val staging =
@@ -188,14 +187,15 @@ class QueryExecutor(
                   .ULID
                   .newULIDString
                   .toLowerCase}"
-            workEnv.info(s"Staging ${sourceName}.${t.name.name} (${rows.size} rows) as ${staging}")
-            SourceTableStaging.loadJsonRows(
+            val rowCount = SourceTableStaging.stageTable(
+              source,
+              List(t.name.name),
               activeDBConnector,
               activeEngine.name,
               staging,
-              rows,
               t.schema.fields
             )
+            workEnv.info(s"Staged ${sourceName}.${t.name.name} (${rowCount} rows) as ${staging}")
             staging
           }
         )
@@ -373,25 +373,31 @@ class QueryExecutor(
       rowCount
 
     // Cross-platform variant for backends that don't expose a JDBC ResultSet (Trino HTTP).
-    // Stream the materialized QueryResult through the same JSON writer the JDBC path produces.
-    def writeJSONLFromXP(r: XPQueryResult, out: File): Long =
+    // Streams the result page by page through the same JSON writer the JDBC path produces, so
+    // large exports never hold the whole result set in memory.
+    def writeJSONLFromXP(batches: Iterator[XPQueryResult], out: File): Long =
       val rowCodec = summon[Weaver[ListMap[String, Any]]]
-      val names    = r.columns.map(_.name.name)
+      var rowCount = 0L
       Using.resource(BufferedWriter(OutputStreamWriter(GZIPOutputStream(FileOutputStream(out))))) {
         w =>
-          r.rows
-            .foreach { row =>
-              val pairs = names
-                .iterator
-                .zip(row.values.iterator)
-                .map { case (n, v) =>
-                  n -> v.orNull.asInstanceOf[Any]
-                }
-              w.write(rowCodec.toJson(ListMap.from(pairs)))
-              w.newLine()
-            }
+          batches.foreach { batch =>
+            val names = batch.columns.map(_.name.name)
+            batch
+              .rows
+              .foreach { row =>
+                val pairs = names
+                  .iterator
+                  .zip(row.values.iterator)
+                  .map { case (n, v) =>
+                    n -> v.orNull.asInstanceOf[Any]
+                  }
+                w.write(rowCodec.toJson(ListMap.from(pairs)))
+                w.newLine()
+                rowCount += 1
+              }
+          }
       }
-      r.rowCount.toLong
+      rowCount
 
     // 1) Execute on Trino (or current engine) and dump to JSONL
     val baseSQL = GenSQL.generateSQLFromRelation(save.child, addHeader = false)
@@ -400,8 +406,10 @@ class QueryExecutor(
     val n                               =
       sourceConn.sqlConnector match
         case Some(sc) =>
-          // HTTP-based engines (e.g. Trino): no JDBC ResultSet, materialize via SqlConnector.
-          writeJSONLFromXP(sc.execute(baseSQL.sql), jsonlFile)
+          // HTTP-based engines (e.g. Trino): no JDBC ResultSet — stream the paginated result.
+          val handle = sc.submit(baseSQL.sql)
+          try writeJSONLFromXP(handle.batches(), jsonlFile)
+          finally handle.close()
         case None =>
           sourceConn.runQuery(baseSQL.sql) { rs =>
             writeJSONL(rs, jsonlFile)

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/connector/SourceTableStaging.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/connector/SourceTableStaging.scala
@@ -31,15 +31,20 @@ import java.nio.file.Files
   */
 object SourceTableStaging extends LogSupport:
 
-  /** Read every row of a connector's table as JSON object strings */
-  def readTableAsJsonRows(source: Connector, qualifiedName: List[String]): Seq[String] =
+  /**
+    * Stream every row of a connector's table as JSON object strings through `body`, without
+    * materializing the table. The iterator is only valid inside `body`
+    */
+  def streamTableAsJsonRows[U](source: Connector, qualifiedName: List[String])(
+      body: Iterator[String] => U
+  ): U =
     source match
       case db: DBConnector =>
         // Quote each identifier part: source engines have their own casing/keyword rules
         val qualified = qualifiedName.map(part => s"\"${part}\"").mkString(".")
-        db.queryJsonRows(s"select * from ${qualified}")
+        db.streamJsonRows(s"select * from ${qualified}")(body)
       case other =>
-        other
+        val rows = other
           .catalog
           .map(_.scan(qualifiedName.last))
           .getOrElse(
@@ -49,18 +54,37 @@ object SourceTableStaging extends LogSupport:
                 s"Connector '${other.name}' (${other.connectorType}) exposes no tables to read"
               )
           )
+        body(rows.iterator)
 
   /**
-    * Land JSON rows in `stagingTable` on the target engine. `schemaFields` builds the empty table
-    * when there are no rows (read_json_auto cannot infer a schema from an empty file)
+    * Copy a source connector's table into `stagingTable` on the target engine, streaming rows as
+    * JSON lines through a temporary file. Returns the number of staged rows. `schemaFields` builds
+    * the empty table when there are no rows (read_json_auto cannot infer a schema from an empty
+    * file)
+    */
+  def stageTable(
+      source: Connector,
+      qualifiedName: List[String],
+      engine: DBConnector,
+      engineName: String,
+      stagingTable: String,
+      schemaFields: Seq[NamedType]
+  ): Long =
+    streamTableAsJsonRows(source, qualifiedName) { rows =>
+      loadJsonRows(engine, engineName, stagingTable, rows, schemaFields)
+    }
+
+  /**
+    * Land JSON rows in `stagingTable` on the target engine, consuming the row iterator
+    * incrementally. Returns the number of loaded rows
     */
   def loadJsonRows(
       engine: DBConnector,
       engineName: String,
       stagingTable: String,
-      rows: Seq[String],
+      rows: Iterator[String],
       schemaFields: Seq[NamedType]
-  ): Unit =
+  ): Long =
     if engine.dbType != DBType.DuckDB then
       throw StatusCode
         .NOT_IMPLEMENTED
@@ -73,6 +97,7 @@ object SourceTableStaging extends LogSupport:
     // the SQL literal
     val filePath = file.toAbsolutePath.toString.replace('\\', '/')
     try
+      var rowCount = 0L
       scala
         .util
         .Using
@@ -80,9 +105,10 @@ object SourceTableStaging extends LogSupport:
           rows.foreach { row =>
             writer.write(row)
             writer.newLine()
+            rowCount += 1
           }
         }
-      if rows.nonEmpty then
+      if rowCount > 0 then
         engine.execute(
           s"""create or replace table "${stagingTable}" as select * from read_json_auto('${filePath}')"""
         )
@@ -91,6 +117,7 @@ object SourceTableStaging extends LogSupport:
           .map(f => s""""${f.name.name}" ${duckdbTypeOf(f.dataType)}""")
           .mkString(", ")
         engine.execute(s"""create or replace table "${stagingTable}" (${columns})""")
+      rowCount
     finally
       Files.deleteIfExists(file)
 

--- a/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/connector/duckdb/DuckDBConnectorTest.scala
+++ b/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/connector/duckdb/DuckDBConnectorTest.scala
@@ -91,6 +91,14 @@ class DuckDBConnectorTest extends WvletDITest:
     val duckdb = dep[DuckDBConnector]
     duckdb.sqlConnector shouldBe empty
 
+  test("should stream JSON rows from a live JDBC result set"):
+    val duckdb   = dep[DuckDBConnector]
+    val rowCount = duckdb.streamJsonRows("select * from range(1000) as t(id)")(_.size)
+    rowCount shouldBe 1000
+    // queryJsonRows materializes on top of the same streaming route
+    val rows = duckdb.queryJsonRows("select 42 as answer")
+    rows shouldBe List("""{"answer":42}""")
+
   test("should return an already-finished handle from asSqlConnector.submit"):
     given QueryProgressMonitor = QueryProgressMonitor.noOp
     val duckdb                 = dep[DuckDBConnector]

--- a/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/connector/trino/TrinoConnectorTest.scala
+++ b/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/connector/trino/TrinoConnectorTest.scala
@@ -100,6 +100,28 @@ class TrinoConnectorTest extends WvletDITest:
       result.columns.map(_.name.name) shouldBe List("one", "src")
       result.rows.head.values shouldBe List(Some("1"), Some("http"))
     }
+
+    test("stream query results in batches over the HTTP protocol") {
+      val handle = trino.submit("select * from unnest(sequence(1, 1000)) as t(id)")
+      try
+        val batches = handle.batches().toList
+        batches.map(_.rowCount).sum shouldBe 1000
+        batches.foreach(b => b.columns.map(_.name.name) shouldBe List("id"))
+      finally
+        handle.close()
+    }
+
+    test("stream JSON rows through the paginated result") {
+      val connector = dep[TrinoConnector]
+      val rowCount  =
+        connector.streamJsonRows("select * from unnest(sequence(1, 1000)) as t(id)")(_.size)
+      rowCount shouldBe 1000
+      // queryJsonRows keeps the materialized List behavior on top of the stream
+      val rows = connector.queryJsonRows("select 1 as id")
+      rows.size shouldBe 1
+      rows.head shouldContain "id"
+      rows.head shouldContain "1"
+    }
   }
 
 end TrinoConnectorTest


### PR DESCRIPTION
## Summary

`QueryHandle` materialized every result set in memory (noted TODO in `TrinoConnector`), so large results on the Trino HTTP path — webhook activations, file exports, cross-connector staging — were bounded by heap. This PR adds chunked/streaming iteration over the Trino HTTP result pages, addressing the **Trino streaming results** standalone item of #1858.

## Changes

- **`QueryHandle.batches(): Iterator[QueryResult]`** — new streaming API. Contract: every batch carries full column metadata; batches concatenate to the complete result; an empty result yields a single zero-row batch (so consumers always see the schema); the stream is single-pass, and `await()` becomes unavailable once streaming begins. The default implementation materializes via `await()` (one batch), so existing backends and small results keep working unchanged.
- **`TrinoQueryHandle`** — overrides `batches()` with true page streaming: one Trino protocol page per batch, rows handed off instead of accumulated, `cancel()` stops iteration at the next page boundary. The best-effort cancel DELETE is factored into an overridable `sendCancelRequest` seam for protocol-level testing.
- **`DBConnector.streamJsonRows`** — JSON-row streaming counterpart of `queryJsonRows` (which is now a thin materializing wrapper over it). The JDBC default streams over a live `ResultSet`; `TrinoConnector` overrides it to page through `batches()`.
- **Consumers converted to streaming**:
  - `QueryExecutor.executeSaveToLocalFileViaDuckDB` writes JSONL page-by-page from a submitted handle instead of materializing `SqlConnector.execute` output
  - `SourceTableStaging` gains a single-pass `stageTable` (stream source rows → temp JSONL → DuckDB `read_json_auto`), used by both `FlowExecutor.materializeForeignTable` and `QueryExecutor.stageSourceTables`

## Tests

- `TrinoQueryHandleTest` (new, cross-platform): protocol-level tests with a fake `HttpSyncClient` serving canned Trino pages — multi-page batch streaming, empty-result schema batch, await/batches exclusivity, single-pass enforcement, cancel at page boundary
- `TrinoConnectorTest` (embedded `TestingTrinoServer`, JDK 25): `batches()` and `streamJsonRows` over the real HTTP protocol
- `DuckDBConnectorTest`: the JDBC streaming default
- Full `runnerJVM/test` (289 tests) and `runnerJVM/testOnly *RunnerSpec*` (494 tests) pass; `langJS/Test/compile` verified

Refs #1858

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WrcVXTskpKEv9cHr3DQuC