### PR TITLE
internal: Enable implicitConversions for the Scala.js UI modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -653,6 +653,7 @@ lazy val ui = project
   .in(file("wvlet-ui"))
   .settings(
     buildSettings,
+    rxHtmlSettings,
     name        := "wvlet-ui",
     description := "UI components that can be testable with Node.js",
     // Run UI tests in headless Chromium via Playwright — gives real DOM APIs plus ES-module
@@ -702,13 +703,21 @@ lazy val playground = project
   )
   .dependsOn(uiMain, lang.js)
 
-def uiSettings: Seq[Setting[?]] = Seq(
-  Test / jsEnv                    := Def.uncached(new org.scalajs.jsenv.nodejs.NodeJSEnv()),
-  scalaJSUseMainModuleInitializer := true,
-  scalaJSLinkerConfig ~= {
-    linkerConfig(_)
-  }
-)
+// uni's rx-html embeds plain strings and DOM nodes as element children through `given
+// Conversion`s (wvlet.uni.dom.all.stringToDomNode etc.), which Scala 3 gates behind the
+// implicitConversions language feature. Enable it for the UI modules here rather than importing
+// scala.language.implicitConversions in every component file.
+val rxHtmlSettings: Seq[Setting[?]] = Seq(scalacOptions += "-language:implicitConversions")
+
+def uiSettings: Seq[Setting[?]] =
+  rxHtmlSettings ++
+    Seq(
+      Test / jsEnv                    := Def.uncached(new org.scalajs.jsenv.nodejs.NodeJSEnv()),
+      scalaJSUseMainModuleInitializer := true,
+      scalaJSLinkerConfig ~= {
+        linkerConfig(_)
+      }
+    )
 
 def linkerConfig(config: StandardConfig): StandardConfig = {
   config


### PR DESCRIPTION
## Summary

Last of the warning cleanups after the Scala 3.9 upgrade (#2048, #2049, #2050). uni's rx-html embeds plain strings and DOM nodes as element children through `given Conversion`s (`wvlet.uni.dom.all.stringToDomNode` etc.), which Scala 3 gates behind the `implicitConversions` language feature, so every UI component file emitted a *"Use of implicit conversion ... should be enabled"* feature warning.

This adds a shared `rxHtmlSettings` with `-language:implicitConversions` to `wvlet-ui`, `wvlet-ui-main`, and the playground, instead of importing `scala.language.implicitConversions` in each file. No source changes.

## Test plan

- [x] `projectJS/Test/compile`: zero warnings across the Scala.js build (was ~70 feature notices)
- [x] `projectJS/test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2ughJ1kagSNvPnhLLFGz8