### PR TITLE
internal: Bump uni to 2026.1.23 to drop rx-html deprecation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import scala.scalanative.build.NativeConfig
 import scala.language.implicitConversions
 import WvletBuildKeys.*
 
-val UNI_VERSION = "2026.1.22"
+val UNI_VERSION = "2026.1.23"
 
 val TRINO_VERSION          = "476"
 val AWS_SDK_VERSION        = "2.20.146"

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,6 +1,6 @@
 // ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
-val UNI_VERSION = "2026.1.22"
+val UNI_VERSION = "2026.1.23"
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.6.2")
 addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo" % "0.13.1")


### PR DESCRIPTION
## Summary

Follow-up to #2048 / #2049. uni 2026.1.23 makes the rx-html `EmbeddableAttribute` / `EmbeddableNode` givens public (wvlet/uni#692, closes wvlet/uni#691), which removes the ~200 *"implicit will no longer be found in Scala 3.10"* deprecation warnings the Scala.js UI modules have emitted since the Scala 3.9 upgrade.

Bumps `UNI_VERSION` in `build.sbt` and `project/plugin.sbt` (sbt-uni, sbt-uni-crossproject, sbt-uni-playwright) to 2026.1.23. No code changes.

## Test plan

- [x] `projectJVM/Test/compile`, `projectJS/Test/compile`, `projectNative/Test/compile`: 0 "not accessible here" deprecations remain (down from 207); only the pre-existing implicit-conversion feature notices are left
- [x] `langJVM/test` + forced `testOnly *ParserSpec* *RoundTripSpec*`, `runnerJVM/testOnly *RunnerSpec*`, `projectJS/test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2ughJ1kagSNvPnhLLFGz8