### PR TITLE
feature: Support activate('file') on Trino via a DuckDB handoff

### DIFF
--- a/website/docs/syntax/flow.md
+++ b/website/docs/syntax/flow.md
@@ -396,9 +396,10 @@ that is still executing.
 external target. Two sinks are built in:
 
 - `activate('file', path: 'out.csv')` exports to a local file. The format comes from the
-  path extension or a `format:` parameter (csv, parquet, or json). File export uses the
-  engine's `COPY TO` statement and is available on DuckDB only; on other engines the stage
-  fails with a clear error
+  path extension or a `format:` parameter (csv, parquet, or json). On DuckDB the file is
+  written directly with `COPY TO`; on engines without local file output (e.g. Trino) the
+  stage output is streamed page by page through a local DuckDB that writes the file, so
+  large results export without holding all rows in memory
 - `activate('webhook', url: 'https://...')` posts the rows to an HTTP endpoint as a JSON
   array, or as newline-delimited JSON with `format: 'ndjson'`. At most `max_rows:` rows
   (1000 by default) are sent

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/ActivationSink.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/ActivationSink.scala
@@ -14,14 +14,24 @@
 package wvlet.lang.runner
 
 import wvlet.lang.api.StatusCode
+import wvlet.lang.compiler.WorkEnv
+import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.connector.DBConnector
+import wvlet.lang.connector.duckdb.DuckDBConnector
+import wvlet.lang.model.DataType.NamedType
+import wvlet.lang.runner.connector.SourceTableStaging
 import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.weaver.codec.PrimitiveWeaver.given
 
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.time.Duration
+import scala.collection.immutable.ListMap
 import scala.util.Using
 
 /**
@@ -62,21 +72,21 @@ trait ActivationSink:
 /**
   * A built-in sink exporting the stage output to a local file: `activate('file', path: 'out.csv')`.
   * The format is taken from the `format:` parameter or the path extension (csv, parquet, or json;
-  * csv by default) and written with the engine's `COPY TO` statement
+  * csv by default). Engines with native `COPY TO` support (DuckDB) write the file directly; other
+  * engines (e.g. Trino) stream the stage table's rows over their paginated result and hand the file
+  * write off to a transient local DuckDB via `read_json_auto` + `COPY TO` — the same pattern
+  * `save to` uses for local files on those engines
+  *
+  * @param handoffEngine
+  *   Builds the local DuckDB used by the handoff path; overridable for tests. The engine is created
+  *   per activation and closed when the export completes
   */
-class FileActivationSink extends ActivationSink with LogSupport:
+class FileActivationSink(handoffEngine: () => DBConnector = () => DuckDBConnector(WorkEnv()))
+    extends ActivationSink
+    with LogSupport:
   override def name: String = "file"
 
   override def activate(request: ActivationRequest): Unit =
-    // COPY TO is DuckDB-specific: fail with a clear, non-retryable error on other engines
-    if !request.connector.dbType.supportSaveAsFile then
-      throw StatusCode
-        .NOT_IMPLEMENTED
-        .newException(
-          s"activate('file') of stage ${request.stageName} is not supported on ${request
-              .connector
-              .dbType}: local file export requires an engine with COPY TO support (e.g. DuckDB)"
-        )
     val path = request
       .params
       .getOrElse(
@@ -104,17 +114,98 @@ class FileActivationSink extends ActivationSink with LogSupport:
             )
     val escapedPath = path.replaceAll("'", "''")
     info(s"Exporting stage ${request.stageName} output ${request.table} to ${path} (${format})")
