### PR TITLE
internal: Sample JSON records and cache file schemas during file-scan typing

### DIFF
--- a/plans/2026-08-28-file-schema-inference.md
+++ b/plans/2026-08-28-file-schema-inference.md
@@ -103,3 +103,26 @@ platform backends; multi-file globs; `s3://` JSON.
 - `./sbt "runnerJVM/testOnly *RunnerSpecBasic"` — specs reading `spec/basic/*.json` still pass
 - `./sbt "langJVM/testOnly *TyperCoverageCheck"` — ratchet unaffected
 - `./sbt scalafmtAll` before commit
+
+## Outcome (PR #2043)
+
+Implemented as designed, rebased on #2042 (`DataFilePath`, jsonl/tsv/zst). Learnings:
+
+- **uni `JSONScanner` contexts push values into their parent.** The scanner calls
+  `stack.head.objectContext/arrayContext` to create child contexts and never calls `add` from the
+  outside; each `JSONValueBuilder` child calls `$outer.add(result)` on `closeContext`. A wrapper
+  that delegates `objectContext` therefore loses the elements — the limited array context must
+  *be* the parent, i.e. subclass `JSONValueBuilder` and override `add`. `JSON.parse` scans with
+  `builder.singleContext(...)` as the root handler, so the sampling root is likewise a tiny
+  `JSONValueBuilder` subclass rather than the builder itself.
+- `JSON.JSONNull` is not typed as a `JSONValue` in uni 2026.1.21, so an empty root holder is an
+  `Option`, not a `JSONNull` default.
+- Simplify-review consolidation: the four angles converged on (1) the 5-line root builder instead
+  of an 11-method delegator, (2) one cached funnel through `DuckDBAnalyzer.guessSchema` instead of
+  per-extension branches, (3) caching remote paths (mtime 0 otherwise meant "never cached" for the
+  slowest inputs), (4) `ConcurrentHashMap` like the other `GlobalContext` caches, (5) byte-based
+  `JSONSource` to skip the String round-trip.
+- JS tests need `pnpm install` in a fresh worktree (`koffi` is loaded by `wvlet-lang.js` test
+  bundle) — otherwise the runner exits with "Cannot find module 'koffi'".
+
+Deferred: single DuckDB session for parquet/csv inference; bounded prefix read for huge JSON.

