### PR TITLE
doc: Refresh the VS Code extension 2026.3.0 changelog for the release

### DIFF
--- a/vscode-wvlet/CHANGELOG.md
+++ b/vscode-wvlet/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wvlet extension will be documented in this file.
 
-## [2026.3.0] - 2026-07-13
+## [2026.3.0] - 2026-08-28
 
 ### Added
 - Workspace-aware language server: each file is analyzed together with the other
@@ -19,6 +19,16 @@ All notable changes to the Wvlet extension will be documented in this file.
 - Typing diagnostics: type errors and warnings are now reported inline in the
   editor (previously only the first syntax error was shown), including a new
   warning when the same type name is bound to different database schemas
+- Standard-library function signatures and documentation are shown in
+  completion and hover, alongside engine functions imported via
+  `wvlet catalog import`
+- Completion for user-defined `trait` and row methods after `.` on a table or
+  alias
+- Completion for statement heads such as `table`, `trait`, and `reshape` at
+  the start of a statement
+- Syntax highlighting for the new table-management statements (`table`,
+  `trait`, `create`/`drop`/`alter`, `reshape`, `rename`, `view`) and the
+  `extends` mixin clause
 
 ## [2026.2.0] - 2026-07-10
 


### PR DESCRIPTION
## Summary
- Refresh the `[2026.3.0]` entry in `vscode-wvlet/CHANGELOG.md` and its date ahead of tagging `v2026.3.0`
- Adds the editor features merged since the entry was written: stdlib signatures/docs in completion & hover (#1989), trait/row-method member completion (#2020), statement-head completion (#2014), grammar updates for the new DDL statements (#1991) and `extends` (#2015)

## Test plan
- Docs-only change; CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1E8LqYMSm9pcKWk36qX8U