-    request
-      .connector
-      .withSession { conn =>
-        Using.resource(conn.createStatement()) { stmt =>
-          stmt.execute(
-            s"""copy (select * from "${request.table}") to '${escapedPath}' ${formatClause}"""
-          )
+    if request.connector.dbType.supportSaveAsFile then
+      request
+        .connector
+        .withSession { conn =>
+          Using.resource(conn.createStatement()) { stmt =>
+            stmt.execute(
+              s"""copy (select * from "${request.table}") to '${escapedPath}' ${formatClause}"""
+            )
+          }
         }
-      }
+    else
+      exportViaDuckDBHandoff(request, escapedPath, formatClause)
 
   end activate
+
+  /**
+    * Export on engines without native `COPY TO`: stream the stage table page by page as JSON lines
+    * into a temporary file, then let a local DuckDB `COPY` it to the target path. Memory stays
+    * bounded by the source's result page size. An empty stage output still produces a file carrying
+    * the schema (e.g. a header-only CSV) by rebuilding the columns from the streamed result's
+    * metadata
+    */
+  private def exportViaDuckDBHandoff(
+      request: ActivationRequest,
+      escapedPath: String,
+      formatClause: String
+  ): Unit =
+    given QueryProgressMonitor = QueryProgressMonitor.noOp
+    val sqlConnector           = request
+      .connector
+      .sqlConnector
+      .getOrElse(
+        throw StatusCode
+          .NOT_IMPLEMENTED
+          .newException(
+            s"activate('file') of stage ${request.stageName} is not supported on ${request
+                .connector
+                .dbType}: the engine has neither COPY TO support nor a streaming result path"
+          )
+      )
+    val jsonlFile = Files.createTempFile("wv_activation_", ".jsonl")
+    // DuckDB accepts forward slashes on every platform; backslashes would need escaping in
+    // the SQL literal
+    val jsonlPath = jsonlFile.toAbsolutePath.toString.replace('\\', '/').replaceAll("'", "''")
+    try
+      val rowCodec                = summon[Weaver[ListMap[String, Any]]]
+      var rowCount                = 0L
+      var columns: Seq[NamedType] = Nil
+      val handle                  = sqlConnector.submit(s"""select * from "${request.table}"""")
+      try
+        Using.resource(Files.newBufferedWriter(jsonlFile, StandardCharsets.UTF_8)) { w =>
+          handle
+            .batches()
+            .foreach { batch =>
+              if columns.isEmpty then
+                columns = batch.columns
+              val names = batch.columns.map(_.name.name)
+              batch
+                .rows
+                .foreach { row =>
+                  w.write(
+                    rowCodec.toJson(ListMap.from(names.zip(row.values.map(v => v.orNull: Any))))
+                  )
+                  w.newLine()
+                  rowCount += 1
+                }
+            }
+        }
+      finally handle.close()
+
+      val duck = handoffEngine()
+      try
+        if rowCount > 0 then
+          duck.execute(
+            s"copy (select * from read_json_auto('${jsonlPath}')) to '${escapedPath}' ${formatClause}"
+          )
+        else
+          // read_json_auto cannot infer a schema from an empty file: rebuild the columns from
+          // the streamed result's metadata so the exported file still carries the schema
+          val cols = columns
+            .map(f => s""""${f.name.name}" ${SourceTableStaging.duckdbTypeOf(f.dataType)}""")
+            .mkString(", ")
+          duck.execute(s"""create or replace table "__wv_activation_empty" (${cols})""")
+          duck.execute(
+            s"""copy (select * from "__wv_activation_empty") to '${escapedPath}' ${formatClause}"""
+          )
+      finally duck.close()
+    finally
+      Files.deleteIfExists(jsonlFile)
+    end try
+
+  end exportViaDuckDBHandoff
 
   private def extensionOf(path: String): Option[String] =
     val name = path.substring(path.lastIndexOf('/') + 1)

--- a/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/connector/trino/TrinoFlowExecutorTest.scala
+++ b/wvlet-runner/.jvm/src/test/scala/wvlet/lang/runner/connector/trino/TrinoFlowExecutorTest.scala
@@ -1,6 +1,5 @@
 package wvlet.lang.runner.connector.trino
 
-import wvlet.lang.api.v1.flow.StageState
 import wvlet.lang.catalog.ConnectorConfig
 import wvlet.lang.catalog.Profile
 import wvlet.lang.compiler.CompilationUnit
@@ -131,19 +130,40 @@ class TrinoFlowExecutorTest extends UniTest:
     FlowExecutor.dropRunTables(connector, result.runId, result.stageResults.map(_.name))
   }
 