--- a/plans/2026-08-28-file-schema-inference.md
+++ b/plans/2026-08-28-file-schema-inference.md
@@ -1,0 +1,105 @@
+# File-schema inference: sampling + cache (learning from DuckDB's binder)
+
+## Context
+
+Question: how does DuckDB plan queries that scan local files, and what can wvlet learn, given
+that wvlet must scan the input file at compile time to obtain the schema?
+
+### How DuckDB does it (research summary)
+
+- DuckDB never *executes* to get a schema: `DESCRIBE` / `PREPARE` stop at the binder. But the
+  table-function bind itself still does I/O:
+  - **JSON** (`read_json`): samples up to `sample_size = 20480` records per file (up to
+    `maximum_sample_files = 32` files), i.e. a file with < 20k records is fully parsed at bind.
+  - **CSV**: sniffer over `sample_size = 20480` rows (24 dialect candidates, then type detection).
+  - **Parquet**: reads only the footer (last 8 bytes → footer length → footer).
+- Caching: `parquet_metadata_cache` caches parsed footers keyed on path and validated by
+  ETag / `last_modified`; the 1.3+ external file cache caches byte ranges validated by ETag or
+  mtime. **CSV/JSON sniff results are never cached** — every bind re-sniffs.
+- Multi-file globs bind against the first file only unless `union_by_name=true`.
+
+### What wvlet does today
+
+Path: `Typer.structuralResolutionRule` (`wvlet-lang/src/main/scala/wvlet/lang/compiler/typer/Typer.scala:816`)
+→ `RelationRefResolver.resolveDataFileRef` (`.../analyzer/RelationRefResolver.scala:375`)
+→ `JSONAnalyzer.analyzeJSONFile` (JSON) or `DuckDB.schemaOf` (parquet/csv).
+
+- **Parquet/CSV**: `select * from '<path>' limit 0` — already bind-only (LIMIT 0 pipeline start
+  is negligible). Fine. The dominant cost is opening a fresh in-memory DuckDB per call
+  (`.jvm/.../duckdb/DuckDBCompat.scala:23-48`, same in `.js`/`.native`).
+- **JSON**: `JSONAnalyzer` (`.../analyzer/JSONAnalyzer.scala:29-83`) reads the **entire** file into
+  a String, parses all of it, and traverses every value. No sampling. This is the real gap vs
+  DuckDB's 20 480-record sample.
+- **No cache anywhere**: every Typer run (each LSP edit, each REPL statement) re-infers every
+  `from 'file'`. `GlobalContext` (`Context.scala:41`) is per-`Compiler` and already hosts other
+  per-compiler caches (`resolvedCatalogs`, `connectorCatalogs`), so it is the natural home.
+
+### Two optimizations to adopt
+
+1. **Sample JSON like DuckDB does** — stop after N top-level records instead of parsing the whole
+   file.
+2. **Cache inferred file schemas per compiler, validated by (path, mtime)** — mirrors DuckDB's
+   `parquet_metadata_cache` / external file cache validation. Removes repeated DuckDB
+   open/close and JSON parses across recompiles.
+
+Out of scope (noted as follow-ups): reusing a single DuckDB session for inference across the three
+platform backends; multi-file globs; `s3://` JSON.
+
+## Design
+
+### 1. `JSONAnalyzer` sampling
+
+- Add `JSONAnalyzer.analyzeJSONFile(path, sampleSize: Int = DefaultSampleSize)` with
+  `DefaultSampleSize = 20480` (same as DuckDB).
+- Implement sampling with uni's streaming scanner instead of `JSON.parse`:
+  `wvlet.uni.json.JSONScanner.scan(JSONSource, handler)` with a handler subclassing
+  `wvlet.uni.json.JSONValueBuilder` (public ctor; `arrayContext`/`add` overridable). The
+  top-level array context counts `add(...)` calls and throws a private control exception once
+  `sampleSize` records are collected; the caller catches it and runs `guessSchema` on the
+  collected prefix. Non-array roots (single object) go through the normal path unchanged.
+- Keep the existing whole-file read (`SourceIO.readAsString` / `readGzipAsString`) — uni's
+  `IO` has no streaming read and the parse, not the read, is the expensive part. Note this in
+  a comment.
+- `guessSchema(json: JSONValue)` stays public and unchanged (used by tests / other callers).
+
+### 2. Per-compiler file-schema cache
+
+- New `wvlet.lang.compiler.analyzer.FileSchemaCache` (shared source, cross-platform):
+  ```scala
+  class FileSchemaCache:
+    private case class Key(path: String, lastModified: Long)
+    def getOrElseUpdate(path: String)(infer: => RelationType): RelationType
+  ```
+  Key on absolute path + `SourceIO.lastUpdatedAt(path)` (already exists in all three
+  `SourceIOCompat`s). Missing file → `lastUpdatedAt` returns 0 → do not cache (so a later-created
+  file is picked up). Use a plain `mutable.Map` guarded by `synchronized` (compilers may be
+  driven from multiple threads on the server). Evict the stale entry for the same path when the
+  mtime changes.
+- Hang one instance on `GlobalContext` (`Context.scala:41`): `val fileSchemaCache = FileSchemaCache()`,
+  and expose `Context.fileSchemaCache`.
+- `RelationRefResolver.resolveDataFileRef` wraps both branches:
+  `context.fileSchemaCache.getOrElseUpdate(file)(JSONAnalyzer.analyzeJSONFile(file))` and the
+  DuckDB branch likewise. Existing `DuckDBAnalyzer.guessSchema` remains the uncached entry point.
+
+### Files
+
+- `wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/JSONAnalyzer.scala` — sampling
+- `wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FileSchemaCache.scala` — new
+- `wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala` — add cache to `GlobalContext`
+- `wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala` — use cache
+- Tests (shared `wvlet-lang/src/test/...`, `UniTest`):
+  - `JSONAnalyzerTest`: sampling stops at N records (generate an array of > N objects where a
+    later record has a different type; assert the schema reflects only the prefix); a
+    single-object root still works; `.json.gz` still works.
+  - `FileSchemaCacheTest`: second lookup does not re-invoke `infer`; rewriting the file (new
+    mtime) re-infers; missing file is not cached.
+- Docs: no user-facing syntax change; add a short note to the `from 'file'` docs page about
+  JSON sampling (first 20 480 records) so users know why a late-appearing field may be missed.
+
+## Verification
+
+- `./sbt "langJVM/testOnly *JSONAnalyzerTest *FileSchemaCacheTest *DuckDBAnalyzerTest"`
+- `./sbt "langJS/testOnly *JSONAnalyzerTest *FileSchemaCacheTest"` (JSON path is pure Scala)
+- `./sbt "runnerJVM/testOnly *RunnerSpecBasic"` — specs reading `spec/basic/*.json` still pass
+- `./sbt "langJVM/testOnly *TyperCoverageCheck"` — ratchet unaffected
+- `./sbt scalafmtAll` before commit

--- a/website/docs/syntax/index.md
+++ b/website/docs/syntax/index.md
@@ -661,6 +661,14 @@ from 'https://(path to your data)/sample.parquet'
 
 Reading data from an URL will also work for S3 Presigned URLs.
 
