### PR TITLE
internal: Replace deprecated JLine terminal size accessors

### DIFF
--- a/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/JLine3Terminal.scala
+++ b/wvlet-cli/src/main/scala/wvlet/lang/cli/terminal/JLine3Terminal.scala
@@ -57,10 +57,12 @@ class JLine3Terminal(workEnv: WorkEnv) extends REPLTerminal:
 
   private val history = new JLine3History(jlineReader)
 
-  override def width: Int  = jlineTerminal.getWidth
-  override def height: Int = jlineTerminal.getHeight
+  override def width: Int  = jlineTerminal.getSize.getColumns
+  override def height: Int = jlineTerminal.getSize.getRows
 
-  override def setSize(width: Int, height: Int): Unit = jlineTerminal.setSize(Size(width, height))
+  override def setSize(width: Int, height: Int): Unit = jlineTerminal.setSize(
+    Size.of(width, height)
+  )
 
   override def write(s: String): Unit = jlineTerminal.writer().print(s)
 
@@ -162,8 +164,8 @@ class JLine3Terminal(workEnv: WorkEnv) extends REPLTerminal:
       subqueryRun: Widget
   ): Unit =
     // Set the default size when opening a new window or inside sbt console
-    if jlineTerminal.getWidth == 0 || jlineTerminal.getHeight == 0 then
-      jlineTerminal.setSize(Size(120, 40))
+    if width == 0 || height == 0 then
+      jlineTerminal.setSize(Size.of(120, 40))
 
     // Add shortcut keys
     val keyMaps = jlineReader.getKeyMaps().get("main")

--- a/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
+++ b/wvlet-runner/.jvm/src/main/scala/wvlet/lang/runner/WvletScriptRunner.scala
@@ -204,10 +204,10 @@ class WvletScriptRunner(
     def print: LastOutput =
       val str            = queryResult.toPrettyBox(maxColWidth = resultMaxColWidth)
       val resultMaxWidth = str.split("\n").map(_.size).max
-      if !config.interactive || resultMaxWidth <= terminal.getWidth then
+      if !config.interactive || resultMaxWidth <= terminal.getSize.getColumns then
         // The result fits in the terminal width
         val output = queryResult.toPrettyBox(
-          maxWidth = Some(terminal.getWidth),
+          maxWidth = Some(terminal.getSize.getColumns),
           maxColWidth = resultMaxColWidth
         )
         if output.trim.nonEmpty then


### PR DESCRIPTION
## Summary

Follow-up to #2048. jline 4.4 deprecates `Terminal.getWidth` / `getHeight` and the `Size(int, int)` constructor, which showed up as the last deprecation warnings in the JVM build under Scala 3.9. Use the replacements:

- `terminal.getSize.getColumns` / `getRows` in `JLine3Terminal` and `WvletScriptRunner`
- `Size.of(cols, rows)` for the default size fallback and `setSize`

Behavior is unchanged.

## Test plan

- [x] `cli/compile`, `runnerJVM/compile` with no deprecation warnings
- [x] `cli/test`, `runnerJVM/test`
- [x] `scalafmtAll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2ughJ1kagSNvPnhLLFGz8