-  test("fail activate('file') on Trino with a clear non-retryable error") {
+  test("export activate('file') output on Trino via the DuckDB handoff") {
+    val exportPath = java.nio.file.Paths.get("target/trino-file-activation.csv")
+    java.nio.file.Files.deleteIfExists(exportPath)
     val (flow, ctx) = compileFlow("""flow TrinoFileFlow = {
-        |  stage src = from [[1]] as t(id)
-        |  stage export = from src | activate('file', path: 'target/trino-export.csv')
+        |  stage src = from [[1, 'a'], [2, 'b']] as t(id, name)
+        |  stage export = from src | activate('file', path: 'target/trino-file-activation.csv')
         |}""".stripMargin)
     val result = FlowExecutor(connector, workEnv).execute(flow)(using ctx)
-    result.isSuccess shouldBe false
-    val exportStage = result.stageResult("export").getOrElse(fail("export stage not found"))
-    exportStage.state shouldBe StageState.Failed
-    // NOT_IMPLEMENTED is non-retryable: the stage fails on the first attempt
-    exportStage.attempts shouldBe 1
-    val error = exportStage.error.getOrElse(fail("export stage has no error"))
-    error.getMessage shouldContain "not supported"
+    result.isSuccess shouldBe true
+    val content = java.nio.file.Files.readString(exportPath)
+    content shouldContain "id"
+    content shouldContain "name"
+    content shouldContain "1"
+    content shouldContain "a"
+    content shouldContain "2"
+    content shouldContain "b"
+    java.nio.file.Files.deleteIfExists(exportPath)
+    FlowExecutor.dropRunTables(connector, result.runId, result.stageResults.map(_.name))
+  }
+
+  test("export an empty stage output on Trino as a schema-only file") {
+    val exportPath = java.nio.file.Paths.get("target/trino-file-activation-empty.csv")
+    java.nio.file.Files.deleteIfExists(exportPath)
+    val (flow, ctx) = compileFlow("""flow TrinoEmptyFileFlow = {
+        |  stage src = from [[1, 'a']] as t(id, name)
+        |  stage export = from src | where id > 100 | activate('file', path: 'target/trino-file-activation-empty.csv')
+        |}""".stripMargin)
+    val result = FlowExecutor(connector, workEnv).execute(flow)(using ctx)
+    result.isSuccess shouldBe true
+    // Header-only CSV: the schema survives even with zero rows
+    val content = java.nio.file.Files.readString(exportPath)
+    content shouldContain "id"
+    content shouldContain "name"
+    java.nio.file.Files.deleteIfExists(exportPath)
     FlowExecutor.dropRunTables(connector, result.runId, result.stageResults.map(_.name))
   }
 


### PR DESCRIPTION
## Summary

`activate('file')` failed with a clear-but-final error on engines without native `COPY TO` (gate added in #1855), so flows running on Trino could not export stage outputs to local files — even though `save to <file>` already solved the exact same problem by streaming Trino HTTP results through DuckDB. This lifts the gate, addressing the **`activate('file')` on Trino via DuckDB handoff** standalone item of #1858.

## Changes

- **`FileActivationSink`**: on engines with `supportSaveAsFile` (DuckDB) the direct `COPY TO` path is unchanged. On other engines the sink now streams the stage table page by page via `QueryHandle.batches()` (#2027) into a temporary JSONL file and hands the write to a transient local DuckDB (`read_json_auto` + `COPY TO`) — memory stays bounded by the source's result page size, and all three formats (csv, parquet, json) work. The DuckDB factory is a constructor parameter so tests can inject one.
- **Empty stage outputs** still produce a schema-carrying file (e.g. a header-only CSV): the columns are rebuilt from the streamed result's metadata, since `read_json_auto` cannot infer a schema from an empty file.
- **Docs**: `website/docs/syntax/flow.md` no longer says file export is DuckDB-only.

## Tests

- `TrinoFlowExecutorTest`: the previous "fail with a clear error" test is replaced by two success tests against the embedded Trino server — a CSV export with rows, and an empty-output export producing a header-only CSV
- `FlowExecutorTest` (DuckDB direct path, 85 tests), full `runnerJVM/test`, and `runnerJVM/testOnly *RunnerSpec*` (494 tests) all pass

Refs #1858, builds on #2027

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WrcVXTskpKEv9cHr3DQuC