+The column names and types of a file are inferred when the query is compiled. For Parquet and
+CSV files, DuckDB reads only the metadata it needs. For a JSON file containing an array of
+records, or a JSON Lines file, the schema is inferred from the first 20,480 records (the same
+sample size DuckDB uses), so a field that first appears after that point will not be part of the
+inferred schema.
+Inferred schemas are cached while the file is unchanged, so repeated compiles of the same query
+do not re-read the file.
+
 #### Raw SQL statements
 
 In case you need to use a raw SQL statement, you can use the `sql` string interpolation:

--- a/wvlet-lang/.js/src/main/scala/wvlet/lang/compiler/SourceIOCompat.scala
+++ b/wvlet-lang/.js/src/main/scala/wvlet/lang/compiler/SourceIOCompat.scala
@@ -19,7 +19,11 @@ trait SourceIOCompat:
   def readAsString(filePath: String): String = IO.readString(IOPath.parse(filePath))
 
   def readGzipAsString(filePath: String): String =
-    new String(Gzip.decompress(IO.readBytes(IOPath.parse(filePath))), StandardCharsets.UTF_8)
+    new String(readGzipAsBytes(filePath), StandardCharsets.UTF_8)
+
+  def readAsBytes(filePath: String): Array[Byte] = IO.readBytes(IOPath.parse(filePath))
+
+  def readGzipAsBytes(filePath: String): Array[Byte] = Gzip.decompress(readAsBytes(filePath))
 
   def existsFile(path: String): Boolean = IO.exists(IOPath.parse(path))
 

--- a/wvlet-lang/.jvm/src/main/scala/wvlet/lang/compiler/SourceIOCompat.scala
+++ b/wvlet-lang/.jvm/src/main/scala/wvlet/lang/compiler/SourceIOCompat.scala
@@ -19,7 +19,11 @@ trait SourceIOCompat:
   def readAsString(filePath: String): String = IO.readString(IOPath.parse(filePath))
 
   def readGzipAsString(filePath: String): String =
-    new String(Gzip.decompress(IO.readBytes(IOPath.parse(filePath))), StandardCharsets.UTF_8)
+    new String(readGzipAsBytes(filePath), StandardCharsets.UTF_8)
+
+  def readAsBytes(filePath: String): Array[Byte] = IO.readBytes(IOPath.parse(filePath))
+
+  def readGzipAsBytes(filePath: String): Array[Byte] = Gzip.decompress(readAsBytes(filePath))
 
   def existsFile(path: String): Boolean = IO.exists(IOPath.parse(path))
 

--- a/wvlet-lang/.native/src/main/scala/wvlet/lang/compiler/SourceIOCompat.scala
+++ b/wvlet-lang/.native/src/main/scala/wvlet/lang/compiler/SourceIOCompat.scala
@@ -19,7 +19,11 @@ trait SourceIOCompat:
   def readAsString(filePath: String): String = IO.readString(IOPath.parse(filePath))
 
   def readGzipAsString(filePath: String): String =
-    new String(Gzip.decompress(IO.readBytes(IOPath.parse(filePath))), StandardCharsets.UTF_8)
+    new String(readGzipAsBytes(filePath), StandardCharsets.UTF_8)
+
+  def readAsBytes(filePath: String): Array[Byte] = IO.readBytes(IOPath.parse(filePath))
+
+  def readGzipAsBytes(filePath: String): Array[Byte] = Gzip.decompress(readAsBytes(filePath))
 
   def existsFile(path: String): Boolean = IO.exists(IOPath.parse(path))
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/Context.scala
@@ -18,6 +18,7 @@ import wvlet.lang.api.Span
 import wvlet.lang.api.StatusCode
 import wvlet.lang.catalog.Catalog
 import wvlet.lang.catalog.InMemoryCatalog
+import wvlet.lang.compiler.analyzer.FileSchemaCache
 import wvlet.lang.compiler.query.QueryProgressMonitor
 import wvlet.lang.compiler.typer.TyperError
 import wvlet.lang.compiler.typer.TyperState
@@ -86,6 +87,10 @@ case class GlobalContext(compilerOptions: CompilerOptions):
   // recorded by SymbolLabeler. A non-empty set means an imported static catalog is active for
   // those locations, so DDL statements can warn on targets the snapshot does not know (#1999)
   val declaredTableBindings = scala.collection.mutable.Set.empty[(String, String)]
+
+  // Schemas inferred for `from '<file>'` references, validated by file mtime, so interactive
+  // recompiles (LSP, REPL) do not re-open DuckDB or re-parse JSON for unchanged files
+  val fileSchemaCache = FileSchemaCache()
 
   var workEnv: WorkEnv = compilerOptions.workEnv
 

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FileSchemaCache.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/FileSchemaCache.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.lang.compiler.analyzer
+
+import wvlet.lang.compiler.SourceIO
+import wvlet.lang.model.RelationType
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+  * Per-compiler cache of schemas inferred for `from '<file>'` references.
+  *
+  * Inferring a file schema is the most expensive step of typing a query that reads a local file:
+  * parquet/csv open a fresh DuckDB instance, and JSON parses (a sample of) the file. Interactive
+  * front-ends (LSP, REPL) re-run the typer on every edit, so without a cache the same file is
+  * re-inferred for every keystroke.
+  *
+  * Entries for local files are validated by the file's last-modified time, mirroring how DuckDB's
+  * own `parquet_metadata_cache` / external file cache validate cached metadata by `last_modified`
+  * (or ETag) before reuse. A local file that does not exist is never cached, so a file created
+  * after a failed lookup is picked up by the next compile. Remote paths (`s3://`, `https://`) have
+  * no cheap freshness probe and are cached for the lifetime of the compiler.
+  */
+class FileSchemaCache:
+  private case class Entry(stamp: Long, schema: RelationType)
+
+  private val cache = ConcurrentHashMap[String, Entry]()
+
+  /**
+    * Return the cached schema for `path` if it is still valid; otherwise run `infer`, cache its
+    * result, and return it.
+    */
+  def getOrElseUpdate(path: String)(infer: => RelationType): RelationType =
+    FileSchemaCache.stampOf(path) match
+      case None =>
+        infer
+      case Some(stamp) =>
+        Option(cache.get(path)).filter(_.stamp == stamp) match
+          case Some(entry) =>
+            entry.schema
+          case None =>
+            val schema = infer
+            cache.put(path, Entry(stamp, schema))
+            schema
+
+  /** Number of cached entries (for tests and diagnostics) */
+  def size: Int = cache.size
+
+end FileSchemaCache
+
+object FileSchemaCache:
+  private val RemoteStamp = -1L
+
+  /**
+    * Freshness token for `path`: the local file's mtime, a constant for remote paths, or None if
+    * the local file is missing (uncacheable)
+    */
+  private def stampOf(path: String): Option[Long] =
+    if DataFilePath.isRemote(path) then
+      Some(RemoteStamp)
+    else
+      Some(SourceIO.lastUpdatedAt(path)).filter(_ != 0L)
+
+end FileSchemaCache

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/JSONAnalyzer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/JSONAnalyzer.scala
@@ -15,6 +15,10 @@ package wvlet.lang.compiler.analyzer
 
 import wvlet.uni.json.JSON
 import wvlet.uni.json.JSON.*
+import wvlet.uni.json.JSONContext
+import wvlet.uni.json.JSONScanner
+import wvlet.uni.json.JSONSource
+import wvlet.uni.json.JSONValueBuilder
 import wvlet.lang.api.StatusCode
 import wvlet.lang.compiler.SourceIO
 import wvlet.lang.compiler.Name
@@ -24,9 +28,20 @@ import wvlet.lang.model.DataType
 import wvlet.lang.model.RelationType
 import wvlet.uni.log.LogSupport
 
+import java.nio.charset.StandardCharsets
 import scala.collection.immutable.ListMap
+import scala.collection.mutable.ArrayBuffer
+import scala.util.control.ControlThrowable
 
 object JSONAnalyzer extends LogSupport:
+
+  /**
+    * Maximum number of records inspected when inferring a schema: the elements of a top-level JSON
+    * array, or the lines of a JSON Lines file. Matches DuckDB's `read_json(sample_size)` default so
+    * that wvlet's compile-time schema agrees with the schema DuckDB itself binds at query time.
+    */
+  val DefaultSampleSize: Int = 20480
+
   /**
     * Infer the schema of a JSON (`.json`), or newline-delimited JSON (`.jsonl`, `.ndjson`) file.
     * Gzip-compressed files (`.gz` suffix) are decompressed on the fly.
@@ -35,45 +50,116 @@ object JSONAnalyzer extends LogSupport:
     val dataFile = DataFilePath.parse(path).getOrElse(DataFilePath(DataFilePath.Format.JSON, None))
     analyzeJSONFile(path, dataFile)
 
-  /** Same as [[analyzeJSONFile]] for a path whose extension has already been classified */
-  def analyzeJSONFile(path: String, dataFile: DataFilePath): RelationType =
-    val json =
+  /**
+    * Same as [[analyzeJSONFile]] for a path whose extension has already been classified. Only the
+    * first `sampleSize` records are inspected; the rest of the file is skipped.
+    */
+  def analyzeJSONFile(
+      path: String,
+      dataFile: DataFilePath,
+      sampleSize: Int = DefaultSampleSize
+  ): RelationType =
+    // uni's IO has no bounded read, so the whole file is loaded. Loading bytes is cheap compared
+    // to building JSON values for every record, which is what the sampling avoids.
+    val bytes =
       if dataFile.isGzip then
-        SourceIO.readGzipAsString(path)
+        SourceIO.readGzipAsBytes(path)
       else
-        SourceIO.readAsString(path)
-    analyzeJSONContent(json, dataFile.isJsonLines)
+        SourceIO.readAsBytes(path)
+    if dataFile.isJsonLines then
+      analyzeJsonLines(String(bytes, StandardCharsets.UTF_8), sampleSize)
+    else
+      guessSchema(parseSample(JSONSource.fromBytes(bytes), sampleSize))
+
+  private[analyzer] def analyzeJSONContent(
+      json: String,
+      isJsonLines: Boolean,
+      sampleSize: Int = DefaultSampleSize
+  ): RelationType =
+    if isJsonLines then
+      analyzeJsonLines(json, sampleSize)
+    else
+      guessSchema(parseSample(JSONSource.fromString(json), sampleSize))
+
+  private def analyzeJsonLines(json: String, sampleSize: Int): RelationType =
+    // Each non-blank line is a standalone JSON value; treat them as one array of records
+    val records = json
+      .linesIterator
+      .zipWithIndex
+      .map((line, i) => (line.trim, i + 1))
+      .filter(_._1.nonEmpty)
+      .take(sampleSize)
+      .map { (line, lineNumber) =>
+        try
+          JSON.parse(line)
+        catch
+          case e: Exception =>
+            throw StatusCode
+              .SYNTAX_ERROR
+              .newException(s"Invalid JSON at line ${lineNumber}: ${e.getMessage}", e)
+      }
+    guessSchema(JSONArray(records.toIndexedSeq))
 
   /**
-    * Maximum number of JSON Lines records inspected for schema inference. Type counts converge long
-    * before this, and it bounds the parse cost for large `.jsonl` files
+    * Parse `source`, keeping at most `sampleSize` elements of a top-level array. Scanning stops as
+    * soon as the sample is complete, so records past the limit are never materialized.
     */
-  private val maxJsonLinesSample = 10000
+  private def parseSample(source: JSONSource, sampleSize: Int): JSONValue =
+    val root = SamplingBuilder(sampleSize)
+    try
+      JSONScanner.scan(source, root)
+      root.result
+    catch
+      case SampleLimitReached =>
+        root.result
 
-  private[analyzer] def analyzeJSONContent(json: String, isJsonLines: Boolean): RelationType =
-    debug(json)
-    val jsonValue =
-      if isJsonLines then
-        // Each non-blank line is a standalone JSON value; treat them as one array of records
-        val records = json
-          .linesIterator
-          .zipWithIndex
-          .map((line, i) => (line.trim, i + 1))
-          .filter(_._1.nonEmpty)
-          .take(maxJsonLinesSample)
-          .map { (line, lineNumber) =>
-            try
-              JSON.parse(line)
-            catch
-              case e: Exception =>
-                throw StatusCode
-                  .SYNTAX_ERROR
-                  .newException(s"Invalid JSON at line ${lineNumber}: ${e.getMessage}", e)
-          }
-        JSONArray(records.toIndexedSeq)
-      else
-        JSON.parse(json)
-    guessSchema(jsonValue)
+  /** Control-flow signal for aborting the scanner once the sample is complete */
+  private object SampleLimitReached extends ControlThrowable
+
+  /**
+    * Root builder (the equivalent of `JSONValueBuilder.singleContext`) that hands the top-level
+    * array to a [[LimitedArrayContext]]. Nested containers are unaffected: the scanner creates
+    * their contexts from the enclosing context, never from this root.
+    */
+  private class SamplingBuilder(limit: Int) extends JSONValueBuilder:
+    private var holder: Option[JSONValue]                 = None
+    private var topLevelArray: LimitedArrayContext | Null = null
+
+    override def add(v: JSONValue): Unit = holder = Some(v)
+
+    // When the root is an array, read it from the array context so that an aborted scan (which
+    // never closes the context) still yields the sampled prefix
+    override def result: JSONValue =
+      topLevelArray match
+        case null =>
+          holder.getOrElse(throw IllegalStateException("no JSON value was scanned"))
+        case ctx =>
+          ctx.result
+
+    override def arrayContext(s: JSONSource, start: Int): JSONContext[JSONValue] =
+      val ctx = LimitedArrayContext(limit)
+      topLevelArray = ctx
+      ctx
+
+  /**
+    * Array context that aborts the scan once `limit` elements have been added. Extends
+    * [[JSONValueBuilder]] so that element contexts (objects, nested arrays) and scalar events
+    * created by the inherited builder methods all report their values through `add`.
+    */
+  private class LimitedArrayContext(limit: Int) extends JSONValueBuilder:
+    private val sampled = ArrayBuffer.empty[JSONValue]
+
+    override def isObjectContext: Boolean = false
+
+    override def add(v: JSONValue): Unit =
+      if sampled.size >= limit then
+        throw SampleLimitReached
+      sampled += v
+
+    override def result: JSONValue = JSONArray(sampled.toIndexedSeq)
+
+    // The root reads this context's result directly, so nothing to publish on close
+    override def closeContext(s: JSONSource, end: Int): Unit = ()
 
   class TypeCountMap:
     private var map                       = Map.empty[DataType, Int]

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/JSONAnalyzer.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/JSONAnalyzer.scala
@@ -59,8 +59,9 @@ object JSONAnalyzer extends LogSupport:
       dataFile: DataFilePath,
       sampleSize: Int = DefaultSampleSize
   ): RelationType =
-    // uni's IO has no bounded read, so the whole file is loaded. Loading bytes is cheap compared
-    // to building JSON values for every record, which is what the sampling avoids.
+    // The whole file is loaded (a bounded prefix read via uni's readChunks is a possible
+    // follow-up). Loading bytes is cheap compared to building JSON values for every record,
+    // which is what the sampling avoids.
     val bytes =
       if dataFile.isGzip then
         SourceIO.readGzipAsBytes(path)

--- a/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
+++ b/wvlet-lang/src/main/scala/wvlet/lang/compiler/analyzer/RelationRefResolver.scala
@@ -370,19 +370,24 @@ object RelationRefResolver extends ContextLogSupport:
   def resolveDataFileRef(f: FileRef)(using context: Context): Option[Relation] = DataFilePath
     .parse(f.filePath)
     .flatMap { dataFile =>
-      if DuckDBAnalyzer.usesJsonAnalyzer(f.filePath, dataFile) then
-        // JSONAnalyzer reads the file itself, so fail early with FILE_NOT_FOUND when missing
-        val file         = context.getDataFile(f.filePath)
-        val relationType = JSONAnalyzer.analyzeJSONFile(file, dataFile)
-        Some(FileScan(SingleQuoteString(file, f.span), relationType, relationType.fields, f.span))
-      else if DuckDB.isAvailable then
-        val file         = context.dataFilePath(f.filePath)
-        val relationType = DuckDB.schemaOf(file)
-        Some(FileScan(SingleQuoteString(file, f.span), relationType, relationType.fields, f.span))
-      else
-        // No DuckDB on this platform (e.g. Scala.js without libduckdb): leave the reference
-        // unresolved so the query can still be compiled and run by the engine
-        None
+      val file =
+        if DuckDBAnalyzer.usesJsonAnalyzer(f.filePath, dataFile) then
+          // JSONAnalyzer reads the file itself, so fail early with FILE_NOT_FOUND when missing
+          Some(context.getDataFile(f.filePath))
+        else if DuckDB.isAvailable then
+          Some(context.dataFilePath(f.filePath))
+        else
+          // No DuckDB on this platform (e.g. Scala.js without libduckdb): leave the reference
+          // unresolved so the query can still be compiled and run by the engine
+          None
+      file.map { path =>
+        val relationType =
+          context
+            .global
+            .fileSchemaCache
+            .getOrElseUpdate(path)(DuckDBAnalyzer.guessSchema(path, Some(dataFile)))
+        FileScan(SingleQuoteString(path, f.span), relationType, relationType.fields, f.span)
+      }
     }
 
 end RelationRefResolver

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/FileSchemaCacheTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/FileSchemaCacheTest.scala
@@ -1,0 +1,99 @@
+package wvlet.lang.compiler.analyzer
+
+import wvlet.lang.compiler.Name
+import wvlet.lang.compiler.SourceIO
+import wvlet.lang.model.DataType
+import wvlet.lang.model.DataType.NamedType
+import wvlet.lang.model.DataType.SchemaType
+import wvlet.lang.model.RelationType
+import wvlet.uni.test.UniTest
+
+class FileSchemaCacheTest extends UniTest:
+
+  private def schema(col: String): RelationType = SchemaType(
+    None,
+    Name.typeName(RelationType.newRelationTypeName),
+    List(NamedType(Name.termName(col), DataType.LongType))
+  )
+
+  private def withTempFile[A](name: String, content: String)(body: String => A): A =
+    val path = s"target/file-schema-cache-test/${name}"
+    SourceIO.writeString(path, content)
+    try body(path)
+    finally SourceIO.deleteFile(path)
+
+  test("reuse the inferred schema while the file is unchanged") {
+    withTempFile("unchanged.json", "[]") { path =>
+      val cache = FileSchemaCache()
+      var calls = 0
+      val first =
+        cache.getOrElseUpdate(path) {
+          calls += 1
+          schema("a")
+        }
+      val second =
+        cache.getOrElseUpdate(path) {
+          calls += 1
+          schema("b")
+        }
+      calls shouldBe 1
+      second shouldBeTheSameInstanceAs first
+      cache.size shouldBe 1
+    }
+  }
+
+  test("re-infer after the file is modified") {
+    withTempFile("modified.json", "[]") { path =>
+      val cache  = FileSchemaCache()
+      val before = SourceIO.lastUpdatedAt(path)
+      cache.getOrElseUpdate(path)(schema("a"))
+
+      // Rewrite until the mtime visibly changes (filesystem timestamp granularity varies)
+      val deadline = System.currentTimeMillis() + 5000
+      while SourceIO.lastUpdatedAt(path) == before && System.currentTimeMillis() < deadline do
+        SourceIO.writeString(path, "[{}]")
+      SourceIO.lastUpdatedAt(path) shouldNotBe before
+
+      var called = false
+      cache.getOrElseUpdate(path) {
+        called = true
+        schema("b")
+      }
+      called shouldBe true
+      cache.size shouldBe 1
+    }
+  }
+
+  test("never cache a missing file") {
+    val cache = FileSchemaCache()
+    var calls = 0
+    cache.getOrElseUpdate("target/file-schema-cache-test/missing.json") {
+      calls += 1
+      schema("a")
+    }
+    cache.getOrElseUpdate("target/file-schema-cache-test/missing.json") {
+      calls += 1
+      schema("a")
+    }
+    calls shouldBe 2
+    cache.size shouldBe 0
+  }
+
+  test("cache remote paths for the lifetime of the compiler") {
+    val cache = FileSchemaCache()
+    var calls = 0
+    Seq("s3://bucket/data.parquet", "https://example.com/data.parquet").foreach { url =>
+      cache.getOrElseUpdate(url) {
+        calls += 1
+        schema("a")
+      }
+      cache.getOrElseUpdate(url) {
+        calls += 1
+        schema("b")
+      }
+    }
+    calls shouldBe 2
+    cache.size shouldBe 2
+  }
+
+end FileSchemaCacheTest

--- a/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/JSONAnalyzerTest.scala
+++ b/wvlet-lang/src/test/scala/wvlet/lang/compiler/analyzer/JSONAnalyzerTest.scala
@@ -1,0 +1,108 @@
+package wvlet.lang.compiler.analyzer
+
+import wvlet.lang.compiler.SourceIO
+import wvlet.lang.model.DataType
+import wvlet.lang.model.RelationType
+import wvlet.uni.test.UniTest
+
+/**
+  * Cross-platform tests for [[JSONAnalyzer]] record sampling. The sampler is pure Scala (uni's
+  * JSONScanner), so the same expectations hold on JVM, JS, and Native.
+  */
+class JSONAnalyzerTest extends UniTest:
+
+  private def columnTypes(rel: RelationType): Map[String, DataType] =
+    rel.fields.map(f => f.name.name -> f.dataType).toMap
+
+  private def records(n: Int): String = (0 until n)
+    .map(i => s"""{"id": ${i}, "name": "u${i}"}""")
+    .mkString("[", ",\n", "]")
+
+  test("infer schema from a top-level array") {
+    val types = columnTypes(
+      JSONAnalyzer.analyzeJSONContent(records(3), isJsonLines = false, sampleSize = 10)
+    )
+    types shouldBe Map("id" -> DataType.LongType, "name" -> DataType.StringType)
+  }
+
+  test("infer schema from a single top-level object") {
+    val types = columnTypes(
+      JSONAnalyzer.analyzeJSONContent(
+        """{"id": 1, "score": 1.5, "ok": true}""",
+        isJsonLines = false,
+        sampleSize = 10
+      )
+    )
+    types shouldBe
+      Map("id" -> DataType.LongType, "score" -> DataType.DoubleType, "ok" -> DataType.BooleanType)
+  }
+
+  test("stop scanning after the sample size is reached") {
+    // A field that first appears past the sample limit must not be part of the schema, and the
+    // sampled records must be the first ones (id values 0..limit-1)
+    val json = (0 until 100)
+      .map { i =>
+        if i < 50 then
+          s"""{"id": ${i}}"""
+        else
+          s"""{"id": ${i}, "late": "x"}"""
+      }
+      .mkString("[", ",", "]")
+    val types = columnTypes(
+      JSONAnalyzer.analyzeJSONContent(json, isJsonLines = false, sampleSize = 50)
+    )
+    types shouldBe Map("id" -> DataType.LongType)
+
+    // Without the limit the late field is visible
+    val all = columnTypes(
+      JSONAnalyzer.analyzeJSONContent(json, isJsonLines = false, sampleSize = 1000)
+    )
+    all shouldBe Map("id" -> DataType.LongType, "late" -> DataType.StringType)
+  }
+
+  test("keep nested arrays intact while sampling") {
+    val json  = """[{"id": 1, "tags": ["a", "b", "c", "d"]}, {"id": 2, "tags": []}]"""
+    val types = columnTypes(
+      JSONAnalyzer.analyzeJSONContent(json, isJsonLines = false, sampleSize = 1)
+    )
+    types shouldBe Map("id" -> DataType.LongType, "tags" -> DataType.StringType)
+  }
+
+  test("analyze a JSON file from the spec folder") {
+    val types = columnTypes(JSONAnalyzer.analyzeJSONFile("spec/basic/person.json"))
+    types shouldBe
+      Map("id" -> DataType.LongType, "name" -> DataType.StringType, "age" -> DataType.LongType)
+  }
+
+  test("sample a JSON file with more records than the sample size") {
+    val path = "target/json-analyzer-test/large.json"
+    SourceIO.writeString(path, records(200))
+    try
+      val types = columnTypes(
+        JSONAnalyzer.analyzeJSONFile(
+          path,
+          DataFilePath(DataFilePath.Format.JSON, None),
+          sampleSize = 20
+        )
+      )
+      types shouldBe Map("id" -> DataType.LongType, "name" -> DataType.StringType)
+    finally
+      SourceIO.deleteFile(path)
+  }
+
+  test("sample JSON Lines records") {
+    val jsonl = (0 until 100)
+      .map { i =>
+        if i < 10 then
+          s"""{"id": ${i}}"""
+        else
+          s"""{"id": ${i}, "late": true}"""
+      }
+      .mkString("\n")
+    val types = columnTypes(
+      JSONAnalyzer.analyzeJSONContent(jsonl, isJsonLines = true, sampleSize = 10)
+    )
+    types shouldBe Map("id" -> DataType.LongType)
+  }
+
+end JSONAnalyzerTest


### PR DESCRIPTION
## Why

`from '<file>'` infers the file schema at compile time. Today that work is repeated on every compile and, for JSON, reads and parses the **entire** file. In the LSP/REPL the typer re-runs on every edit, so a large JSON input is re-parsed per keystroke.

This PR applies two techniques from DuckDB's binder (research notes in `plans/2026-08-28-file-schema-inference.md`):

| DuckDB | Wvlet before | Wvlet after |
|---|---|---|
| `read_json` samples `sample_size = 20480` records at bind | parses the whole file (JSONL: first 10 000 lines after #2042) | stops scanning after 20 480 records — array elements or JSON Lines (`JSONAnalyzer.DefaultSampleSize`) |
| `parquet_metadata_cache` / external file cache validated by `last_modified` / ETag | no cache | `FileSchemaCache` per compiler, validated by file mtime |
| `DESCRIBE`/`PREPARE` bind only | `select * from '<file>' limit 0` (already bind-only) | unchanged |

Rebased on #2042 (`DataFilePath` classification, jsonl/tsv/zst); the JSONL line cap and the JSON array sample now share one `DefaultSampleSize`.

## What

- `JSONAnalyzer`: a `JSONValueBuilder` subclass hands the top-level array to a `LimitedArrayContext` that aborts uni's `JSONScanner` once the sample is full, so records past the limit are never materialized. Single-object roots and nested arrays are unaffected.
- `FileSchemaCache` on `GlobalContext`: memoizes inferred schemas keyed on path, validated by `SourceIO.lastUpdatedAt`. Missing local files are never cached; remote paths (`DataFilePath.isRemote`) are cached for the compiler's lifetime (no cheap freshness probe).
- `RelationRefResolver.resolveDataFileRef` funnels every data file through one cached `DuckDBAnalyzer.guessSchema` call; the JSONAnalyzer-vs-DuckDB routing and the DuckDB-less fallback from #2042 are preserved.
- `SourceIO.readAsBytes` / `readGzipAsBytes` (JVM/JS/Native) so JSON is scanned from bytes without a `String` decode/encode round-trip.
- Docs: note on sampling and caching in the `from 'file'` section.

## Tests

- `JSONAnalyzerTest` (cross-platform): array/object roots, sampling stops at N and fields first appearing later are excluded, nested arrays intact, `.json` file with more records than the sample, JSON Lines sampling.
- `FileSchemaCacheTest`: reuse while unchanged, re-infer after mtime change, missing file never cached, remote paths cached.
- Verified after rebase: `langJVM` (`JSONAnalyzerTest`, `FileSchemaCacheTest`, `DuckDBAnalyzerTest`, `DataFilePathTest`, `TyperCoverageCheck`), `langJS` (same analyzer tests), `RunnerSpecBasic` (157 pass, incl. the new jsonl/tsv/gz specs), `projectNative/Test/compile`.

## Follow-ups (out of scope)

- Reuse one in-memory DuckDB session across parquet/csv inferences (currently one open/close per cache miss, on all three backends).
- Bounded prefix read for huge JSON files (uni `IO` has no streaming read yet; sampling already removes the parse cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QbwioVQRkoyYaDjtkXbtz
